### PR TITLE
Revert flex-grow on title bar

### DIFF
--- a/bae-ui/src/components/title_bar.rs
+++ b/bae-ui/src/components/title_bar.rs
@@ -136,7 +136,7 @@ pub fn TitleBarView(
         // Title bar
         div {
             id: "title-bar",
-            class: "shrink-0 grow h-10 bg-surface-raised flex items-center justify-between px-2 cursor-default border-b border-border-subtle",
+            class: "shrink-0 h-10 bg-surface-raised flex items-center justify-between px-2 cursor-default border-b border-border-subtle",
             style: "padding-left: {left_padding}px;",
             onmousedown: move |_| {
                 if let Some(handler) = &on_bar_mousedown {


### PR DESCRIPTION
## Summary
- Reverts the `grow` class added in #89 which was causing the title bar to expand vertically in the desktop app's column flex layout

## Test plan
- [ ] Title bar is back to fixed 40px height in desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)