### PR TITLE
Update bytes 1.11.0 -> 1.11.1 (RUSTSEC-2026-0007)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,9 +1027,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
## Summary
- Fixes security audit failure from newly published advisory RUSTSEC-2026-0007 (integer overflow in `BytesMut::reserve`)
- `bytes` is a transitive dependency; only `Cargo.lock` changes

## Test plan
- [ ] CI security audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)