### PR TITLE
Remove duplicate sccache-action from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,6 @@ jobs:
       with:
         install-dioxus: 'true'
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
-
     - name: Setup Node.js environment
       uses: ./.github/actions/setup-node
       with:


### PR DESCRIPTION
PR #14 added it to release.yml, PR #15 moved it into setup-rust but didn't remove the release.yml copy. Oops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)