### PR TITLE
Consolidate clippy integration test loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,25 +106,14 @@ jobs:
         cargo clippy -p bae-ui --target wasm32-unknown-unknown -- -D warnings
         cargo clippy -p bae-mocks --target wasm32-unknown-unknown -- -D warnings
         # Check integration tests with test-utils feature
-        for test_file in bae-core/tests/*.rs; do
-          if [ -f "$test_file" ]; then
-            test_name=$(basename "$test_file" .rs)
-            echo "Checking integration test: $test_name"
-            cargo clippy -p bae-core --test "$test_name" --features bae-core/test-utils -- -D warnings
-          fi
-        done
+        cargo clippy -p bae-core --tests --features bae-core/test-utils -- -D warnings
 
     - name: Run Clippy (Windows)
       if: runner.os == 'Windows'
       shell: cmd
       run: |
         cargo clippy --workspace --target x86_64-pc-windows-gnu -- -D warnings
-        for %%f in (bae-core\tests\*.rs) do (
-          for %%n in ("%%~nf") do (
-            echo Checking integration test: %%~n
-            cargo clippy -p bae-core --target x86_64-pc-windows-gnu --test "%%~n" --features bae-core/test-utils -- -D warnings
-          )
-        )
+        cargo clippy -p bae-core --tests --target x86_64-pc-windows-gnu --features bae-core/test-utils -- -D warnings
 
     - name: Check for WASM-only APIs in desktop code
       if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Replace 7 individual `cargo clippy --test <name>` invocations with single `cargo clippy --tests` flag
- Eliminates redundant re-linking of bae-core for each integration test file
- Same change applied to both Linux/macOS and Windows clippy steps

## Test plan
- [ ] CI passes on macOS and Ubuntu (clippy + tests green)
- [ ] Compare total CI time against recent ~15-17 min baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)