### PR TITLE
Mention MusicBrainz before Discogs in docs and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # bae
 
-A desktop music library app. Album-oriented, metadata-first: you pick releases from Discogs or MusicBrainz, point bae at your files, and it handles storage, playback, and organization.
+A desktop music library app. Album-oriented, metadata-first: you pick releases from MusicBrainz or Discogs, point bae at your files, and it handles storage, playback, and organization.
 
 ## Features
 
 **Import**
 - Local folders (file-per-track or CUE/FLAC)
-- Metadata-driven: select a Discogs or MusicBrainz release, bae matches your files and pulls album art, credits, label info, catalog numbers
+- Metadata-driven: select a MusicBrainz or Discogs release, bae matches your files and pulls album art, credits, label info, catalog numbers
 
 **Playback**
 - Native audio via cpal

--- a/website/src/content/docs/getting-started/quick-start.mdx
+++ b/website/src/content/docs/getting-started/quick-start.mdx
@@ -8,7 +8,7 @@ description: Get started with bae in minutes
 bae helps you build and organize your music library. Here's what you can do:
 
 1. **Import music** from local files (individual tracks or CUE/FLAC albums)
-2. **Enrich metadata** automatically from Discogs and MusicBrainz
+2. **Enrich metadata** automatically from MusicBrainz and Discogs
 3. **Browse your library** by artist, album, genre, or year
 
 ## Your first import
@@ -21,7 +21,7 @@ The easiest way to start is importing music you already have:
 2. Select **Local Files**
 3. Choose a folder containing your music
 4. bae scans the folder and shows you what it found
-5. Select a Discogs or MusicBrainz release to match
+5. Select a MusicBrainz or Discogs release to match
 6. Click **Import**
 
 bae copies the files to your library and downloads artwork and metadata.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -6,7 +6,7 @@ import { Image } from 'astro:assets';
 <head>
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="bae - Your music as easy as streaming. Metadata-driven import from Discogs and MusicBrainz, pregap-accurate playback, encrypted storage." />
+	<meta name="description" content="bae - Your music as easy as streaming. Metadata-driven import from MusicBrainz and Discogs, pregap-accurate playback, encrypted storage." />
 	<title>bae - Your music as easy as streaming</title>
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -82,7 +82,7 @@ import { Image } from 'astro:assets';
 
 			<div class="concept">
 				<h2>Rich collecting</h2>
-				<p>bae understands <em>releases</em>, not just files. Point it at a folder, search Discogs or MusicBrainz for the release, and bae pulls in album art, credits, label, catalog number, barcode — everything the database knows about that pressing.</p>
+				<p>bae understands <em>releases</em>, not just files. Point it at a folder, search MusicBrainz or Discogs for the release, and bae pulls in album art, credits, label, catalog number, barcode — everything the database knows about that pressing.</p>
 			</div>
 
 			<div class="concept">


### PR DESCRIPTION
## Summary
- Reorder mentions to list MusicBrainz before Discogs in README, website landing page, and quick-start docs

## Test plan
- [ ] Verify README reads correctly
- [ ] Verify website meta description and landing page copy
- [ ] Verify quick-start guide steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)