### PR TITLE
Detect duplicates at candidate selection time

### DIFF
--- a/bae-desktop/src/ui/import_helpers.rs
+++ b/bae-desktop/src/ui/import_helpers.rs
@@ -144,6 +144,7 @@ pub fn to_display_candidate(candidate: &MatchCandidate) -> DisplayMatchCandidate
         musicbrainz_release_group_id,
         discogs_release_id,
         discogs_master_id,
+        existing_album_id: None,
     }
 }
 
@@ -268,6 +269,31 @@ async fn handle_discid_lookup_result(
         DiscIdLookupResult::SingleMatch(Box::new(display_candidates.into_iter().next().unwrap()))
     } else {
         DiscIdLookupResult::MultipleMatches(display_candidates)
+    }
+}
+
+// ============================================================================
+// Duplicate detection helper
+// ============================================================================
+
+/// Check candidates against the library by exact release ID.
+pub async fn check_candidates_for_duplicates(
+    app: &AppService,
+    candidates: &mut [DisplayMatchCandidate],
+) {
+    let lm = app.library_manager.get();
+    for candidate in candidates.iter_mut() {
+        if let Some(id) = &candidate.musicbrainz_release_id {
+            if let Ok(Some(dup)) = lm.find_duplicate_by_musicbrainz(Some(id), None).await {
+                candidate.existing_album_id = Some(dup.id);
+                continue;
+            }
+        }
+        if let Some(id) = &candidate.discogs_release_id {
+            if let Ok(Some(dup)) = lm.find_duplicate_by_discogs(None, Some(id)).await {
+                candidate.existing_album_id = Some(dup.id);
+            }
+        }
     }
 }
 
@@ -661,48 +687,6 @@ pub async fn confirm_and_start_import(
 
     let import_id = uuid::Uuid::new_v4().to_string();
 
-    // Check for duplicates based on source type
-    match candidate.source_type {
-        MatchSourceType::Discogs => {
-            if let Ok(Some(duplicate)) = app
-                .library_manager
-                .get()
-                .find_duplicate_by_discogs(
-                    candidate.discogs_master_id.as_deref(),
-                    candidate.discogs_release_id.as_deref(),
-                )
-                .await
-            {
-                import_store
-                    .write()
-                    .dispatch(CandidateEvent::ImportFailed(format!(
-                        "This release already exists in your library: {}",
-                        duplicate.title,
-                    )));
-                return Err("Duplicate album found".to_string());
-            }
-        }
-        MatchSourceType::MusicBrainz => {
-            if let Ok(Some(duplicate)) = app
-                .library_manager
-                .get()
-                .find_duplicate_by_musicbrainz(
-                    candidate.musicbrainz_release_id.as_deref(),
-                    candidate.musicbrainz_release_group_id.as_deref(),
-                )
-                .await
-            {
-                import_store
-                    .write()
-                    .dispatch(CandidateEvent::ImportFailed(format!(
-                        "This release already exists in your library: {}",
-                        duplicate.title,
-                    )));
-                return Err("Duplicate album found".to_string());
-            }
-        }
-    }
-
     // Get state from store
     let (storage_profile_id, metadata, selected_cover) = {
         let state = import_store.read();
@@ -917,14 +901,17 @@ pub async fn load_selected_release(
                     });
             }
             Ok(DiscIdLookupResult::SingleMatch(candidate)) => {
+                let mut matches = vec![*candidate];
+                check_candidates_for_duplicates(app, &mut matches).await;
                 import_store
                     .write()
                     .dispatch(CandidateEvent::DiscIdLookupComplete {
-                        matches: vec![*candidate],
+                        matches,
                         error: None,
                     });
             }
-            Ok(DiscIdLookupResult::MultipleMatches(candidates)) => {
+            Ok(DiscIdLookupResult::MultipleMatches(mut candidates)) => {
+                check_candidates_for_duplicates(app, &mut candidates).await;
                 import_store
                     .write()
                     .dispatch(CandidateEvent::DiscIdLookupComplete {

--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -363,6 +363,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
             musicbrainz_release_group_id: Some("mock-mb-rg-001".to_string()),
             discogs_release_id: None,
             discogs_master_id: None,
+            existing_album_id: None,
         },
         MatchCandidate {
             title: "Neon Frequencies (Deluxe)".to_string(),
@@ -380,6 +381,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
             musicbrainz_release_group_id: Some("mock-mb-rg-001".to_string()),
             discogs_release_id: None,
             discogs_master_id: None,
+            existing_album_id: None,
         },
     ];
 
@@ -540,6 +542,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                         musicbrainz_release_group_id: None,
                         discogs_release_id: None,
                         discogs_master_id: None,
+                        existing_album_id: None,
                     }),
                 selected_cover: selected_cover(),
                 selected_profile_id: selected_profile_id(),
