### PR TITLE
Fix Select stale context, encode URL state as base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ name = "bae-mocks"
 version = "0.1.0"
 dependencies = [
  "bae-ui",
+ "base64",
  "dioxus",
  "getrandom 0.2.17",
  "serde",

--- a/bae-mocks/Cargo.toml
+++ b/bae-mocks/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+base64 = "0.22"
 bae-ui = { path = "../bae-ui" }
 dioxus = { workspace = true, features = ["router", "web", "asset", "document", "launch"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- **Select component**: `use_context_provider` only runs its closure on first mount, so `SelectContext.current_value` (a plain `String`) was frozen at the initial value. Changed to `Signal<String>` that stays in sync with the `value` prop — checkmarks now update correctly across all dropdowns. Added `use_drop` cleanup so unmounted `SelectOption`s are removed from the options list.
- **URL state encoding**: Switched from raw `key=value,key=value` format to base64-encoded JSON. The old format produced confusing URLs like `?state=state=Confirming` because the control key "state" collided with the query parameter name "state". URLs are now opaque (e.g. `?eyJzdGF0ZSI6IkNvbmZpcm1pbmcifQ`).

## Test plan
- [ ] Open any mock page with dropdowns (e.g. `/folder-import?`)
- [ ] Switch presets — verify checkmark moves to the selected item
- [ ] Verify URL updates to an opaque base64 string
- [ ] Reload the page with a base64 URL — verify state restores correctly
- [ ] Check viewport and inline enum dropdowns also track selection properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)