### PR TITLE
Auto-symbolicate crash reports via GitHub Actions

### DIFF
--- a/.github/workflows/symbolicate.yml
+++ b/.github/workflows/symbolicate.yml
@@ -1,0 +1,125 @@
+name: Symbolicate Crash Report
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  symbolicate:
+    name: Symbolicate
+    runs-on: macos-latest
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'crash') ||
+      (github.event.action == 'opened' && contains(toJSON(github.event.issue.labels.*.name), 'crash'))
+    steps:
+    - name: Parse crash report
+      id: parse
+      env:
+        ISSUE_BODY: ${{ github.event.issue.body }}
+      run: |
+        VERSION=$(echo "$ISSUE_BODY" | sed -n 's/^Version: *//p' | tr -d '[:space:]')
+        SLIDE=$(echo "$ISSUE_BODY" | sed -n 's/^Slide: *//p' | tr -d '[:space:]')
+        ADDRS=$(echo "$ISSUE_BODY" | grep -oE '0x[0-9a-f]{16}' | tr '\n' ' ')
+
+        if [[ -z "$VERSION" || -z "$SLIDE" || -z "$ADDRS" ]]; then
+          echo "could not parse crash report"
+          echo "parsed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "slide=$SLIDE" >> "$GITHUB_OUTPUT"
+        echo "addrs=$ADDRS" >> "$GITHUB_OUTPUT"
+        echo "parsed=true" >> "$GITHUB_OUTPUT"
+
+    - name: Comment on parse failure
+      if: steps.parse.outputs.parsed == 'false'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh issue comment "${{ github.event.issue.number }}" \
+          -R "${{ github.repository }}" \
+          --body "Could not parse crash report — expected \`Version:\`, \`Slide:\`, and a backtrace with hex addresses."
+
+    - name: Download dSYM
+      if: steps.parse.outputs.parsed == 'true'
+      id: dsym
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ steps.parse.outputs.version }}"
+        mkdir -p /tmp/dsym
+        if gh release download "v${VERSION}" -R "${{ github.repository }}" -p 'bae.dSYM.zip' -D /tmp/dsym 2>/dev/null; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Comment on missing dSYM
+      if: steps.parse.outputs.parsed == 'true' && steps.dsym.outputs.found == 'false'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ steps.parse.outputs.version }}"
+        gh issue comment "${{ github.event.issue.number }}" \
+          -R "${{ github.repository }}" \
+          --body "Could not symbolicate — no dSYM found for release v${VERSION}."
+
+    - name: Symbolicate and comment
+      if: steps.parse.outputs.parsed == 'true' && steps.dsym.outputs.found == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd /tmp/dsym
+        unzip -q bae.dSYM.zip
+
+        DSYM_PATH=$(find . -name "bae.dSYM" -type d | head -1)
+        if [[ -z "$DSYM_PATH" ]]; then
+          gh issue comment "${{ github.event.issue.number }}" \
+            -R "${{ github.repository }}" \
+            --body "Downloaded dSYM archive but could not find bae.dSYM bundle inside."
+          exit 0
+        fi
+
+        SLIDE="${{ steps.parse.outputs.slide }}"
+        read -ra ADDR_ARRAY <<< "${{ steps.parse.outputs.addrs }}"
+
+        SYMBOLS=$(atos -o "$DSYM_PATH" -s "$SLIDE" "${ADDR_ARRAY[@]}" 2>/dev/null || true)
+
+        if [[ -z "$SYMBOLS" ]]; then
+          gh issue comment "${{ github.event.issue.number }}" \
+            -R "${{ github.repository }}" \
+            --body "atos produced no output — the dSYM may not match this build."
+          exit 0
+        fi
+
+        # Build formatted backtrace with frame numbers
+        BACKTRACE=""
+        FRAME=0
+        while IFS= read -r line; do
+          BACKTRACE+="$(printf '%3d: %s' "$FRAME" "$line")"$'\n'
+          FRAME=$((FRAME + 1))
+        done <<< "$SYMBOLS"
+
+        VERSION="${{ steps.parse.outputs.version }}"
+        ADDRS="${{ steps.parse.outputs.addrs }}"
+
+        cat > /tmp/comment.md <<EOF
+        ## Symbolicated backtrace
+
+        Using the dSYM from v${VERSION} and the ASLR slide (\`${SLIDE}\`):
+
+        \`\`\`
+        atos -o bae.dSYM -s ${SLIDE} ${ADDRS}
+        \`\`\`
+
+        \`\`\`
+        ${BACKTRACE}\`\`\`
+        EOF
+
+        gh issue comment "${{ github.event.issue.number }}" \
+          -R "${{ github.repository }}" \
+          --body-file /tmp/comment.md


### PR DESCRIPTION
## Summary
- Add `symbolicate.yml` workflow that triggers when the `crash` label is added to an issue
- Parses crash report body for version, ASLR slide, and backtrace addresses
- Downloads the matching dSYM from the GitHub Release and runs `atos` to symbolicate
- Posts the symbolicated backtrace as a comment on the issue

Also created the `crash` label in the repo (the crash report UI already tries to set it).

## Test plan
- [ ] Merge to main, then add `crash` label to #36 — workflow should post symbolicated backtrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)