@@ -588,8 +591,6 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
         candidate_states,
         loading_candidates: HashMap::new(),
         is_looking_up: false,
-        duplicate_album_id: None,
-        import_error_message: import_error,
         folder_files: folder_files.clone(),
         is_scanning_candidates: false,
         discid_lookup_attempted: std::collections::HashSet::new(),
@@ -668,7 +669,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                     on_edit: |_| {},
                     on_confirm: |_| {},
                     on_configure_storage: |_| {},
-                    on_view_duplicate: |_| {},
+                    on_view_in_library: |_| {},
                 }
             }
         }

--- a/bae-ui/src/components/import/workflow/cd_import.rs
+++ b/bae-ui/src/components/import/workflow/cd_import.rs
@@ -66,7 +66,7 @@ pub struct CdImportViewProps {
     pub on_confirm: EventHandler<()>,
     pub on_configure_storage: EventHandler<()>,
     pub on_clear: EventHandler<()>,
-    pub on_view_duplicate: EventHandler<String>,
+    pub on_view_in_library: EventHandler<String>,
 }
 
 /// CD import workflow view
@@ -116,6 +116,7 @@ pub fn CdImportView(props: CdImportViewProps) -> Element {
                             on_manual_confirm: props.on_manual_confirm,
                             on_retry_cover: props.on_retry_cover,
                             on_retry_discid_lookup: props.on_retry_discid_lookup,
+                            on_view_in_library: props.on_view_in_library,
                         }
                     }
                 },
@@ -129,7 +130,7 @@ pub fn CdImportView(props: CdImportViewProps) -> Element {
                         on_edit: props.on_edit,
                         on_confirm: props.on_confirm,
                         on_configure_storage: props.on_configure_storage,
-                        on_view_duplicate: props.on_view_duplicate,
+                        on_view_in_library: props.on_view_in_library,
                     }
                 },
             }
@@ -160,6 +161,7 @@ fn CdIdentifyContent(
     on_manual_confirm: EventHandler<MatchCandidate>,
     on_retry_cover: EventHandler<usize>,
     on_retry_discid_lookup: EventHandler<()>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read TOC info at leaf level
     let st = state.read();
@@ -192,6 +194,7 @@ fn CdIdentifyContent(
                         on_select: on_exact_match_select,
                         on_confirm: on_confirm_exact_match,
                         on_switch_to_manual_search,
+                        on_view_in_library,
                     }
                 },
                 IdentifyMode::ManualSearch => rsx! {
@@ -215,6 +218,7 @@ fn CdIdentifyContent(
                         on_cancel_search,
                         on_confirm: on_manual_confirm,
                         on_retry_cover,
+                        on_view_in_library,
                         on_switch_to_exact_matches,
                     }
                 },
@@ -234,7 +238,7 @@ fn CdConfirmContent(
     on_edit: EventHandler<()>,
     on_confirm: EventHandler<()>,
     on_configure_storage: EventHandler<()>,
-    on_view_duplicate: EventHandler<String>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read state at leaf level
     let st = state.read();
@@ -271,8 +275,6 @@ fn CdConfirmContent(
         })
         .unwrap_or((false, None, None));
 
-    let import_error = import_error.or_else(|| st.import_error_message.clone());
-    let duplicate_album_id = st.duplicate_album_id.clone();
     drop(st);
 
     let Some(candidate) = confirmed_candidate else {
@@ -304,12 +306,9 @@ fn CdConfirmContent(
                 on_edit,
                 on_confirm,
                 on_configure_storage,
+                on_view_in_library,
             }
-            ImportErrorDisplayView {
-                error_message: import_error,
-                duplicate_album_id,
-                on_view_duplicate,
-            }
+            ImportErrorDisplayView { error_message: import_error }
         }
     }
 }

--- a/bae-ui/src/components/import/workflow/confirmation.rs
+++ b/bae-ui/src/components/import/workflow/confirmation.rs
@@ -41,7 +41,10 @@ pub fn ConfirmationView(
     on_confirm: EventHandler<()>,
     /// Called to navigate to settings
     on_configure_storage: EventHandler<()>,
+    /// Called when user clicks "View in library" for a duplicate
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
+    let is_duplicate = candidate.existing_album_id.is_some();
     let mut show_cover_picker = use_signal(|| false);
     let mut picker_open_count = use_signal(|| 0u32);
 
@@ -197,54 +200,73 @@ pub fn ConfirmationView(
                 }
             }
 
