### PR TITLE
Trigger manual search on Enter key

### DIFF
--- a/bae-ui/src/components/import/workflow/manual_search_panel.rs
+++ b/bae-ui/src/components/import/workflow/manual_search_panel.rs
@@ -146,6 +146,11 @@ pub fn ManualSearchPanelView(
 
                 // Search form based on active tab
                 div {
+                    onkeydown: move |evt: KeyboardEvent| {
+                        if evt.key() == Key::Enter && !searching {
+                            on_search.call(());
+                        }
+                    },
                     match tab {
                         SearchTab::General => rsx! {
                             div { class: "flex gap-3",


### PR DESCRIPTION
## Summary
- Pressing Enter in any search input (artist, album, catalog number, barcode) now triggers the search
- Single `onkeydown` handler on the form wrapper div catches Enter from all tabs

## Test plan
- [ ] Type in artist/album fields on Title tab, press Enter — search runs
- [ ] Switch to Catalog # tab, type, press Enter — search runs
- [ ] Switch to Barcode tab, type, press Enter — search runs
- [ ] While search is in progress, Enter does not re-trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)