### PR TITLE
Reduce ghost button hover glow

### DIFF
--- a/bae-ui/assets/main.css
+++ b/bae-ui/assets/main.css
@@ -149,5 +149,5 @@ textarea,
 }
 
 .ghost-text-glow:hover {
-    text-shadow: 0 0 8px rgba(255, 255, 255, 0.5);
+    text-shadow: 0 0 2px rgba(255, 255, 255, 0.15);
 }


### PR DESCRIPTION
## Summary
- Reduce ghost button text-shadow on hover from `0 0 8px` at 0.5 opacity to `0 0 2px` at 0.15 opacity for a more subtle effect

## Test plan
- [ ] Hover over ghost buttons and verify the glow is visible but subtle

🤖 Generated with [Claude Code](https://claude.com/claude-code)