-            // Storage profile selection + Import button
-            div { class: "flex items-center gap-3 px-5",
-                label { class: "text-sm text-gray-400 ml-auto", "Storage:" }
-                Select {
-                    value: selected_profile_id.clone().unwrap_or_else(|| "__none__".to_string()),
-                    disabled: is_importing,
-                    onchange: move |val: String| {
-                        if val == "__none__" {
-                            on_storage_profile_change.call(None);
-                        } else {
-                            on_storage_profile_change.call(Some(val));
+            // Bottom action area
+            if is_duplicate {
+                // Already in library notice
+                div { class: "flex items-center gap-3 px-5",
+                    div { class: "ml-auto flex items-center gap-3",
+                        span { class: "text-sm font-medium text-amber-400/80", "Already in library" }
+                        Button {
+                            variant: ButtonVariant::Outline,
+                            size: ButtonSize::Small,
+                            onclick: {
+                                let album_id = candidate.existing_album_id.clone().unwrap_or_default();
+                                move |_| on_view_in_library.call(album_id.clone())
+                            },
+                            "View in library"
                         }
-                    },
-                    SelectOption {
-                        value: "__none__",
-                        label: "No Storage (files stay in place)",
                     }
-                    for profile in storage_profiles.read().iter() {
+                }
+            } else {
+                // Storage profile selection + Import button
+                div { class: "flex items-center gap-3 px-5",
+                    label { class: "text-sm text-gray-400 ml-auto", "Storage:" }
+                    Select {
+                        value: selected_profile_id.clone().unwrap_or_else(|| "__none__".to_string()),
+                        disabled: is_importing,
+                        onchange: move |val: String| {
+                            if val == "__none__" {
+                                on_storage_profile_change.call(None);
+                            } else {
+                                on_storage_profile_change.call(Some(val));
+                            }
+                        },
                         SelectOption {
-                            key: "{profile.id}",
-                            value: "{profile.id}",
-                            label: profile.name.clone(),
+                            value: "__none__",
+                            label: "No Storage (files stay in place)",
+                        }
+                        for profile in storage_profiles.read().iter() {
+                            SelectOption {
+                                key: "{profile.id}",
+                                value: "{profile.id}",
+                                label: profile.name.clone(),
+                            }
                         }
                     }
-                }
-                Button {
-                    variant: ButtonVariant::Ghost,
-                    size: ButtonSize::Small,
-                    onclick: move |_| on_configure_storage.call(()),
-                    "Configure"
-                }
+                    Button {
+                        variant: ButtonVariant::Ghost,
+                        size: ButtonSize::Small,
+                        onclick: move |_| on_configure_storage.call(()),
+                        "Configure"
+                    }
 
-                // Import status and button
-                if is_importing {
-                    if let Some(ref step) = preparing_step_text {
-                        span { class: "text-sm text-gray-400", "{step}" }
-                    }
-                }
-                Button {
-                    variant: ButtonVariant::Primary,
-                    size: ButtonSize::Small,
-                    disabled: is_importing,
-                    loading: is_importing,
-                    onclick: move |_| on_confirm.call(()),
+                    // Import status and button
                     if is_importing {
-                        div { class: "animate-spin rounded-full h-4 w-4 border-b-2 border-white" }
+                        if let Some(ref step) = preparing_step_text {
+                            span { class: "text-sm text-gray-400", "{step}" }
+                        }
                     }
-                    "Import"
+                    Button {
+                        variant: ButtonVariant::Primary,
+                        size: ButtonSize::Small,
+                        disabled: is_importing,
+                        loading: is_importing,
+                        onclick: move |_| on_confirm.call(()),
+                        if is_importing {
+                            div { class: "animate-spin rounded-full h-4 w-4 border-b-2 border-white" }
+                        }
+                        "Import"
+                    }
                 }
             }
         }

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -81,7 +81,7 @@ pub struct FolderImportViewProps {
     pub on_edit: EventHandler<()>,
     pub on_confirm: EventHandler<()>,
     pub on_configure_storage: EventHandler<()>,
-    pub on_view_duplicate: EventHandler<String>,
+    pub on_view_in_library: EventHandler<String>,
 }
 
 /// Folder import workflow view - main content area only
@@ -152,7 +152,7 @@ pub fn FolderImportView(props: FolderImportViewProps) -> Element {
                             on_edit: props.on_edit,
                             on_confirm: props.on_confirm,
                             on_configure_storage: props.on_configure_storage,
-                            on_view_duplicate: props.on_view_duplicate,
+                            on_view_in_library: props.on_view_in_library,
                         }
                     }
                 }
@@ -216,7 +216,7 @@ fn WorkflowContent(
     on_edit: EventHandler<()>,
     on_confirm: EventHandler<()>,
     on_configure_storage: EventHandler<()>,
-    on_view_duplicate: EventHandler<String>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     rsx! {
         div { class: "flex-1 min-h-0 overflow-auto bg-gray-900/40 rounded-tl-xl flex flex-col",
@@ -241,6 +241,7 @@ fn WorkflowContent(
                         on_manual_confirm,
                         on_retry_cover,
                         on_retry_discid_lookup,
+                        on_view_in_library,
                     }
                 },
                 ImportStep::Confirm => rsx! {
@@ -252,7 +253,7 @@ fn WorkflowContent(
                         on_edit,
                         on_confirm,
                         on_configure_storage,
-                        on_view_duplicate,
+                        on_view_in_library,
                     }
                 },
             }
@@ -285,6 +286,7 @@ fn IdentifyStep(
     on_manual_confirm: EventHandler<MatchCandidate>,
     on_retry_cover: EventHandler<usize>,
     on_retry_discid_lookup: EventHandler<()>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read to determine mode - this is routing
     let mode = state.read().get_identify_mode();
@@ -306,6 +308,7 @@ fn IdentifyStep(
                     on_select: on_exact_match_select,
                     on_confirm: on_confirm_exact_match,
                     on_switch_to_manual_search,
+                    on_view_in_library,
                 }
             },
             IdentifyMode::ManualSearch => rsx! {
@@ -322,6 +325,7 @@ fn IdentifyStep(
                     on_cancel_search,
                     on_confirm: on_manual_confirm,
                     on_retry_cover,
+                    on_view_in_library,
                     on_switch_to_exact_matches,
                 }
             },
@@ -343,7 +347,7 @@ fn ConfirmStep(
     on_edit: EventHandler<()>,
     on_confirm: EventHandler<()>,
     on_configure_storage: EventHandler<()>,
-    on_view_duplicate: EventHandler<String>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read state at this level to get confirm-specific data
     let st = state.read();
@@ -375,9 +379,6 @@ fn ConfirmStep(
         })
         .unwrap_or((false, None, None));
 
-    let import_error = import_error.or_else(|| st.import_error_message.clone());
-    let duplicate_album_id = st.duplicate_album_id.clone();
-
     let Some(candidate) = confirmed_candidate else {
         return rsx! {};
     };
@@ -400,13 +401,10 @@ fn ConfirmStep(
                 on_edit,
                 on_confirm,
                 on_configure_storage,
+                on_view_in_library,
             }
 
-            ImportErrorDisplayView {
-                error_message: import_error,
-                duplicate_album_id,
-                on_view_duplicate,
-            }
+            ImportErrorDisplayView { error_message: import_error }
         }
     }
 }

