### PR TITLE
Center disc ID lookup view vertically

### DIFF
--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -220,7 +220,7 @@ fn WorkflowContent(
     on_view_duplicate: EventHandler<String>,
 ) -> Element {
     rsx! {
-        div { class: "flex-1 min-h-0 overflow-auto bg-gray-900/40 rounded-tl-xl",
+        div { class: "flex-1 min-h-0 overflow-auto bg-gray-900/40 rounded-tl-xl flex flex-col",
             match step {
                 ImportStep::Identify => rsx! {
                     IdentifyStep {


### PR DESCRIPTION
## Summary
- Add `flex flex-col` to WorkflowContent wrapper div so child `flex-1` expands to fill available height
- Fixes the disc ID lookup spinner sitting at the top instead of being vertically centered

## Test plan
- [ ] Open folder import, trigger disc ID lookup — "Checking MusicBrainz..." should be vertically centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)