### PR TITLE
Remove macOS-only cfg gates from title bar context hooks

### DIFF
--- a/bae-desktop/src/ui/components/active_imports_context.rs
+++ b/bae-desktop/src/ui/components/active_imports_context.rs
@@ -39,8 +39,7 @@ pub struct ActiveImportsState {
     pub is_loading: Signal<bool>,
 }
 impl ActiveImportsState {
-    /// Dismiss/remove an import from the list (used by ImportsDropdown on macOS)
-    #[cfg(target_os = "macos")]
+    /// Dismiss/remove an import from the list (used by ImportsDropdown)
     pub fn dismiss(&self, import_id: &str) {
         let mut imports = self.imports;
         imports.with_mut(|list| {
@@ -186,8 +185,7 @@ fn handle_progress_event(imports: Signal<Vec<ActiveImport>>, event: ImportProgre
         }
     }
 }
-/// Hook to access active imports state (used by TitleBar components on macOS)
-#[cfg(target_os = "macos")]
+/// Hook to access active imports state (used by TitleBar components)
 pub fn use_active_imports() -> ActiveImportsState {
     use_context::<ActiveImportsState>()
 }

--- a/bae-desktop/src/ui/components/library_search_context.rs
+++ b/bae-desktop/src/ui/components/library_search_context.rs
@@ -1,7 +1,6 @@
 use dioxus::prelude::*;
 
-/// Shared library search state that tracks search query across the app (macOS only)
-#[cfg(target_os = "macos")]
+/// Shared library search state that tracks search query across the app
 #[derive(Clone)]
 pub struct LibrarySearchState {
     pub search_query: Signal<String>,
@@ -10,19 +9,15 @@ pub struct LibrarySearchState {
 /// Provider component to make library search state available throughout the app
 #[component]
 pub fn LibrarySearchContextProvider(children: Element) -> Element {
-    #[cfg(target_os = "macos")]
-    {
-        let search_query = use_signal(String::new);
-        let search_state = LibrarySearchState { search_query };
-        use_context_provider(|| search_state.clone());
-    }
+    let search_query = use_signal(String::new);
+    let search_state = LibrarySearchState { search_query };
+    use_context_provider(|| search_state.clone());
     rsx! {
         {children}
     }
 }
 
-/// Hook to access the library search query (used by TitleBar on macOS)
-#[cfg(target_os = "macos")]
+/// Hook to access the library search query (used by TitleBar)
 pub fn use_library_search() -> Signal<String> {
     let state = use_context::<LibrarySearchState>();
     state.search_query


### PR DESCRIPTION
The use_active_imports and use_library_search hooks were gated to macOS only, but they're used by title_bar.rs which compiles on all platforms. This caused CI failures on Linux.