### PR TITLE
Multi-level sorting for library view

### DIFF
--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -15,11 +15,26 @@ pub enum LibrarySortField {
     DateAdded,
 }
 
+impl LibrarySortField {
+    pub const ALL: [LibrarySortField; 4] = [
+        LibrarySortField::Title,
+        LibrarySortField::Artist,
+        LibrarySortField::Year,
+        LibrarySortField::DateAdded,
+    ];
+}
+
 /// Sort direction
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SortDirection {
     Ascending,
     Descending,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SortCriterion {
+    pub field: LibrarySortField,
+    pub direction: SortDirection,
 }
 
 /// Album display info


### PR DESCRIPTION
## Summary

- Replace single sort field + direction with an ordered list of sort criteria
- Each criterion has its own field and direction, toggled independently
- "+" button adds next unused field; "X" removes a criterion (minimum one)
- Sort uses chained comparison — first non-equal criterion wins

## Test plan

- [ ] Open library, verify default sort (Date Added desc) works
- [ ] Add a second sort criterion, verify albums re-sort with chained comparison
- [ ] Toggle direction on second criterion independently
- [ ] Remove a criterion, verify sort updates
- [ ] Add all 4 fields, verify "+" disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)