### PR TITLE
Restyle queue sidebar, add play-from-queue

### DIFF
--- a/bae-desktop/src/ui/components/queue_sidebar.rs
+++ b/bae-desktop/src/ui/components/queue_sidebar.rs
@@ -41,6 +41,9 @@ pub fn QueueSidebar() -> Element {
 
     let playback_for_clear = playback_handle.clone();
     let playback_for_remove = playback_handle.clone();
+    let playback_for_skip = playback_handle.clone();
+    let playback_for_pause = playback_handle.clone();
+    let playback_for_resume = playback_handle.clone();
 
     rsx! {
         QueueSidebarView {
@@ -50,6 +53,9 @@ pub fn QueueSidebar() -> Element {
             on_clear: move |_| playback_for_clear.clear_queue(),
             on_remove: move |idx: usize| playback_for_remove.remove_from_queue(idx),
             on_track_click,
+            on_play_index: move |idx: usize| playback_for_skip.skip_to(idx),
+            on_pause: move |_| playback_for_pause.pause(),
+            on_resume: move |_| playback_for_resume.resume(),
         }
     }
 }

--- a/bae-mocks/src/pages/layout.rs
+++ b/bae-mocks/src/pages/layout.rs
@@ -285,6 +285,9 @@ pub fn DemoLayout() -> Element {
                     on_clear: move |_| {},
                     on_remove: move |_idx| {},
                     on_track_click: move |_track_id: String| {},
+                    on_play_index: move |_idx| {},
+                    on_pause: move |_| {},
+                    on_resume: move |_| {},
                 }
             },
             Outlet::<Route> {}

