### PR TITLE
Install sccache in CI setup-rust action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -30,6 +30,10 @@ runs:
       shell: bash
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
+    - name: Install sccache
+      shell: bash
+      run: cargo binstall sccache --no-confirm --locked
+
     - name: Install Dioxus CLI
       if: inputs.install-dioxus == 'true'
       shell: bash


### PR DESCRIPTION
## Summary
- `.cargo/config.toml` sets `rustc-wrapper = "sccache"` but CI never explicitly installed it
- Release build [failed](https://github.com/bae-fm/bae/actions/runs/21547301603) when the runner didn't have sccache pre-installed
- Adds `cargo binstall sccache` to the shared `setup-rust` action so all workflows get it

## Test plan
- [ ] Re-run release workflow and confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)