### PR TITLE
Ghost button text glow hover, Configure button as ghost

### DIFF
--- a/bae-ui/assets/main.css
+++ b/bae-ui/assets/main.css
@@ -140,3 +140,14 @@ textarea,
 .animate-pulse-glow {
     animation: pulse-glow 2s ease-in-out infinite;
 }
+
+/* Ghost button text glow on hover */
+.ghost-text-glow {
+    transition-property: color, text-shadow;
+    transition-duration: 200ms;
+    transition-timing-function: ease;
+}
+
+.ghost-text-glow:hover {
+    text-shadow: 0 0 8px rgba(255, 255, 255, 0.5);
+}

--- a/bae-ui/src/components/button.rs
+++ b/bae-ui/src/components/button.rs
@@ -100,7 +100,7 @@ pub fn Button(
             "border border-transparent bg-red-600 hover:bg-red-500 text-white disabled:opacity-50 disabled:cursor-not-allowed"
         }
         ButtonVariant::Ghost => {
-            "border border-transparent text-gray-400 hover:text-white hover:bg-gray-700/50"
+            "border border-transparent text-gray-400 hover:text-white ghost-text-glow"
         }
         ButtonVariant::Outline => {
             "border border-gray-600 text-gray-300 hover:border-gray-500 hover:text-white hover:bg-gray-700/30"

--- a/bae-ui/src/components/import/workflow/confirmation.rs
+++ b/bae-ui/src/components/import/workflow/confirmation.rs
@@ -162,7 +162,7 @@ pub fn ConfirmationView(
                     }
                 }
                 Button {
-                    variant: ButtonVariant::Outline,
+                    variant: ButtonVariant::Ghost,
                     size: ButtonSize::Small,
                     onclick: move |_| on_configure_storage.call(()),
                     "Configure"


### PR DESCRIPTION
## Summary
- Replace ghost button background hover (`hover:bg-gray-700/50`) with a text glow effect (`text-shadow`) that animates in on hover
- Change the Configure button next to the storage selector on the confirm step from Outline to Ghost variant

## Test plan
- [ ] Hover over ghost buttons and verify text glows instead of showing a background
- [ ] Verify the Configure button on the import confirm step renders as a ghost button
- [ ] Check that the glow transition animates smoothly (200ms ease)

🤖 Generated with [Claude Code](https://claude.com/claude-code)