### PR TITLE
Add sccache-action to release workflow

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,10 +24,6 @@ runs:
       shell: bash
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-    - name: Install sccache
-      shell: bash
-      run: cargo binstall sccache --no-confirm --locked
-
     - name: Install Dioxus CLI
       if: inputs.install-dioxus == 'true'
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
       with:
         install-dioxus: 'true'
 
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
     - name: Setup Node.js environment
       uses: ./.github/actions/setup-node
       with:


### PR DESCRIPTION
## Summary
- Release workflow was missing `mozilla-actions/sccache-action` — the step CI already has — causing [build failure](https://github.com/bae-fm/bae/actions/runs/21547301603) when cargo couldn't find sccache
- Remove redundant manual `cargo binstall sccache` from `setup-rust` since the action handles installation
- Purged 12 stale `Swatinem/rust-cache` entries from the Actions cache

## Test plan
- [ ] Re-run release workflow and confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)