### PR TITLE
Add cover art picker to album detail view

### DIFF
--- a/bae-desktop/src/ui/components/album_detail/page.rs
+++ b/bae-desktop/src/ui/components/album_detail/page.rs
@@ -5,7 +5,7 @@ use super::utils::maybe_not_empty;
 use super::AlbumDetailView;
 use crate::ui::app_service::use_app;
 use crate::ui::Route;
-use bae_ui::display_types::PlaybackDisplay;
+use bae_ui::display_types::{CoverChange, PlaybackDisplay};
 use bae_ui::stores::{
     AlbumDetailStateStoreExt, AppStateStoreExt, PlaybackStatus, PlaybackUiStateStoreExt,
     StorageProfilesStateStoreExt,
@@ -236,6 +236,26 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
         }
     });
 
+    // Cover picker callbacks
+    let on_fetch_remote_covers = EventHandler::new({
+        let app = app.clone();
+        move |_: ()| {
+            app.fetch_remote_covers();
+        }
+    });
+    let on_select_cover = EventHandler::new({
+        let app = app.clone();
+        move |selection: CoverChange| {
+            let album_id = album_id();
+            let release_id = state
+                .selected_release_id()
+                .read()
+                .clone()
+                .unwrap_or_default();
+            app.change_cover(&album_id, &release_id, selection);
+        }
+    });
+
     // Available storage profiles for transfer
     let available_profiles = app.state.storage_profiles().profiles().read().clone();
 
@@ -281,6 +301,8 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
                 on_add_album_to_queue,
                 on_transfer_to_profile,
                 on_eject,
+                on_fetch_remote_covers,
+                on_select_cover,
                 available_profiles,
             }
         } else {

--- a/bae-desktop/src/ui/protocol_handler.rs
+++ b/bae-desktop/src/ui/protocol_handler.rs
@@ -32,6 +32,8 @@ pub fn handle_protocol_request(uri: &str, services: &ImageServices) -> ProtocolR
 }
 
 fn handle_cover(release_id: &str, services: &ImageServices) -> ProtocolResponse {
+    // Strip query params (e.g. ?t=123 for cache busting)
+    let release_id = release_id.split('?').next().unwrap_or(release_id);
     let covers_dir = services.library_path.join("covers");
 
     // Try common image extensions

--- a/bae-mocks/src/mocks/album_detail.rs
+++ b/bae-mocks/src/mocks/album_detail.rs
@@ -147,6 +147,8 @@ pub fn AlbumDetailMock(initial_state: Option<String>) -> Element {
         storage_profile: None,
         transfer_progress: None,
         transfer_error: None,
+        remote_covers: vec![],
+        loading_remote_covers: false,
     });
 
     // Get tracks lens for per-track reactivity
@@ -195,6 +197,8 @@ pub fn AlbumDetailMock(initial_state: Option<String>) -> Element {
                 on_add_album_to_queue: |_| {},
                 on_transfer_to_profile: |_| {},
                 on_eject: |_| {},
+                on_fetch_remote_covers: |_| {},
+                on_select_cover: |_| {},
                 available_profiles: vec![],
             }
         }

--- a/bae-mocks/src/pages/album_detail.rs
+++ b/bae-mocks/src/pages/album_detail.rs
@@ -42,6 +42,8 @@ pub fn AlbumDetail(album_id: String) -> Element {
         storage_profile: None,
         transfer_progress: None,
         transfer_error: None,
+        remote_covers: vec![],
+        loading_remote_covers: false,
     });
 
     // Get tracks lens for per-track reactivity
