### PR TITLE
Add "Clear incomplete" option to import sidebar menu

### DIFF
--- a/bae-desktop/src/ui/components/import/workflow/page.rs
+++ b/bae-desktop/src/ui/components/import/workflow/page.rs
@@ -120,6 +120,13 @@ pub fn ImportPage() -> Element {
         }
     };
 
+    let on_clear_incomplete = {
+        let app = app.clone();
+        move |_| {
+            app.state.import().write().clear_incomplete_candidates();
+        }
+    };
+
     let on_open_folder = move |path: String| {
         let _ = std::process::Command::new("open").arg(&path).spawn();
     };
@@ -133,6 +140,7 @@ pub fn ImportPage() -> Element {
             on_add_folder,
             on_remove_candidate,
             on_clear_all,
+            on_clear_incomplete,
             on_open_folder,
 
             match selected_source {

--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -612,6 +612,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 on_add_folder: |_| {},
                 on_remove_candidate: |_| {},
                 on_clear_all: |_| {},
+                on_clear_incomplete: |_| {},
                 on_open_folder: |_| {},
                 FolderImportView {
                     state: import_state,

--- a/bae-mocks/src/pages/import.rs
+++ b/bae-mocks/src/pages/import.rs
@@ -20,6 +20,7 @@ pub fn Import() -> Element {
             on_add_folder: |_| {},
             on_remove_candidate: |_| {},
             on_clear_all: |_| {},
+            on_clear_incomplete: |_| {},
             on_open_folder: |_| {},
 
             match *selected_source.read() {

--- a/bae-ui/src/components/import/view.rs
+++ b/bae-ui/src/components/import/view.rs
@@ -27,6 +27,8 @@ pub fn ImportView(
     on_remove_candidate: EventHandler<usize>,
     /// Sidebar: called to clear all candidates
     on_clear_all: EventHandler<()>,
+    /// Sidebar: called to clear incomplete candidates
+    on_clear_incomplete: EventHandler<()>,
     /// Sidebar: called to open a folder in the native file manager
     on_open_folder: EventHandler<String>,
     children: Element,
@@ -67,6 +69,7 @@ pub fn ImportView(
                                 on_add_folder,
                                 on_remove: on_remove_candidate,
                                 on_clear_all,
+                                on_clear_incomplete,
                                 on_open_folder,
                             }
                         }

--- a/bae-ui/src/components/import/workflow/release_sidebar.rs
+++ b/bae-ui/src/components/import/workflow/release_sidebar.rs
@@ -30,6 +30,8 @@ pub fn ReleaseSidebarView(
     on_remove: EventHandler<usize>,
     /// Called to clear all folders
     on_clear_all: EventHandler<()>,
+    /// Called to clear incomplete folders only
+    on_clear_incomplete: EventHandler<()>,
     /// Called to open a folder in the native file manager
     on_open_folder: EventHandler<String>,
 ) -> Element {
@@ -39,6 +41,10 @@ pub fn ReleaseSidebarView(
     let candidates = st.get_detected_candidates_display();
     let selected_index = st.get_selected_candidate_index();
     drop(st);
+
+    let has_incomplete = candidates
+        .iter()
+        .any(|c| matches!(c.status, DetectedCandidateStatus::Incomplete { .. }));
 
     let mut show_menu = use_signal(|| false);
     let is_open: ReadSignal<bool> = show_menu.into();
@@ -105,13 +111,23 @@ pub fn ReleaseSidebarView(
                             FolderIcon { class: "w-3.5 h-3.5 text-gray-400" }
                             span { "Add" }
                         }
+                        if has_incomplete {
+                            MenuItem {
+                                onclick: move |_| {
+                                    show_menu.set(false);
+                                    on_clear_incomplete.call(());
+                                },
+                                TrashIcon { class: "w-3.5 h-3.5 text-gray-400" }
+                                span { "Clear incomplete" }
+                            }
+                        }
                         MenuItem {
                             onclick: move |_| {
                                 show_menu.set(false);
                                 show_clear_confirm.set(true);
                             },
                             TrashIcon { class: "w-3.5 h-3.5 text-gray-400" }
-                            span { "Clear" }
+                            span { "Clear all" }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Add "Clear incomplete" menu item to the sidebar dropdown, shown only when there are incomplete candidates
- Removes only candidates with corrupt/bad audio or image files
- Rename existing "Clear" to "Clear all" to distinguish the two options

## Test plan
- [ ] Import folders where some have corrupt files (incomplete status)
- [ ] Verify "Clear incomplete" appears in menu only when incomplete candidates exist
- [ ] Click "Clear incomplete" and confirm only incomplete candidates are removed
- [ ] Verify "Clear all" still works as before (with confirmation dialog)
- [ ] Verify selected candidate switches correctly if the selected one was incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)