--- a/bae-ui/src/components/import/workflow/manual_search_panel.rs
+++ b/bae-ui/src/components/import/workflow/manual_search_panel.rs
@@ -28,6 +28,7 @@ pub fn ManualSearchPanelView(
     on_cancel_search: EventHandler<()>,
     on_confirm: EventHandler<MatchCandidate>,
     on_retry_cover: EventHandler<usize>,
+    on_view_in_library: EventHandler<String>,
     on_switch_to_exact_matches: EventHandler<String>,
 ) -> Element {
     // Read state at this leaf component
@@ -270,6 +271,7 @@ pub fn ManualSearchPanelView(
                     on_select: move |index| on_match_select.call(index),
                     on_confirm,
                     on_retry_cover,
+                    on_view_in_library,
                     confirm_button_text: "Select",
                 }
             }

--- a/bae-ui/src/components/import/workflow/match_results_panel.rs
+++ b/bae-ui/src/components/import/workflow/match_results_panel.rs
@@ -12,6 +12,7 @@ pub fn MatchResultsPanel(
     on_select: EventHandler<usize>,
     on_confirm: EventHandler<MatchCandidate>,
     on_retry_cover: EventHandler<usize>,
+    on_view_in_library: EventHandler<String>,
     confirm_button_text: &'static str,
 ) -> Element {
     if candidates.is_empty() {
@@ -32,6 +33,7 @@ pub fn MatchResultsPanel(
                             move |_| on_confirm.call(candidate.clone())
                         },
                         on_retry_cover: move |_| on_retry_cover.call(index),
+                        on_view_in_library,
                         confirm_button_text,
                     }
                 }

