### PR TITLE
Show error in lightbox when text file can't be read

### DIFF
--- a/bae-desktop/src/ui/components/import/workflow/folder_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/folder_import.rs
@@ -518,7 +518,7 @@ pub fn FolderImport() -> Element {
             let artwork_count = files.artwork.len();
             let doc = files.documents.get(idx.checked_sub(artwork_count)?)?;
             let path = std::path::Path::new(&folder).join(&doc.name);
-            bae_core::text_encoding::read_text_file(&path).ok()
+            Some(bae_core::text_encoding::read_text_file(&path).map_err(|e| e.to_string()))
         }
     });
 

--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -625,12 +625,18 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                             .and_then(|idx| {
                                 let files = files?;
                                 let doc = files.documents.get(idx.checked_sub(files.artwork.len())?)?;
-                                Some(
-                                    format!(
-                                        "Mock content for {}\n\nThis is placeholder text for the file viewer.\nLine 3\nLine 4\nLine 5",
-                                        doc.name,
-                                    ),
-                                )
+                                if doc.name.ends_with(".nfo") {
+                                    Some(Err("Permission denied (os error 13)".to_string()))
+                                } else {
+                                    Some(
+                                        Ok(
+                                            format!(
+                                                "Mock content for {}\n\nThis is placeholder text for the file viewer.\nLine 3\nLine 4\nLine 5",
+                                                doc.name,
+                                            ),
+                                        ),
+                                    )
+                                }
                             })
                     },
                     storage_profiles,

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -50,7 +50,7 @@ pub struct FolderImportViewProps {
     pub viewing_index: ReadSignal<Option<usize>>,
     /// Loaded text file content (for viewed file, if it's a text file)
     #[props(default)]
-    pub text_file_content: Option<String>,
+    pub text_file_content: Option<Result<String, String>>,
 
     // === External data (not in ImportState) ===
     /// Storage profiles (from app context)
@@ -447,7 +447,7 @@ fn DetailHeader(state: ReadStore<ImportState>) -> Element {
 fn FilesColumn(
     state: ReadStore<ImportState>,
     viewing_index: ReadSignal<Option<usize>>,
-    text_file_content: Option<String>,
+    text_file_content: Option<Result<String, String>>,
     on_view_change: EventHandler<Option<usize>>,
 ) -> Element {
     // Read files at this level

--- a/bae-ui/src/components/import/workflow/gallery_lightbox.rs
+++ b/bae-ui/src/components/import/workflow/gallery_lightbox.rs
@@ -10,8 +10,13 @@ use dioxus::prelude::*;
 /// Content variant for a gallery item
 #[derive(Clone, Debug, PartialEq)]
 pub enum GalleryItemContent {
-    Image { url: String, thumbnail_url: String },
-    Text { content: Option<String> },
+    Image {
+        url: String,
+        thumbnail_url: String,
+    },
+    Text {
+        content: Option<Result<String, String>>,
+    },
 }
 
 /// An item in the gallery lightbox (image or text file)
@@ -173,12 +178,20 @@ pub fn GalleryLightbox(
                                 div { class: "mt-4 text-gray-300 text-sm", {label.clone()} }
                             }
                         },
-                        GalleryItemContent::Text { content: Some(text) } => rsx! {
+                        GalleryItemContent::Text { content: Some(Ok(text)) } => rsx! {
                             div { class: "flex flex-col items-center",
                                 div { class: "bg-gray-800 rounded-lg w-[min(42rem,90vw)] max-h-[80vh] overflow-auto shadow-2xl",
                                     pre { class: "text-sm text-gray-300 font-mono whitespace-pre-wrap select-text p-4",
                                         {text.clone()}
                                     }
+                                }
+                                div { class: "mt-4 text-gray-300 text-sm", {label.clone()} }
+                            }
+                        },
+                        GalleryItemContent::Text { content: Some(Err(err)) } => rsx! {
+                            div { class: "flex flex-col items-center",
+                                div { class: "bg-gray-800 rounded-lg w-[min(42rem,90vw)] p-8 flex items-center justify-center shadow-2xl",
+                                    span { class: "text-red-400 text-sm", "Could not read file: {err}" }
                                 }
                                 div { class: "mt-4 text-gray-300 text-sm", {label.clone()} }
                             }

--- a/bae-ui/src/components/import/workflow/smart_file_display.rs
+++ b/bae-ui/src/components/import/workflow/smart_file_display.rs
@@ -56,7 +56,7 @@ fn FileSection(label: &'static str, children: Element) -> Element {
 pub fn SmartFileDisplayView(
     files: CategorizedFileInfo,
     viewing_index: ReadSignal<Option<usize>>,
-    text_file_content: Option<String>,
+    text_file_content: Option<Result<String, String>>,
     on_view_change: EventHandler<Option<usize>>,
 ) -> Element {
     if files.is_empty() {


### PR DESCRIPTION
## Summary
- Changed `text_file_content` from `Option<String>` to `Option<Result<String, String>>` through the prop chain
- Lightbox now shows "Could not read file: {error}" in red when `read_text_file` fails (I/O errors)
- Mock shows error state on `.nfo` files for visual testing

## Test plan
- [ ] Open the "Proof by Induction" candidate in the mock, click the `.nfo` file — should show error message
- [ ] Click other text files (`.log`, `.txt`) — should display content normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)