### PR TITLE
Add crash reporting and dSYM archiving

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,17 @@ jobs:
         # Only build .app bundle, skip DMG (we create our own signed DMG later)
         dx bundle --release --package-types macos
 
+    - name: Archive dSYM bundle
+      run: |
+        DSYM_PATH=$(find target/release -name "*.dSYM" -type d | head -1)
+        if [[ -n "$DSYM_PATH" ]]; then
+          zip -r target/bae.dSYM.zip "$DSYM_PATH"
+          echo "DSYM_ARCHIVE=target/bae.dSYM.zip" >> $GITHUB_ENV
+          echo "Found dSYM at $DSYM_PATH"
+        else
+          echo "::warning::No dSYM bundle found"
+        fi
+
     - name: Rename app bundle to lowercase
       run: mv target/dx/bae/bundle/macos/bundle/macos/Bae.app target/dx/bae/bundle/macos/bundle/macos/bae.app
 
@@ -258,6 +269,14 @@ jobs:
         path: target/bae.dmg
         retention-days: 30
 
+    - name: Upload dSYM
+      if: env.DSYM_ARCHIVE != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: bae-dSYM
+        path: ${{ env.DSYM_ARCHIVE }}
+        retention-days: 90
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
@@ -265,6 +284,7 @@ jobs:
         files: |
           target/bae.dmg
           target/appcast.xml
+          target/bae.dSYM.zip
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ tracing = "0.1.41"
 lto = true
 codegen-units = 1
 strip = true
+split-debuginfo = "packed"
+debug = "line-tables-only"

--- a/bae-desktop/src/crash_report.rs
+++ b/bae-desktop/src/crash_report.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+
+fn crash_log_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".bae").join("crash.log"))
+}
+
+pub fn install_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = (|| -> std::io::Result<()> {
+            let path = match crash_log_path() {
+                Some(p) => p,
+                None => return Ok(()),
+            };
+
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+
+            let message = if let Some(s) = info.payload().downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = info.payload().downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic".to_string()
+            };
+
+            let location = info
+                .location()
+                .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+                .unwrap_or_else(|| "unknown".to_string());
+
+            let backtrace = std::backtrace::Backtrace::force_capture();
+            let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
+            let version = env!("BAE_VERSION");
+
+            let report = format!(
+                "bae crash report\n================\nTime: {now}\nVersion: {version}\n\nPanic: {message}\nLocation: {location}\n\nBacktrace:\n{backtrace}",
+            );
+
+            std::fs::write(&path, report)?;
+            Ok(())
+        })();
+
+        default_hook(info);
+    }));
+}
+
+pub fn check_for_crash_report() {
+    let path = match crash_log_path() {
+        Some(p) if p.exists() => p,
+        _ => return,
+    };
+
+    let report = match std::fs::read_to_string(&path) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    let _ = std::fs::remove_file(&path);
+
+    let should_report = rfd::MessageDialog::new()
+        .set_title("bae crashed")
+        .set_description("bae crashed during the last session. Would you like to open a GitHub issue with the crash report?")
+        .set_buttons(rfd::MessageButtons::YesNo)
+        .show();
+
+    if should_report == rfd::MessageDialogResult::Yes {
+        // Truncate report for URL length limits
+        let truncated: String = report.chars().take(4000).collect();
+        let body = format!(
+            "<details>\n<summary>Crash report</summary>\n\n```\n{truncated}\n```\n\n</details>"
+        );
+        let url = format!(
+            "https://github.com/bae-fm/bae/issues/new?title={}&body={}&labels=crash",
+            urlencoding::encode("Crash report"),
+            urlencoding::encode(&body),
+        );
+
+        let _ = std::process::Command::new("open").arg(&url).spawn();
+    }
+}

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -8,6 +8,7 @@ use bae_core::{network, torrent};
 use tracing::warn;
 use tracing::{error, info};
 
+mod crash_report;
 mod media_controls;
 mod ui;
 mod updater;
@@ -81,8 +82,10 @@ fn configure_logging() {
 }
 
 fn main() {
+    crash_report::install_panic_hook();
     let config = config::Config::load();
     configure_logging();
+    crash_report::check_for_crash_report();
 
     // Initialize FFmpeg for audio processing
     audio_codec::init();


### PR DESCRIPTION
## Summary

- Panic hook writes crash report (`~/.bae/crash.log`) with message, location, backtrace, version, and timestamp
- On next launch, native dialog offers to open a pre-filled GitHub issue with the crash report
- Release builds now produce `.dSYM` bundles for symbolication; CI archives and uploads them alongside the DMG

## Test plan

- [ ] Add a temporary `panic!("test")` after startup, confirm `~/.bae/crash.log` is written
- [ ] Relaunch — confirm dialog appears, click "Yes" — confirm browser opens with pre-filled issue
- [ ] Relaunch again — confirm no dialog (crash.log deleted)
- [ ] Run a release build — confirm `.dSYM` bundle is produced in `target/release/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)