### PR TITLE
Load Discogs API key from keyring on startup

### DIFF
--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -84,7 +84,8 @@ fn configure_logging() {
 fn main() {
     crash_report::install_panic_hook();
     config::init_keyring();
-    let config = config::Config::load();
+    let mut config = config::Config::load();
+    config.load_discogs_key();
     configure_logging();
     crash_report::check_for_crash_report();
 


### PR DESCRIPTION
## Summary
- `Config::load()` sets `discogs_api_key: None` because the key is loaded lazily from the system keyring, but `load_discogs_key()` was never called during startup
- The key was effectively lost between sessions — users had to re-enter it each launch
- Calls `config.load_discogs_key()` right after `Config::load()` so the key is available immediately

## Test plan
- [ ] Set a Discogs API key in settings, quit, relaunch — verify key persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)