### PR TITLE
Fix search bar dropdown flash, / shortcut, Escape

### DIFF
--- a/bae-desktop/src/ui/components/title_bar.rs
+++ b/bae-desktop/src/ui/components/title_bar.rs
@@ -39,8 +39,6 @@ pub fn TitleBar() -> Element {
     let current_route = use_route::<Route>();
     let search_store = app.state.ui().search();
     let mut search_query_store = search_store.query();
-    let mut show_results = use_signal(|| false);
-    let show_results_read: ReadSignal<bool> = show_results.into();
     let mut search_results = use_signal(GroupedSearchResults::default);
     let mut imports_dropdown_open = use_signal(|| false);
     let imports_dropdown_open_read: ReadSignal<bool> = imports_dropdown_open.into();
@@ -58,7 +56,6 @@ pub fn TitleBar() -> Element {
             let query = search_query_store.read().clone();
             if query.is_empty() {
                 search_results.set(GroupedSearchResults::default());
-                show_results.set(false);
             } else {
                 let library_manager = library_manager.clone();
                 let query = query.clone();
@@ -100,7 +97,6 @@ pub fn TitleBar() -> Element {
                                     .collect(),
                             };
                             search_results.set(grouped);
-                            show_results.set(true);
                         }
                         Err(e) => {
                             tracing::warn!("Search failed: {}", e);
@@ -163,7 +159,6 @@ pub fn TitleBar() -> Element {
             on_search_change: move |value| search_query_store.set(value),
             search_results: search_results(),
             on_search_result_click: move |action: SearchAction| {
-                show_results.set(false);
                 search_query_store.set(String::new());
                 match action {
                     SearchAction::Artist(artist_id) => {
@@ -185,8 +180,6 @@ pub fn TitleBar() -> Element {
                     }
                 }
             },
-            show_search_results: show_results_read,
-            on_search_dismiss: move |_| show_results.set(false),
             on_search_focus: move |_| {
                 if search_query_store.read().is_empty() {
                     // Show top artists as suggestions
@@ -198,10 +191,7 @@ pub fn TitleBar() -> Element {
                                 albums: vec![],
                                 tracks: vec![],
                             });
-                        show_results.set(true);
                     }
-                } else {
-                    show_results.set(true);
                 }
             },
             on_search_blur: |_| {},

--- a/bae-mocks/src/mocks/title_bar.rs
+++ b/bae-mocks/src/mocks/title_bar.rs
@@ -33,7 +33,6 @@ pub fn TitleBarMock(initial_state: Option<String>) -> Element {
 
     let active_nav = registry.get_string("active_nav");
     let show_search_results_bool = registry.get_bool("show_search_results");
-    let show_search_results: ReadSignal<bool> = use_memo(move || show_search_results_bool).into();
 
     let nav_items = vec![
         NavItem {
@@ -50,6 +49,7 @@ pub fn TitleBarMock(initial_state: Option<String>) -> Element {
 
     let settings_active = active_nav == "settings";
 
+    // When the mock toggle is on, always provide results (the panel shows on focus)
     let search_results = if show_search_results_bool {
         mock_search_results()
     } else {
@@ -68,8 +68,6 @@ pub fn TitleBarMock(initial_state: Option<String>) -> Element {
                 on_search_change: |_| {},
                 search_results,
                 on_search_result_click: |_: SearchAction| {},
-                show_search_results,
-                on_search_dismiss: |_| {},
                 on_search_focus: |_| {},
                 on_search_blur: |_| {},
                 on_settings_click: |_| {},

--- a/bae-mocks/src/pages/layout.rs
+++ b/bae-mocks/src/pages/layout.rs
@@ -93,8 +93,6 @@ fn mock_queue() -> Vec<QueueItem> {
 pub fn DemoLayout() -> Element {
     let current_route = use_route::<Route>();
     let mut search_query = use_signal(String::new);
-    let mut show_search_results = use_signal(|| false);
-    let show_search_results_read: ReadSignal<bool> = show_search_results.into();
     let mut imports_open = use_signal(|| false);
     let imports_open_read: ReadSignal<bool> = imports_open.into();
     let mock_imports = mock_active_imports();
@@ -228,12 +226,10 @@ pub fn DemoLayout() -> Element {
                     },
                     search_value: search_query(),
                     on_search_change: move |value: String| {
-                        search_query.set(value.clone());
-                        show_search_results.set(!value.is_empty());
+                        search_query.set(value);
                     },
                     search_results,
                     on_search_result_click: move |action: SearchAction| {
-                        show_search_results.set(false);
                         search_query.set(String::new());
                         match action {
                             SearchAction::Album(album_id) | SearchAction::Track { album_id } => {
@@ -242,13 +238,7 @@ pub fn DemoLayout() -> Element {
                             SearchAction::Artist(_) => {}
                         }
                     },
-                    show_search_results: show_search_results_read,
-                    on_search_dismiss: move |_| show_search_results.set(false),
-                    on_search_focus: move |_| {
-                        if !search_query().is_empty() {
-                            show_search_results.set(true);
-                        }
-                    },
+                    on_search_focus: |_| {},
                     on_search_blur: |_| {},
                     on_settings_click: move |_| {
                         navigator().push(Route::Settings {});


### PR DESCRIPTION
## Summary
- Search results panel no longer uses the Dropdown/popover component — replaced with a plain positioned div whose visibility is tied to input focus state, fixing the flash-on-click caused by popover light dismiss racing with the opening pointer event
- "/" shortcut moved to a global `document.addEventListener('keydown')` so it works regardless of which element has focus
- Escape blurs the search input (deferred via `spawn` to avoid re-entrant RefCell borrow in wry)
- `onmousedown` stop-propagation on the search container prevents macOS `drag_window()` from interfering with focus
- Removed `show_search_results` and `on_search_dismiss` props from `TitleBarView` — no longer needed since visibility follows focus

## Test plan
- [ ] Click search input → results panel appears, stays open
- [ ] Click outside search → panel closes
- [ ] Click a search result → navigates correctly
- [ ] Press "/" from anywhere → focuses search input
- [ ] Press Escape while in search → blurs input, panel closes
- [ ] Type a query → results update live
- [ ] macOS: clicking search doesn't start a window drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)