### PR TITLE
Lightbox click-to-close and full-size remote covers

### DIFF
--- a/bae-ui/src/components/import/workflow/confirmation.rs
+++ b/bae-ui/src/components/import/workflow/confirmation.rs
@@ -70,9 +70,19 @@ pub fn ConfirmationView(
             MatchSourceType::MusicBrainz => "MusicBrainz",
             MatchSourceType::Discogs => "Discogs",
         };
+        // Use full-size CAA image for the lightbox (the thumbnail URL is only 250px)
+        let lightbox_url = match (&candidate.source_type, &candidate.musicbrainz_release_id) {
+            (MatchSourceType::MusicBrainz, Some(mb_id)) => {
+                format!("https://coverartarchive.org/release/{mb_id}/front-1200")
+            }
+            _ => url.clone(),
+        };
         picker_items.push(GalleryItem {
             label: format!("{source_label} cover"),
-            content: GalleryItemContent::Image { url: url.clone() },
+            content: GalleryItemContent::Image {
+                url: lightbox_url,
+                thumbnail_url: url.clone(),
+            },
         });
         picker_covers.push(SelectedCover::Remote {
             url: url.clone(),
@@ -84,6 +94,7 @@ pub fn ConfirmationView(
             label: img.name.clone(),
             content: GalleryItemContent::Image {
                 url: img.display_url.clone(),
+                thumbnail_url: img.display_url.clone(),
             },
         });
         picker_covers.push(SelectedCover::Local {
@@ -95,6 +106,7 @@ pub fn ConfirmationView(
             label: img.name.clone(),
             content: GalleryItemContent::Image {
                 url: img.display_url.clone(),
+                thumbnail_url: img.display_url.clone(),
             },
         });
         picker_covers.push(SelectedCover::Local {

--- a/bae-ui/src/components/import/workflow/gallery_lightbox.rs
+++ b/bae-ui/src/components/import/workflow/gallery_lightbox.rs
@@ -10,7 +10,7 @@ use dioxus::prelude::*;
 /// Content variant for a gallery item
 #[derive(Clone, Debug, PartialEq)]
 pub enum GalleryItemContent {
-    Image { url: String },
+    Image { url: String, thumbnail_url: String },
     Text { content: Option<String> },
 }
 
@@ -73,9 +73,7 @@ pub fn GalleryLightbox(
 
     rsx! {
         Modal { is_open, on_close,
-            div {
-                onkeydown: on_keydown,
-                class: "flex flex-col items-center min-w-[50vw]",
+            div { onkeydown: on_keydown, class: "flex flex-col items-center",
 
                 // Close button
                 button {
@@ -122,7 +120,7 @@ pub fn GalleryLightbox(
                     // Selection mode (images only): overlay with label and select button
                     {
                         let url = match &current_item.content {
-                            GalleryItemContent::Image { url } => url,
+                            GalleryItemContent::Image { url, .. } => url,
                             _ => unreachable!(),
                         };
                         rsx! {
@@ -156,7 +154,7 @@ pub fn GalleryLightbox(
                 } else {
                     // View mode: render based on content type
                     match &current_item.content {
-                        GalleryItemContent::Image { url } => rsx! {
+                        GalleryItemContent::Image { url, .. } => rsx! {
                             div { class: "flex flex-col items-center",
                                 img {
                                     src: "{url}",
@@ -168,7 +166,7 @@ pub fn GalleryLightbox(
                         },
                         GalleryItemContent::Text { content: Some(text) } => rsx! {
                             div { class: "flex flex-col items-center",
-                                div { class: "bg-gray-800 rounded-lg max-w-2xl w-full max-h-[80vh] overflow-auto shadow-2xl",
+                                div { class: "bg-gray-800 rounded-lg w-[min(42rem,90vw)] max-h-[80vh] overflow-auto shadow-2xl",
                                     pre { class: "text-sm text-gray-300 font-mono whitespace-pre-wrap select-text p-4",
                                         {text.clone()}
                                     }
@@ -178,7 +176,7 @@ pub fn GalleryLightbox(
                         },
                         GalleryItemContent::Text { content: None } => rsx! {
                             div { class: "flex flex-col items-center",
-                                div { class: "bg-gray-800 rounded-lg max-w-2xl w-full p-8 flex items-center justify-center shadow-2xl",
+                                div { class: "bg-gray-800 rounded-lg w-[min(42rem,90vw)] p-8 flex items-center justify-center shadow-2xl",
                                     span { class: "text-gray-400 text-sm", "Loading..." }
                                 }
                                 div { class: "mt-4 text-gray-300 text-sm", {label.clone()} }
@@ -208,8 +206,12 @@ pub fn GalleryLightbox(
                                         onclick: move |_| navigate(i),
                                         div { class: "w-full h-full rounded-md overflow-clip",
                                             match &item.content {
-                                                GalleryItemContent::Image { url } => rsx! {
-                                                    img { src: "{url}", alt: "{item.label}", class: "w-full h-full object-cover" }
+                                                GalleryItemContent::Image { thumbnail_url, .. } => rsx! {
+                                                    img {
+                                                        src: "{thumbnail_url}",
+                                                        alt: "{item.label}",
+                                                        class: "w-full h-full object-cover",
+                                                    }
                                                 },
                                                 GalleryItemContent::Text { .. } => rsx! {
                                                     div { class: "w-full h-full bg-gray-800 flex items-center justify-center",

--- a/bae-ui/src/components/import/workflow/smart_file_display.rs
+++ b/bae-ui/src/components/import/workflow/smart_file_display.rs
@@ -84,6 +84,7 @@ pub fn SmartFileDisplayView(
             label: file.name.clone(),
             content: GalleryItemContent::Image {
                 url: file.display_url.clone(),
+                thumbnail_url: file.display_url.clone(),
             },
         });
     }


### PR DESCRIPTION
## Summary
- Remove `min-w-[50vw]` from lightbox content div so clicks outside the image/text reach the modal backdrop and close the lightbox
- Use fixed `w-[min(42rem,90vw)]` for text file views to maintain readable width
- Use CAA `front-1200` for MusicBrainz covers in the lightbox main view, keep 250px thumbnail for the gallery strip via `thumbnail_url` on `GalleryItemContent::Image`

## Test plan
- [ ] Open lightbox with an image — click dead space left/right of the image dismisses it
- [ ] Open lightbox with a text file — text container has fixed width, click outside dismisses
- [ ] Open cover picker in confirm step with MB match — lightbox shows full-size cover, gallery strip shows thumbnail
- [ ] Gallery strip navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)