### PR TITLE
Make library_id required, fix mismatched IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ BAE_ENCRYPTION_KEY=generate-a-new-key-here
 # Discogs API key - get from https://www.discogs.com/settings/developers
 BAE_DISCOGS_API_KEY=your-discogs-key-here
 
-# Optional: Will be auto-generated if missing
-# BAE_LIBRARY_ID=550e8400-e29b-41d4-a716-446655440000
+# Library ID — auto-generated and persisted to .env on first run if missing
+# BAE_LIBRARY_ID=
 
 # Optional: Network interface to bind torrent clients to
 # Examples: "eth0", "tun0", "0.0.0.0:6881"

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -74,7 +74,36 @@ fn WelcomeScreen() -> Element {
         let bae_dir = home_dir.join(".bae");
         let id = uuid::Uuid::new_v4().to_string();
         let library_path = bae_dir.join("libraries").join(&id);
-        std::fs::create_dir_all(&bae_dir).expect("Failed to create ~/.bae");
+        std::fs::create_dir_all(&library_path).expect("Failed to create library directory");
+
+        // Write config.yaml with library_id
+        let config = bae_core::config::Config {
+            library_id: id,
+            library_path: library_path.clone(),
+            discogs_key_stored: false,
+            encryption_key_stored: false,
+            encryption_key_fingerprint: None,
+            torrent_bind_interface: None,
+            torrent_listen_port: None,
+            torrent_enable_upnp: true,
+            torrent_enable_natpmp: true,
+            torrent_max_connections: None,
+            torrent_max_connections_per_torrent: None,
+            torrent_max_uploads: None,
+            torrent_max_uploads_per_torrent: None,
+            subsonic_enabled: true,
+            subsonic_port: 4533,
+            cloud_sync_enabled: false,
+            cloud_sync_bucket: None,
+            cloud_sync_region: None,
+            cloud_sync_endpoint: None,
+            cloud_sync_last_upload: None,
+        };
+        config
+            .save_to_config_yaml()
+            .expect("Failed to write config.yaml");
+
+        // Write pointer file last (makes this idempotent on failure)
         std::fs::write(
             bae_dir.join("library"),
             library_path.to_string_lossy().as_ref(),


### PR DESCRIPTION
## Summary

- `library_id` was `Option<String>` in `ConfigYaml` and silently auto-generated when missing — separately from `library_path`, which generated its own random UUID. The two could mismatch, breaking cloud sync.
- `ConfigYaml.library_id` is now a required `String`. Dev mode auto-generates and persists to `.env` on first run. Production mode requires the pointer file and `config.yaml` from the first-run flow — no more silent fallback.
- Welcome screen "Create new library" now writes `config.yaml` with `library_id` before the pointer file (was only writing the pointer, leaving no config for `from_config_file()` to read).

## Test plan

- [x] 10 unit tests added covering config roundtrip, pointer/config requirements, `.env` persistence
- [ ] Manual: `rm -rf ~/.bae && cargo run -p bae-desktop` — verify library_id generated and persisted to `.env`
- [ ] Manual: second run picks up persisted ID (no "generated" log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)