### PR TITLE
Hoist album card dropdown signal above virtual scroll scope

### DIFF
--- a/bae-mocks/src/pages/mock_dropdown.rs
+++ b/bae-mocks/src/pages/mock_dropdown.rs
@@ -27,6 +27,7 @@ fn generate_test_albums() -> Vec<(Album, Vec<Artist>)> {
 #[component]
 pub fn MockDropdownTest() -> Element {
     let albums = generate_test_albums();
+    let open_dropdown: Signal<Option<String>> = use_signal(|| None);
 
     rsx! {
         style {
@@ -52,6 +53,7 @@ pub fn MockDropdownTest() -> Element {
                         on_artist_click: |_| {},
                         on_play: |_| {},
                         on_add_to_queue: |_| {},
+                        open_dropdown,
                     }
                 }
             }

--- a/bae-ui/src/components/artist_detail.rs
+++ b/bae-ui/src/components/artist_detail.rs
@@ -102,6 +102,8 @@ fn ArtistAlbumGrid(
         gap: 24.0,
     };
 
+    let open_dropdown: Signal<Option<String>> = use_signal(|| None);
+
     let render_item = RenderFn(Rc::new(move |item: AlbumGridItem, _idx: usize| {
         rsx! {
             AlbumCard {
@@ -112,6 +114,7 @@ fn ArtistAlbumGrid(
                 on_artist_click,
                 on_play: on_play_album,
                 on_add_to_queue: on_add_album_to_queue,
+                open_dropdown,
             }
         }
     }));

--- a/bae-ui/src/components/library.rs
+++ b/bae-ui/src/components/library.rs
@@ -268,6 +268,10 @@ fn AlbumGrid(
         gap: 24.0,
     };
 
+    // Track which album's dropdown menu is open. Hoisted here so the signal
+    // outlives virtual scroll item scopes (prevents use-after-drop on recycled items).
+    let open_dropdown: Signal<Option<String>> = use_signal(|| None);
+
     // Create render function that captures the event handlers
     let render_item = RenderFn(Rc::new(move |item: AlbumGridItem, _idx: usize| {
         rsx! {
@@ -279,6 +283,7 @@ fn AlbumGrid(
                 on_artist_click,
                 on_play: on_play_album,
                 on_add_to_queue: on_add_album_to_queue,
+                open_dropdown,
             }
         }
     }));


### PR DESCRIPTION
## Summary
- The `show_dropdown` signal lived inside `AlbumCard`, a child of `ElementScrollGrid`. The `Dropdown` component (rendered in the popover top-layer) could outlive the grid item scope when virtual scroll recycles off-screen items, causing use-after-drop panics in wry-bindgen (`U8BufferEmpty` crash).
- Replaced per-card `Signal<bool>` with a single `Signal<Option<String>>` in `AlbumGrid`/`ArtistAlbumGrid`, keyed by album ID. This signal outlives the virtual scroll item scopes and also enforces only one dropdown open at a time.

## Test plan
- [ ] Open library grid, click ellipsis on album cards — dropdown opens/closes correctly
- [ ] Scroll rapidly through library while a dropdown is open — no crash
- [ ] Verify the Dioxus "CopyValue used in non-descendant scope" warning is gone
- [ ] Test artist detail page album grid dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)