### PR TITLE
Make folder icon clickable on incomplete candidates

### DIFF
--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -284,7 +284,8 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 ]),
                 artwork: vec![mock_artwork("AlbumArt.jpg", 450_000, "JPEG", 5)],
                 documents: vec![],
-                ..Default::default()
+                bad_audio_count: 2,
+                bad_image_count: 1,
             },
         ),
         // Folder 5: Vinyl rip with extensive documentation
@@ -522,6 +523,28 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
     let mut candidate_states = HashMap::new();
     if has_candidates {
         candidate_states.insert(folder_path.clone(), candidate_state);
+
+        // Add state for the incomplete candidate so its status is computed correctly
+        for (candidate, files) in &folder_data {
+            if candidate.path != folder_path
+                && (files.bad_audio_count > 0 || files.bad_image_count > 0)
+            {
+                candidate_states.insert(
+                    candidate.path.clone(),
+                    CandidateState::Identifying(IdentifyingState {
+                        files: files.clone(),
+                        metadata: FolderMetadata::default(),
+                        mode: IdentifyMode::ManualSearch,
+                        auto_matches: vec![],
+                        selected_match_index: None,
+                        search_state: ManualSearchState::default(),
+                        discid_lookup_error: None,
+                        disc_id_not_found: None,
+                        source_disc_id: None,
+                    }),
+                );
+            }
+        }
     }
 
     // Create store once, then update when registry values change

--- a/bae-ui/src/components/import/workflow/release_sidebar.rs
+++ b/bae-ui/src/components/import/workflow/release_sidebar.rs
@@ -246,9 +246,25 @@ fn CandidateRow(
                 DetectedCandidateStatus::Imported => rsx! {
                     CheckIcon { class: "w-4 h-4 flex-shrink-0 text-green-500" }
                 },
-                DetectedCandidateStatus::Incomplete { .. } => rsx! {
-                    FolderIcon { class: "w-4 h-4 flex-shrink-0 text-gray-600" }
-                },
+                DetectedCandidateStatus::Incomplete { .. } => {
+                    let open_path = path.clone();
+                    rsx! {
+                        Tooltip {
+                            text: platform::reveal_in_file_manager().to_string(),
+                            placement: Placement::TopStart,
+                            nowrap: true,
+                            cross_axis_offset: -TOOLTIP_PADDING_X,
+                            button {
+                                class: "flex-shrink-0 text-gray-600 hover:text-white transition-colors",
+                                onclick: move |e: MouseEvent| {
+                                    e.stop_propagation();
+                                    on_open_folder.call(open_path.clone());
+                                },
+                                FolderIcon { class: "w-4 h-4" }
+                            }
+                        }
+                    }
+                }
             }
 
             div { class: "flex-1 min-w-0",


### PR DESCRIPTION
## Summary
- The folder icon on incomplete sidebar rows was static and unclickable — now wraps it in a tooltip + button so users can reveal the folder in their file manager
- Adds an incomplete candidate to the folder import mock for testing this state

## Test plan
- [ ] Open folder import mock in bae-mocks (`dx serve -p bae-mocks`)
- [ ] Verify the "Apartment Garden - Grow Light" row shows as incomplete with subtitle text
- [ ] Hover over the folder icon on the incomplete row — tooltip should show "Reveal in Finder"
- [ ] Click the folder icon — should trigger the open folder action

🤖 Generated with [Claude Code](https://claude.com/claude-code)