### PR TITLE
Store search results per (tab, source) combination

### DIFF
--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -469,21 +469,24 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
         search_barcode: search_barcode(),
         search_tab: current_tab,
         is_searching,
-        general: if current_tab == SearchTab::General {
+        general_mb: if current_tab == SearchTab::General {
             active_tab_state.clone()
         } else {
             TabSearchState::default()
         },
-        catalog_number: if current_tab == SearchTab::CatalogNumber {
+        general_discogs: TabSearchState::default(),
+        catalog_number_mb: if current_tab == SearchTab::CatalogNumber {
             active_tab_state.clone()
         } else {
             TabSearchState::default()
         },
-        barcode: if current_tab == SearchTab::Barcode {
+        catalog_number_discogs: TabSearchState::default(),
+        barcode_mb: if current_tab == SearchTab::Barcode {
             active_tab_state
         } else {
             TabSearchState::default()
         },
+        barcode_discogs: TabSearchState::default(),
     };
 
     // Build candidate state based on step

--- a/bae-ui/src/components/import/workflow/torrent_import.rs
+++ b/bae-ui/src/components/import/workflow/torrent_import.rs
@@ -191,7 +191,7 @@ fn TorrentIdentifyContent(
     let detected_metadata = st.get_metadata();
     let has_searched = st
         .get_search_state()
-        .map(|s| s.general.has_searched || s.catalog_number.has_searched || s.barcode.has_searched)
+        .map(|s| s.any_tab_searched())
         .unwrap_or(false);
     drop(st);
 

--- a/bae-ui/src/stores/import.rs
+++ b/bae-ui/src/stores/import.rs
@@ -68,25 +68,43 @@ pub struct ManualSearchState {
     pub search_barcode: String,
     pub search_tab: SearchTab,
     pub is_searching: bool,
-    pub general: TabSearchState,
-    pub catalog_number: TabSearchState,
-    pub barcode: TabSearchState,
+    pub general_mb: TabSearchState,
+    pub general_discogs: TabSearchState,
+    pub catalog_number_mb: TabSearchState,
+    pub catalog_number_discogs: TabSearchState,
+    pub barcode_mb: TabSearchState,
+    pub barcode_discogs: TabSearchState,
 }
 
 impl ManualSearchState {
+    pub fn any_tab_searched(&self) -> bool {
+        self.general_mb.has_searched
+            || self.general_discogs.has_searched
+            || self.catalog_number_mb.has_searched
+            || self.catalog_number_discogs.has_searched
+            || self.barcode_mb.has_searched
+            || self.barcode_discogs.has_searched
+    }
+
     pub fn current_tab_state(&self) -> &TabSearchState {
-        match self.search_tab {
-            SearchTab::General => &self.general,
-            SearchTab::CatalogNumber => &self.catalog_number,
-            SearchTab::Barcode => &self.barcode,
+        match (self.search_tab, self.search_source) {
+            (SearchTab::General, SearchSource::MusicBrainz) => &self.general_mb,
+            (SearchTab::General, SearchSource::Discogs) => &self.general_discogs,
+            (SearchTab::CatalogNumber, SearchSource::MusicBrainz) => &self.catalog_number_mb,
+            (SearchTab::CatalogNumber, SearchSource::Discogs) => &self.catalog_number_discogs,
+            (SearchTab::Barcode, SearchSource::MusicBrainz) => &self.barcode_mb,
+            (SearchTab::Barcode, SearchSource::Discogs) => &self.barcode_discogs,
         }
     }
 
     pub fn current_tab_state_mut(&mut self) -> &mut TabSearchState {
-        match self.search_tab {
-            SearchTab::General => &mut self.general,
-            SearchTab::CatalogNumber => &mut self.catalog_number,
-            SearchTab::Barcode => &mut self.barcode,
+        match (self.search_tab, self.search_source) {
+            (SearchTab::General, SearchSource::MusicBrainz) => &mut self.general_mb,
+            (SearchTab::General, SearchSource::Discogs) => &mut self.general_discogs,
+            (SearchTab::CatalogNumber, SearchSource::MusicBrainz) => &mut self.catalog_number_mb,
+            (SearchTab::CatalogNumber, SearchSource::Discogs) => &mut self.catalog_number_discogs,
+            (SearchTab::Barcode, SearchSource::MusicBrainz) => &mut self.barcode_mb,
+            (SearchTab::Barcode, SearchSource::Discogs) => &mut self.barcode_discogs,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Store `TabSearchState` per (SearchTab, SearchSource) pair instead of just per tab
- Switching between MusicBrainz and Discogs now preserves each source's results
- Add `any_tab_searched()` helper to replace direct field access

Stacked on #60.

## Test plan
- [ ] Search on MusicBrainz, switch to Discogs, switch back — MB results still visible
- [ ] Search on different tabs with different sources — each combination retains its results independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)