--- a/bae-ui/src/components/import/workflow/multiple_exact_matches.rs
+++ b/bae-ui/src/components/import/workflow/multiple_exact_matches.rs
@@ -17,6 +17,7 @@ pub fn MultipleExactMatchesView(
     on_select: EventHandler<usize>,
     on_confirm: EventHandler<MatchCandidate>,
     on_switch_to_manual_search: EventHandler<()>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read state at leaf - these are computed values
     let st = state.read();
@@ -62,6 +63,7 @@ pub fn MultipleExactMatchesView(
                 on_select: move |index| on_select.call(index),
                 on_confirm: move |candidate| on_confirm.call(candidate),
                 on_retry_cover: move |_| {},
+                on_view_in_library,
                 confirm_button_text: "Select",
             }
         }

--- a/bae-ui/src/components/import/workflow/shared/error_display.rs
+++ b/bae-ui/src/components/import/workflow/shared/error_display.rs
@@ -92,13 +92,9 @@ pub fn DiscIdLookupErrorView(
     }
 }
 
-/// Display import error with optional link to duplicate album
+/// Display import error
 #[component]
-pub fn ImportErrorDisplayView(
-    error_message: Option<String>,
-    duplicate_album_id: Option<String>,
-    on_view_duplicate: EventHandler<String>,
-) -> Element {
+pub fn ImportErrorDisplayView(error_message: Option<String>) -> Element {
     let Some(ref error) = error_message else {
         return rsx! {};
     };
@@ -106,19 +102,6 @@ pub fn ImportErrorDisplayView(
     rsx! {
         div { class: "bg-red-50 border border-red-200 rounded-lg p-4",
             p { class: "text-sm text-red-700 select-text break-words font-mono", "Error: {error}" }
-            if let Some(ref dup_id) = duplicate_album_id {
-                div { class: "mt-2",
-                    Button {
-                        variant: ButtonVariant::Ghost,
-                        size: ButtonSize::Small,
-                        onclick: {
-                            let dup_id = dup_id.clone();
-                            move |_| on_view_duplicate.call(dup_id.clone())
-                        },
-                        "View existing album"
-                    }
-                }
-            }
         }
     }
 }

--- a/bae-ui/src/components/import/workflow/torrent_import.rs
+++ b/bae-ui/src/components/import/workflow/torrent_import.rs
@@ -78,7 +78,7 @@ pub struct TorrentImportViewProps {
     pub on_confirm: EventHandler<()>,
     pub on_configure_storage: EventHandler<()>,
     pub on_clear: EventHandler<()>,
-    pub on_view_duplicate: EventHandler<String>,
+    pub on_view_in_library: EventHandler<String>,
 }
 
 /// Torrent import workflow view
@@ -131,6 +131,7 @@ pub fn TorrentImportView(props: TorrentImportViewProps) -> Element {
                             on_retry_cover: props.on_retry_cover,
                             on_retry_discid_lookup: props.on_retry_discid_lookup,
                             on_detect_metadata: props.on_detect_metadata,
+                            on_view_in_library: props.on_view_in_library,
                         }
                     }
                 },
@@ -148,7 +149,7 @@ pub fn TorrentImportView(props: TorrentImportViewProps) -> Element {
                         on_edit: props.on_edit,
                         on_confirm: props.on_confirm,
                         on_configure_storage: props.on_configure_storage,
-                        on_view_duplicate: props.on_view_duplicate,
+                        on_view_in_library: props.on_view_in_library,
                     }
                 },
             }
@@ -182,6 +183,7 @@ fn TorrentIdentifyContent(
     on_retry_cover: EventHandler<usize>,
     on_retry_discid_lookup: EventHandler<()>,
     on_detect_metadata: EventHandler<()>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read state at leaf level
     let st = state.read();
@@ -219,6 +221,7 @@ fn TorrentIdentifyContent(
                         on_select: on_exact_match_select,
                         on_confirm: on_confirm_exact_match,
                         on_switch_to_manual_search,
+                        on_view_in_library,
                     }
                 },
                 IdentifyMode::ManualSearch => rsx! {
@@ -245,6 +248,7 @@ fn TorrentIdentifyContent(
                         on_cancel_search,
                         on_confirm: on_manual_confirm,
                         on_retry_cover,
+                        on_view_in_library,
                         on_switch_to_exact_matches,
                     }
                 },
