### PR TITLE
Deduplicate artists across MusicBrainz and Discogs imports

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -4,6 +4,8 @@ CREATE TABLE artists (
     sort_name TEXT,
     discogs_artist_id TEXT,
     bandcamp_artist_id TEXT,
+    musicbrainz_artist_id TEXT,
+    image_path TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
@@ -197,6 +199,8 @@ CREATE TABLE imports (
 
 -- Indexes
 CREATE INDEX idx_artists_discogs_id ON artists (discogs_artist_id);
+CREATE INDEX idx_artists_mb_id ON artists (musicbrainz_artist_id);
+CREATE INDEX idx_artists_name ON artists (name COLLATE NOCASE);
 CREATE INDEX idx_album_artists_album_id ON album_artists (album_id);
 CREATE INDEX idx_album_artists_artist_id ON album_artists (artist_id);
 CREATE INDEX idx_track_artists_track_id ON track_artists (track_id);

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -53,6 +53,10 @@ pub struct DbArtist {
     pub discogs_artist_id: Option<String>,
     /// Artist ID from Bandcamp (for future multi-source support)
     pub bandcamp_artist_id: Option<String>,
+    /// Artist ID from MusicBrainz (for deduplication across imports)
+    pub musicbrainz_artist_id: Option<String>,
+    /// Path to artist image on disk (relative to library, e.g. "artists/{id}.jpg")
+    pub image_path: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -288,6 +292,8 @@ impl DbArtist {
             sort_name: None,
             discogs_artist_id: Some(discogs_artist_id.to_string()),
             bandcamp_artist_id: None,
+            musicbrainz_artist_id: None,
+            image_path: None,
             created_at: now,
             updated_at: now,
         }

--- a/bae-core/src/import/artist_image.rs
+++ b/bae-core/src/import/artist_image.rs
@@ -1,0 +1,114 @@
+use crate::discogs::DiscogsClient;
+use crate::library::LibraryManager;
+use std::path::Path;
+use tracing::{debug, info, warn};
+
+/// Fetch and save an artist image from Discogs.
+///
+/// Skips if the artist already has an image on disk.
+/// Downloads the primary image from Discogs and saves to `{artists_dir}/{artist_id}.{ext}`.
+/// Best-effort: logs warnings on failure, never fails the import.
+///
+/// Returns the relative image path (e.g. "artists/{artist_id}.jpg") if saved successfully.
+pub async fn fetch_and_save_artist_image(
+    artist_id: &str,
+    discogs_artist_id: &str,
+    discogs_client: &DiscogsClient,
+    artists_dir: &Path,
+    library_manager: &LibraryManager,
+) -> Option<String> {
+    // Check if image already exists on disk
+    for ext in &["jpg", "jpeg", "png", "webp"] {
+        let path = artists_dir.join(format!("{}.{}", artist_id, ext));
+        if path.exists() {
+            debug!("Artist image already exists: {}", path.display());
+            return None;
+        }
+    }
+
+    let image_url = match discogs_client.get_artist_image(discogs_artist_id).await {
+        Ok(Some(url)) => url,
+        Ok(None) => {
+            debug!("No image found for Discogs artist {}", discogs_artist_id);
+            return None;
+        }
+        Err(e) => {
+            warn!("Failed to fetch artist image URL from Discogs: {}", e);
+            return None;
+        }
+    };
+
+    // Download the image
+    let client = match reqwest::Client::builder()
+        .user_agent("bae/1.0 +https://github.com/hideselfview/bae")
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to create HTTP client for artist image: {}", e);
+            return None;
+        }
+    };
+
+    let response = match client.get(&image_url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Failed to download artist image: {}", e);
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        warn!(
+            "Artist image download returned status {}",
+            response.status()
+        );
+        return None;
+    }
+
+    let bytes = match response.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("Failed to read artist image bytes: {}", e);
+            return None;
+        }
+    };
+
+    if bytes.len() < 100 {
+        warn!("Downloaded artist image too small ({} bytes)", bytes.len());
+        return None;
+    }
+
+    let ext = super::image_extension_from_url(&image_url);
+
+    if let Err(e) = std::fs::create_dir_all(artists_dir) {
+        warn!("Failed to create artists directory: {}", e);
+        return None;
+    }
+
+    let filename = format!("{}.{}", artist_id, ext);
+    let save_path = artists_dir.join(&filename);
+
+    if let Err(e) = std::fs::write(&save_path, &bytes) {
+        warn!("Failed to write artist image: {}", e);
+        return None;
+    }
+
+    let relative_path = format!("artists/{}", filename);
+
+    info!(
+        "Saved artist image ({} bytes) to {}",
+        bytes.len(),
+        save_path.display()
+    );
+
+    // Update DB with image path
+    if let Err(e) = library_manager
+        .update_artist_image(artist_id, &relative_path)
+        .await
+    {
+        warn!("Failed to update artist image_path in DB: {}", e);
+    }
+
+    Some(relative_path)
+}

