### PR TITLE
Import flow UI nits

### DIFF
--- a/bae-ui/src/components/import/workflow/confirmation.rs
+++ b/bae-ui/src/components/import/workflow/confirmation.rs
@@ -197,7 +197,7 @@ pub fn ConfirmationView(
                         size: ButtonSize::Small,
                         disabled: is_importing,
                         onclick: move |_| on_edit.call(()),
-                        "Edit"
+                        "Change"
                     }
                 }
             }

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -432,7 +432,9 @@ fn DetailHeader(state: ReadStore<ImportState>) -> Element {
     rsx! {
         div { class: "flex-shrink-0 px-4 py-4 bg-gray-800/30",
             div { class: "cursor-default", title: "{tooltip}",
-                span { class: "text-base font-medium text-gray-300 truncate", "{name}" }
+                span { class: "text-[0.9375rem] font-medium text-gray-300 truncate select-text",
+                    "{name}"
+                }
             }
         }
     }

--- a/bae-ui/src/components/import/workflow/manual_search_panel.rs
+++ b/bae-ui/src/components/import/workflow/manual_search_panel.rs
@@ -75,7 +75,7 @@ pub fn ManualSearchPanelView(
     drop(st);
 
     rsx! {
-        div { class: "p-5 space-y-4",
+        div { class: "flex-1 flex flex-col p-5 space-y-4",
             // Info banner if disc ID lookup found no results
             if let Some(disc_id) = disc_id_not_found {
                 div { class: "bg-blue-500/15 rounded-lg p-3 flex items-center gap-2",
@@ -247,7 +247,7 @@ pub fn ManualSearchPanelView(
 
             // Results
             if searching {
-                div { class: "flex flex-col items-center gap-4 py-8",
+                div { class: "flex-1 flex flex-col items-center justify-center gap-4",
                     LoadingIndicator { message: format!("Searching {}...", source.display_name()) }
                     Button {
                         variant: ButtonVariant::Outline,
@@ -267,7 +267,7 @@ pub fn ManualSearchPanelView(
                     on_select: move |index| on_match_select.call(index),
                     on_confirm,
                     on_retry_cover,
-                    confirm_button_text: "Confirm",
+                    confirm_button_text: "Select",
                 }
             }
         }

--- a/bae-ui/src/components/import/workflow/multiple_exact_matches.rs
+++ b/bae-ui/src/components/import/workflow/multiple_exact_matches.rs
@@ -62,7 +62,7 @@ pub fn MultipleExactMatchesView(
                 on_select: move |index| on_select.call(index),
                 on_confirm: move |candidate| on_confirm.call(candidate),
                 on_retry_cover: move |_| {},
-                confirm_button_text: "Continue",
+                confirm_button_text: "Select",
             }
         }
     }


### PR DESCRIPTION
## Summary
- Make header text user-selectable (select-text)
- Rename "Continue"/"Confirm" to "Select" on match results
- Rename "Edit" to "Change" on confirm page
- Vertically center the searching spinner/cancel button

## Test plan
- [ ] Visual check in mock: header text is selectable
- [ ] Mock manual search: "Select" button, spinner centered
- [ ] Mock confirm page: "Change" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)