### PR TITLE
Show import spinner immediately when button is clicked

### DIFF
--- a/bae-desktop/src/ui/components/import/workflow/cd_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/cd_import.rs
@@ -434,6 +434,10 @@ pub fn CdImport() -> Element {
         let app = app.clone();
         move |_| {
             let app = app.clone();
+            app.state
+                .import()
+                .write()
+                .dispatch(CandidateEvent::StartImport);
             spawn(async move {
                 let confirmed = app.state.import().read().get_confirmed_candidate();
                 if let Some(candidate) = confirmed {
@@ -441,7 +445,19 @@ pub fn CdImport() -> Element {
                         confirm_and_start_import(&app, candidate, ImportSource::Cd).await
                     {
                         warn!("Failed to confirm and start import: {}", e);
+                        app.state
+                            .import()
+                            .write()
+                            .dispatch(CandidateEvent::ImportFailed(e));
                     }
+                } else {
+                    warn!("No confirmed candidate after StartImport");
+                    app.state
+                        .import()
+                        .write()
+                        .dispatch(CandidateEvent::ImportFailed(
+                            "No candidate selected".to_string(),
+                        ));
                 }
             });
         }

--- a/bae-desktop/src/ui/components/import/workflow/folder_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/folder_import.rs
@@ -349,6 +349,10 @@ pub fn FolderImport() -> Element {
         let app = app.clone();
         move |_| {
             let app = app.clone();
+            app.state
+                .import()
+                .write()
+                .dispatch(CandidateEvent::StartImport);
             spawn(async move {
                 let confirmed = app.state.import().read().get_confirmed_candidate();
                 if let Some(candidate) = confirmed {
@@ -356,7 +360,19 @@ pub fn FolderImport() -> Element {
                         confirm_and_start_import(&app, candidate, ImportSource::Folder).await
                     {
                         warn!("Failed to confirm and start import: {}", e);
+                        app.state
+                            .import()
+                            .write()
+                            .dispatch(CandidateEvent::ImportFailed(e));
                     }
+                } else {
+                    warn!("No confirmed candidate after StartImport");
+                    app.state
+                        .import()
+                        .write()
+                        .dispatch(CandidateEvent::ImportFailed(
+                            "No candidate selected".to_string(),
+                        ));
                 }
             });
         }

--- a/bae-desktop/src/ui/components/import/workflow/torrent_import.rs
+++ b/bae-desktop/src/ui/components/import/workflow/torrent_import.rs
@@ -461,6 +461,10 @@ pub fn TorrentImport() -> Element {
         let app = app.clone();
         move |_| {
             let app = app.clone();
+            app.state
+                .import()
+                .write()
+                .dispatch(CandidateEvent::StartImport);
             spawn(async move {
                 let confirmed = app.state.import().read().get_confirmed_candidate();
                 if let Some(candidate) = confirmed {
@@ -468,7 +472,19 @@ pub fn TorrentImport() -> Element {
                         confirm_and_start_import(&app, candidate, ImportSource::Torrent).await
                     {
                         warn!("Failed to confirm and start import: {}", e);
+                        app.state
+                            .import()
+                            .write()
+                            .dispatch(CandidateEvent::ImportFailed(e));
                     }
+                } else {
+                    warn!("No confirmed candidate after StartImport");
+                    app.state
+                        .import()
+                        .write()
+                        .dispatch(CandidateEvent::ImportFailed(
+                            "No candidate selected".to_string(),
+                        ));
                 }
             });
         }

--- a/bae-desktop/src/ui/import_helpers.rs
+++ b/bae-desktop/src/ui/import_helpers.rs
@@ -655,9 +655,6 @@ pub async fn confirm_and_start_import(
             .ok_or_else(|| "No candidate selected for import".to_string())?
     };
 
-    // Signal that import is starting
-    import_store.write().dispatch(CandidateEvent::StartImport);
-
     let import_id = uuid::Uuid::new_v4().to_string();
 
     // Get state from store

--- a/bae-ui/src/components/import/workflow/cd_import.rs
+++ b/bae-ui/src/components/import/workflow/cd_import.rs
@@ -352,7 +352,7 @@ fn CdConfirmContent(
             });
             let (importing, completed, album_id, preparing, error) = match &cs.phase {
                 ConfirmPhase::Ready => (false, false, None, None, None),
-                ConfirmPhase::Preparing(msg) => (false, false, None, Some(msg.clone()), None),
+                ConfirmPhase::Preparing(msg) => (true, false, None, Some(msg.clone()), None),
                 ConfirmPhase::Importing => (true, false, None, None, None),
                 ConfirmPhase::Failed(err) => (false, false, None, None, Some(err.clone())),
                 ConfirmPhase::Completed(id) => (false, true, Some(id.clone()), None, None),

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -401,7 +401,7 @@ fn ConfirmStep(
             });
             let (importing, completed, album_id, preparing, error) = match &cs.phase {
                 ConfirmPhase::Ready => (false, false, None, None, None),
-                ConfirmPhase::Preparing(msg) => (false, false, None, Some(msg.clone()), None),
+                ConfirmPhase::Preparing(msg) => (true, false, None, Some(msg.clone()), None),
                 ConfirmPhase::Importing => (true, false, None, None, None),
                 ConfirmPhase::Failed(err) => (false, false, None, None, Some(err.clone())),
                 ConfirmPhase::Completed(id) => (false, true, Some(id.clone()), None, None),

--- a/bae-ui/src/components/import/workflow/torrent_import.rs
+++ b/bae-ui/src/components/import/workflow/torrent_import.rs
@@ -385,7 +385,7 @@ fn TorrentConfirmContent(
             });
             let (importing, completed, album_id, preparing, error) = match &cs.phase {
                 ConfirmPhase::Ready => (false, false, None, None, None),
-                ConfirmPhase::Preparing(msg) => (false, false, None, Some(msg.clone()), None),
+                ConfirmPhase::Preparing(msg) => (true, false, None, Some(msg.clone()), None),
                 ConfirmPhase::Importing => (true, false, None, None, None),
                 ConfirmPhase::Failed(err) => (false, false, None, None, Some(err.clone())),
                 ConfirmPhase::Completed(id) => (false, true, Some(id.clone()), None, None),


### PR DESCRIPTION
## Summary
- Move `StartImport` dispatch from inside `spawn(async)` to the synchronous `on_confirm` handler so Dioxus renders the spinner before any async work begins
- Fix `Preparing` phase to set `is_importing = true` so the button actually disables and shows a spinner (was `false`)
- Dispatch `ImportFailed` on error paths so the UI doesn't get stuck in the Preparing state

## Test plan
- [ ] Click Import on a folder import — spinner should appear instantly, not after the MusicBrainz/Discogs fetch
- [ ] Verify the button is disabled during the Preparing phase (no double-clicks)
- [ ] Disconnect network and try importing — should show error, not get stuck spinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)