### PR TITLE
Add repeat mode button to now playing bar

### DIFF
--- a/bae-desktop/src/ui/components/now_playing_bar.rs
+++ b/bae-desktop/src/ui/components/now_playing_bar.rs
@@ -6,7 +6,7 @@
 use crate::ui::app_service::use_app;
 use crate::ui::Route;
 use bae_ui::stores::{
-    AppStateStoreExt, PlaybackUiStateStoreExt, SidebarStateStoreExt, UiStateStoreExt,
+    AppStateStoreExt, PlaybackUiStateStoreExt, RepeatMode, SidebarStateStoreExt, UiStateStoreExt,
 };
 use bae_ui::NowPlayingBarView;
 use dioxus::prelude::*;
@@ -52,6 +52,8 @@ pub fn NowPlayingBar() -> Element {
     let playback_for_resume = playback_handle.clone();
     let playback_for_next = playback_handle.clone();
     let playback_for_seek = playback_handle.clone();
+    let playback_for_repeat = playback_handle.clone();
+    let repeat_mode_store = playback_store.repeat_mode();
 
     rsx! {
         NowPlayingBarView {
@@ -61,6 +63,14 @@ pub fn NowPlayingBar() -> Element {
             on_resume: move |_| playback_for_resume.resume(),
             on_next: move |_| playback_for_next.next(),
             on_seek: move |ms: u64| playback_for_seek.seek(std::time::Duration::from_millis(ms)),
+            on_cycle_repeat: move |_| {
+                let next = match *repeat_mode_store.read() {
+                    RepeatMode::None => bae_core::playback::RepeatMode::Album,
+                    RepeatMode::Album => bae_core::playback::RepeatMode::Track,
+                    RepeatMode::Track => bae_core::playback::RepeatMode::None,
+                };
+                playback_for_repeat.set_repeat_mode(next);
+            },
             on_toggle_queue: move |_| {
                 let current = *sidebar_is_open.read();
                 sidebar_is_open.set(!current);

--- a/bae-mocks/src/pages/layout.rs
+++ b/bae-mocks/src/pages/layout.rs
@@ -269,6 +269,7 @@ pub fn DemoLayout() -> Element {
                     on_resume: move |_| {},
                     on_next: move |_| {},
                     on_seek: move |_pos| {},
+                    on_cycle_repeat: move |_| {},
                     on_toggle_queue: move |_| {
                         let current = *sidebar_is_open.read();
                         sidebar_is_open.set(!current);

--- a/bae-ui/src/components/icons.rs
+++ b/bae-ui/src/components/icons.rs
@@ -814,6 +814,49 @@ pub fn SettingsIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Elemen
     }
 }
 
+/// Repeat icon (looping arrows - for repeat all/album)
+#[component]
+pub fn RepeatIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {
+    rsx! {
+        svg {
+            class: "{class}",
+            xmlns: "http://www.w3.org/2000/svg",
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            stroke_width: "2",
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            path { d: "m17 2 4 4-4 4" }
+            path { d: "M3 11v-1a4 4 0 0 1 4-4h14" }
+            path { d: "m7 22-4-4 4-4" }
+            path { d: "M21 13v1a4 4 0 0 1-4 4H3" }
+        }
+    }
+}
+
+/// Repeat 1 icon (looping arrows with "1" - for repeat single track)
+#[component]
+pub fn Repeat1Icon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {
+    rsx! {
+        svg {
+            class: "{class}",
+            xmlns: "http://www.w3.org/2000/svg",
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            stroke_width: "2",
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            path { d: "m17 2 4 4-4 4" }
+            path { d: "M3 11v-1a4 4 0 0 1 4-4h14" }
+            path { d: "m7 22-4-4 4-4" }
+            path { d: "M21 13v1a4 4 0 0 1-4 4H3" }
+            path { d: "M11 10h1v4" }
+        }
+    }
+}
+
 /// Lucide "copy" icon — two overlapping rectangles
 #[component]
 pub fn CopyIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {

--- a/bae-ui/src/components/playback/now_playing_bar.rs
+++ b/bae-ui/src/components/playback/now_playing_bar.rs
@@ -5,9 +5,13 @@
 //! Each sub-component reads only the fields it needs for granular reactivity.
 
 use crate::components::error_toast::ErrorToast;
-use crate::components::icons::{MenuIcon, PauseIcon, PlayIcon, SkipBackIcon, SkipForwardIcon};
+use crate::components::icons::{
+    MenuIcon, PauseIcon, PlayIcon, Repeat1Icon, RepeatIcon, SkipBackIcon, SkipForwardIcon,
+};
 use crate::components::{Button, ButtonSize, ButtonVariant, ChromelessButton};
-use crate::stores::playback::{PlaybackStatus, PlaybackUiState, PlaybackUiStateStoreExt};
+use crate::stores::playback::{
+    PlaybackStatus, PlaybackUiState, PlaybackUiStateStoreExt, RepeatMode,
+};
 use dioxus::prelude::*;
 
 /// Now playing bar view - accepts store for granular reactivity
@@ -21,6 +25,7 @@ pub fn NowPlayingBarView(
     on_resume: EventHandler<()>,
     on_next: EventHandler<()>,
     on_seek: EventHandler<u64>,
+    on_cycle_repeat: EventHandler<()>,
     on_toggle_queue: EventHandler<()>,
     on_track_click: EventHandler<String>,
     on_artist_click: EventHandler<String>,
@@ -42,6 +47,8 @@ pub fn NowPlayingBarView(
                 TrackInfoSection { state, on_track_click, on_artist_click }
 
                 PositionSection { state, on_seek }
+
+                RepeatModeButton { state, on_cycle_repeat }
 
                 Button {
                     variant: ButtonVariant::Secondary,
@@ -310,6 +317,37 @@ fn PositionSection(state: ReadStore<PlaybackUiState>, on_seek: EventHandler<u64>
             }
         } else {
             div { class: "w-72" }
+        }
+    }
+}
+
+/// Repeat mode toggle - reads only repeat_mode
+#[component]
+fn RepeatModeButton(
+    state: ReadStore<PlaybackUiState>,
+    on_cycle_repeat: EventHandler<()>,
+) -> Element {
+    let repeat_mode = *state.repeat_mode().read();
+
+    let (aria_label, color) = match repeat_mode {
+        RepeatMode::None => ("Repeat album", "text-gray-500 hover:text-white"),
+        RepeatMode::Album => ("Repeat track", "text-blue-400 hover:text-blue-300"),
+        RepeatMode::Track => ("Repeat off", "text-blue-400 hover:text-blue-300"),
+    };
+
+    rsx! {
+        ChromelessButton {
+            class: Some(format!("p-1 rounded-md {color} transition-all")),
+            aria_label: Some(aria_label.to_string()),
+            onclick: move |_| on_cycle_repeat.call(()),
+            match repeat_mode {
+                RepeatMode::Track => rsx! {
+                    Repeat1Icon { class: "w-5 h-5" }
+                },
+                _ => rsx! {
+                    RepeatIcon { class: "w-5 h-5" }
+                },
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `RepeatIcon` and `Repeat1Icon` (Lucide SVGs) to the icon set
- Adds a repeat mode toggle button to the now playing bar, between the seek bar and queue toggle
- Cycles None → Album → Track → None, with dimmed icon when off and blue when active

## Test plan
- [ ] Run the app, verify the repeat button appears in the now playing bar
- [ ] Click the button and verify it cycles through None (gray) → Album (blue repeat) → Track (blue repeat-1) → None
- [ ] Verify the macOS menu repeat mode stays in sync with the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)