@@ -268,7 +272,7 @@ fn TorrentConfirmContent(
     on_edit: EventHandler<()>,
     on_confirm: EventHandler<()>,
     on_configure_storage: EventHandler<()>,
-    on_view_duplicate: EventHandler<String>,
+    on_view_in_library: EventHandler<String>,
 ) -> Element {
     // Read state at leaf level
     let st = state.read();
@@ -296,8 +300,6 @@ fn TorrentConfirmContent(
         })
         .unwrap_or((false, None, None));
 
-    let import_error = import_error.or_else(|| st.import_error_message.clone());
-    let duplicate_album_id = st.duplicate_album_id.clone();
     drop(st);
 
     let Some(candidate) = confirmed_candidate else {
@@ -333,12 +335,9 @@ fn TorrentConfirmContent(
                 on_edit,
                 on_confirm,
                 on_configure_storage,
+                on_view_in_library,
             }
-            ImportErrorDisplayView {
-                error_message: import_error,
-                duplicate_album_id,
-                on_view_duplicate,
-            }
+            ImportErrorDisplayView { error_message: import_error }
         }
     }
 }

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -217,6 +217,8 @@ pub struct MatchCandidate {
     pub discogs_release_id: Option<String>,
     /// Discogs master ID
     pub discogs_master_id: Option<String>,
+    /// ID of existing album in library (duplicate detection)
+    pub existing_album_id: Option<String>,
 }
 
 /// Detected folder metadata for UI display

--- a/bae-ui/src/stores/import.rs
+++ b/bae-ui/src/stores/import.rs
@@ -381,8 +381,9 @@ impl IdentifyingState {
                     state.disc_id_not_found = disc_id;
                     state.mode = IdentifyMode::ManualSearch;
                 } else if matches.len() == 1 {
-                    // Single match - auto-confirm
-                    let candidate = matches.into_iter().next().unwrap();
+                    // Single match — auto-confirm, but keep in auto_matches
+                    // so "view exact matches" works if user goes back
+                    let candidate = matches[0].clone();
                     let selected_cover = default_cover(&candidate, &state.files);
                     return CandidateState::Confirming(Box::new(ConfirmingState {
                         files: state.files,
@@ -391,7 +392,7 @@ impl IdentifyingState {
                         selected_cover,
                         selected_profile_id: None,
                         phase: ConfirmPhase::Ready,
-                        auto_matches: vec![],
+                        auto_matches: matches,
                         search_state: state.search_state,
                         source_disc_id: disc_id,
                     }));
@@ -598,10 +599,6 @@ pub struct ImportState {
     pub loading_candidates: std::collections::HashMap<String, bool>,
     /// Whether DiscID lookup is in progress
     pub is_looking_up: bool,
-    /// ID of duplicate album if found during import
-    pub duplicate_album_id: Option<String>,
-    /// Error message from import process
-    pub import_error_message: Option<String>,
     /// Files in current folder (for UI reactivity)
     pub folder_files: CategorizedFileInfo,
     /// True while scanning a folder for release candidates
@@ -626,8 +623,6 @@ impl ImportState {
         self.candidate_states.clear();
         self.loading_candidates.clear();
         self.is_looking_up = false;
-        self.duplicate_album_id = None;
-        self.import_error_message = None;
         self.folder_files = CategorizedFileInfo::default();
         self.is_scanning_candidates = false;
         self.discid_lookup_attempted.clear();


### PR DESCRIPTION
## Summary
- Moves duplicate detection from import-time to candidate-display-time so users see which releases already exist in their library before trying to import
- `MatchItemView` shows an "In library" badge with amber styling, disables selection, and offers a "View" button for duplicate candidates
- `ConfirmationView` replaces the Import button with an "Already in library" notice for confirmed duplicates
- Removes the old duplicate check from `confirm_and_start_import` and cleans up dead code (`duplicate_album_id`, `import_error_message`, `on_view_duplicate`)

## Test plan
- [ ] Import a folder whose release is already in the library — DiscID exact match should show "In library" badge, Import button disabled
- [ ] Manual search — matching results show "In library" badge, cannot be selected
- [ ] "View" / "View in library" links navigate to the album detail page
- [ ] Import a non-duplicate release — normal flow unchanged
- [ ] Actual import errors (e.g. network failure) still show in `ImportErrorDisplayView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)