### PR TITLE
Fix Discogs manual search flow

### DIFF
--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -447,13 +447,11 @@ impl Database {
         for row in rows {
             let discogs_master_id: Option<String> = row.get("discogs_master_id");
             let discogs_release_id: Option<String> = row.get("discogs_release_id");
-            let discogs_release = match (discogs_master_id, discogs_release_id) {
-                (Some(mid), Some(rid)) => Some(crate::db::models::DiscogsMasterRelease {
-                    master_id: mid,
+            let discogs_release =
+                discogs_release_id.map(|rid| crate::db::models::DiscogsMasterRelease {
+                    master_id: discogs_master_id,
                     release_id: rid,
-                }),
-                _ => None,
-            };
+                });
             let mb_release_group_id: Option<String> = row.get("musicbrainz_release_group_id");
             let mb_release_id: Option<String> = row.get("musicbrainz_release_id");
             let musicbrainz_release = match (mb_release_group_id, mb_release_id) {
@@ -504,13 +502,11 @@ impl Database {
         Ok(row.map(|row| {
             let discogs_master_id: Option<String> = row.get("discogs_master_id");
             let discogs_release_id: Option<String> = row.get("discogs_release_id");
-            let discogs_release = match (discogs_master_id, discogs_release_id) {
-                (Some(mid), Some(rid)) => Some(crate::db::models::DiscogsMasterRelease {
-                    master_id: mid,
+            let discogs_release =
+                discogs_release_id.map(|rid| crate::db::models::DiscogsMasterRelease {
+                    master_id: discogs_master_id,
                     release_id: rid,
-                }),
-                _ => None,
-            };
+                });
             let mb_release_group_id: Option<String> = row.get("musicbrainz_release_group_id");
             let mb_release_id: Option<String> = row.get("musicbrainz_release_id");
             let musicbrainz_release = match (mb_release_group_id, mb_release_id) {
@@ -887,13 +883,11 @@ impl Database {
         Ok(row.map(|row| {
             let discogs_master_id: Option<String> = row.get("discogs_master_id");
             let discogs_release_id: Option<String> = row.get("discogs_release_id");
-            let discogs_release = match (discogs_master_id, discogs_release_id) {
-                (Some(mid), Some(rid)) => Some(crate::db::models::DiscogsMasterRelease {
-                    master_id: mid,
+            let discogs_release =
+                discogs_release_id.map(|rid| crate::db::models::DiscogsMasterRelease {
+                    master_id: discogs_master_id,
                     release_id: rid,
-                }),
-                _ => None,
-            };
+                });
             let mb_release_group_id: Option<String> = row.get("musicbrainz_release_group_id");
             let mb_release_id: Option<String> = row.get("musicbrainz_release_id");
             let musicbrainz_release = match (mb_release_group_id, mb_release_id) {
@@ -998,13 +992,11 @@ impl Database {
         Ok(row.map(|row| {
             let discogs_master_id: Option<String> = row.get("discogs_master_id");
             let discogs_release_id: Option<String> = row.get("discogs_release_id");
-            let discogs_release = match (discogs_master_id, discogs_release_id) {
-                (Some(mid), Some(rid)) => Some(crate::db::models::DiscogsMasterRelease {
-                    master_id: mid,
+            let discogs_release =
+                discogs_release_id.map(|rid| crate::db::models::DiscogsMasterRelease {
+                    master_id: discogs_master_id,
                     release_id: rid,
-                }),
-                _ => None,
-            };
+                });
             let mb_release_group_id: Option<String> = row.get("musicbrainz_release_group_id");
             let mb_release_id: Option<String> = row.get("musicbrainz_release_id");
             let musicbrainz_release = match (mb_release_group_id, mb_release_id) {

--- a/bae-core/src/discogs/models.rs
+++ b/bae-core/src/discogs/models.rs
@@ -18,9 +18,10 @@ pub struct DiscogsRelease {
     pub label: Vec<String>,
     pub cover_image: Option<String>,
     pub thumb: Option<String>,
+    pub catno: Option<String>,
     pub artists: Vec<DiscogsArtist>,
     pub tracklist: Vec<DiscogsTrack>,
-    pub master_id: String,
+    pub master_id: Option<String>,
 }
 /// Represents a track from Discogs
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -1388,6 +1388,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
         label: vec!["Test Label".to_string()],
         cover_image: None,
         thumb: None,
+        catno: None,
         artists: vec![],
         tracklist: vec![
             DiscogsTrack {
@@ -1406,6 +1407,6 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 duration: Some("0:10".to_string()),
             },
         ],
-        master_id: "test-master".to_string(),
+        master_id: Some("test-master".to_string()),
     }
 }

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -198,6 +198,7 @@ fn create_test_album() -> DiscogsRelease {
         label: vec!["Test Label".to_string()],
         cover_image: None,
         thumb: None,
+        catno: None,
         artists: vec![DiscogsArtist {
             name: "Test Artist".to_string(),
             id: "test-artist-1".to_string(),
@@ -214,7 +215,7 @@ fn create_test_album() -> DiscogsRelease {
                 duration: Some("0:10".to_string()),
             },
         ],
-        master_id: "test-master-123".to_string(),
+        master_id: Some("test-master-123".to_string()),
     }
 }
 /// Copy pre-generated FLAC fixtures to test directory
@@ -298,6 +299,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
         label: vec!["Test Label".to_string()],
         cover_image: None,
         thumb: None,
+        catno: None,
         artists: vec![DiscogsArtist {
             name: "Test Artist".to_string(),
             id: "test-artist-1".to_string(),
@@ -319,7 +321,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 duration: Some("0:10".to_string()),
             },
         ],
-        master_id: "test-master-cue-flac".to_string(),
+        master_id: Some("test-master-cue-flac".to_string()),
     }
 }
 
@@ -1983,6 +1985,7 @@ impl HighSampleRateTestFixture {
             label: vec!["Test Label".to_string()],
             cover_image: None,
             thumb: None,
+            catno: None,
             artists: vec![DiscogsArtist {
                 name: "Test Artist".to_string(),
                 id: "test-artist-1".to_string(),
@@ -1992,7 +1995,7 @@ impl HighSampleRateTestFixture {
                 title: "96kHz Track".to_string(),
                 duration: Some("0:03".to_string()),
             }],
-            master_id: "test-master-96khz".to_string(),
+            master_id: Some("test-master-96khz".to_string()),
         };
 
         let import_handle = bae_core::import::ImportService::start(

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -108,6 +108,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
         label: vec!["Test Label".to_string()],
         cover_image: None,
         thumb: None,
+        catno: None,
         artists: vec![DiscogsArtist {
             name: "Test Artist".to_string(),
             id: "test-artist-1".to_string(),
@@ -129,7 +130,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 duration: Some("1:40".to_string()), // 100 seconds
             },
         ],
-        master_id: "test-master".to_string(),
+        master_id: Some("test-master".to_string()),
     }
 }
 

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -649,6 +649,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
         label: vec!["Test Label".to_string()],
         cover_image: None,
         thumb: None,
+        catno: None,
         artists: vec![],
         tracklist: vec![
             DiscogsTrack {
@@ -667,7 +668,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 duration: Some("2:30".to_string()),
             },
         ],
-        master_id: "test-master-storage".to_string(),
+        master_id: Some("test-master-storage".to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary
- Make `master_id` optional throughout — not all Discogs releases have a master
- Parse labels and catalog number from the Discogs release API
- Populate format, label, catalog_number, and country in `DbRelease` from Discogs data
- Add `catno` and `barcode` fields to `DiscogsSearchResult` for display in search results
- Extract cover art URLs in the unranked Discogs search path
- Cross-reference Discogs data when importing from MusicBrainz (if MB release has a Discogs URL relationship, fetch and link both sources)

## Test plan
- [ ] Manual search for a Discogs release without a master_id succeeds
- [ ] Catalog number shows in search results when available
- [ ] Cover art appears for unranked Discogs search results
- [ ] Confirmed Discogs imports populate label, format, country, catalog number in the DB
- [ ] MB import for a release with Discogs URL relationship populates album_discogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)