--- a/bae-ui/src/components/app_layout.rs
+++ b/bae-ui/src/components/app_layout.rs
@@ -25,14 +25,18 @@ pub fn AppLayoutView(
     extra: Option<Element>,
 ) -> Element {
     rsx! {
-        LayoutContainer {
-            if let Some(tb) = title_bar {
-                {tb}
+        div { class: "h-screen flex",
+            // Left: title bar, content, playback bar
+            div { class: "flex-1 flex flex-col min-w-0",
+                if let Some(tb) = title_bar {
+                    {tb}
+                }
+                div { class: "flex-1 overflow-y-auto", {children} }
+                if let Some(pb) = playback_bar {
+                    {pb}
+                }
             }
-            {children}
-            if let Some(pb) = playback_bar {
-                {pb}
-            }
+            // Right: queue sidebar (full height)
             if let Some(qs) = queue_sidebar {
                 {qs}
             }
@@ -40,12 +44,5 @@ pub fn AppLayoutView(
                 {ex}
             }
         }
-    }
-}
-
-#[component]
-fn LayoutContainer(children: Element) -> Element {
-    rsx! {
-        div { class: "h-screen flex flex-col", {children} }
     }
 }

--- a/bae-ui/src/components/playback/queue_sidebar.rs
+++ b/bae-ui/src/components/playback/queue_sidebar.rs
@@ -4,11 +4,12 @@
 //! Accepts `ReadStore<PlaybackUiState>` and reads fields via lenses.
 //! Each section only re-renders when its specific data changes.
 
-use crate::components::icons::{ImageIcon, MenuIcon, XIcon};
+use crate::components::icons::{EllipsisIcon, ImageIcon, PauseIcon, PlayIcon, XIcon};
 use crate::components::utils::format_duration;
 use crate::components::{Button, ButtonSize, ButtonVariant, ChromelessButton};
+use crate::components::{MenuDropdown, MenuItem, Placement};
 use crate::display_types::QueueItem;
-use crate::stores::playback::{PlaybackUiState, PlaybackUiStateStoreExt};
+use crate::stores::playback::{PlaybackStatus, PlaybackUiState, PlaybackUiStateStoreExt};
 use crate::stores::ui::{SidebarState, SidebarStateStoreExt};
 use dioxus::prelude::*;
 
@@ -30,6 +31,9 @@ pub fn QueueSidebarView(
     on_clear: EventHandler<()>,
     on_remove: EventHandler<usize>,
     on_track_click: EventHandler<String>,
+    on_play_index: EventHandler<usize>,
+    on_pause: EventHandler<()>,
+    on_resume: EventHandler<()>,
 ) -> Element {
     // Read is_open via lens - only this check re-runs when visibility changes
     let is_open = *sidebar.is_open().read();
@@ -39,41 +43,57 @@ pub fn QueueSidebarView(
     }
 
     rsx! {
-        div { class: "fixed top-0 right-0 h-full w-80 bg-gray-900 border-l border-gray-700 z-50 flex flex-col shadow-2xl",
-            div { class: "flex-1 overflow-y-auto",
-                NowPlayingSection { playback, on_track_click, on_remove }
-
-                UpNextSection { playback, on_track_click, on_remove }
+        div { class: "w-80 flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col",
+            // Header with controls
+            div { class: "flex items-center justify-between px-4 py-3 border-b border-gray-700",
+                h2 { class: "text-sm font-semibold text-gray-300 uppercase tracking-wide",
+                    "Queue"
+                }
+                div { class: "flex items-center gap-2",
+                    Button {
+                        variant: ButtonVariant::Secondary,
+                        size: ButtonSize::Small,
+                        onclick: move |_| on_clear.call(()),
+                        "Clear"
+                    }
+                    ChromelessButton {
+                        class: Some("text-gray-400 hover:text-white transition-colors".to_string()),
+                        aria_label: Some("Close queue".to_string()),
+                        onclick: move |_| on_close.call(()),
+                        XIcon { class: "w-5 h-5" }
+                    }
+                }
             }
 
-            // Footer with controls
-            div { class: "flex items-center justify-between p-4 border-t border-gray-700",
-                Button {
-                    variant: ButtonVariant::Secondary,
-                    size: ButtonSize::Small,
-                    onclick: move |_| on_clear.call(()),
-                    "Clear"
+            div { class: "flex-1 overflow-y-auto",
+                NowPlayingSection {
+                    playback,
+                    on_track_click,
+                    on_pause,
+                    on_resume,
                 }
-                Button {
-                    variant: ButtonVariant::Secondary,
-                    size: ButtonSize::Medium,
-                    onclick: move |_| on_close.call(()),
-                    MenuIcon { class: "w-5 h-5" }
+
+                UpNextSection {
+                    playback,
+                    on_track_click,
+                    on_remove,
+                    on_play_index,
                 }
             }
         }
     }
 }
 
-/// Now playing section - reads only current_track
+/// Now playing section - reads current_track and status
 #[component]
 fn NowPlayingSection(
     playback: ReadStore<PlaybackUiState>,
     on_track_click: EventHandler<String>,
-    on_remove: EventHandler<usize>,
+    on_pause: EventHandler<()>,
+    on_resume: EventHandler<()>,
 ) -> Element {
-    // Read only current_track via lens
     let current_track = playback.current_track().read().clone();
+    let status = *playback.status().read();
 
     rsx! {
         div {
@@ -83,15 +103,89 @@ fn NowPlayingSection(
                 }
             }
             if let Some(item) = current_track {
-                QueueItemView {
+                NowPlayingItem {
                     item,
-                    index: 0,
-                    is_current: true,
-                    on_click: on_track_click,
-                    on_remove,
+                    status,
+                    on_track_click,
+                    on_pause,
+                    on_resume,
                 }
             } else {
                 div { class: "px-4 py-3 text-gray-500 text-sm", "Nothing playing" }
+            }
+        }
+    }
+}
+
+/// Now playing track row - special styling for the currently playing track
+#[component]
+fn NowPlayingItem(
+    item: QueueItem,
+    status: PlaybackStatus,
+    on_track_click: EventHandler<String>,
+    on_pause: EventHandler<()>,
+    on_resume: EventHandler<()>,
+) -> Element {
+    let is_playing = status == PlaybackStatus::Playing;
+    let is_paused = status == PlaybackStatus::Paused;
+
+    rsx! {
+        div { class: "flex items-center gap-3 py-2 px-3 mx-2 rounded-lg bg-accent/10 hover:bg-accent/15 transition-colors group",
+            // Play/pause button
+            if is_playing {
+                ChromelessButton {
+                    class: Some(
+                        "w-6 h-6 rounded-full border border-blue-400 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center text-blue-400 hover:text-blue-300 hover:bg-blue-400/10"
+                            .to_string(),
+                    ),
+                    aria_label: Some("Pause".to_string()),
+                    onclick: move |_| on_pause.call(()),
+                    PauseIcon { class: "w-3 h-3" }
+                }
+            } else if is_paused {
+                ChromelessButton {
+                    class: Some(
+                        "w-6 h-6 rounded-full border border-blue-400 flex items-center justify-center text-blue-400 hover:text-blue-300 hover:bg-blue-400/10 transition-colors"
+                            .to_string(),
+                    ),
+                    aria_label: Some("Resume".to_string()),
+                    onclick: move |_| on_resume.call(()),
+                    PlayIcon { class: "w-3 h-3" }
+                }
+            } else {
+                div { class: "w-6" }
+            }
+
+            // Album cover
+            div { class: "w-10 h-10 flex-shrink-0 bg-gray-700 rounded overflow-clip",
+                if let Some(ref url) = item.cover_url {
+                    img {
+                        src: "{url}",
+                        alt: "Album cover",
+                        class: "w-full h-full object-cover",
+                    }
+                } else {
+                    div { class: "w-full h-full flex items-center justify-center text-gray-500",
+                        ImageIcon { class: "w-5 h-5" }
+                    }
+                }
+            }
+
+            // Track info
+            div { class: "flex-1 min-w-0",
+                div { class: "flex items-center gap-2",
+                    h3 { class: "font-medium text-accent-soft truncate flex-1 text-left",
+                        "{item.track.title}"
+                    }
+                    span { class: "text-sm text-gray-400 font-mono flex-shrink-0",
+                        if let Some(duration_ms) = item.track.duration_ms {
+                            {format_duration(duration_ms)}
+                        } else {
+                            "—:—"
+                        }
+                    }
+                }
+                div { class: "text-sm text-gray-400 truncate", "{item.album_title}" }
             }
         }
     }
@@ -103,8 +197,8 @@ fn UpNextSection(
     playback: ReadStore<PlaybackUiState>,
     on_track_click: EventHandler<String>,
     on_remove: EventHandler<usize>,
+    on_play_index: EventHandler<usize>,
 ) -> Element {
-    // Read only queue_items via lens
     let queue = playback.queue_items().read().clone();
 
     rsx! {
@@ -120,9 +214,9 @@ fn UpNextSection(
                         key: "{item.track.id}",
                         item: item.clone(),
                         index,
-                        is_current: false,
-                        on_click: on_track_click,
+                        on_track_click,
                         on_remove,
+                        on_play_index,
                     }
                 }
             } else {
@@ -132,18 +226,36 @@ fn UpNextSection(
     }
 }
 
+/// Queue item row for "up next" tracks
 #[component]
 fn QueueItemView(
     item: QueueItem,
     index: usize,
-    is_current: bool,
-    on_click: EventHandler<String>,
+    on_track_click: EventHandler<String>,
     on_remove: EventHandler<usize>,
+    on_play_index: EventHandler<usize>,
 ) -> Element {
+    let mut show_menu = use_signal(|| false);
+    let is_open: ReadSignal<bool> = show_menu.into();
+    let anchor_id = format!("queue-menu-{}", item.track.id);
+
+    let menu_is_open = is_open();
+
     rsx! {
-        div { class: if is_current { "flex items-center gap-3 p-3 border-b border-gray-700 bg-blue-500/10 hover:bg-blue-500/15 group" } else { "flex items-center gap-3 p-3 border-b border-gray-700 hover:bg-gray-800 group" },
+        div { class: "flex items-center gap-3 py-2 px-3 mx-2 rounded-lg hover:bg-hover transition-colors group",
+            // Play button (appears on hover)
+            ChromelessButton {
+                class: Some(
+                    "w-6 h-6 rounded-full border border-blue-400 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center text-blue-400 hover:text-blue-300 hover:bg-blue-400/10"
+                        .to_string(),
+                ),
+                aria_label: Some("Play".to_string()),
+                onclick: move |_| on_play_index.call(index),
+                PlayIcon { class: "w-3 h-3" }
+            }
+
             // Album cover
-            div { class: "w-12 h-12 flex-shrink-0 bg-gray-700 rounded overflow-clip",
+            div { class: "w-10 h-10 flex-shrink-0 bg-gray-700 rounded overflow-clip",
                 if let Some(ref url) = item.cover_url {
                     img {
                         src: "{url}",
@@ -152,30 +264,18 @@ fn QueueItemView(
                     }
                 } else {
                     div { class: "w-full h-full flex items-center justify-center text-gray-500",
-                        ImageIcon { class: "w-6 h-6" }
+                        ImageIcon { class: "w-5 h-5" }
                     }
                 }
             }
+
             // Track info
             div { class: "flex-1 min-w-0",
                 div { class: "flex items-center gap-2",
-                    ChromelessButton {
-                        class: Some(
-                            if is_current {
-                                "font-medium text-blue-300 hover:text-blue-200 text-left truncate flex-1"
-                                    .to_string()
-                            } else {
-                                "font-medium text-white hover:text-blue-300 text-left truncate flex-1"
-                                    .to_string()
-                            },
-                        ),
-                        onclick: {
-                            let track_id = item.track.id.clone();
-                            move |_| on_click.call(track_id.clone())
-                        },
+                    h3 { class: "font-medium text-white group-hover:text-accent-soft transition-colors truncate flex-1 text-left",
                         "{item.track.title}"
                     }
-                    span { class: "text-sm text-gray-400 flex-shrink-0",
+                    span { class: "text-sm text-gray-400 font-mono flex-shrink-0",
                         if let Some(duration_ms) = item.track.duration_ms {
                             {format_duration(duration_ms)}
                         } else {
@@ -185,16 +285,36 @@ fn QueueItemView(
                 }
                 div { class: "text-sm text-gray-400 truncate", "{item.album_title}" }
             }
-            // Remove button (only for non-current tracks)
-            if !is_current {
-                ChromelessButton {
-                    class: Some(
-                        "px-2 py-1 text-gray-400 hover:text-red-400 rounded opacity-0 group-hover:opacity-100 transition-opacity"
-                            .to_string(),
-                    ),
-                    aria_label: Some("Remove from queue".to_string()),
-                    onclick: move |_| on_remove.call(index),
-                    XIcon { class: "w-4 h-4" }
+
+            // Context menu
+            ChromelessButton {
+                id: Some(anchor_id.clone()),
+                class: Some(
+                    if menu_is_open {
+                        "px-2 py-1 rounded-md text-gray-400 hover:text-white hover:bg-hover transition-all"
+                            .to_string()
+                    } else {
+                        "px-2 py-1 rounded-md text-gray-400 hover:text-white hover:bg-hover opacity-0 group-hover:opacity-100 transition-all"
+                            .to_string()
+                    },
+                ),
+                aria_label: Some("Track menu".to_string()),
+                onclick: move |_| show_menu.set(!show_menu()),
+                EllipsisIcon { class: "w-4 h-4" }
+            }
+
+            MenuDropdown {
+                anchor_id: anchor_id.clone(),
+                is_open,
+                on_close: move |_| show_menu.set(false),
+                placement: Placement::BottomEnd,
+
+                MenuItem {
+                    onclick: move |_| {
+                        show_menu.set(false);
+                        on_remove.call(index);
+                    },
+                    "Remove from Queue"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Visual refresh of queue sidebar to match album detail track row style (rounded rows, accent colors, monospace durations, hover effects)
- Add play button on hover for queued tracks via new `SkipTo` playback command
- Pause/resume button on the currently playing track in the sidebar
- Context menu (three dots) replaces X button for removing tracks from queue
- Sidebar now occupies layout space (full-height right column) instead of overlaying as a fixed panel
- Controls (Clear, close) moved to a header row
- Fix tooltip crash: blur listener now uses fallible signal access to avoid panic when component is already unmounted

## Test plan
- [ ] Play an album, open queue sidebar — verify visual style matches album detail rows
- [ ] Hover a queued track — play button appears, clicking it starts that track
- [ ] Hover current track — pause/resume button works
- [ ] Three-dot menu on queued tracks — "Remove from Queue" works
- [ ] Sidebar takes layout space, title bar and playback bar stay on the left
- [ ] Close sidebar via X button or playback bar toggle
- [ ] Rapidly open/close sidebar and switch windows — no tooltip crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)