### PR TITLE
Multi-library UI: per-library keyring, library settings tab

### DIFF
--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -305,7 +305,7 @@ impl ImportService {
             scan_tx,
             scan_events_tx,
             // Tests always run in dev mode
-            KeyService::new(true),
+            KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         )
     }
@@ -369,7 +369,7 @@ impl ImportService {
             scan_tx,
             scan_events_tx,
             // Tests always run in dev mode
-            KeyService::new(true),
+            KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         )
     }

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -47,7 +47,7 @@ async fn test_cue_flac_records_track_positions() {
         shared_library_manager,
         encryption_service,
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
     let discogs_release = create_test_discogs_release();
@@ -197,7 +197,7 @@ async fn test_cue_flac_playback_uses_track_positions() {
         shared_library_manager,
         encryption_service.clone(),
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
     let discogs_release = create_test_discogs_release();
@@ -351,7 +351,7 @@ async fn test_cue_flac_decoded_duration_matches_cue_timing() {
         shared_library_manager,
         encryption_service.clone(),
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
     let discogs_release = create_test_discogs_release();
@@ -489,7 +489,7 @@ async fn test_cue_flac_byte_ranges_have_no_gaps() {
         shared_library_manager,
         encryption_service,
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
 
@@ -643,7 +643,7 @@ async fn test_cue_flac_builds_dense_seektable() {
         shared_library_manager,
         encryption_service,
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
 

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -60,7 +60,7 @@ impl PlaybackTestFixture {
             shared_library_manager.clone(),
             encryption_service.clone(),
             database_arc,
-            bae_core::keys::KeyService::new(true),
+            bae_core::keys::KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         );
         let master_year = discogs_release.year.unwrap_or(2024);
@@ -368,7 +368,7 @@ impl CueFlacTestFixture {
             shared_library_manager.clone(),
             encryption_service.clone(),
             database_arc,
-            bae_core::keys::KeyService::new(true),
+            bae_core::keys::KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         );
 
@@ -2005,7 +2005,7 @@ impl HighSampleRateTestFixture {
             shared_library_manager.clone(),
             encryption_service.clone(),
             database_arc,
-            bae_core::keys::KeyService::new(true),
+            bae_core::keys::KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         );
 

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -176,7 +176,7 @@ impl CueFlacTestFixture {
             shared_library_manager.clone(),
             encryption_service.clone(),
             database_arc,
-            bae_core::keys::KeyService::new(true),
+            bae_core::keys::KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         );
 

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -90,7 +90,7 @@ async fn test_storageless_import() {
         shared_library_manager,
         encryption_service,
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
 
@@ -241,7 +241,7 @@ async fn test_storageless_delete_preserves_files() {
         shared_library_manager.clone(),
         encryption_service,
         database_arc,
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
 
@@ -410,7 +410,7 @@ async fn run_storage_test(location: StorageLocation, encrypted: bool) {
             shared_library_manager,
             encryption_service.clone(),
             database_arc,
-            bae_core::keys::KeyService::new(true),
+            bae_core::keys::KeyService::new(true, "test".to_string()),
             std::env::temp_dir().join("bae-test-covers"),
         )
     };
@@ -928,7 +928,7 @@ async fn run_real_album_test(album_dir: PathBuf, location: StorageLocation, encr
         shared_library_manager,
         encryption_service.clone(),
         database_arc.clone(),
-        bae_core::keys::KeyService::new(true),
+        bae_core::keys::KeyService::new(true, "test".to_string()),
         std::env::temp_dir().join("bae-test-covers"),
     );
     let (_album_id, release_id) = import_handle

--- a/bae-desktop/src/ui/components/settings/library.rs
+++ b/bae-desktop/src/ui/components/settings/library.rs
@@ -1,0 +1,140 @@
+//! Library settings section — business logic wrapper
+
+use bae_core::config::Config;
+use bae_ui::LibrarySectionView;
+use dioxus::prelude::*;
+use std::path::PathBuf;
+use tracing::{error, info};
+
+use crate::ui::app_service::use_app;
+
+/// Convert bae-core LibraryInfo to bae-ui LibraryInfo (PathBuf -> String)
+fn discover_ui_libraries() -> Vec<bae_ui::LibraryInfo> {
+    Config::discover_libraries()
+        .into_iter()
+        .map(|lib| bae_ui::LibraryInfo {
+            id: lib.id,
+            name: lib.name,
+            path: lib.path.to_string_lossy().to_string(),
+            is_active: lib.is_active,
+        })
+        .collect()
+}
+
+#[component]
+pub fn LibrarySection() -> Element {
+    let app = use_app();
+    let mut libraries = use_signal(discover_ui_libraries);
+
+    let on_switch = {
+        let app = app.clone();
+        move |path: String| {
+            let library_path = PathBuf::from(&path);
+            let mut config = app.config.clone();
+            config.library_path = library_path;
+            if let Err(e) = config.save_library_path() {
+                error!("Failed to save library path: {e}");
+                return;
+            }
+
+            info!("Switching to library at {path}");
+            super::super::welcome::relaunch();
+        }
+    };
+
+    let on_create = {
+        let app = app.clone();
+        move |_| {
+            let dev_mode = app.key_service.is_dev_mode();
+            let config = match Config::create_new_library(dev_mode) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("Failed to create new library: {e}");
+                    return;
+                }
+            };
+
+            if let Err(e) = config.save_library_path() {
+                error!("Failed to save library pointer: {e}");
+                return;
+            }
+
+            super::super::welcome::relaunch();
+        }
+    };
+
+    let on_add_existing = {
+        let app = app.clone();
+        move |_| {
+            let config = app.config.clone();
+            spawn(async move {
+                let picked = rfd::AsyncFileDialog::new()
+                    .set_title("Choose a folder containing a bae library")
+                    .pick_folder()
+                    .await;
+
+                let folder = match picked {
+                    Some(f) => f,
+                    None => return,
+                };
+
+                let path = PathBuf::from(folder.path());
+                let config_path = path.join("config.yaml");
+
+                if !config_path.exists() {
+                    error!("Selected folder has no config.yaml: {}", path.display());
+                    return;
+                }
+
+                if let Err(e) = Config::add_known_library(&path) {
+                    error!("Failed to register library: {e}");
+                    return;
+                }
+
+                // Switch to the added library
+                let mut config = config;
+                config.library_path = path;
+                if let Err(e) = config.save_library_path() {
+                    error!("Failed to save library path: {e}");
+                    return;
+                }
+
+                info!("Added and switching to existing library");
+                super::super::welcome::relaunch();
+            });
+        }
+    };
+
+    let on_rename = move |(path, new_name): (String, String)| {
+        let library_path = PathBuf::from(&path);
+        if let Err(e) = Config::rename_library(&library_path, &new_name) {
+            error!("Failed to rename library: {e}");
+            return;
+        }
+
+        info!("Renamed library at {path} to '{new_name}'");
+        libraries.set(discover_ui_libraries());
+    };
+
+    let on_remove = move |path: String| {
+        let library_path = PathBuf::from(&path);
+        if let Err(e) = Config::remove_known_library(&library_path) {
+            error!("Failed to remove library from known list: {e}");
+            return;
+        }
+
+        info!("Removed library {path} from known list");
+        libraries.set(discover_ui_libraries());
+    };
+
+    rsx! {
+        LibrarySectionView {
+            libraries: libraries.read().clone(),
+            on_switch,
+            on_create,
+            on_add_existing,
+            on_rename,
+            on_remove,
+        }
+    }
+}

--- a/bae-desktop/src/ui/components/settings/mod.rs
+++ b/bae-desktop/src/ui/components/settings/mod.rs
@@ -2,6 +2,7 @@ mod about;
 mod bittorrent;
 mod cloud;
 mod discogs;
+mod library;
 mod storage_profiles;
 mod subsonic;
 
@@ -19,6 +20,9 @@ pub fn Settings() -> Element {
             active_tab: *active_tab.read(),
             on_tab_change: move |tab| active_tab.set(tab),
             match *active_tab.read() {
+                SettingsTab::Library => rsx! {
+                    library::LibrarySection {}
+                },
                 SettingsTab::Storage => rsx! {
                     storage_profiles::StorageProfilesSection {}
                 },

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -3,8 +3,8 @@
 use bae_ui::stores::CloudSyncStatus;
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, CloudSectionView,
-    DiscogsSectionView, SettingsTab, SettingsView, StorageLocation, StorageProfile,
-    StorageProfilesSectionView, SubsonicSectionView,
+    DiscogsSectionView, LibraryInfo, LibrarySectionView, SettingsTab, SettingsView,
+    StorageLocation, StorageProfile, StorageProfilesSectionView, SubsonicSectionView,
 };
 use dioxus::prelude::*;
 
@@ -18,6 +18,16 @@ pub fn Settings() -> Element {
             on_tab_change: move |tab| active_tab.set(tab),
 
             match *active_tab.read() {
+                SettingsTab::Library => rsx! {
+                    LibrarySectionView {
+                        libraries: mock_libraries(),
+                        on_switch: |_| {},
+                        on_create: |_| {},
+                        on_add_existing: |_| {},
+                        on_rename: |_| {},
+                        on_remove: |_| {},
+                    }
+                },
                 SettingsTab::Storage => rsx! {
                     StorageProfilesSectionView {
                         profiles: mock_storage_profiles(),
@@ -140,6 +150,29 @@ pub fn Settings() -> Element {
             }
         }
     }
+}
+
+fn mock_libraries() -> Vec<LibraryInfo> {
+    vec![
+        LibraryInfo {
+            id: "abc-123".to_string(),
+            name: Some("My Music".to_string()),
+            path: "/Users/demo/.bae/libraries/abc-123".to_string(),
+            is_active: true,
+        },
+        LibraryInfo {
+            id: "def-456".to_string(),
+            name: Some("Jazz Collection".to_string()),
+            path: "/Users/demo/.bae/libraries/def-456".to_string(),
+            is_active: false,
+        },
+        LibraryInfo {
+            id: "ghi-789".to_string(),
+            name: None,
+            path: "/Volumes/External/bae-library".to_string(),
+            is_active: false,
+        },
+    ]
 }
 
 fn mock_storage_profiles() -> Vec<StorageProfile> {

--- a/bae-ui/src/components/mod.rs
+++ b/bae-ui/src/components/mod.rs
@@ -70,8 +70,9 @@ pub use segmented_control::{Segment, SegmentedControl};
 pub use select::{Select, SelectOption};
 pub use settings::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, CloudSectionView,
-    DiscogsSectionView, SettingsTab, SettingsView, StorageLocation, StorageProfile,
-    StorageProfileEditorView, StorageProfilesSectionView, SubsonicSectionView,
+    DiscogsSectionView, LibraryInfo, LibrarySectionView, SettingsTab, SettingsView,
+    StorageLocation, StorageProfile, StorageProfileEditorView, StorageProfilesSectionView,
+    SubsonicSectionView,
 };
 pub use text_input::{TextInput, TextInputSize, TextInputType};
 pub use title_bar::{

--- a/bae-ui/src/components/settings/library.rs
+++ b/bae-ui/src/components/settings/library.rs
@@ -1,0 +1,138 @@
+//! Library management section for settings
+
+use dioxus::prelude::*;
+
+/// Library info for the settings UI (uses String for path since bae-ui targets wasm too)
+#[derive(Clone, PartialEq)]
+pub struct LibraryInfo {
+    pub id: String,
+    pub name: Option<String>,
+    pub path: String,
+    pub is_active: bool,
+}
+
+/// Pure view component for the Library settings section
+#[component]
+pub fn LibrarySectionView(
+    libraries: Vec<LibraryInfo>,
+    on_switch: EventHandler<String>,
+    on_create: EventHandler<()>,
+    on_add_existing: EventHandler<()>,
+    on_rename: EventHandler<(String, String)>,
+    on_remove: EventHandler<String>,
+) -> Element {
+    let mut renaming_path = use_signal(|| None::<String>);
+    let mut rename_value = use_signal(String::new);
+
+    let mut start_rename = move |lib: &LibraryInfo| {
+        renaming_path.set(Some(lib.path.clone()));
+        rename_value.set(lib.name.clone().unwrap_or_default());
+    };
+
+    let mut commit_rename = move |path: String| {
+        let new_name = rename_value.read().clone();
+        renaming_path.set(None);
+        on_rename.call((path, new_name));
+    };
+
+    let mut cancel_rename = move |_| {
+        renaming_path.set(None);
+    };
+
+    rsx! {
+        div { class: "space-y-6",
+            div { class: "flex items-center justify-between",
+                div {
+                    h2 { class: "text-xl font-semibold text-white", "Library" }
+                    p { class: "text-sm text-gray-400 mt-1", "Manage your music libraries" }
+                }
+                div { class: "flex gap-2",
+                    button {
+                        class: "px-3 py-1.5 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors",
+                        onclick: move |_| on_create.call(()),
+                        "New Library"
+                    }
+                    button {
+                        class: "px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-md transition-colors",
+                        onclick: move |_| on_add_existing.call(()),
+                        "Add Existing..."
+                    }
+                }
+            }
+
+            div { class: "space-y-2",
+                for lib in &libraries {
+                    {
+                        let lib_path_rename = lib.path.clone();
+                        let lib_path_switch = lib.path.clone();
+                        let lib_path_remove = lib.path.clone();
+                        let is_renaming = renaming_path.read().as_ref() == Some(&lib.path);
+
+                        rsx! {
+                            div {
+                                key: "{lib.id}",
+                                class: "flex items-center justify-between p-4 bg-gray-800 rounded-lg border border-gray-700",
+                                div { class: "flex-1 min-w-0",
+                                    div { class: "flex items-center gap-2",
+                                        if is_renaming {
+                                            input {
+                                                class: "bg-gray-700 text-white text-sm rounded px-2 py-1 border border-gray-600 focus:border-indigo-500 outline-none",
+                                                value: "{rename_value}",
+                                                autofocus: true,
+                                                oninput: move |e| rename_value.set(e.value()),
+                                                onkeydown: {
+                                                    let path = lib_path_rename.clone();
+                                                    move |e: KeyboardEvent| {
+                                                        if e.key() == Key::Enter {
+                                                            commit_rename(path.clone());
+                                                        } else if e.key() == Key::Escape {
+                                                            cancel_rename(());
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        } else {
+                                            span { class: "text-sm font-medium text-white",
+                                                "{lib.name.as_deref().unwrap_or(&lib.id)}"
+                                            }
+                                        }
+                                        if lib.is_active {
+                                            span { class: "px-2 py-0.5 text-xs bg-indigo-600 text-white rounded-full",
+                                                "Active"
+                                            }
+                                        }
+                                    }
+                                    p { class: "text-xs text-gray-500 mt-1 truncate", "{lib.path}" }
+                                }
+                                div { class: "flex items-center gap-2 ml-4 flex-shrink-0",
+                                    if !is_renaming {
+                                        button {
+                                            class: "px-2 py-1 text-xs text-gray-400 hover:text-white transition-colors",
+                                            onclick: {
+                                                let lib_clone = lib.clone();
+                                                move |_| start_rename(&lib_clone)
+                                            },
+                                            "Rename"
+                                        }
+                                    }
+                                    if !lib.is_active {
+                                        button {
+                                            class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors",
+                                            onclick: move |_| on_switch.call(lib_path_switch.clone()),
+                                            "Switch"
+                                        }
+                                        button {
+                                            class: "px-2 py-1 text-xs text-red-400 hover:text-red-300 transition-colors",
+                                            onclick: move |_| on_remove.call(lib_path_remove.clone()),
+                                            "Remove"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bae-ui/src/components/settings/mod.rs
+++ b/bae-ui/src/components/settings/mod.rs
@@ -6,6 +6,7 @@ mod about;
 mod bittorrent;
 mod cloud;
 mod discogs;
+mod library;
 mod storage_profiles;
 mod subsonic;
 mod view;
@@ -14,6 +15,7 @@ pub use about::AboutSectionView;
 pub use bittorrent::{BitTorrentSectionView, BitTorrentSettings};
 pub use cloud::CloudSectionView;
 pub use discogs::DiscogsSectionView;
+pub use library::{LibraryInfo, LibrarySectionView};
 pub use storage_profiles::{
     StorageLocation, StorageProfile, StorageProfileEditorView, StorageProfilesSectionView,
 };

--- a/bae-ui/src/components/settings/view.rs
+++ b/bae-ui/src/components/settings/view.rs
@@ -6,6 +6,7 @@ use dioxus::prelude::*;
 /// Available settings tabs
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub enum SettingsTab {
+    Library,
     #[default]
     Storage,
     Discogs,
@@ -18,6 +19,7 @@ pub enum SettingsTab {
 impl SettingsTab {
     pub fn label(&self) -> &'static str {
         match self {
+            SettingsTab::Library => "Library",
             SettingsTab::Storage => "Storage",
             SettingsTab::Discogs => "Discogs",
             SettingsTab::BitTorrent => "BitTorrent",
@@ -29,6 +31,7 @@ impl SettingsTab {
 
     pub fn all() -> &'static [SettingsTab] {
         &[
+            SettingsTab::Library,
             SettingsTab::Storage,
             SettingsTab::Discogs,
             #[cfg(feature = "torrent")]


### PR DESCRIPTION
## Summary
- Namespace keyring entries by `library_id` so each library gets its own encryption key, Discogs key, and cloud sync keys. Includes one-time migration from global entries.
- Add Library tab to Settings for switching, creating, renaming, and removing libraries. Discovery scans `~/.bae/libraries/` plus `~/.bae/known_libraries.yaml` for external paths.
- Extract `Config::create_new_library()` to share library creation logic between welcome screen and settings.

## Test plan
- [ ] Verify Library tab appears first in Settings and lists the active library
- [ ] Create a new library from Settings — app relaunches into new library
- [ ] Switch back to original library — app relaunches, data intact
- [ ] Rename a library — name updates in the list
- [ ] "Add Existing..." with a folder containing config.yaml — library appears and switches
- [ ] Remove a non-active library from the list
- [ ] Fresh install: welcome screen "Create new library" still works
- [ ] Existing install: key migration runs once on first launch (check `keys_migrated: true` in config.yaml after)
- [ ] `cargo test -p bae-core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)