### PR TITLE
Transfer releases between storage profiles

### DIFF
--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -79,6 +79,11 @@ name = "test_playback_cpu"
 path = "tests/test_playback_cpu.rs"
 required-features = ["test-utils"]
 
+[[test]]
+name = "test_transfer"
+path = "tests/test_transfer.rs"
+required-features = ["test-utils"]
+
 [features]
 default = []
 test-utils = []

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -1743,6 +1743,24 @@ impl Database {
         .await?;
         Ok(row.map(|row| self.row_to_storage_profile(&row)))
     }
+    /// Delete release storage link (release_storage row)
+    pub async fn delete_release_storage(&self, release_id: &str) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM release_storage WHERE release_id = ?")
+            .bind(release_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Delete all file records for a release
+    pub async fn delete_files_for_release(&self, release_id: &str) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM files WHERE release_id = ?")
+            .bind(release_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Insert a new import operation record
     pub async fn insert_import(&self, import: &DbImport) -> Result<(), sqlx::Error> {
         sqlx::query(

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -672,6 +672,27 @@ impl LibraryManager {
             .get_storage_profile_for_release(release_id)
             .await?)
     }
+    /// Delete release storage link
+    pub async fn delete_release_storage(&self, release_id: &str) -> Result<(), LibraryError> {
+        Ok(self.database.delete_release_storage(release_id).await?)
+    }
+
+    /// Delete all file records for a release
+    pub async fn delete_files_for_release(&self, release_id: &str) -> Result<(), LibraryError> {
+        Ok(self.database.delete_files_for_release(release_id).await?)
+    }
+
+    /// Insert release storage link
+    pub async fn insert_release_storage(
+        &self,
+        release_storage: &crate::db::DbReleaseStorage,
+    ) -> Result<(), LibraryError> {
+        Ok(self
+            .database
+            .insert_release_storage(release_storage)
+            .await?)
+    }
+
     /// Insert a new import operation record
     pub async fn insert_import(&self, import: &DbImport) -> Result<(), LibraryError> {
         Ok(self.database.insert_import(import).await?)

--- a/bae-core/src/storage/cleanup.rs
+++ b/bae-core/src/storage/cleanup.rs
@@ -1,0 +1,338 @@
+//! Deferred file cleanup after storage transfers
+//!
+//! After a transfer swaps DB records, old file locations are queued for
+//! deletion via a manifest file. Cleanup runs on app startup and after
+//! a delay post-transfer, giving in-flight playback seeks and Subsonic
+//! streams time to complete.
+
+use crate::db::DbStorageProfile;
+use crate::storage::create_storage_reader;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use tokio::time::{sleep, Duration};
+use tracing::{info, warn};
+
+/// Delay before cleaning up old files after a transfer.
+/// Long enough for in-flight seeks/streams to complete.
+const CLEANUP_DELAY: Duration = Duration::from_secs(30);
+
+const MANIFEST_FILENAME: &str = "pending_deletions.json";
+
+/// A file queued for deferred deletion
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "location")]
+pub enum PendingDeletion {
+    #[serde(rename = "local")]
+    Local { path: String },
+    #[serde(rename = "cloud")]
+    Cloud { profile_id: String, key: String },
+}
+
+/// Append pending deletions to the manifest file
+pub async fn append_pending_deletions(
+    library_path: &Path,
+    deletions: &[PendingDeletion],
+) -> Result<(), std::io::Error> {
+    let manifest_path = library_path.join(MANIFEST_FILENAME);
+
+    let mut existing = read_manifest(&manifest_path).await;
+    existing.extend(deletions.iter().cloned());
+
+    let json = serde_json::to_string_pretty(&existing).map_err(std::io::Error::other)?;
+    tokio::fs::write(&manifest_path, json).await?;
+
+    info!(
+        "Queued {} deletions (total pending: {})",
+        deletions.len(),
+        existing.len()
+    );
+
+    Ok(())
+}
+
+/// Process all pending deletions from the manifest.
+///
+/// Called on app startup and after a delay post-transfer.
+pub async fn process_pending_deletions(library_path: &Path, get_profile: impl AsyncProfileLookup) {
+    let manifest_path = library_path.join(MANIFEST_FILENAME);
+    let pending = read_manifest(&manifest_path).await;
+
+    if pending.is_empty() {
+        return;
+    }
+
+    info!("Processing {} pending file deletions", pending.len());
+
+    let mut remaining = Vec::new();
+
+    for deletion in pending {
+        match &deletion {
+            PendingDeletion::Local { path } => {
+                match tokio::fs::remove_file(path).await {
+                    Ok(_) => info!("Deleted local file: {}", path),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        // Already gone, that's fine
+                    }
+                    Err(e) => {
+                        warn!("Failed to delete {}: {}, will retry", path, e);
+                        remaining.push(deletion);
+                    }
+                }
+            }
+            PendingDeletion::Cloud { profile_id, key } => {
+                match get_profile.get_profile(profile_id).await {
+                    Some(profile) => match create_storage_reader(&profile).await {
+                        Ok(reader) => {
+                            if let Err(e) = reader.delete(key).await {
+                                warn!("Failed to delete cloud file {}: {}, will retry", key, e);
+                                remaining.push(deletion);
+                            } else {
+                                info!("Deleted cloud file: {}", key);
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to create storage reader for profile {}: {}, will retry",
+                                profile_id, e
+                            );
+                            remaining.push(deletion);
+                        }
+                    },
+                    None => {
+                        warn!(
+                            "Storage profile {} not found, dropping deletion for {}",
+                            profile_id, key
+                        );
+                        // Profile was deleted, can't clean up — drop it
+                    }
+                }
+            }
+        }
+    }
+
+    // Write back any that failed
+    if remaining.is_empty() {
+        let _ = tokio::fs::remove_file(&manifest_path).await;
+    } else if let Ok(json) = serde_json::to_string_pretty(&remaining) {
+        let _ = tokio::fs::write(&manifest_path, json).await;
+    }
+}
+
+/// Schedule deferred cleanup after a transfer completes
+pub fn schedule_cleanup(library_path: &Path, get_profile: impl AsyncProfileLookup + 'static) {
+    let library_path = library_path.to_path_buf();
+    tokio::spawn(async move {
+        sleep(CLEANUP_DELAY).await;
+        process_pending_deletions(&library_path, get_profile).await;
+    });
+}
+
+async fn read_manifest(manifest_path: &Path) -> Vec<PendingDeletion> {
+    match tokio::fs::read_to_string(manifest_path).await {
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Trait for looking up storage profiles (allows mocking in tests)
+#[async_trait::async_trait]
+pub trait AsyncProfileLookup: Send + Sync {
+    async fn get_profile(&self, profile_id: &str) -> Option<DbStorageProfile>;
+}
+
+/// Implementation that uses LibraryManager
+#[async_trait::async_trait]
+impl AsyncProfileLookup for crate::library::SharedLibraryManager {
+    async fn get_profile(&self, profile_id: &str) -> Option<DbStorageProfile> {
+        self.get()
+            .database()
+            .get_storage_profile(profile_id)
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// A no-op profile lookup that always returns None
+    struct NoOpProfileLookup;
+
+    #[async_trait::async_trait]
+    impl AsyncProfileLookup for NoOpProfileLookup {
+        async fn get_profile(&self, _profile_id: &str) -> Option<DbStorageProfile> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn test_append_creates_manifest() {
+        let temp = TempDir::new().unwrap();
+        let library_path = temp.path();
+
+        let deletions = vec![
+            PendingDeletion::Local {
+                path: "/old/file1.flac".to_string(),
+            },
+            PendingDeletion::Cloud {
+                profile_id: "prof-1".to_string(),
+                key: "release-1/file2.flac".to_string(),
+            },
+        ];
+
+        append_pending_deletions(library_path, &deletions)
+            .await
+            .unwrap();
+
+        let manifest_path = library_path.join(MANIFEST_FILENAME);
+        assert!(manifest_path.exists());
+
+        let contents = tokio::fs::read_to_string(&manifest_path).await.unwrap();
+        let parsed: Vec<PendingDeletion> = serde_json::from_str(&contents).unwrap();
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_append_accumulates() {
+        let temp = TempDir::new().unwrap();
+        let library_path = temp.path();
+
+        append_pending_deletions(
+            library_path,
+            &[PendingDeletion::Local {
+                path: "/old/a.flac".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        append_pending_deletions(
+            library_path,
+            &[PendingDeletion::Local {
+                path: "/old/b.flac".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        let manifest_path = library_path.join(MANIFEST_FILENAME);
+        let contents = tokio::fs::read_to_string(&manifest_path).await.unwrap();
+        let parsed: Vec<PendingDeletion> = serde_json::from_str(&contents).unwrap();
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_process_deletes_local_files() {
+        let temp = TempDir::new().unwrap();
+        let library_path = temp.path();
+
+        // Create files to delete
+        let file1 = temp.path().join("file1.flac");
+        let file2 = temp.path().join("file2.flac");
+        tokio::fs::write(&file1, b"data1").await.unwrap();
+        tokio::fs::write(&file2, b"data2").await.unwrap();
+
+        append_pending_deletions(
+            library_path,
+            &[
+                PendingDeletion::Local {
+                    path: file1.display().to_string(),
+                },
+                PendingDeletion::Local {
+                    path: file2.display().to_string(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        process_pending_deletions(library_path, NoOpProfileLookup).await;
+
+        assert!(!file1.exists());
+        assert!(!file2.exists());
+        // Manifest should be cleaned up
+        assert!(!library_path.join(MANIFEST_FILENAME).exists());
+    }
+
+    #[tokio::test]
+    async fn test_process_not_found_files_are_silently_removed() {
+        let temp = TempDir::new().unwrap();
+        let library_path = temp.path();
+
+        // Queue a file that doesn't exist
+        append_pending_deletions(
+            library_path,
+            &[PendingDeletion::Local {
+                path: "/nonexistent/file.flac".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        process_pending_deletions(library_path, NoOpProfileLookup).await;
+
+        // Manifest should be cleaned up (not-found is not a retry)
+        assert!(!library_path.join(MANIFEST_FILENAME).exists());
+    }
+
+    #[tokio::test]
+    async fn test_process_cloud_with_missing_profile_drops_entry() {
+        let temp = TempDir::new().unwrap();
+        let library_path = temp.path();
+
+        append_pending_deletions(
+            library_path,
+            &[PendingDeletion::Cloud {
+                profile_id: "deleted-profile".to_string(),
+                key: "release-1/file.flac".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        // NoOpProfileLookup returns None for all profiles
+        process_pending_deletions(library_path, NoOpProfileLookup).await;
+
+        // Entry should be dropped (not retried), manifest cleaned up
+        assert!(!library_path.join(MANIFEST_FILENAME).exists());
+    }
+
+    #[tokio::test]
+    async fn test_process_with_no_manifest_is_noop() {
+        let temp = TempDir::new().unwrap();
+        // No manifest file exists — should not panic
+        process_pending_deletions(temp.path(), NoOpProfileLookup).await;
+    }
+
+    #[tokio::test]
+    async fn test_serde_roundtrip() {
+        let deletions = vec![
+            PendingDeletion::Local {
+                path: "/some/path.flac".to_string(),
+            },
+            PendingDeletion::Cloud {
+                profile_id: "prof-1".to_string(),
+                key: "key/path.flac".to_string(),
+            },
+        ];
+
+        let json = serde_json::to_string_pretty(&deletions).unwrap();
+        let parsed: Vec<PendingDeletion> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        match &parsed[0] {
+            PendingDeletion::Local { path } => assert_eq!(path, "/some/path.flac"),
+            _ => panic!("Expected Local variant"),
+        }
+        match &parsed[1] {
+            PendingDeletion::Cloud { profile_id, key } => {
+                assert_eq!(profile_id, "prof-1");
+                assert_eq!(key, "key/path.flac");
+            }
+            _ => panic!("Expected Cloud variant"),
+        }
+    }
+}

--- a/bae-core/src/storage/mod.rs
+++ b/bae-core/src/storage/mod.rs
@@ -3,8 +3,10 @@
 //! Provides flexible storage options for releases. Storage is configured via
 //! StorageProfile (location + encrypted) and implemented by a single
 //! ReleaseStorageImpl that applies transforms based on the profile.
+pub mod cleanup;
 mod reader;
 mod traits;
+pub mod transfer;
 
 pub use reader::create_storage_reader;
 pub use traits::{ReleaseStorage, ReleaseStorageImpl};

--- a/bae-core/src/storage/transfer.rs
+++ b/bae-core/src/storage/transfer.rs
@@ -1,0 +1,373 @@
+//! Transfer service — moves releases between storage profiles
+//!
+//! Orchestrates reading files from the source location, writing them to the
+//! destination, updating DB records atomically, and queuing old files for
+//! deferred cleanup.
+
+use crate::cloud_storage::CloudStorage;
+use crate::db::{DbFile, DbReleaseStorage, DbStorageProfile, StorageLocation};
+use crate::encryption::EncryptionService;
+use crate::library::SharedLibraryManager;
+use crate::storage::{create_storage_reader, ReleaseStorage, ReleaseStorageImpl};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+
+use super::cleanup::PendingDeletion;
+
+/// Progress updates emitted during a transfer
+#[derive(Debug, Clone)]
+pub enum TransferProgress {
+    /// Transfer started
+    Started {
+        release_id: String,
+        total_files: usize,
+    },
+    /// A file is being transferred
+    FileProgress {
+        release_id: String,
+        file_index: usize,
+        total_files: usize,
+        filename: String,
+        percent: u8,
+    },
+    /// Transfer completed
+    Complete { release_id: String },
+    /// Transfer failed
+    Failed { release_id: String, error: String },
+}
+
+/// Where to transfer a release
+pub enum TransferTarget {
+    /// Move to a managed storage profile
+    Profile(DbStorageProfile),
+    /// Eject to a user-chosen local folder (removes from managed storage)
+    Eject(PathBuf),
+}
+
+/// Transfer service that moves releases between storage profiles
+pub struct TransferService {
+    library_manager: SharedLibraryManager,
+    encryption_service: Option<EncryptionService>,
+    library_path: PathBuf,
+    #[cfg(feature = "test-utils")]
+    injected_source_cloud: Option<Arc<dyn CloudStorage>>,
+    #[cfg(feature = "test-utils")]
+    injected_dest_cloud: Option<Arc<dyn CloudStorage>>,
+}
+
+impl TransferService {
+    pub fn new(
+        library_manager: SharedLibraryManager,
+        encryption_service: Option<EncryptionService>,
+        library_path: PathBuf,
+    ) -> Self {
+        Self {
+            library_manager,
+            encryption_service,
+            library_path,
+            #[cfg(feature = "test-utils")]
+            injected_source_cloud: None,
+            #[cfg(feature = "test-utils")]
+            injected_dest_cloud: None,
+        }
+    }
+
+    #[cfg(feature = "test-utils")]
+    pub fn with_injected_clouds(
+        mut self,
+        source: Option<Arc<dyn CloudStorage>>,
+        dest: Option<Arc<dyn CloudStorage>>,
+    ) -> Self {
+        self.injected_source_cloud = source;
+        self.injected_dest_cloud = dest;
+        self
+    }
+
+    /// Transfer a release to a new storage target.
+    ///
+    /// Returns a receiver for progress updates.
+    pub fn transfer(
+        &self,
+        release_id: String,
+        target: TransferTarget,
+    ) -> mpsc::UnboundedReceiver<TransferProgress> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let library_manager = self.library_manager.clone();
+        let encryption_service = self.encryption_service.clone();
+        let library_path = self.library_path.clone();
+
+        #[cfg(feature = "test-utils")]
+        let injected_source = self.injected_source_cloud.clone();
+        #[cfg(feature = "test-utils")]
+        let injected_dest = self.injected_dest_cloud.clone();
+
+        tokio::spawn(async move {
+            let result = do_transfer(
+                &release_id,
+                target,
+                &library_manager,
+                encryption_service.as_ref(),
+                &library_path,
+                &tx,
+                #[cfg(feature = "test-utils")]
+                injected_source,
+                #[cfg(feature = "test-utils")]
+                injected_dest,
+            )
+            .await;
+
+            if let Err(e) = result {
+                error!("Transfer failed for release {}: {}", release_id, e);
+                let _ = tx.send(TransferProgress::Failed {
+                    release_id,
+                    error: e.to_string(),
+                });
+            }
+        });
+
+        rx
+    }
+}
+
+async fn do_transfer(
+    release_id: &str,
+    target: TransferTarget,
+    library_manager: &SharedLibraryManager,
+    encryption_service: Option<&EncryptionService>,
+    library_path: &Path,
+    tx: &mpsc::UnboundedSender<TransferProgress>,
+    #[cfg(feature = "test-utils")] injected_source: Option<Arc<dyn CloudStorage>>,
+    #[cfg(feature = "test-utils")] injected_dest: Option<Arc<dyn CloudStorage>>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mgr = library_manager.get();
+
+    // 1. Get current files and source profile
+    let old_files = mgr.get_files_for_release(release_id).await?;
+    let source_profile = mgr.get_storage_profile_for_release(release_id).await?;
+
+    if old_files.is_empty() {
+        return Err("Release has no files".into());
+    }
+
+    let _ = tx.send(TransferProgress::Started {
+        release_id: release_id.to_string(),
+        total_files: old_files.len(),
+    });
+
+    info!(
+        "Starting transfer for release {} ({} files)",
+        release_id,
+        old_files.len()
+    );
+
+    // 2. Read all files from source, decrypting if needed
+    let source_reader: Option<Arc<dyn CloudStorage>> = if let Some(ref profile) = source_profile {
+        #[cfg(feature = "test-utils")]
+        if let Some(ref cloud) = injected_source {
+            Some(cloud.clone())
+        } else {
+            Some(create_storage_reader(profile).await?)
+        }
+        #[cfg(not(feature = "test-utils"))]
+        Some(create_storage_reader(profile).await?)
+    } else {
+        None
+    };
+
+    let source_encrypted = source_profile
+        .as_ref()
+        .map(|p| p.encrypted)
+        .unwrap_or(false);
+
+    // Read source files into memory with decryption
+    let mut file_data: Vec<(String, Vec<u8>)> = Vec::with_capacity(old_files.len());
+    for (i, file) in old_files.iter().enumerate() {
+        let _ = tx.send(TransferProgress::FileProgress {
+            release_id: release_id.to_string(),
+            file_index: i,
+            total_files: old_files.len(),
+            filename: file.original_filename.clone(),
+            percent: 0,
+        });
+
+        let raw_data = read_file_data(file, source_reader.as_ref()).await?;
+
+        let data = if source_encrypted {
+            let enc =
+                encryption_service.ok_or("Encryption service required for encrypted source")?;
+            enc.decrypt(&raw_data)?
+        } else {
+            raw_data
+        };
+
+        file_data.push((file.original_filename.clone(), data));
+
+        let _ = tx.send(TransferProgress::FileProgress {
+            release_id: release_id.to_string(),
+            file_index: i,
+            total_files: old_files.len(),
+            filename: file.original_filename.clone(),
+            percent: 50,
+        });
+    }
+
+    // 3. Write files to destination
+    match &target {
+        TransferTarget::Profile(dest_profile) => {
+            // Delete old file records first (new ones will be created by write_file)
+            mgr.delete_files_for_release(release_id).await?;
+            mgr.delete_release_storage(release_id).await?;
+
+            let database = Arc::new(mgr.database().clone());
+
+            #[cfg(feature = "test-utils")]
+            let storage = if let Some(ref cloud) = injected_dest {
+                ReleaseStorageImpl::with_cloud(
+                    dest_profile.clone(),
+                    encryption_service.cloned(),
+                    cloud.clone(),
+                    database,
+                )
+            } else {
+                ReleaseStorageImpl::from_profile(
+                    dest_profile.clone(),
+                    encryption_service.cloned(),
+                    database,
+                )
+                .await?
+            };
+
+            #[cfg(not(feature = "test-utils"))]
+            let storage = ReleaseStorageImpl::from_profile(
+                dest_profile.clone(),
+                encryption_service.cloned(),
+                database,
+            )
+            .await?;
+
+            for (i, (filename, data)) in file_data.iter().enumerate() {
+                let total_files = file_data.len();
+                let tx_clone = tx.clone();
+                let rid = release_id.to_string();
+                let fname = filename.clone();
+
+                storage
+                    .write_file(
+                        release_id,
+                        filename,
+                        data,
+                        Box::new(move |bytes_written, total_bytes| {
+                            let percent = if total_bytes > 0 {
+                                ((bytes_written as f64 / total_bytes as f64) * 50.0 + 50.0) as u8
+                            } else {
+                                100
+                            };
+                            let _ = tx_clone.send(TransferProgress::FileProgress {
+                                release_id: rid.clone(),
+                                file_index: i,
+                                total_files,
+                                filename: fname.clone(),
+                                percent,
+                            });
+                        }),
+                    )
+                    .await?;
+            }
+
+            // Link release to new profile
+            let release_storage = DbReleaseStorage::new(release_id, &dest_profile.id);
+            mgr.insert_release_storage(&release_storage).await?;
+        }
+        TransferTarget::Eject(target_dir) => {
+            // Write files to target directory as plain files
+            tokio::fs::create_dir_all(target_dir).await?;
+
+            for (i, (filename, data)) in file_data.iter().enumerate() {
+                let dest_path = target_dir.join(filename);
+                tokio::fs::write(&dest_path, data).await?;
+
+                let _ = tx.send(TransferProgress::FileProgress {
+                    release_id: release_id.to_string(),
+                    file_index: i,
+                    total_files: file_data.len(),
+                    filename: filename.clone(),
+                    percent: 100,
+                });
+            }
+
+            // Update DB: remove storage link and file records, create new file records
+            // pointing to the ejected location
+            mgr.delete_files_for_release(release_id).await?;
+            mgr.delete_release_storage(release_id).await?;
+
+            for (filename, data) in &file_data {
+                let dest_path = target_dir.join(filename);
+                let format = Path::new(filename)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("bin")
+                    .to_lowercase();
+                let mut db_file = DbFile::new(release_id, filename, data.len() as i64, &format);
+                db_file.source_path = Some(dest_path.display().to_string());
+                mgr.add_file(&db_file).await?;
+            }
+        }
+    }
+
+    // 4. Queue old files for deferred deletion
+    let pending: Vec<PendingDeletion> = old_files
+        .iter()
+        .filter_map(|f| {
+            let source_path = f.source_path.as_ref()?;
+            if let Some(ref profile) = source_profile {
+                if profile.location == StorageLocation::Cloud {
+                    Some(PendingDeletion::Cloud {
+                        profile_id: profile.id.clone(),
+                        key: source_path.clone(),
+                    })
+                } else {
+                    Some(PendingDeletion::Local {
+                        path: source_path.clone(),
+                    })
+                }
+            } else {
+                // Self-managed files: don't delete originals
+                None
+            }
+        })
+        .collect();
+
+    if !pending.is_empty() {
+        if let Err(e) = super::cleanup::append_pending_deletions(library_path, &pending).await {
+            warn!("Failed to queue deferred deletions: {}", e);
+        }
+    }
+
+    info!("Transfer complete for release {}", release_id);
+
+    let _ = tx.send(TransferProgress::Complete {
+        release_id: release_id.to_string(),
+    });
+
+    Ok(())
+}
+
+/// Read file data from its source location
+async fn read_file_data(
+    file: &DbFile,
+    source_reader: Option<&Arc<dyn CloudStorage>>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let source_path = file
+        .source_path
+        .as_ref()
+        .ok_or_else(|| format!("File {} has no source_path", file.id))?;
+
+    if let Some(reader) = source_reader {
+        Ok(reader.download(source_path).await?)
+    } else {
+        // Self-managed: read from disk directly
+        Ok(tokio::fs::read(source_path).await?)
+    }
+}

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -1,0 +1,464 @@
+#![cfg(feature = "test-utils")]
+//! Integration tests for the storage transfer service.
+//!
+//! Tests:
+//! - Self-managed → local profile transfer
+//! - Local profile → local profile transfer
+//! - Local profile → eject (export to folder)
+//! - Self-managed originals are preserved after transfer
+
+mod support;
+
+use bae_core::db::{
+    Database, DbAlbum, DbFile, DbRelease, DbReleaseStorage, DbStorageProfile, ImportStatus,
+};
+use bae_core::library::LibraryManager;
+use bae_core::storage::cleanup::PendingDeletion;
+use bae_core::storage::transfer::{TransferProgress, TransferService, TransferTarget};
+use chrono::Utc;
+use std::path::Path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+fn tracing_init() {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_line_number(true)
+        .with_target(false)
+        .with_file(true)
+        .try_init();
+}
+
+/// Set up a database and library manager in a temp directory
+async fn setup_db(temp: &TempDir) -> (Database, LibraryManager) {
+    let db_path = temp.path().join("test.db");
+    let db = Database::new(db_path.to_str().unwrap()).await.unwrap();
+    let enc = support::test_encryption_service();
+    let mgr = LibraryManager::new(db.clone(), enc);
+    (db, mgr)
+}
+
+/// Create a test album + release in the DB, return (album_id, release_id)
+async fn create_album_and_release(db: &Database) -> (String, String) {
+    let now = Utc::now();
+    let album = DbAlbum {
+        id: Uuid::new_v4().to_string(),
+        title: "Transfer Test Album".to_string(),
+        year: Some(2024),
+        discogs_release: None,
+        musicbrainz_release: None,
+        bandcamp_album_id: None,
+        cover_release_id: None,
+        cover_art_url: None,
+        is_compilation: false,
+        created_at: now,
+        updated_at: now,
+    };
+    db.insert_album(&album).await.unwrap();
+
+    let release = DbRelease {
+        id: Uuid::new_v4().to_string(),
+        album_id: album.id.clone(),
+        release_name: None,
+        year: None,
+        discogs_release_id: None,
+        bandcamp_release_id: None,
+        format: None,
+        label: None,
+        catalog_number: None,
+        country: None,
+        barcode: None,
+        import_status: ImportStatus::Complete,
+        created_at: now,
+        updated_at: now,
+    };
+    db.insert_release(&release).await.unwrap();
+
+    (album.id, release.id)
+}
+
+/// Create self-managed files on disk and insert DbFile records pointing to them
+async fn create_self_managed_files(
+    mgr: &LibraryManager,
+    release_id: &str,
+    source_dir: &Path,
+) -> Vec<(String, Vec<u8>)> {
+    let files = vec![
+        ("track1.flac", b"file-data-track-one" as &[u8]),
+        ("track2.flac", b"file-data-track-two"),
+        ("cover.jpg", b"jpeg-cover-data"),
+    ];
+
+    let mut result = Vec::new();
+    for (name, data) in &files {
+        let file_path = source_dir.join(name);
+        tokio::fs::write(&file_path, data).await.unwrap();
+
+        let mut db_file = DbFile::new(release_id, name, data.len() as i64, "flac");
+        db_file.source_path = Some(file_path.display().to_string());
+        mgr.add_file(&db_file).await.unwrap();
+
+        result.push((name.to_string(), data.to_vec()));
+    }
+
+    result
+}
+
+/// Create files in a local storage profile directory and insert DbFile + release_storage records
+async fn create_profile_files(
+    db: &Database,
+    mgr: &LibraryManager,
+    release_id: &str,
+    profile: &DbStorageProfile,
+    storage_dir: &Path,
+) -> Vec<(String, Vec<u8>)> {
+    let files = vec![
+        ("track1.flac", b"stored-data-track-one" as &[u8]),
+        ("track2.flac", b"stored-data-track-two"),
+    ];
+
+    let release_dir = storage_dir.join(release_id);
+    tokio::fs::create_dir_all(&release_dir).await.unwrap();
+
+    let mut result = Vec::new();
+    for (name, data) in &files {
+        let file_path = release_dir.join(name);
+        tokio::fs::write(&file_path, data).await.unwrap();
+
+        let mut db_file = DbFile::new(release_id, name, data.len() as i64, "flac");
+        db_file.source_path = Some(file_path.display().to_string());
+        mgr.add_file(&db_file).await.unwrap();
+
+        result.push((name.to_string(), data.to_vec()));
+    }
+
+    // Link release to profile
+    let rs = DbReleaseStorage::new(release_id, &profile.id);
+    db.insert_release_storage(&rs).await.unwrap();
+
+    result
+}
+
+/// Drain all progress events from a transfer receiver
+async fn collect_progress(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<TransferProgress>,
+) -> Vec<TransferProgress> {
+    let mut events = Vec::new();
+    while let Some(event) = rx.recv().await {
+        let is_terminal = matches!(
+            event,
+            TransferProgress::Complete { .. } | TransferProgress::Failed { .. }
+        );
+        events.push(event);
+        if is_terminal {
+            break;
+        }
+    }
+    events
+}
+
+/// Read the pending_deletions.json manifest from the library path
+async fn read_pending_deletions(library_path: &Path) -> Vec<PendingDeletion> {
+    let manifest = library_path.join("pending_deletions.json");
+    if !manifest.exists() {
+        return Vec::new();
+    }
+    let contents = tokio::fs::read_to_string(&manifest).await.unwrap();
+    serde_json::from_str(&contents).unwrap()
+}
+
+/// Transfer self-managed files into a local storage profile.
+/// Verifies: files written to storage, DB updated, original files preserved, no pending deletions.
+#[tokio::test]
+async fn test_transfer_self_managed_to_local_profile() {
+    tracing_init();
+
+    let temp = TempDir::new().unwrap();
+    let source_dir = temp.path().join("source");
+    let storage_dir = temp.path().join("storage");
+    let library_path = temp.path().join("library");
+    tokio::fs::create_dir_all(&source_dir).await.unwrap();
+    tokio::fs::create_dir_all(&storage_dir).await.unwrap();
+    tokio::fs::create_dir_all(&library_path).await.unwrap();
+
+    let (db, mgr) = setup_db(&temp).await;
+    let (_album_id, release_id) = create_album_and_release(&db).await;
+    let original_files = create_self_managed_files(&mgr, &release_id, &source_dir).await;
+
+    // Create destination profile
+    let dest_profile =
+        DbStorageProfile::new_local("Local Storage", storage_dir.to_str().unwrap(), false);
+    db.insert_storage_profile(&dest_profile).await.unwrap();
+
+    // Execute transfer
+    let shared_mgr = bae_core::library::SharedLibraryManager::new(mgr);
+    let service = TransferService::new(shared_mgr.clone(), None, library_path.clone());
+    let rx = service.transfer(
+        release_id.clone(),
+        TransferTarget::Profile(dest_profile.clone()),
+    );
+    let events = collect_progress(rx).await;
+
+    // Verify progress events
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, TransferProgress::Started { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, TransferProgress::Complete { .. })));
+    assert!(!events
+        .iter()
+        .any(|e| matches!(e, TransferProgress::Failed { .. })));
+
+    // Verify DB: release now linked to dest profile
+    let profile = shared_mgr
+        .get()
+        .get_storage_profile_for_release(&release_id)
+        .await
+        .unwrap();
+    assert!(profile.is_some());
+    assert_eq!(profile.unwrap().id, dest_profile.id);
+
+    // Verify DB: new file records exist with storage paths
+    let new_files = shared_mgr
+        .get()
+        .get_files_for_release(&release_id)
+        .await
+        .unwrap();
+    assert_eq!(new_files.len(), original_files.len());
+    for file in &new_files {
+        let source_path = file.source_path.as_ref().unwrap();
+        assert!(
+            source_path.contains(storage_dir.to_str().unwrap()),
+            "New file should be in storage dir: {}",
+            source_path
+        );
+        // Verify file actually exists on disk
+        assert!(
+            Path::new(source_path).exists(),
+            "Stored file should exist: {}",
+            source_path
+        );
+    }
+
+    // Verify original files are preserved (self-managed → no pending deletions)
+    for (name, _) in &original_files {
+        let orig_path = source_dir.join(name);
+        assert!(
+            orig_path.exists(),
+            "Original file should be preserved: {:?}",
+            orig_path
+        );
+    }
+
+    // Self-managed sources should NOT queue deletions
+    let pending = read_pending_deletions(&library_path).await;
+    assert!(
+        pending.is_empty(),
+        "Self-managed transfer should not queue deletions"
+    );
+}
+
+/// Transfer from one local profile to another.
+/// Verifies: files written to new location, DB updated, old files queued for deletion.
+#[tokio::test]
+async fn test_transfer_local_profile_to_local_profile() {
+    tracing_init();
+
+    let temp = TempDir::new().unwrap();
+    let storage_a = temp.path().join("storage_a");
+    let storage_b = temp.path().join("storage_b");
+    let library_path = temp.path().join("library");
+    tokio::fs::create_dir_all(&storage_a).await.unwrap();
+    tokio::fs::create_dir_all(&storage_b).await.unwrap();
+    tokio::fs::create_dir_all(&library_path).await.unwrap();
+
+    let (db, mgr) = setup_db(&temp).await;
+    let (_album_id, release_id) = create_album_and_release(&db).await;
+
+    // Create source profile and files
+    let source_profile =
+        DbStorageProfile::new_local("Profile A", storage_a.to_str().unwrap(), false);
+    db.insert_storage_profile(&source_profile).await.unwrap();
+    let original_files =
+        create_profile_files(&db, &mgr, &release_id, &source_profile, &storage_a).await;
+
+    // Create destination profile
+    let dest_profile = DbStorageProfile::new_local("Profile B", storage_b.to_str().unwrap(), false);
+    db.insert_storage_profile(&dest_profile).await.unwrap();
+
+    // Record old file paths for checking pending deletions
+    let old_file_paths: Vec<String> = mgr
+        .get_files_for_release(&release_id)
+        .await
+        .unwrap()
+        .iter()
+        .map(|f| f.source_path.clone().unwrap())
+        .collect();
+
+    // Execute transfer
+    let shared_mgr = bae_core::library::SharedLibraryManager::new(mgr);
+    let service = TransferService::new(shared_mgr.clone(), None, library_path.clone());
+    let rx = service.transfer(
+        release_id.clone(),
+        TransferTarget::Profile(dest_profile.clone()),
+    );
+    let events = collect_progress(rx).await;
+
+    // Verify success
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, TransferProgress::Complete { .. })));
+
+    // Verify DB: release now linked to dest profile
+    let profile = shared_mgr
+        .get()
+        .get_storage_profile_for_release(&release_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(profile.id, dest_profile.id);
+
+    // Verify new files exist in storage_b
+    let new_files = shared_mgr
+        .get()
+        .get_files_for_release(&release_id)
+        .await
+        .unwrap();
+    assert_eq!(new_files.len(), original_files.len());
+    for file in &new_files {
+        let source_path = file.source_path.as_ref().unwrap();
+        assert!(
+            source_path.contains(storage_b.to_str().unwrap()),
+            "New file should be in storage_b: {}",
+            source_path
+        );
+        assert!(Path::new(source_path).exists());
+    }
+
+    // Verify old files are queued for deferred deletion
+    let pending = read_pending_deletions(&library_path).await;
+    assert_eq!(pending.len(), old_file_paths.len());
+    for deletion in &pending {
+        match deletion {
+            PendingDeletion::Local { path } => {
+                assert!(
+                    old_file_paths.contains(path),
+                    "Pending deletion should be an old file: {}",
+                    path
+                );
+            }
+            _ => panic!("Expected Local deletion for local profile transfer"),
+        }
+    }
+}
+
+/// Eject from a local profile to a user-chosen folder.
+/// Verifies: files written to target folder, release_storage removed, new DbFile records
+/// point to ejected location, old files queued for deletion.
+#[tokio::test]
+async fn test_eject_from_local_profile() {
+    tracing_init();
+
+    let temp = TempDir::new().unwrap();
+    let storage_dir = temp.path().join("storage");
+    let eject_dir = temp.path().join("ejected");
+    let library_path = temp.path().join("library");
+    tokio::fs::create_dir_all(&storage_dir).await.unwrap();
+    tokio::fs::create_dir_all(&library_path).await.unwrap();
+
+    let (db, mgr) = setup_db(&temp).await;
+    let (_album_id, release_id) = create_album_and_release(&db).await;
+
+    // Create source profile and files
+    let source_profile =
+        DbStorageProfile::new_local("Managed Storage", storage_dir.to_str().unwrap(), false);
+    db.insert_storage_profile(&source_profile).await.unwrap();
+    let original_files =
+        create_profile_files(&db, &mgr, &release_id, &source_profile, &storage_dir).await;
+
+    // Execute eject
+    let shared_mgr = bae_core::library::SharedLibraryManager::new(mgr);
+    let service = TransferService::new(shared_mgr.clone(), None, library_path.clone());
+    let rx = service.transfer(release_id.clone(), TransferTarget::Eject(eject_dir.clone()));
+    let events = collect_progress(rx).await;
+
+    // Verify success
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, TransferProgress::Complete { .. })));
+
+    // Verify DB: no storage profile linked
+    let profile = shared_mgr
+        .get()
+        .get_storage_profile_for_release(&release_id)
+        .await
+        .unwrap();
+    assert!(
+        profile.is_none(),
+        "Ejected release should not have a storage profile"
+    );
+
+    // Verify files exist in eject directory
+    for (name, data) in &original_files {
+        let ejected_path = eject_dir.join(name);
+        assert!(
+            ejected_path.exists(),
+            "Ejected file should exist: {:?}",
+            ejected_path
+        );
+        let ejected_data = tokio::fs::read(&ejected_path).await.unwrap();
+        assert_eq!(&ejected_data, data, "Ejected file content should match");
+    }
+
+    // Verify DB: new file records point to ejected location
+    let new_files = shared_mgr
+        .get()
+        .get_files_for_release(&release_id)
+        .await
+        .unwrap();
+    assert_eq!(new_files.len(), original_files.len());
+    for file in &new_files {
+        let source_path = file.source_path.as_ref().unwrap();
+        assert!(
+            source_path.contains(eject_dir.to_str().unwrap()),
+            "Ejected file record should point to eject dir: {}",
+            source_path
+        );
+    }
+
+    // Verify old files queued for deletion
+    let pending = read_pending_deletions(&library_path).await;
+    assert_eq!(pending.len(), original_files.len());
+}
+
+/// Transfer with no files should fail gracefully.
+#[tokio::test]
+async fn test_transfer_empty_release_fails() {
+    tracing_init();
+
+    let temp = TempDir::new().unwrap();
+    let storage_dir = temp.path().join("storage");
+    let library_path = temp.path().join("library");
+    tokio::fs::create_dir_all(&storage_dir).await.unwrap();
+    tokio::fs::create_dir_all(&library_path).await.unwrap();
+
+    let (db, mgr) = setup_db(&temp).await;
+    let (_album_id, release_id) = create_album_and_release(&db).await;
+    // No files created
+
+    let dest_profile = DbStorageProfile::new_local("Storage", storage_dir.to_str().unwrap(), false);
+    db.insert_storage_profile(&dest_profile).await.unwrap();
+
+    let shared_mgr = bae_core::library::SharedLibraryManager::new(mgr);
+    let service = TransferService::new(shared_mgr, None, library_path);
+    let rx = service.transfer(release_id.clone(), TransferTarget::Profile(dest_profile));
+    let events = collect_progress(rx).await;
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, TransferProgress::Failed { .. })),
+        "Transfer with no files should fail"
+    );
+}

--- a/bae-desktop/src/ui/components/album_detail/page.rs
+++ b/bae-desktop/src/ui/components/album_detail/page.rs
@@ -8,6 +8,7 @@ use crate::ui::Route;
 use bae_ui::display_types::PlaybackDisplay;
 use bae_ui::stores::{
     AlbumDetailStateStoreExt, AppStateStoreExt, PlaybackStatus, PlaybackUiStateStoreExt,
+    StorageProfilesStateStoreExt,
 };
 use dioxus::prelude::*;
 use rfd::AsyncFileDialog;
@@ -221,6 +222,23 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
         }
     });
 
+    // Transfer callbacks
+    let on_transfer_to_profile = EventHandler::new({
+        let app = app.clone();
+        move |(release_id, profile_id): (String, String)| {
+            app.transfer_release_storage(&release_id, &profile_id);
+        }
+    });
+    let on_eject = EventHandler::new({
+        let app = app.clone();
+        move |release_id: String| {
+            app.eject_release_storage(&release_id);
+        }
+    });
+
+    // Available storage profiles for transfer
+    let available_profiles = app.state.storage_profiles().profiles().read().clone();
+
     // Release select callback - navigate to new URL which triggers data reload
     let on_release_select = {
         move |new_release_id: String| {
@@ -261,6 +279,9 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
                 on_artist_click,
                 on_play_album,
                 on_add_album_to_queue,
+                on_transfer_to_profile,
+                on_eject,
+                available_profiles,
             }
         } else {
             AlbumDetailLoading {}

--- a/bae-mocks/src/mocks/album_detail.rs
+++ b/bae-mocks/src/mocks/album_detail.rs
@@ -144,6 +144,9 @@ pub fn AlbumDetailMock(initial_state: Option<String>) -> Element {
         error: None,
         import_progress: None,
         import_error: None,
+        storage_profile: None,
+        transfer_progress: None,
+        transfer_error: None,
     });
 
     // Get tracks lens for per-track reactivity
@@ -190,6 +193,9 @@ pub fn AlbumDetailMock(initial_state: Option<String>) -> Element {
                 on_artist_click: |_| {},
                 on_play_album: |_| {},
                 on_add_album_to_queue: |_| {},
+                on_transfer_to_profile: |_| {},
+                on_eject: |_| {},
+                available_profiles: vec![],
             }
         }
     }

--- a/bae-mocks/src/pages/album_detail.rs
+++ b/bae-mocks/src/pages/album_detail.rs
@@ -39,6 +39,9 @@ pub fn AlbumDetail(album_id: String) -> Element {
         error: None,
         import_progress: None,
         import_error: None,
+        storage_profile: None,
+        transfer_progress: None,
+        transfer_error: None,
     });
 
     // Get tracks lens for per-track reactivity
@@ -72,6 +75,9 @@ pub fn AlbumDetail(album_id: String) -> Element {
                 },
                 on_play_album: |_| {},
                 on_add_album_to_queue: |_| {},
+                on_transfer_to_profile: |_| {},
+                on_eject: |_| {},
+                available_profiles: vec![],
             }
         } else {
             ErrorDisplay { message: "Album not found in demo data".to_string() }

--- a/bae-ui/src/components/album_detail/storage_modal.rs
+++ b/bae-ui/src/components/album_detail/storage_modal.rs
@@ -1,9 +1,14 @@
-//! Storage modal — shows file list and storage status for a release
+//! Storage modal — shows storage status, file list, and transfer actions
 
-use crate::components::icons::XIcon;
+use crate::components::icons::{
+    AlertTriangleIcon, ArrowRightLeftIcon, CloudIcon, DownloadIcon, FolderIcon, HardDriveIcon,
+    LoaderIcon, LockIcon, XIcon,
+};
+use crate::components::settings::StorageProfile;
 use crate::components::utils::format_file_size;
 use crate::components::Modal;
 use crate::display_types::File;
+use crate::stores::album_detail::TransferProgressState;
 use dioxus::prelude::*;
 
 #[component]
@@ -11,10 +16,26 @@ pub fn StorageModal(
     is_open: ReadSignal<bool>,
     on_close: EventHandler<()>,
     files: Vec<File>,
+    storage_profile: Option<StorageProfile>,
+    transfer_progress: Option<TransferProgressState>,
+    transfer_error: Option<String>,
+    available_profiles: Vec<StorageProfile>,
+    on_transfer_to_profile: EventHandler<String>,
+    on_eject: EventHandler<()>,
 ) -> Element {
+    let total_size: i64 = files
+        .iter()
+        .map(|f| f.file_size)
+        .collect::<Vec<_>>()
+        .iter()
+        .sum();
+    let is_self_managed = storage_profile.is_none();
+    let is_transferring = transfer_progress.is_some();
+
     rsx! {
         Modal { is_open, on_close: move |_| on_close.call(()),
             div { class: "bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col",
+                // Header
                 div { class: "flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-700",
                     h2 { class: "text-xl font-bold text-white", "Storage" }
                     button {
@@ -23,17 +44,39 @@ pub fn StorageModal(
                         XIcon { class: "w-5 h-5" }
                     }
                 }
+
                 div { class: "p-6 overflow-y-auto flex-1 space-y-6",
-                    // Storage status placeholder
-                    div { class: "flex items-center justify-between p-4 bg-gray-700/50 rounded-lg",
-                        div {
-                            div { class: "text-sm font-medium text-white", "No storage profile" }
-                            div { class: "text-xs text-gray-400 mt-1",
-                                "Files are referenced from their original location"
+                    // Current storage status
+                    StorageStatusSection {
+                        storage_profile: storage_profile.clone(),
+                        total_size,
+                        file_count: files.len(),
+                    }
+
+                    // Transfer progress
+                    if let Some(ref progress) = transfer_progress {
+                        TransferProgressSection { progress: progress.clone() }
+                    }
+
+                    // Transfer error
+                    if let Some(ref error) = transfer_error {
+                        div { class: "flex items-start gap-3 p-4 bg-red-900/30 border border-red-700/50 rounded-lg",
+                            AlertTriangleIcon { class: "w-5 h-5 text-red-400 shrink-0 mt-0.5" }
+                            div {
+                                div { class: "text-sm font-medium text-red-300", "Transfer failed" }
+                                div { class: "text-xs text-red-400 mt-1", {error.clone()} }
                             }
                         }
-                        button { class: "px-3 py-1.5 text-xs font-medium text-blue-400 hover:text-blue-300 border border-blue-500/50 hover:border-blue-400/50 rounded-lg transition-colors",
-                            "Set Up Storage"
+                    }
+
+                    // Transfer actions
+                    if !is_transferring {
+                        TransferActionsSection {
+                            is_self_managed,
+                            storage_profile: storage_profile.clone(),
+                            available_profiles,
+                            on_transfer_to_profile,
+                            on_eject,
                         }
                     }
 
@@ -57,6 +100,210 @@ pub fn StorageModal(
                                     }
                                 }
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn StorageStatusSection(
+    storage_profile: Option<StorageProfile>,
+    total_size: i64,
+    file_count: usize,
+) -> Element {
+    match storage_profile {
+        Some(ref profile) => {
+            let is_cloud = profile.location == crate::components::settings::StorageLocation::Cloud;
+            rsx! {
+                div { class: "p-4 bg-gray-700/50 rounded-lg space-y-2",
+                    div { class: "flex items-center gap-3",
+                        div { class: "p-2 rounded-lg bg-blue-500/20",
+                            if is_cloud {
+                                CloudIcon { class: "w-5 h-5 text-blue-400" }
+                            } else {
+                                HardDriveIcon { class: "w-5 h-5 text-blue-400" }
+                            }
+                        }
+                        div {
+                            div { class: "text-sm font-medium text-white", {profile.name.clone()} }
+                            div { class: "text-xs text-gray-400 mt-0.5",
+                                if is_cloud {
+                                    {
+                                        format!(
+                                            "Cloud storage • {} files • {}",
+                                            file_count,
+                                            format_file_size(total_size),
+                                        )
+                                    }
+                                } else {
+                                    {
+                                        format!(
+                                            "Local storage • {} files • {}",
+                                            file_count,
+                                            format_file_size(total_size),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        if profile.encrypted {
+                            div { class: "ml-auto",
+                                LockIcon { class: "w-4 h-4 text-yellow-400" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None => {
+            rsx! {
+                div { class: "p-4 bg-gray-700/50 rounded-lg",
+                    div { class: "flex items-center gap-3",
+                        div { class: "p-2 rounded-lg bg-gray-600/50",
+                            FolderIcon { class: "w-5 h-5 text-gray-400" }
+                        }
+                        div {
+                            div { class: "text-sm font-medium text-white", "Self-managed" }
+                            div { class: "text-xs text-gray-400 mt-0.5",
+                                {
+                                    format!(
+                                        "Files referenced from original location • {} files • {}",
+                                        file_count,
+                                        format_file_size(total_size),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn TransferProgressSection(progress: TransferProgressState) -> Element {
+    let overall_percent = if progress.total_files > 0 {
+        let file_weight = 100.0 / progress.total_files as f64;
+        let completed = progress.file_index as f64 * file_weight;
+        let current = progress.percent as f64 / 100.0 * file_weight;
+        (completed + current) as u8
+    } else {
+        0
+    };
+
+    rsx! {
+        div { class: "p-4 bg-blue-900/20 border border-blue-700/30 rounded-lg space-y-3",
+            div { class: "flex items-center gap-2",
+                LoaderIcon { class: "w-4 h-4 text-blue-400 animate-spin" }
+                div { class: "text-sm font-medium text-blue-300", "Transferring..." }
+            }
+            div { class: "text-xs text-gray-400",
+                {
+                    format!(
+                        "File {} of {}: {}",
+                        progress.file_index + 1,
+                        progress.total_files,
+                        progress.filename,
+                    )
+                }
+            }
+            // Progress bar
+            div { class: "w-full bg-gray-700 rounded-full h-2",
+                div {
+                    class: "bg-blue-500 h-2 rounded-full transition-all duration-300",
+                    style: "width: {overall_percent}%",
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn TransferActionsSection(
+    is_self_managed: bool,
+    storage_profile: Option<StorageProfile>,
+    available_profiles: Vec<StorageProfile>,
+    on_transfer_to_profile: EventHandler<String>,
+    on_eject: EventHandler<()>,
+) -> Element {
+    // Filter out the current profile from available targets
+    let current_profile_id = storage_profile.as_ref().map(|p| p.id.clone());
+    let target_profiles: Vec<&StorageProfile> = available_profiles
+        .iter()
+        .filter(|p| Some(&p.id) != current_profile_id.as_ref())
+        .collect();
+
+    let has_targets = !target_profiles.is_empty();
+    let can_eject = !is_self_managed;
+
+    if !has_targets && !can_eject {
+        return rsx! {};
+    }
+
+    rsx! {
+        div { class: "space-y-3",
+            div { class: "text-sm font-medium text-gray-300",
+                if is_self_managed {
+                    "Move to storage"
+                } else {
+                    "Transfer"
+                }
+            }
+
+            if has_targets {
+                div { class: "space-y-2",
+                    for profile in target_profiles {
+                        {
+                            let profile_id = profile.id.clone();
+                            let is_cloud = profile.location
+                                == crate::components::settings::StorageLocation::Cloud;
+                            rsx! {
+                                button {
+                                    class: "w-full flex items-center gap-3 p-3 bg-gray-700/50 hover:bg-gray-700 rounded-lg transition-colors text-left",
+                                    onclick: move |_| on_transfer_to_profile.call(profile_id.clone()),
+                                    div { class: "p-1.5 rounded bg-gray-600/50",
+                                        if is_cloud {
+                                            CloudIcon { class: "w-4 h-4 text-gray-300" }
+                                        } else {
+                                            HardDriveIcon { class: "w-4 h-4 text-gray-300" }
+                                        }
+                                    }
+                                    div { class: "flex-1",
+                                        div { class: "text-sm text-white", {profile.name.clone()} }
+                                        div { class: "text-xs text-gray-400",
+                                            if is_cloud {
+                                                "Cloud storage"
+                                            } else {
+                                                "Local storage"
+                                            }
+                                            if profile.encrypted {
+                                                " • Encrypted"
+                                            }
+                                        }
+                                    }
+                                    ArrowRightLeftIcon { class: "w-4 h-4 text-gray-400" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if can_eject {
+                button {
+                    class: "w-full flex items-center gap-3 p-3 bg-gray-700/50 hover:bg-gray-700 rounded-lg transition-colors text-left",
+                    onclick: move |_| on_eject.call(()),
+                    div { class: "p-1.5 rounded bg-gray-600/50",
+                        DownloadIcon { class: "w-4 h-4 text-gray-300" }
+                    }
+                    div { class: "flex-1",
+                        div { class: "text-sm text-white", "Eject to folder" }
+                        div { class: "text-xs text-gray-400",
+                            "Export files to a local folder and remove from managed storage"
                         }
                     }
                 }

--- a/bae-ui/src/components/icons.rs
+++ b/bae-ui/src/components/icons.rs
@@ -941,3 +941,78 @@ pub fn CopyIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {
         }
     }
 }
+
+/// Lucide cloud icon
+#[component]
+pub fn CloudIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {
+    rsx! {
+        svg {
+            class: "{class}",
+            xmlns: "http://www.w3.org/2000/svg",
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            stroke_width: "2",
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            path { d: "M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" }
+        }
+    }
+}
+
+/// Lucide arrow-right-left icon (transfer/move)
+#[component]
+pub fn ArrowRightLeftIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {
+    rsx! {
+        svg {
+            class: "{class}",
+            xmlns: "http://www.w3.org/2000/svg",
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            stroke_width: "2",
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            path { d: "m16 3 4 4-4 4" }
+            path { d: "M20 7H4" }
+            path { d: "m8 21-4-4 4-4" }
+            path { d: "M4 17h16" }
+        }
+    }
+}
+
+/// Lucide hard-drive icon (local storage)
+#[component]
+pub fn HardDriveIcon(#[props(default = "w-4 h-4")] class: &'static str) -> Element {
+    rsx! {
+        svg {
+            class: "{class}",
+            xmlns: "http://www.w3.org/2000/svg",
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            stroke_width: "2",
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            line {
+                x1: "22",
+                x2: "2",
+                y1: "12",
+                y2: "12",
+            }
+            path { d: "M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" }
+            line {
+                x1: "6",
+                x2: "6.01",
+                y1: "16",
+                y2: "16",
+            }
+            line {
+                x1: "10",
+                x2: "10.01",
+                y1: "16",
+                y2: "16",
+            }
+        }
+    }
+}

--- a/bae-ui/src/components/mod.rs
+++ b/bae-ui/src/components/mod.rs
@@ -43,12 +43,12 @@ pub use helpers::{
     BackButton, ConfirmDialogView, ErrorDisplay, LoadingSpinner, Tooltip, TooltipBubble,
 };
 pub use icons::{
-    AlertTriangleIcon, ArrowDownIcon, ArrowLeftIcon, ArrowUpIcon, CheckIcon, ChevronDownIcon,
-    ChevronLeftIcon, ChevronRightIcon, CloudOffIcon, DiscIcon, DownloadIcon, EllipsisIcon,
-    ExternalLinkIcon, FileIcon, FileTextIcon, FolderIcon, ImageIcon, InfoIcon, KeyIcon, LayersIcon,
-    LoaderIcon, LockIcon, MenuIcon, MonitorIcon, PauseIcon, PencilIcon, PlayIcon, PlusIcon,
-    RefreshIcon, RowsIcon, SearchIcon, SettingsIcon, SkipBackIcon, SkipForwardIcon, StarIcon,
-    TrashIcon, UploadIcon, UserIcon, XIcon,
+    AlertTriangleIcon, ArrowDownIcon, ArrowLeftIcon, ArrowRightLeftIcon, ArrowUpIcon, CheckIcon,
+    ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon, CloudIcon, CloudOffIcon, DiscIcon,
+    DownloadIcon, EllipsisIcon, ExternalLinkIcon, FileIcon, FileTextIcon, FolderIcon,
+    HardDriveIcon, ImageIcon, InfoIcon, KeyIcon, LayersIcon, LoaderIcon, LockIcon, MenuIcon,
+    MonitorIcon, PauseIcon, PencilIcon, PlayIcon, PlusIcon, RefreshIcon, RowsIcon, SearchIcon,
+    SettingsIcon, SkipBackIcon, SkipForwardIcon, StarIcon, TrashIcon, UploadIcon, UserIcon, XIcon,
 };
 pub use import::{
     CdDriveStatus, CdSelectorView, ConfirmationView, DiscIdLookupErrorView, FileListView,

--- a/bae-ui/src/stores/album_detail.rs
+++ b/bae-ui/src/stores/album_detail.rs
@@ -1,7 +1,17 @@
 //! Album detail state store
 
+use crate::components::settings::StorageProfile;
 use crate::display_types::{Album, Artist, File, Image, Release, Track};
 use dioxus::prelude::*;
+
+/// Transfer progress state
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransferProgressState {
+    pub file_index: usize,
+    pub total_files: usize,
+    pub filename: String,
+    pub percent: u8,
+}
 
 /// State for the album detail view
 #[derive(Clone, Debug, Default, PartialEq, Store)]
@@ -34,4 +44,10 @@ pub struct AlbumDetailState {
     pub import_progress: Option<u8>,
     /// Import error message if import failed
     pub import_error: Option<String>,
+    /// Storage profile for the current release (None = self-managed)
+    pub storage_profile: Option<StorageProfile>,
+    /// Transfer progress (Some when a transfer is active)
+    pub transfer_progress: Option<TransferProgressState>,
+    /// Transfer error message
+    pub transfer_error: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Add transfer service to move releases between storage profiles (self-managed → profile, profile → profile, profile → eject)
- Deferred cleanup of old files via manifest, with 30s grace period for in-flight playback/streams
- Rewrite storage modal UI with profile display, transfer actions, and progress bar
- Wire up app service with progress channel subscription and startup cleanup

## Test plan

- [x] Unit tests for cleanup module (7 tests): manifest CRUD, local deletion, not-found handling, missing profile drops entry
- [x] Integration tests for transfer service (4 tests): self-managed → local, local → local, local → eject, empty release fails
- [x] All existing tests pass (189 unit + 12 integration)
- [ ] Manual test: import release, transfer to local profile, verify playback
- [ ] Manual test: transfer between profiles, verify old files cleaned up after delay
- [ ] Manual test: eject from profile, verify files exported and playback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)