### PR TITLE
Keep import page visible after import completes

### DIFF
--- a/bae-desktop/src/ui/components/import/workflow/cd_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/cd_import.rs
@@ -435,12 +435,11 @@ pub fn CdImport() -> Element {
         let app = app.clone();
         move |_| {
             let app = app.clone();
-            let navigator = navigator;
             spawn(async move {
                 let confirmed = app.state.import().read().get_confirmed_candidate();
                 if let Some(candidate) = confirmed {
                     if let Err(e) =
-                        confirm_and_start_import(&app, candidate, ImportSource::Cd, navigator).await
+                        confirm_and_start_import(&app, candidate, ImportSource::Cd).await
                     {
                         warn!("Failed to confirm and start import: {}", e);
                     }
@@ -556,7 +555,13 @@ pub fn CdImport() -> Element {
             on_confirm,
             on_configure_storage: |_| {},
             on_clear,
-            on_view_in_library: |_| {},
+            on_view_in_library: move |album_id: String| {
+                navigator
+                    .push(crate::ui::Route::AlbumDetail {
+                        album_id,
+                        release_id: String::new(),
+                    });
+            },
         }
     }
 }

--- a/bae-desktop/src/ui/components/import/workflow/folder_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/folder_import.rs
@@ -334,13 +334,11 @@ pub fn FolderImport() -> Element {
         let app = app.clone();
         move |_| {
             let app = app.clone();
-            let navigator = navigator;
             spawn(async move {
                 let confirmed = app.state.import().read().get_confirmed_candidate();
                 if let Some(candidate) = confirmed {
                     if let Err(e) =
-                        confirm_and_start_import(&app, candidate, ImportSource::Folder, navigator)
-                            .await
+                        confirm_and_start_import(&app, candidate, ImportSource::Folder).await
                     {
                         warn!("Failed to confirm and start import: {}", e);
                     }
@@ -495,7 +493,7 @@ pub fn FolderImport() -> Element {
         navigator.push(Route::Settings {});
     };
 
-    // View album in library (for duplicate candidates)
+    // View album in library
     let on_view_in_library = move |album_id: String| {
         navigator.push(Route::AlbumDetail {
             album_id,

--- a/bae-desktop/src/ui/components/import/workflow/torrent_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/torrent_import.rs
@@ -455,13 +455,11 @@ pub fn TorrentImport() -> Element {
         let app = app.clone();
         move |_| {
             let app = app.clone();
-            let navigator = navigator;
             spawn(async move {
                 let confirmed = app.state.import().read().get_confirmed_candidate();
                 if let Some(candidate) = confirmed {
                     if let Err(e) =
-                        confirm_and_start_import(&app, candidate, ImportSource::Torrent, navigator)
-                            .await
+                        confirm_and_start_import(&app, candidate, ImportSource::Torrent).await
                     {
                         warn!("Failed to confirm and start import: {}", e);
                     }
@@ -582,7 +580,13 @@ pub fn TorrentImport() -> Element {
             on_confirm,
             on_configure_storage: |_| {},
             on_clear,
-            on_view_in_library: |_| {},
+            on_view_in_library: move |album_id: String| {
+                navigator
+                    .push(crate::ui::Route::AlbumDetail {
+                        album_id,
+                        release_id: String::new(),
+                    });
+            },
         }
     }
 }

--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -516,7 +516,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 "Preparing" => ConfirmPhase::Preparing("Fetching release data...".to_string()),
                 "Importing" => ConfirmPhase::Importing,
                 "Failed" => ConfirmPhase::Failed(import_error.clone().unwrap_or_default()),
-                "Completed" => ConfirmPhase::Completed,
+                "Completed" => ConfirmPhase::Completed("mock-album-id".to_string()),
                 _ => ConfirmPhase::Ready,
             };
             CandidateState::Confirming(Box::new(ConfirmingState {

--- a/bae-ui/src/components/import/workflow/cd_import.rs
+++ b/bae-ui/src/components/import/workflow/cd_import.rs
@@ -260,20 +260,20 @@ fn CdConfirmContent(
         .unwrap_or_default();
     let selected_profile_id = st.get_storage_profile_id();
 
-    let (is_importing, preparing_step_text, import_error) = st
+    let (is_importing, is_completed, completed_album_id, preparing_step_text, import_error) = st
         .current_candidate_state()
         .and_then(|s| match s {
             CandidateState::Confirming(cs) => Some(&cs.phase),
             _ => None,
         })
         .map(|phase| match phase {
-            ConfirmPhase::Ready => (false, None, None),
-            ConfirmPhase::Preparing(msg) => (false, Some(msg.clone()), None),
-            ConfirmPhase::Importing => (true, None, None),
-            ConfirmPhase::Failed(err) => (false, None, Some(err.clone())),
-            ConfirmPhase::Completed => (false, None, None),
+            ConfirmPhase::Ready => (false, false, None, None, None),
+            ConfirmPhase::Preparing(msg) => (false, false, None, Some(msg.clone()), None),
+            ConfirmPhase::Importing => (true, false, None, None, None),
+            ConfirmPhase::Failed(err) => (false, false, None, None, Some(err.clone())),
+            ConfirmPhase::Completed(album_id) => (false, true, Some(album_id.clone()), None, None),
         })
-        .unwrap_or((false, None, None));
+        .unwrap_or((false, false, None, None, None));
 
     drop(st);
 
@@ -299,6 +299,8 @@ fn CdConfirmContent(
                 storage_profiles,
                 selected_profile_id,
                 is_importing,
+                is_completed,
+                completed_album_id,
                 preparing_step_text,
                 on_select_cover,
                 on_storage_profile_change,

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -360,20 +360,20 @@ fn ConfirmStep(
         .unwrap_or_default();
     let selected_profile_id = st.get_storage_profile_id();
 
-    let (is_importing, preparing_step_text, import_error) = st
+    let (is_importing, is_completed, completed_album_id, preparing_step_text, import_error) = st
         .current_candidate_state()
         .and_then(|s| match s {
             CandidateState::Confirming(cs) => Some(&cs.phase),
             _ => None,
         })
         .map(|phase| match phase {
-            ConfirmPhase::Ready => (false, None, None),
-            ConfirmPhase::Preparing(msg) => (false, Some(msg.clone()), None),
-            ConfirmPhase::Importing => (true, None, None),
-            ConfirmPhase::Failed(err) => (false, None, Some(err.clone())),
-            ConfirmPhase::Completed => (false, None, None),
+            ConfirmPhase::Ready => (false, false, None, None, None),
+            ConfirmPhase::Preparing(msg) => (false, false, None, Some(msg.clone()), None),
+            ConfirmPhase::Importing => (true, false, None, None, None),
+            ConfirmPhase::Failed(err) => (false, false, None, None, Some(err.clone())),
+            ConfirmPhase::Completed(album_id) => (false, true, Some(album_id.clone()), None, None),
         })
-        .unwrap_or((false, None, None));
+        .unwrap_or((false, false, None, None, None));
 
     let Some(candidate) = confirmed_candidate else {
         return rsx! {};
@@ -390,6 +390,8 @@ fn ConfirmStep(
                 storage_profiles,
                 selected_profile_id,
                 is_importing,
+                is_completed,
+                completed_album_id,
                 preparing_step_text,
                 on_select_cover,
                 on_storage_profile_change,

--- a/bae-ui/src/components/import/workflow/torrent_import.rs
+++ b/bae-ui/src/components/import/workflow/torrent_import.rs
@@ -285,20 +285,20 @@ fn TorrentConfirmContent(
         .unwrap_or_default();
     let selected_profile_id = st.get_storage_profile_id();
 
-    let (is_importing, preparing_step_text, import_error) = st
+    let (is_importing, is_completed, completed_album_id, preparing_step_text, import_error) = st
         .current_candidate_state()
         .and_then(|s| match s {
             CandidateState::Confirming(cs) => Some(&cs.phase),
             _ => None,
         })
         .map(|phase| match phase {
-            ConfirmPhase::Ready => (false, None, None),
-            ConfirmPhase::Preparing(msg) => (false, Some(msg.clone()), None),
-            ConfirmPhase::Importing => (true, None, None),
-            ConfirmPhase::Failed(err) => (false, None, Some(err.clone())),
-            ConfirmPhase::Completed => (false, None, None),
+            ConfirmPhase::Ready => (false, false, None, None, None),
+            ConfirmPhase::Preparing(msg) => (false, false, None, Some(msg.clone()), None),
+            ConfirmPhase::Importing => (true, false, None, None, None),
+            ConfirmPhase::Failed(err) => (false, false, None, None, Some(err.clone())),
+            ConfirmPhase::Completed(album_id) => (false, true, Some(album_id.clone()), None, None),
         })
-        .unwrap_or((false, None, None));
+        .unwrap_or((false, false, None, None, None));
 
     drop(st);
 
@@ -328,6 +328,8 @@ fn TorrentConfirmContent(
                 storage_profiles,
                 selected_profile_id,
                 is_importing,
+                is_completed,
+                completed_album_id,
                 preparing_step_text,
                 on_select_cover,
                 on_storage_profile_change,


### PR DESCRIPTION
## Summary
- Import confirmation view now stays visible after import completes instead of resetting and navigating away
- Two read-only states: **Importing** (spinner, all controls disabled) and **Imported** (green check + "View in Library" link, all controls disabled)
- `ConfirmPhase::Completed` and `CandidateEvent::ImportCompleted` now carry the `album_id` so the UI can link to the imported album

## Test plan
- [ ] Import a release from folder → page stays, shows spinner during import, then green check + "Imported" + "View in Library"
- [ ] All controls (cover picker, Change, Storage select, Configure, Import) are disabled during and after import
- [ ] "View in Library" navigates to the album detail page
- [ ] Mock tool shows Completed state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)