### PR TITLE
Cache cover art to library dir for fast browsing

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -13,7 +13,7 @@ CREATE TABLE albums (
     title TEXT NOT NULL,
     year INTEGER,
     bandcamp_album_id TEXT,
-    cover_image_id TEXT,
+    cover_release_id TEXT,
     cover_art_url TEXT,
     is_compilation BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TEXT NOT NULL,

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -202,7 +202,7 @@ impl Database {
         let rows = sqlx::query(
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -242,7 +242,7 @@ impl Database {
                 discogs_release,
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
-                cover_image_id: row.get("cover_image_id"),
+                cover_release_id: row.get("cover_release_id"),
                 cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 created_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("created_at"))
@@ -365,7 +365,7 @@ impl Database {
         sqlx::query(
                 r#"
             INSERT INTO albums (
-                id, title, year, bandcamp_album_id, cover_image_id, cover_art_url, is_compilation, created_at, updated_at
+                id, title, year, bandcamp_album_id, cover_release_id, cover_art_url, is_compilation, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             )
@@ -373,7 +373,7 @@ impl Database {
             .bind(&album.title)
             .bind(album.year)
             .bind(&album.bandcamp_album_id)
-            .bind(&album.cover_image_id)
+            .bind(&album.cover_release_id)
             .bind(&album.cover_art_url)
             .bind(album.is_compilation)
             .bind(album.created_at.to_rfc3339())
@@ -477,7 +477,7 @@ impl Database {
         sqlx::query(
                 r#"
             INSERT INTO albums (
-                id, title, year, bandcamp_album_id, cover_image_id, cover_art_url, is_compilation, created_at, updated_at
+                id, title, year, bandcamp_album_id, cover_release_id, cover_art_url, is_compilation, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             )
@@ -485,7 +485,7 @@ impl Database {
             .bind(&album.title)
             .bind(album.year)
             .bind(&album.bandcamp_album_id)
-            .bind(&album.cover_image_id)
+            .bind(&album.cover_release_id)
             .bind(&album.cover_art_url)
             .bind(album.is_compilation)
             .bind(album.created_at.to_rfc3339())
@@ -616,7 +616,7 @@ impl Database {
         let rows = sqlx::query(
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -653,7 +653,7 @@ impl Database {
                 discogs_release,
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
-                cover_image_id: row.get("cover_image_id"),
+                cover_release_id: row.get("cover_release_id"),
                 cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 created_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("created_at"))
@@ -671,7 +671,7 @@ impl Database {
         let row = sqlx::query(
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -708,7 +708,7 @@ impl Database {
                 discogs_release,
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
-                cover_image_id: row.get("cover_image_id"),
+                cover_release_id: row.get("cover_release_id"),
                 cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 created_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("created_at"))
@@ -1004,7 +1004,7 @@ impl Database {
         let query = if master_id.is_some() && release_id.is_some() {
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1017,7 +1017,7 @@ impl Database {
         } else if master_id.is_some() {
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1030,7 +1030,7 @@ impl Database {
         } else if release_id.is_some() {
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1089,7 +1089,7 @@ impl Database {
                 discogs_release,
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
-                cover_image_id: row.get("cover_image_id"),
+                cover_release_id: row.get("cover_release_id"),
                 cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 created_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("created_at"))
@@ -1113,7 +1113,7 @@ impl Database {
         let query = if release_id.is_some() && release_group_id.is_some() {
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1126,7 +1126,7 @@ impl Database {
         } else if release_id.is_some() {
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1139,7 +1139,7 @@ impl Database {
         } else if release_group_id.is_some() {
             r#"
             SELECT 
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_image_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
                 a.is_compilation, a.created_at, a.updated_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1198,7 +1198,7 @@ impl Database {
                 discogs_release,
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
-                cover_image_id: row.get("cover_image_id"),
+                cover_release_id: row.get("cover_release_id"),
                 cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 created_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("created_at"))
@@ -1529,14 +1529,14 @@ impl Database {
                 .with_timezone(&Utc),
         }))
     }
-    /// Update album's cover_image_id
-    pub async fn set_album_cover_image(
+    /// Update album's cover_release_id
+    pub async fn set_album_cover_release(
         &self,
         album_id: &str,
-        cover_image_id: &str,
+        cover_release_id: &str,
     ) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE albums SET cover_image_id = ? WHERE id = ?")
-            .bind(cover_image_id)
+        sqlx::query("UPDATE albums SET cover_release_id = ? WHERE id = ?")
+            .bind(cover_release_id)
             .bind(album_id)
             .execute(&self.pool)
             .await?;

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -122,10 +122,10 @@ pub struct DbAlbum {
     pub musicbrainz_release: Option<MusicBrainzRelease>,
     /// Album ID from Bandcamp (optional, for future multi-source support)
     pub bandcamp_album_id: Option<String>,
-    /// Reference to the cover image (DbImage.id) - set after import
-    pub cover_image_id: Option<String>,
+    /// Release ID whose cover art is used for this album
+    pub cover_release_id: Option<String>,
     /// Cover art URL for immediate display (remote URL or bae://local/... for local files)
-    /// Used before import completes and cover_image_id is set
+    /// Used before import completes and cover_release_id is set
     pub cover_art_url: Option<String>,
     /// True for "Various Artists" compilation albums
     pub is_compilation: bool,
@@ -325,7 +325,7 @@ impl DbAlbum {
             discogs_release: None,
             musicbrainz_release: None,
             bandcamp_album_id: None,
-            cover_image_id: None,
+            cover_release_id: None,
             cover_art_url: None,
             is_compilation: false,
             created_at: now,
@@ -355,7 +355,7 @@ impl DbAlbum {
             discogs_release: Some(discogs_release),
             musicbrainz_release: None,
             bandcamp_album_id: None,
-            cover_image_id: None,
+            cover_release_id: None,
             cover_art_url,
             is_compilation: false,
             created_at: now,
@@ -385,7 +385,7 @@ impl DbAlbum {
             discogs_release: None,
             musicbrainz_release: Some(musicbrainz_release),
             bandcamp_album_id: None,
-            cover_image_id: None,
+            cover_release_id: None,
             cover_art_url,
             is_compilation: false,
             created_at: now,

--- a/bae-core/src/import/progress/handle.rs
+++ b/bae-core/src/import/progress/handle.rs
@@ -192,7 +192,7 @@ mod tests {
         assert!(filter.matches(&ImportProgress::Complete {
             id: "release-1".to_string(),
             release_id: None,
-            cover_image_id: None,
+
             import_id: None,
         },),);
         assert!(!filter.matches(&ImportProgress::Progress {
@@ -217,13 +217,13 @@ mod tests {
         assert!(filter.matches(&ImportProgress::Complete {
             id: "track-1".to_string(),
             release_id: Some("release-1".to_string()),
-            cover_image_id: None,
+
             import_id: None,
         },),);
         assert!(!filter.matches(&ImportProgress::Complete {
             id: "track-1".to_string(),
             release_id: Some("release-2".to_string()),
-            cover_image_id: None,
+
             import_id: None,
         },),);
     }
@@ -241,7 +241,7 @@ mod tests {
         assert!(filter.matches(&ImportProgress::Complete {
             id: "track-1".to_string(),
             release_id: Some("release-1".to_string()),
-            cover_image_id: None,
+
             import_id: None,
         },),);
         assert!(!filter.matches(&ImportProgress::Progress {
@@ -303,7 +303,7 @@ mod tests {
         assert!(filter.matches(&ImportProgress::Complete {
             id: "release-1".to_string(),
             release_id: None,
-            cover_image_id: None,
+
             import_id: Some("import-1".to_string()),
         },),);
         assert!(filter.matches(&ImportProgress::Failed {
@@ -354,7 +354,7 @@ mod tests {
         assert!(filter.matches(&ImportProgress::Complete {
             id: "release-1".to_string(),
             release_id: None,
-            cover_image_id: None,
+
             import_id: Some("import-3".to_string()),
         },),);
         assert!(filter.matches(&ImportProgress::Failed {
@@ -375,7 +375,7 @@ mod tests {
         assert!(!filter.matches(&ImportProgress::Complete {
             id: "release-1".to_string(),
             release_id: None,
-            cover_image_id: None,
+
             import_id: None,
         },),);
     }

--- a/bae-core/src/import/types.rs
+++ b/bae-core/src/import/types.rs
@@ -122,8 +122,6 @@ pub enum ImportProgress {
         /// For track completions, this is the parent release ID (for filtering)
         /// For release completions, this is None
         release_id: Option<String>,
-        /// For release completions, the cover image ID (for reactive UI update)
-        cover_image_id: Option<String>,
         import_id: Option<String>,
     },
     Failed {
@@ -246,8 +244,10 @@ pub enum ImportCommand {
         cue_flac_metadata: Option<HashMap<PathBuf, CueFlacMetadata>>,
         /// Storage profile ID. None means no bae storage (files stay in place).
         storage_profile_id: Option<String>,
-        /// Resolved absolute path to the cover image file
+        /// Resolved absolute path to a local cover image file
         cover_image_path: Option<PathBuf>,
+        /// Whether a remote cover was already downloaded and cached by the handle
+        remote_cover_set: bool,
         /// Import operation ID for progress tracking
         import_id: String,
     },

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -454,14 +454,14 @@ impl LibraryManager {
         Ok(data)
     }
 
-    /// Set an album's cover image
-    pub async fn set_album_cover_image(
+    /// Set an album's cover release (which release provides the cover art)
+    pub async fn set_album_cover_release(
         &self,
         album_id: &str,
-        cover_image_id: &str,
+        cover_release_id: &str,
     ) -> Result<(), LibraryError> {
         self.database
-            .set_album_cover_image(album_id, cover_image_id)
+            .set_album_cover_release(album_id, cover_release_id)
             .await?;
         Ok(())
     }
@@ -734,7 +734,7 @@ mod tests {
             discogs_release: None,
             musicbrainz_release: None,
             bandcamp_album_id: None,
-            cover_image_id: None,
+            cover_release_id: None,
             cover_art_url: None,
             is_compilation: false,
             created_at: Utc::now(),

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -48,6 +48,7 @@ async fn test_cue_flac_records_track_positions() {
         encryption_service,
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
     let discogs_release = create_test_discogs_release();
     let import_id = uuid::Uuid::new_v4().to_string();
@@ -197,6 +198,7 @@ async fn test_cue_flac_playback_uses_track_positions() {
         encryption_service.clone(),
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
     let discogs_release = create_test_discogs_release();
     let import_id = uuid::Uuid::new_v4().to_string();
@@ -350,6 +352,7 @@ async fn test_cue_flac_decoded_duration_matches_cue_timing() {
         encryption_service.clone(),
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
     let discogs_release = create_test_discogs_release();
     let import_id = uuid::Uuid::new_v4().to_string();
@@ -487,6 +490,7 @@ async fn test_cue_flac_byte_ranges_have_no_gaps() {
         encryption_service,
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
 
     let discogs_release = create_test_discogs_release();
@@ -640,6 +644,7 @@ async fn test_cue_flac_builds_dense_seektable() {
         encryption_service,
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
 
     let discogs_release = create_test_discogs_release();

--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -27,7 +27,7 @@ fn create_test_album() -> DbAlbum {
         discogs_release: None,
         musicbrainz_release: None,
         bandcamp_album_id: None,
-        cover_image_id: None,
+        cover_release_id: None,
         cover_art_url: None,
         is_compilation: false,
         created_at: Utc::now(),

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -61,6 +61,7 @@ impl PlaybackTestFixture {
             encryption_service.clone(),
             database_arc,
             bae_core::keys::KeyService::new(true),
+            std::env::temp_dir().join("bae-test-covers"),
         );
         let master_year = discogs_release.year.unwrap_or(2024);
         let import_id = uuid::Uuid::new_v4().to_string();
@@ -368,6 +369,7 @@ impl CueFlacTestFixture {
             encryption_service.clone(),
             database_arc,
             bae_core::keys::KeyService::new(true),
+            std::env::temp_dir().join("bae-test-covers"),
         );
 
         let master_year = discogs_release.year.unwrap_or(2024);
@@ -2004,6 +2006,7 @@ impl HighSampleRateTestFixture {
             encryption_service.clone(),
             database_arc,
             bae_core::keys::KeyService::new(true),
+            std::env::temp_dir().join("bae-test-covers"),
         );
 
         let import_id = uuid::Uuid::new_v4().to_string();

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -177,6 +177,7 @@ impl CueFlacTestFixture {
             encryption_service.clone(),
             database_arc,
             bae_core::keys::KeyService::new(true),
+            std::env::temp_dir().join("bae-test-covers"),
         );
 
         let master_year = discogs_release.year.unwrap_or(2024);

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -91,6 +91,7 @@ async fn test_storageless_import() {
         encryption_service,
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
 
     let discogs_release = create_test_discogs_release();
@@ -241,6 +242,7 @@ async fn test_storageless_delete_preserves_files() {
         encryption_service,
         database_arc,
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
 
     let discogs_release = create_test_discogs_release();
@@ -409,6 +411,7 @@ async fn run_storage_test(location: StorageLocation, encrypted: bool) {
             encryption_service.clone(),
             database_arc,
             bae_core::keys::KeyService::new(true),
+            std::env::temp_dir().join("bae-test-covers"),
         )
     };
     let discogs_release = create_test_discogs_release();
@@ -588,11 +591,11 @@ async fn run_storage_test(location: StorageLocation, encrypted: bool) {
         .expect("Failed to get album")
         .expect("Album should exist");
     assert_eq!(
-        album.cover_image_id.as_ref(),
-        Some(&cover_image.id),
-        "Album cover_image_id should match the cover DbImage",
+        album.cover_release_id.as_ref(),
+        Some(&release_id),
+        "Album cover_release_id should match the release",
     );
-    info!("✓ Album cover_image_id is set correctly");
+    info!("✓ Album cover_release_id is set correctly");
     verify_image_loadable(
         cover_image,
         &library_manager,
@@ -926,6 +929,7 @@ async fn run_real_album_test(album_dir: PathBuf, location: StorageLocation, encr
         encryption_service.clone(),
         database_arc.clone(),
         bae_core::keys::KeyService::new(true),
+        std::env::temp_dir().join("bae-test-covers"),
     );
     let (_album_id, release_id) = import_handle
         .send_request(ImportRequest::Folder {

--- a/bae-core/tests/test_storage_profile_flow.rs
+++ b/bae-core/tests/test_storage_profile_flow.rs
@@ -254,7 +254,7 @@ fn create_test_album(title: &str) -> DbAlbum {
         discogs_release: None,
         musicbrainz_release: None,
         bandcamp_album_id: None,
-        cover_image_id: None,
+        cover_release_id: None,
         cover_art_url: None,
         is_compilation: false,
         created_at: now,

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -149,6 +149,7 @@ fn main() {
         torrent_manager.clone(),
         std::sync::Arc::new(database.clone()),
         key_service.clone(),
+        config.library_path.clone(),
     );
     #[cfg(not(feature = "torrent"))]
     let import_handle = import::ImportService::start(
@@ -157,6 +158,7 @@ fn main() {
         encryption_service.clone(),
         std::sync::Arc::new(database.clone()),
         key_service.clone(),
+        config.library_path.clone(),
     );
 
     let playback_handle = playback::PlaybackService::start(
@@ -168,6 +170,7 @@ fn main() {
     let media_controls = match media_controls::setup_media_controls(
         playback_handle.clone(),
         library_manager.clone(),
+        config.library_path.clone(),
         runtime_handle.clone(),
     ) {
         Ok(controls) => {

--- a/bae-desktop/src/media_controls.rs
+++ b/bae-desktop/src/media_controls.rs
@@ -12,6 +12,7 @@ use tracing::{error, info, trace};
 pub fn setup_media_controls(
     playback_handle: PlaybackHandle,
     library_manager: SharedLibraryManager,
+    library_path: PathBuf,
     runtime_handle: tokio::runtime::Handle,
 ) -> Result<Arc<Mutex<MediaControls>>, souvlaki::Error> {
     let current_state = Arc::new(Mutex::new(PlaybackState::Stopped));
@@ -108,6 +109,7 @@ pub fn setup_media_controls(
             let mut progress_rx = playback_handle_for_progress.subscribe_progress();
             let current_state = current_state_for_progress;
             let library_manager = library_manager_for_metadata;
+            let library_path = library_path;
             while let Some(progress) = progress_rx.recv().await {
                 match progress {
                     PlaybackProgress::StateChanged { state } => {
@@ -153,6 +155,7 @@ pub fn setup_media_controls(
                                 update_media_metadata(
                                     &controls_shared,
                                     &library_manager,
+                                    &library_path,
                                     track,
                                     duration,
                                 )
@@ -213,6 +216,7 @@ fn update_playback_position(
 async fn update_media_metadata(
     controls: &Arc<Mutex<MediaControls>>,
     library_manager: &SharedLibraryManager,
+    library_path: &std::path::Path,
     track: &bae_core::db::DbTrack,
     duration: Option<std::time::Duration>,
 ) {
@@ -237,13 +241,17 @@ async fn update_media_metadata(
             None
         }
     };
-    let (album_name, cover_image_id, cover_art_url) = match library_manager
+    let (album_name, cover_release_id, cover_art_url) = match library_manager
         .get()
         .get_album_id_for_release(&track.release_id)
         .await
     {
         Ok(album_id) => match library_manager.get().get_album_by_id(&album_id).await {
-            Ok(Some(album)) => (Some(album.title), album.cover_image_id, album.cover_art_url),
+            Ok(Some(album)) => (
+                Some(album.title),
+                album.cover_release_id,
+                album.cover_art_url,
+            ),
             Ok(None) => {
                 error!(
                     "Album {} not found for release {}",
@@ -265,9 +273,7 @@ async fn update_media_metadata(
         }
     };
 
-    let cover_url = resolve_cover_file_url(library_manager, &track.release_id, cover_image_id)
-        .await
-        .or(cover_art_url);
+    let cover_url = resolve_cover_file_url(library_path, cover_release_id).or(cover_art_url);
     let title = track.title.clone();
     let artist_str = artist_name.as_deref();
     let album_str = album_name.as_deref();
@@ -294,102 +300,20 @@ async fn update_media_metadata(
 }
 
 /// Resolve cover art to a file:// URL for macOS media controls.
-/// Downloads from cloud and/or decrypts if needed, caching the result.
-async fn resolve_cover_file_url(
-    library_manager: &SharedLibraryManager,
-    release_id: &str,
-    cover_image_id: Option<String>,
+/// Looks up the cover in the library's covers cache directory.
+fn resolve_cover_file_url(
+    library_path: &std::path::Path,
+    cover_release_id: Option<String>,
 ) -> Option<String> {
-    let image_id = cover_image_id?;
+    let release_id = cover_release_id?;
+    let covers_dir = library_path.join("covers");
 
-    // Check if we can use the file directly (local unencrypted)
-    if let Some(path) = get_direct_file_path(library_manager, release_id, &image_id).await {
-        return Some(format!("file://{}", path));
-    }
-
-    // For cloud or encrypted files, we need to cache a decrypted copy
-    let cover_path = get_media_cover_cache_path(&image_id);
-
-    // Check if already cached
-    if cover_path.exists() {
-        return Some(format!("file://{}", cover_path.display()));
-    }
-
-    // Fetch bytes (handles S3 download + decryption)
-    let data = match library_manager.get().fetch_image_bytes(&image_id).await {
-        Ok(d) => d,
-        Err(e) => {
-            error!("Failed to fetch cover image: {}", e);
-            return None;
-        }
-    };
-
-    // Write to cache
-    if let Some(parent) = cover_path.parent() {
-        if let Err(e) = tokio::fs::create_dir_all(parent).await {
-            error!("Failed to create cover cache dir: {}", e);
-            return None;
+    for ext in &["jpg", "jpeg", "png", "webp", "gif"] {
+        let path = covers_dir.join(format!("{}.{}", release_id, ext));
+        if path.exists() {
+            return Some(format!("file://{}", path.display()));
         }
     }
 
-    if let Err(e) = tokio::fs::write(&cover_path, &data).await {
-        error!("Failed to write cover to cache: {}", e);
-        return None;
-    }
-
-    Some(format!("file://{}", cover_path.display()))
-}
-
-/// Check if the image can be served directly from a local unencrypted file.
-/// Returns the file path if so, None otherwise.
-async fn get_direct_file_path(
-    library_manager: &SharedLibraryManager,
-    release_id: &str,
-    image_id: &str,
-) -> Option<String> {
-    let image = library_manager
-        .get()
-        .get_image_by_id(image_id)
-        .await
-        .ok()??;
-
-    let filename_only = std::path::Path::new(&image.filename)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(&image.filename);
-
-    let file = library_manager
-        .get()
-        .get_file_by_release_and_filename(release_id, filename_only)
-        .await
-        .ok()??;
-
-    let source_path = file.source_path?;
-
-    // Cloud storage needs download
-    if source_path.starts_with("s3://") {
-        return None;
-    }
-
-    // Check if encrypted
-    if let Ok(Some(profile)) = library_manager
-        .get()
-        .get_storage_profile_for_release(release_id)
-        .await
-    {
-        if profile.encrypted {
-            return None;
-        }
-    }
-
-    Some(source_path)
-}
-
-/// Get the cache path for a media control cover image
-fn get_media_cover_cache_path(image_id: &str) -> PathBuf {
-    dirs::home_dir()
-        .expect("Failed to get home directory")
-        .join(".bae")
-        .join("media-covers")
-        .join(image_id)
+    None
 }

--- a/bae-desktop/src/ui/app.rs
+++ b/bae-desktop/src/ui/app.rs
@@ -33,6 +33,7 @@ pub enum Route {
 pub fn make_config(context: &AppContext) -> DioxusConfig {
     let services = ImageServices {
         library_manager: context.library_manager.clone(),
+        library_path: context.config.library_path.clone(),
     };
 
     DioxusConfig::default()

--- a/bae-desktop/src/ui/app_service.rs
+++ b/bae-desktop/src/ui/app_service.rs
@@ -10,10 +10,10 @@
 //! - Read state reactively from `app.state`
 //! - Call action methods like `app.play_album()`
 
+use crate::ui::cover_url;
 use crate::ui::display_types::{
     album_from_db_ref, artist_from_db_ref, release_from_db_ref, track_from_db_ref,
 };
-use crate::ui::image_url;
 use crate::ui::import_helpers::consume_scan_events;
 use bae_core::cache;
 use bae_core::config;
@@ -201,9 +201,9 @@ impl AppService {
                                                     .await
                                             {
                                                 let cover = album
-                                                    .cover_image_id
+                                                    .cover_release_id
                                                     .as_ref()
-                                                    .map(|id| image_url(id))
+                                                    .map(|release_id| cover_url(release_id))
                                                     .or(album.cover_art_url.clone());
                                                 (album.title, cover)
                                             } else {
@@ -298,9 +298,9 @@ impl AppService {
                                         library_manager.get().get_album_by_id(&album_id).await
                                     {
                                         let cover = album
-                                            .cover_image_id
+                                            .cover_release_id
                                             .as_ref()
-                                            .map(|id| image_url(id))
+                                            .map(|release_id| cover_url(release_id))
                                             .or(album.cover_art_url.clone());
                                         (album.title, cover)
                                     } else {
@@ -493,7 +493,6 @@ impl AppService {
                             progress_percent: None,
                             release_id: db.release_id,
                             cover_art_url: None,
-                            cover_image_id: None,
                         })
                         .collect();
                     state.active_imports().imports().set(imports);
@@ -1071,7 +1070,6 @@ fn handle_import_progress(state: &Store<AppState>, event: ImportProgress) {
                         progress_percent: None,
                         release_id: None,
                         cover_art_url,
-                        cover_image_id: None,
                     });
                 }
             });
@@ -1119,7 +1117,6 @@ fn handle_import_progress(state: &Store<AppState>, event: ImportProgress) {
             id,
             import_id,
             release_id,
-            cover_image_id,
             ..
         } => {
             // Update active imports
@@ -1130,9 +1127,6 @@ fn handle_import_progress(state: &Store<AppState>, event: ImportProgress) {
                         import.progress_percent = Some(100);
                         if release_id.is_some() {
                             import.release_id = release_id.clone();
-                        }
-                        if cover_image_id.is_some() {
-                            import.cover_image_id = cover_image_id.clone();
                         }
                     }
                 });

--- a/bae-desktop/src/ui/components/imports_dropdown.rs
+++ b/bae-desktop/src/ui/components/imports_dropdown.rs
@@ -3,7 +3,7 @@
 //! Thin wrapper that bridges App state to ImportsDropdownView.
 
 use crate::ui::app_service::use_app;
-use crate::ui::{image_url, Route};
+use crate::ui::Route;
 use bae_ui::display_types::{ActiveImport as DisplayActiveImport, ImportStatus};
 use bae_ui::stores::{ActiveImportsUiStateStoreExt, AppStateStoreExt, ImportOperationStatus};
 use bae_ui::ImportsDropdownView;
@@ -22,11 +22,7 @@ pub fn ImportsDropdown() -> Element {
     let display_imports: Vec<DisplayActiveImport> = imports
         .iter()
         .map(|i| {
-            let cover_url = i
-                .cover_image_id
-                .as_ref()
-                .map(|id| image_url(id))
-                .or_else(|| i.cover_art_url.clone());
+            let cover_url = i.cover_art_url.clone();
 
             DisplayActiveImport {
                 import_id: i.import_id.clone(),

--- a/bae-desktop/src/ui/display_types.rs
+++ b/bae-desktop/src/ui/display_types.rs
@@ -1,6 +1,6 @@
 //! Conversions from DB types to bae-ui display types
 
-use crate::ui::image_url;
+use crate::ui::cover_url;
 use bae_core::db::{DbAlbum, DbArtist, DbRelease, DbTrack, ImportStatus};
 
 // Re-export bae-ui types so existing code continues to work
@@ -8,9 +8,9 @@ pub use bae_ui::{Album, Artist, Release, Track, TrackImportState};
 
 pub fn album_from_db_ref(db: &DbAlbum) -> Album {
     let cover_url = db
-        .cover_image_id
+        .cover_release_id
         .as_ref()
-        .map(|id| image_url(id))
+        .map(|release_id| cover_url(release_id))
         .or_else(|| db.cover_art_url.clone());
 
     Album {

--- a/bae-desktop/src/ui/local_file_url.rs
+++ b/bae-desktop/src/ui/local_file_url.rs
@@ -1,16 +1,17 @@
 //! Helpers for generating bae:// URLs
 //!
 //! The bae:// custom protocol is registered in app.rs and serves:
-//! - Images from storage: bae://image/{image_id}
+//! - Cover art from cache: bae://cover/{release_id}
 //! - Local files: bae://local{url_encoded_path}
+//! - Images from storage: bae://image/{image_id} (legacy, requires DB + decrypt)
 
 use std::path::Path;
 
-/// Convert a DbImage ID to a bae:// URL for serving from storage.
+/// Convert a release ID to a bae://cover/ URL for serving from the covers cache.
 ///
-/// The image will be read and decrypted on demand.
-pub fn image_url(image_id: &str) -> String {
-    format!("bae://image/{}", image_id)
+/// The cover is served directly from disk — no DB lookup or decryption.
+pub fn cover_url(release_id: &str) -> String {
+    format!("bae://cover/{}", release_id)
 }
 
 /// Convert a local file path to a bae://local/... URL.
@@ -33,8 +34,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_image_url() {
-        assert_eq!(image_url("abc"), "bae://image/abc");
+    fn test_cover_url() {
+        assert_eq!(cover_url("abc"), "bae://cover/abc");
     }
 
     #[test]

--- a/bae-desktop/src/ui/mod.rs
+++ b/bae-desktop/src/ui/mod.rs
@@ -12,4 +12,4 @@ pub mod window_activation;
 pub use app::*;
 // Legacy re-exports for backwards compatibility
 pub use app_context::AppContext;
-pub use local_file_url::image_url;
+pub use local_file_url::cover_url;

--- a/bae-desktop/src/ui/protocol_handler.rs
+++ b/bae-desktop/src/ui/protocol_handler.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::path::PathBuf;
 
 use bae_core::library::SharedLibraryManager;
 use dioxus::desktop::wry::http::Response as HttpResponse;
@@ -9,6 +10,7 @@ type ProtocolResponse = HttpResponse<Cow<'static, [u8]>>;
 #[derive(Clone)]
 pub struct ImageServices {
     pub library_manager: SharedLibraryManager,
+    pub library_path: PathBuf,
 }
 
 pub fn handle_protocol_request(uri: &str, services: &ImageServices) -> ProtocolResponse {
@@ -16,6 +18,8 @@ pub fn handle_protocol_request(uri: &str, services: &ImageServices) -> ProtocolR
 
     if let Some(encoded_path) = uri.strip_prefix("bae://local") {
         handle_local_file(encoded_path)
+    } else if let Some(release_id) = uri.strip_prefix("bae://cover/") {
+        handle_cover(release_id, services)
     } else if let Some(image_id) = uri.strip_prefix("bae://image/") {
         handle_image(image_id, services)
     } else {
@@ -25,6 +29,29 @@ pub fn handle_protocol_request(uri: &str, services: &ImageServices) -> ProtocolR
             .body(Cow::Borrowed(b"Invalid URL" as &[u8]))
             .unwrap()
     }
+}
+
+fn handle_cover(release_id: &str, services: &ImageServices) -> ProtocolResponse {
+    let covers_dir = services.library_path.join("covers");
+
+    // Try common image extensions
+    for ext in &["jpg", "jpeg", "png", "webp", "gif"] {
+        let path = covers_dir.join(format!("{}.{}", release_id, ext));
+        if let Ok(data) = std::fs::read(&path) {
+            let mime = mime_type_for_extension(ext);
+            return HttpResponse::builder()
+                .status(200)
+                .header("Content-Type", mime)
+                .body(Cow::Owned(data))
+                .unwrap();
+        }
+    }
+
+    warn!("Cover not found for album {}", release_id);
+    HttpResponse::builder()
+        .status(404)
+        .body(Cow::Borrowed(b"Cover not found" as &[u8]))
+        .unwrap()
 }
 
 fn handle_local_file(encoded_path: &str) -> ProtocolResponse {

--- a/bae-ui/src/stores/active_imports.rs
+++ b/bae-ui/src/stores/active_imports.rs
@@ -36,8 +36,6 @@ pub struct ActiveImport {
     pub release_id: Option<String>,
     /// External cover art URL (ephemeral, shown during import)
     pub cover_art_url: Option<String>,
-    /// Stored cover image ID (shown after import complete)
-    pub cover_image_id: Option<String>,
 }
 
 /// UI state for active imports (shown in toolbar dropdown)


### PR DESCRIPTION
## Summary
- Extract cover art to `{library_path}/covers/{release_id}.{ext}` during import — browsing the library no longer requires reading from storage or decrypting
- New `bae://cover/{release_id}` protocol serves covers directly from disk (no DB lookup, no decrypt)
- Replace `cover_image_id` with `cover_release_id` on `DbAlbum` — album stores which release provides the cover, not a DbImage reference
- Simplify media controls cover resolution to read from covers cache (removed S3 download/decrypt logic, removed `~/.bae/media-covers/` cache)
- Make `library_path` a required config field (defaults to `~/.bae/libraries/{id}/`), passed to ImportService and protocol handler

## Test plan
- [x] `cargo clippy -p bae-desktop && cargo clippy -p bae-mocks` clean
- [x] `cargo test -p bae-core` passes
- [x] `cargo test -p bae-desktop` passes
- [ ] Import an album → `covers/{release_id}.jpg` created
- [ ] Album grid shows covers without hitting storage/decryption
- [ ] Encrypted storage: covers still display (served from plaintext cache)
- [ ] macOS media controls show cover art

🤖 Generated with [Claude Code](https://claude.com/claude-code)