--- a/bae-core/src/import/cover_art.rs
+++ b/bae-core/src/import/cover_art.rs
@@ -128,18 +128,7 @@ pub async fn fetch_cover_art_for_mb_release(
 
 /// Download cover art from a URL and return the raw bytes and file extension.
 pub async fn download_cover_art_bytes(cover_art_url: &str) -> Result<(Vec<u8>, String), String> {
-    let extension = cover_art_url
-        .split('.')
-        .next_back()
-        .and_then(|ext| {
-            let ext_lower = ext.to_lowercase();
-            if ["jpg", "jpeg", "png", "gif", "webp"].contains(&ext_lower.as_str()) {
-                Some(ext_lower)
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "jpg".to_string());
+    let extension = super::image_extension_from_url(cover_art_url);
 
     info!("Downloading cover art from {}", cover_art_url);
 

--- a/bae-core/src/import/discogs_parser.rs
+++ b/bae-core/src/import/discogs_parser.rs
@@ -33,9 +33,11 @@ pub fn parse_discogs_release(
         let artist = DbArtist {
             id: Uuid::new_v4().to_string(),
             name: artist_name.clone(),
-            sort_name: Some(artist_name.clone()),
+            sort_name: Some(artist_name),
             discogs_artist_id: None,
             bandcamp_artist_id: None,
+            musicbrainz_artist_id: None,
+            image_path: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -55,6 +57,8 @@ pub fn parse_discogs_release(
                 sort_name: Some(discogs_artist.name.clone()),
                 discogs_artist_id: Some(discogs_artist.id.clone()),
                 bandcamp_artist_id: None,
+                musicbrainz_artist_id: None,
+                image_path: None,
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             };

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -1,3 +1,4 @@
+pub mod artist_image;
 pub mod cover_art;
 mod discogs_matcher;
 mod discogs_parser;
@@ -21,3 +22,78 @@ pub use service::ImportService;
 #[cfg(feature = "torrent")]
 pub use types::TorrentSource;
 pub use types::{CoverSelection, ImportPhase, ImportProgress, ImportRequest, PrepareStep};
+
+/// Extract a image file extension from a URL using proper URL parsing.
+///
+/// Parses the URL, extracts the path component (ignoring query params),
+/// and returns the extension if it's a known image type. Falls back to "jpg".
+fn image_extension_from_url(url: &str) -> String {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| {
+            parsed.path().rsplit('.').next().and_then(|ext| {
+                let lower = ext.to_lowercase();
+                if ["jpg", "jpeg", "png", "gif", "webp"].contains(&lower.as_str()) {
+                    Some(lower)
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or_else(|| "jpg".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_jpg_url() {
+        assert_eq!(
+            image_extension_from_url("https://example.com/image.jpg"),
+            "jpg"
+        );
+    }
+
+    #[test]
+    fn test_png_with_query_params() {
+        assert_eq!(
+            image_extension_from_url("https://img.discogs.com/artist/12345.png?token=abc"),
+            "png"
+        );
+    }
+
+    #[test]
+    fn test_jpeg_with_path_segments() {
+        assert_eq!(
+            image_extension_from_url("https://cdn.example.com/images/artists/photo.jpeg"),
+            "jpeg"
+        );
+    }
+
+    #[test]
+    fn test_webp_extension() {
+        assert_eq!(
+            image_extension_from_url("https://example.com/img.webp"),
+            "webp"
+        );
+    }
+
+    #[test]
+    fn test_unknown_extension_falls_back_to_jpg() {
+        assert_eq!(
+            image_extension_from_url("https://example.com/img.bmp"),
+            "jpg"
+        );
+    }
+
+    #[test]
+    fn test_no_extension_falls_back_to_jpg() {
+        assert_eq!(image_extension_from_url("https://example.com/image"), "jpg");
+    }
+
+    #[test]
+    fn test_invalid_url_falls_back_to_jpg() {
+        assert_eq!(image_extension_from_url("not-a-url"), "jpg");
+    }
+}

--- a/bae-core/src/import/musicbrainz_parser.rs
+++ b/bae-core/src/import/musicbrainz_parser.rs
@@ -87,16 +87,23 @@ fn parse_mb_release_from_json(
                     .and_then(|v| v.as_str())
                     .unwrap_or("Unknown Artist")
                     .to_string();
-                let _mb_artist_id = artist_obj
+                let mb_artist_id = artist_obj
                     .get("id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                let sort_name = artist_obj
+                    .get("sort-name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| artist_name.clone());
                 let artist = DbArtist {
                     id: Uuid::new_v4().to_string(),
-                    name: artist_name.clone(),
-                    sort_name: Some(artist_name.clone()),
+                    name: artist_name,
+                    sort_name: Some(sort_name),
                     discogs_artist_id: None,
                     bandcamp_artist_id: None,
+                    musicbrainz_artist_id: mb_artist_id,
+                    image_path: None,
                     created_at: chrono::Utc::now(),
                     updated_at: chrono::Utc::now(),
                 };
@@ -116,9 +123,11 @@ fn parse_mb_release_from_json(
         let artist = DbArtist {
             id: Uuid::new_v4().to_string(),
             name: artist_name.clone(),
-            sort_name: Some(artist_name.clone()),
+            sort_name: Some(artist_name),
             discogs_artist_id: None,
             bandcamp_artist_id: None,
+            musicbrainz_artist_id: None,
+            image_path: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -301,6 +301,39 @@ impl LibraryManager {
             .get_artist_by_discogs_id(discogs_artist_id)
             .await?)
     }
+
+    /// Get artist by MusicBrainz ID (for deduplication)
+    pub async fn get_artist_by_mb_id(&self, mb_id: &str) -> Result<Option<DbArtist>, LibraryError> {
+        Ok(self.database.get_artist_by_mb_id(mb_id).await?)
+    }
+
+    /// Get artist by name (case-insensitive, first match)
+    pub async fn get_artist_by_name(&self, name: &str) -> Result<Option<DbArtist>, LibraryError> {
+        Ok(self.database.get_artist_by_name(name).await?)
+    }
+
+    /// Fill in NULL external IDs on an existing artist (never overwrites)
+    pub async fn update_artist_external_ids(
+        &self,
+        id: &str,
+        discogs_id: Option<&str>,
+        mb_id: Option<&str>,
+        sort_name: Option<&str>,
+    ) -> Result<(), LibraryError> {
+        Ok(self
+            .database
+            .update_artist_external_ids(id, discogs_id, mb_id, sort_name)
+            .await?)
+    }
+
+    /// Update artist image path
+    pub async fn update_artist_image(
+        &self,
+        id: &str,
+        image_path: &str,
+    ) -> Result<(), LibraryError> {
+        Ok(self.database.update_artist_image(id, image_path).await?)
+    }
     /// Insert album-artist relationship
     pub async fn insert_album_artist(
         &self,

--- a/bae-desktop/src/ui/display_types.rs
+++ b/bae-desktop/src/ui/display_types.rs
@@ -24,9 +24,14 @@ pub fn album_from_db_ref(db: &DbAlbum) -> Album {
 }
 
 pub fn artist_from_db_ref(db: &DbArtist) -> Artist {
+    let image_url = db
+        .image_path
+        .as_ref()
+        .map(|_| format!("bae://artist-image/{}", db.id));
     Artist {
         id: db.id.clone(),
         name: db.name.clone(),
+        image_url,
     }
 }
 

--- a/bae-mocks/src/demo_data.rs
+++ b/bae-mocks/src/demo_data.rs
@@ -93,6 +93,7 @@ fn get_demo_data() -> &'static DemoData {
             let album_artist = Artist {
                 id: artist_id,
                 name: album_data.artist.clone(),
+                image_url: None,
             };
             artists_by_album.insert(album_id.clone(), vec![album_artist]);
 

--- a/bae-mocks/src/mocks/album_detail.rs
+++ b/bae-mocks/src/mocks/album_detail.rs
@@ -59,6 +59,7 @@ pub fn AlbumDetailMock(initial_state: Option<String>) -> Element {
     let artists = vec![Artist {
         id: "artist-1".to_string(),
         name: "The Midnight Signal".to_string(),
+        image_url: None,
     }];
 
     let all_releases = vec![

--- a/bae-mocks/src/mocks/library.rs
+++ b/bae-mocks/src/mocks/library.rs
@@ -237,6 +237,7 @@ fn mock_albums_with_artists(count: usize) -> (Vec<Album>, HashMap<String, Vec<Ar
             vec![Artist {
                 id: format!("a{}", idx + 1),
                 name: artist_name.to_string(),
+                image_url: None,
             }],
         );
     }

--- a/bae-mocks/src/pages/mock_dropdown.rs
+++ b/bae-mocks/src/pages/mock_dropdown.rs
@@ -18,6 +18,7 @@ fn generate_test_albums() -> Vec<(Album, Vec<Artist>)> {
             let artist = Artist {
                 id: format!("artist-{}", i),
                 name: format!("Artist {}", i),
+                image_url: None,
             };
             (album, vec![artist])
         })

--- a/bae-ui/src/components/artist_detail.rs
+++ b/bae-ui/src/components/artist_detail.rs
@@ -46,7 +46,15 @@ pub fn ArtistDetailView(
                 } else if let Some(err) = error {
                     ErrorDisplay { message: err }
                 } else if let Some(artist) = artist {
-                    h1 { class: "text-3xl font-bold text-white mb-2", "{artist.name}" }
+                    div { class: "flex items-center gap-6 mb-2",
+                        if let Some(ref image_url) = artist.image_url {
+                            img {
+                                class: "w-32 h-32 rounded-full object-cover",
+                                src: "{image_url}",
+                            }
+                        }
+                        h1 { class: "text-3xl font-bold text-white", "{artist.name}" }
+                    }
 
                     if !albums.is_empty() {
                         {

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -60,6 +60,7 @@ pub struct Album {
 pub struct Artist {
     pub id: String,
     pub name: String,
+    pub image_url: Option<String>,
 }
 
 /// Track import state for UI display

--- a/bae-web/src/api.rs
+++ b/bae-web/src/api.rs
@@ -93,6 +93,7 @@ pub async fn fetch_albums() -> Result<(Vec<Album>, HashMap<String, Vec<Artist>>)
             vec![Artist {
                 id: artist_id,
                 name: artist_name,
+                image_url: None,
             }],
         );
 
@@ -144,6 +145,7 @@ pub async fn fetch_album(album_id: &str) -> Result<AlbumDetailState, String> {
     let artists = vec![Artist {
         id: artist_id,
         name: artist_name,
+        image_url: None,
     }];
 
     let songs = sa.song.unwrap_or_default();


### PR DESCRIPTION
## Summary
- MusicBrainz imports were creating duplicate artist rows because the MB parser discarded the artist ID and dedup only checked `discogs_artist_id`. The same dedup block was also copy-pasted 3 times across folder/torrent/CD import paths.
- Adds `musicbrainz_artist_id` and `image_path` columns to artists, stores the MB artist ID in the parser, and replaces the 3 copy-pasted dedup blocks with a unified `find_or_create_artists` function (lookup chain: discogs_id → mb_id → case-insensitive name with conflict check → insert new).
- Fetches and saves artist images from Discogs after import, serves them via `bae://artist-image/` protocol, and displays them in the artist detail view.
- Extracts `image_extension_from_url` helper using proper URL parsing (`reqwest::Url`) to fix extension detection when URLs have query parameters — applied to both cover art and artist image downloads.

## Test plan
- [x] `cargo clippy` clean on bae-core, bae-desktop, bae-mocks (pre-commit hooks pass)
- [x] All 200 existing tests pass + 8 new dedup tests + 7 new URL extension tests
- [ ] Import same artist from MB twice → one artist row (not two)
- [ ] Import same artist from Discogs then MB → one artist row with both IDs accumulated
- [ ] Import two different artists with the same name but different MB IDs → two separate rows
- [ ] Artist has image on disk after Discogs import
- [ ] Artist detail page shows image when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)