### PR TITLE
Pass GITHUB_TOKEN to cargo-binstall

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -35,3 +35,5 @@ runs:
       if: inputs.install-dioxus == 'true'
       shell: bash
       run: cargo binstall dioxus-cli@0.7.2 --no-confirm --locked
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,8 @@ jobs:
 
     - name: Install cargo-audit
       run: cargo binstall cargo-audit --no-confirm --force
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run security audit
       run: cargo audit --ignore RUSTSEC-2023-0071


### PR DESCRIPTION
## Summary
- Adds `GITHUB_TOKEN` env to both `cargo binstall` steps (dioxus-cli and cargo-audit)
- Unauthenticated GitHub API requests share a 60 req/hr limit per runner IP, which caused a 403 and a 22-minute source compile fallback on macOS: https://github.com/bae-fm/bae/actions/runs/21598926439

🤖 Generated with [Claude Code](https://claude.com/claude-code)