### PR TITLE
Move sccache-action into setup-rust

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Rust Build Environment'
-description: 'Install Rust toolchain and common tools. Build caching is handled by sccache (configured in .cargo/config.toml + CI workflow).'
+description: 'Install Rust toolchain, sccache, and common tools'
 
 inputs:
   install-dioxus:
@@ -20,13 +20,12 @@ runs:
       shell: bash
       run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
     - name: Install cargo-binstall
       shell: bash
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
-    - name: Install sccache
-      shell: bash
-      run: cargo binstall sccache --no-confirm --locked
 
     - name: Install Dioxus CLI
       if: inputs.install-dioxus == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,6 @@ jobs:
       with:
         install-dioxus: 'true'
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
-
     - name: Setup Node.js environment
       uses: ./.github/actions/setup-node
 


### PR DESCRIPTION
## Summary
- Move `mozilla-actions/sccache-action` into the shared `setup-rust` composite action so every job gets sccache automatically
- Remove per-workflow sccache steps from CI and release workflows
- Fixes the release build failure and prevents future jobs from forgetting to add it

## Test plan
- [ ] CI passes (sccache provided by setup-rust)
- [ ] Re-run release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)