### PR TITLE
Restructure library directory to `~/.bae/libraries/<id>/`

### DIFF
--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -27,10 +27,12 @@ async fn create_cache_manager() -> cache::CacheManager {
 
 /// Initialize database
 async fn create_database(config: &config::Config) -> Database {
-    let library_path = config.get_library_path();
-    info!("Creating library directory: {}", library_path.display());
-    std::fs::create_dir_all(&library_path).expect("Failed to create library directory");
-    let db_path = library_path.join("library.db");
+    info!(
+        "Creating library directory: {}",
+        config.library_path.display()
+    );
+    std::fs::create_dir_all(&config.library_path).expect("Failed to create library directory");
+    let db_path = config.library_path.join("library.db");
     info!("Initializing database at: {}", db_path.display());
     let database = Database::new(db_path.to_str().unwrap())
         .await

--- a/bae-desktop/src/ui/window_activation/macos_window.rs
+++ b/bae-desktop/src/ui/window_activation/macos_window.rs
@@ -311,7 +311,7 @@ unsafe fn open_library_picker(create_new: bool) {
 
     // Save the library path pointer (persists for future launches)
     let mut config = bae_core::config::Config::load();
-    config.set_library_path(path.clone());
+    config.library_path = path.clone();
     if let Err(e) = config.save_library_path() {
         error!("Failed to save library path: {}", e);
         return;

--- a/plans/02-library-directory-restructuring.md
+++ b/plans/02-library-directory-restructuring.md
@@ -1,0 +1,51 @@
+# PR 2: Library directory restructuring
+
+**Branch:** `encryption-ux` (continuing from PR 1)
+
+## Goal
+
+`~/.bae/libraries/<library-id>/` replaces flat `~/.bae/`. No migration — clean break.
+
+## Target layout
+
+```
+~/.bae/
+├── library                          # pointer file (always exists, contains path)
+└── libraries/
+    └── <library-id>/
+        ├── config.yaml
+        └── library.db
+```
+
+## Changes
+
+### `bae-core/src/config.rs`
+
+**`Config.library_path: PathBuf`** (was `Option<PathBuf>`)
+
+- Remove `get_library_path()` — use `self.library_path` directly
+- Remove `set_library_path()` — direct field assignment
+
+**`from_config_file()`** — resolve library path:
+1. Pointer file exists → use it
+2. No pointer file → generate ID, path = `~/.bae/libraries/<id>/`, write pointer
+
+**`save_library_path()`** — drop the `Option` unwrap, just write `self.library_path`
+
+**`save_to_config_yaml()`** — `self.library_path` instead of `self.get_library_path()`
+
+**`from_env()`** — `BAE_LIBRARY_PATH` env var or default `~/.bae/libraries/<generated-id>/`
+
+### `bae-desktop/src/main.rs`
+
+- `create_database()` — `config.library_path` instead of `config.get_library_path()`
+
+### `bae-desktop/src/ui/window_activation/macos_window.rs`
+
+- Menu handler: `config.library_path = path` instead of `config.set_library_path(path)`
+
+## Verification
+
+- `cargo clippy -p bae-desktop && cargo clippy -p bae-mocks` clean
+- `cargo test -p bae-core` passes
+- Run app: creates `~/.bae/libraries/<id>/` with config.yaml and library.db


### PR DESCRIPTION
## Summary
- `Config.library_path` is now `PathBuf` (was `Option<PathBuf>`)
- Fresh installs create `~/.bae/libraries/<uuid>/` and write the pointer file
- Removed `get_library_path()` and `set_library_path()` — direct field access
- Foundation for multi-library and cloud sync

Chained on #100.

## Test plan
- [x] `cargo clippy -p bae-desktop && cargo clippy -p bae-mocks` clean
- [x] `cargo test -p bae-core` passes (172 tests)
- [ ] Run app: creates `~/.bae/libraries/<id>/` with config.yaml and library.db

🤖 Generated with [Claude Code](https://claude.com/claude-code)