@@ -77,6 +79,8 @@ pub fn AlbumDetail(album_id: String) -> Element {
                 on_add_album_to_queue: |_| {},
                 on_transfer_to_profile: |_| {},
                 on_eject: |_| {},
+                on_fetch_remote_covers: |_| {},
+                on_select_cover: |_| {},
                 available_profiles: vec![],
             }
         } else {

--- a/bae-ui/src/components/album_detail/album_cover_section.rs
+++ b/bae-ui/src/components/album_detail/album_cover_section.rs
@@ -21,6 +21,7 @@ pub fn AlbumCoverSection(
     on_view_release_info: EventHandler<String>,
     on_view_storage: EventHandler<String>,
     on_open_gallery: EventHandler<String>,
+    on_change_cover: EventHandler<String>,
 ) -> Element {
     let mut show_dropdown = use_signal(|| false);
     let is_open: ReadSignal<bool> = show_dropdown.into();
@@ -87,7 +88,7 @@ pub fn AlbumCoverSection(
                 on_close: move |_| show_dropdown.set(false),
                 placement: Placement::BottomEnd,
 
-                // Release Info - only for single release
+                // Release Info, Storage, Export - only for single release
                 if has_single_release {
                     if let Some(ref release_id) = first_release_id {
                         MenuItem {
@@ -127,6 +128,20 @@ pub fn AlbumCoverSection(
                                 "Export"
                             }
                         }
+                    }
+                }
+                // Change Cover - available for all albums
+                if let Some(ref release_id) = first_release_id {
+                    MenuItem {
+                        disabled: is_deleting || is_exporting,
+                        onclick: {
+                            let release_id = release_id.clone();
+                            move |_| {
+                                show_dropdown.set(false);
+                                on_change_cover.call(release_id.clone());
+                            }
+                        },
+                        "Change Cover"
                     }
                 }
                 MenuItem {

--- a/bae-ui/src/components/album_detail/cover_picker.rs
+++ b/bae-ui/src/components/album_detail/cover_picker.rs
@@ -1,0 +1,90 @@
+//! Cover picker wrapper - combines existing images + remote covers into GalleryLightbox
+
+use crate::components::{GalleryItem, GalleryItemContent, GalleryLightbox};
+use crate::display_types::CoverChange;
+use crate::stores::album_detail::{AlbumDetailState, AlbumDetailStateStoreExt};
+use dioxus::prelude::*;
+
+/// Cover picker that reuses GalleryLightbox in selection mode.
+///
+/// Combines existing release images with async-fetched remote covers.
+/// Maps gallery index back to `CoverChange` on selection.
+#[component]
+pub fn CoverPickerWrapper(
+    state: ReadStore<AlbumDetailState>,
+    show: Signal<bool>,
+    on_select: EventHandler<CoverChange>,
+) -> Element {
+    let images = state.images().read().clone();
+    let remote_covers = state.remote_covers().read().clone();
+    let loading_remote_covers = *state.loading_remote_covers().read();
+
+    // Build combined gallery items + parallel CoverChange mapping
+    let mut gallery_items: Vec<GalleryItem> = Vec::new();
+    let mut change_map: Vec<CoverChange> = Vec::new();
+
+    // Existing images first
+    let mut cover_index: Option<usize> = None;
+    for img in &images {
+        if img.is_cover {
+            cover_index = Some(gallery_items.len());
+        }
+        change_map.push(CoverChange::ExistingImage {
+            image_id: img.id.clone(),
+        });
+        gallery_items.push(GalleryItem {
+            label: img.filename.clone(),
+            content: GalleryItemContent::Image {
+                url: img.url.clone(),
+                thumbnail_url: img.url.clone(),
+            },
+        });
+    }
+
+    // Remote covers after existing images
+    for rc in &remote_covers {
+        change_map.push(CoverChange::RemoteCover {
+            url: rc.url.clone(),
+            source: rc.source.clone(),
+        });
+        gallery_items.push(GalleryItem {
+            label: rc.label.clone(),
+            content: GalleryItemContent::Image {
+                url: rc.url.clone(),
+                thumbnail_url: rc.thumbnail_url.clone(),
+            },
+        });
+    }
+
+    // If still loading, add a placeholder text item
+    if loading_remote_covers {
+        gallery_items.push(GalleryItem {
+            label: "Loading remote covers...".to_string(),
+            content: GalleryItemContent::Text {
+                content: Some(Ok(
+                    "Fetching covers from MusicBrainz and Discogs...".to_string()
+                )),
+            },
+        });
+    }
+
+    let initial_index = cover_index.unwrap_or(0);
+    let is_open: ReadSignal<bool> = show.into();
+
+    rsx! {
+        GalleryLightbox {
+            is_open,
+            items: gallery_items,
+            initial_index,
+            on_close: move |_| show.set(false),
+            on_navigate: move |_: usize| {},
+            selected_index: cover_index,
+            on_select: move |index: usize| {
+                if let Some(change) = change_map.get(index) {
+                    on_select.call(change.clone());
+                    show.set(false);
+                }
+            },
+        }
+    }
+}

--- a/bae-ui/src/components/album_detail/mod.rs
+++ b/bae-ui/src/components/album_detail/mod.rs
@@ -3,6 +3,7 @@
 mod album_art;
 mod album_cover_section;
 mod album_metadata;
+mod cover_picker;
 mod delete_album_dialog;
 mod delete_release_dialog;
 mod export_error_toast;

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -148,6 +148,22 @@ pub struct Image {
     pub url: String,
 }
 
+/// A remote cover option fetched from MusicBrainz or Discogs
+#[derive(Clone, Debug, PartialEq)]
+pub struct RemoteCoverOption {
+    pub url: String,
+    pub thumbnail_url: String,
+    pub label: String,
+    pub source: String,
+}
+
+/// Cover selection from the cover picker
+#[derive(Clone, Debug, PartialEq)]
+pub enum CoverChange {
+    ExistingImage { image_id: String },
+    RemoteCover { url: String, source: String },
+}
+
 /// Import operation status for UI display
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ImportStatus {

--- a/bae-ui/src/stores/album_detail.rs
+++ b/bae-ui/src/stores/album_detail.rs
@@ -1,7 +1,7 @@
 //! Album detail state store
 
 use crate::components::settings::StorageProfile;
-use crate::display_types::{Album, Artist, File, Image, Release, Track};
+use crate::display_types::{Album, Artist, File, Image, Release, RemoteCoverOption, Track};
 use dioxus::prelude::*;
 
 /// Transfer progress state
@@ -50,4 +50,8 @@ pub struct AlbumDetailState {
     pub transfer_progress: Option<TransferProgressState>,
     /// Transfer error message
     pub transfer_error: Option<String>,
+    /// Remote cover options fetched from MusicBrainz/Discogs
+    pub remote_covers: Vec<RemoteCoverOption>,
+    /// Whether remote covers are currently loading
+    pub loading_remote_covers: bool,
 }

--- a/bae-web/src/api.rs
+++ b/bae-web/src/api.rs
@@ -201,5 +201,7 @@ pub async fn fetch_album(album_id: &str) -> Result<AlbumDetailState, String> {
         storage_profile: None,
         transfer_progress: None,
         transfer_error: None,
+        remote_covers: vec![],
+        loading_remote_covers: false,
     })
 }

--- a/bae-web/src/pages/album_detail.rs
+++ b/bae-web/src/pages/album_detail.rs
@@ -139,6 +139,8 @@ pub fn AlbumDetail(album_id: String) -> Element {
                     },
                     on_transfer_to_profile: |_| {},
                     on_eject: |_| {},
+                    on_fetch_remote_covers: |_| {},
+                    on_select_cover: |_| {},
                     available_profiles: vec![],
                 }
             }


### PR DESCRIPTION
## Summary
- Add "Change Cover" option to album cover dropdown menu, available for all albums
- Opens GalleryLightbox in selection mode with existing images + async-fetched remote covers from MusicBrainz Cover Art Archive and Discogs
- On selection, updates DB cover, writes cover cache to disk, and refreshes both album detail and library grid with cache-busted URL

## Test plan
- [ ] Open album with images → hover cover → "Change Cover" appears in dropdown
- [ ] Click "Change Cover" → gallery opens in selection mode with current cover highlighted green
- [ ] Select a different existing image → cover updates in detail view and library grid
- [ ] Album with MB release ID → MusicBrainz cover appears in picker after loading
- [ ] Discogs key configured + release has Discogs ID → Discogs cover appears
- [ ] Select remote cover → downloads, saves to DB, cover updates everywhere
- [ ] Multi-release album → "Change Cover" still available in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)