### PR TITLE
Move import error above button row, add search error mock

### DIFF
--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -103,6 +103,10 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
         )
         .visible_when("state", "Identifying")
         .visible_when("identify_mode", "ManualSearch")
+        .bool_control("search_error", "Search Error", false)
+        .doc("Shows error banner in search results")
+        .visible_when("state", "Identifying")
+        .visible_when("identify_mode", "ManualSearch")
         .bool_control("disc_id_not_found", "Disc ID Not Found", false)
         .doc("Shows 'no releases found for Disc ID' banner")
         .visible_when("state", "Identifying")
@@ -131,6 +135,10 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
             Preset::new("Manual Search")
                 .set_string("state", "Identifying")
                 .set_string("identify_mode", "ManualSearch"),
+            Preset::new("Search Error")
+                .set_string("state", "Identifying")
+                .set_string("identify_mode", "ManualSearch")
+                .set_bool("search_error", true),
             Preset::new("Confirm")
                 .set_string("state", "Confirming")
                 .set_string("confirm_phase", "Ready"),
@@ -190,6 +198,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
 
     // Boolean flags
     let show_discid_lookup_error = registry.get_bool("discid_lookup_error");
+    let show_search_error = registry.get_bool("search_error");
     let show_disc_id_not_found = registry.get_bool("disc_id_not_found");
 
     // Define folder data - each folder has different file compositions
@@ -457,11 +466,16 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
 
     // Build search state with per-tab results
     let current_tab = search_tab();
+    let search_error_message = if show_search_error {
+        Some("MusicBrainz API returned 503 Service Unavailable".to_string())
+    } else {
+        None
+    };
     let active_tab_state = TabSearchState {
         has_searched,
         search_results: manual_match_candidates.clone(),
         selected_result_index: selected_match_index(),
-        error_message: None,
+        error_message: search_error_message,
     };
     let mock_search_state = ManualSearchState {
         search_source: search_source(),

--- a/bae-ui/src/components/import/workflow/cd_import.rs
+++ b/bae-ui/src/components/import/workflow/cd_import.rs
@@ -13,8 +13,8 @@
 //! Pass `ReadStore<ImportState>` down to children. Use lenses where possible.
 
 use super::{
-    CdRipperView, CdTocDisplayView, ConfirmationView, DiscIdLookupErrorView,
-    ImportErrorDisplayView, ManualSearchPanelView, MultipleExactMatchesView, SelectedSourceView,
+    CdRipperView, CdTocDisplayView, ConfirmationView, DiscIdLookupErrorView, ManualSearchPanelView,
+    MultipleExactMatchesView, SelectedSourceView,
 };
 use crate::components::StorageProfile;
 use crate::display_types::{
@@ -415,10 +415,7 @@ fn CdConfirmContent(
                 on_confirm,
                 on_configure_storage,
                 on_view_in_library,
-            }
-            ImportErrorDisplayView {
-                error_message: import_error,
-                on_retry: move |_| on_confirm.call(()),
+                import_error,
             }
         }
     }

--- a/bae-ui/src/components/import/workflow/confirmation.rs
+++ b/bae-ui/src/components/import/workflow/confirmation.rs
@@ -1,6 +1,7 @@
 //! Confirmation view component
 
 use super::gallery_lightbox::{GalleryItem, GalleryItemContent, GalleryLightbox};
+use super::shared::ImportErrorDisplayView;
 use crate::components::icons::{CheckIcon, ImageIcon, PencilIcon};
 use crate::components::{
     Button, ButtonSize, ButtonVariant, ChromelessButton, Select, SelectOption, StorageProfile,
@@ -45,6 +46,8 @@ pub fn ConfirmationView(
     on_configure_storage: EventHandler<()>,
     /// Called to navigate to the album in the library
     on_view_in_library: EventHandler<String>,
+    /// Import error message (shown between release card and action row)
+    import_error: Option<String>,
 ) -> Element {
     let is_duplicate = candidate.existing_album_id.is_some();
     let mut show_cover_picker = use_signal(|| false);
@@ -189,6 +192,12 @@ pub fn ConfirmationView(
                         "Change"
                     }
                 }
+            }
+
+            // Import error (between release card and action row)
+            ImportErrorDisplayView {
+                error_message: import_error,
+                on_retry: move |_| on_confirm.call(()),
             }
 
             // Bottom action area

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -19,8 +19,8 @@
 //! actually render values.
 
 use super::{
-    ConfirmationView, DiscIdPill, DiscIdSource, ImportErrorDisplayView, LoadingIndicator,
-    ManualSearchPanelView, MultipleExactMatchesView, SmartFileDisplayView,
+    ConfirmationView, DiscIdPill, DiscIdSource, LoadingIndicator, ManualSearchPanelView,
+    MultipleExactMatchesView, SmartFileDisplayView,
 };
 use crate::components::icons::{CloudOffIcon, LoaderIcon};
 use crate::components::StorageProfile;
@@ -438,31 +438,25 @@ fn ConfirmStep(
     };
 
     rsx! {
-        div { class: "space-y-6",
-            ConfirmationView {
-                candidate: candidate.clone(),
-                selected_cover,
-                display_cover_url,
-                artwork_files,
-                remote_cover_url: candidate.cover_url.clone(),
-                storage_profiles,
-                selected_profile_id,
-                is_importing,
-                is_completed,
-                completed_album_id,
-                preparing_step_text,
-                on_select_cover,
-                on_storage_profile_change,
-                on_edit,
-                on_confirm,
-                on_configure_storage,
-                on_view_in_library,
-            }
-
-            ImportErrorDisplayView {
-                error_message: import_error,
-                on_retry: move |_| on_confirm.call(()),
-            }
+        ConfirmationView {
+            candidate: candidate.clone(),
+            selected_cover,
+            display_cover_url,
+            artwork_files,
+            remote_cover_url: candidate.cover_url.clone(),
+            storage_profiles,
+            selected_profile_id,
+            is_importing,
+            is_completed,
+            completed_album_id,
+            preparing_step_text,
+            on_select_cover,
+            on_storage_profile_change,
+            on_edit,
+            on_confirm,
+            on_configure_storage,
+            on_view_in_library,
+            import_error,
         }
     }
 }

--- a/bae-ui/src/components/import/workflow/manual_search_panel.rs
+++ b/bae-ui/src/components/import/workflow/manual_search_panel.rs
@@ -5,7 +5,7 @@ use super::search_source_selector::SearchSourceSelectorView;
 use super::{DiscIdPill, DiscIdSource, LoadingIndicator};
 use crate::components::button::ButtonVariant;
 use crate::components::segmented_control::{Segment, SegmentedControl};
-use crate::components::{Button, ButtonSize, TextInput, TextInputSize, TextInputType};
+use crate::components::{Button, ButtonSize, ErrorBanner, TextInput, TextInputSize, TextInputType};
 use crate::display_types::{MatchCandidate, SearchSource, SearchTab};
 use crate::floating_ui::Placement;
 use crate::stores::import::{CandidateState, ImportState, ImportStateStoreExt};
@@ -162,8 +162,11 @@ pub fn ManualSearchPanelView(
 
                 // Error message
                 if let Some(ref err) = error {
-                    div { class: "bg-red-500/15 rounded-lg p-3",
-                        p { class: "text-sm text-red-300 select-text", "Error: {err}" }
+                    ErrorBanner {
+                        heading: "Search failed".to_string(),
+                        detail: err.clone(),
+                        button_label: "Retry Search".to_string(),
+                        on_retry: move |_| on_search.call(()),
                     }
                 }
 

--- a/bae-ui/src/components/import/workflow/torrent_import.rs
+++ b/bae-ui/src/components/import/workflow/torrent_import.rs
@@ -13,9 +13,9 @@
 //! Pass `ReadStore<ImportState>` down to children. Use lenses where possible.
 
 use super::{
-    ConfirmationView, DiscIdLookupErrorView, ImportErrorDisplayView, ManualSearchPanelView,
-    MetadataDetectionPromptView, MultipleExactMatchesView, SelectedSourceView,
-    TorrentFilesDisplayView, TorrentInfoDisplayView, TorrentTrackerDisplayView, TrackerStatus,
+    ConfirmationView, DiscIdLookupErrorView, ManualSearchPanelView, MetadataDetectionPromptView,
+    MultipleExactMatchesView, SelectedSourceView, TorrentFilesDisplayView, TorrentInfoDisplayView,
+    TorrentTrackerDisplayView, TrackerStatus,
 };
 use crate::components::StorageProfile;
 use crate::display_types::{
@@ -452,10 +452,7 @@ fn TorrentConfirmContent(
                 on_confirm,
                 on_configure_storage,
                 on_view_in_library,
-            }
-            ImportErrorDisplayView {
-                error_message: import_error,
-                on_retry: move |_| on_confirm.call(()),
+                import_error,
             }
         }
     }


### PR DESCRIPTION
## Summary
- Move `ImportErrorDisplayView` inside `ConfirmationView` so the error banner renders between the release card and the storage/import button row (was below the button row)
- Replace the red inline error in `ManualSearchPanelView` with the shared `ErrorBanner` component ("Search failed" heading + "Retry Search" button)
- Add "Search Error" preset and `search_error` toggle to the folder import mock

## Test plan
- [ ] Open FolderImportView mock → select "Confirm Failed" preset → error banner should appear above the Import button row, not below it
- [ ] Select "Search Error" preset → manual search shows amber ErrorBanner with "Search failed" heading
- [ ] CD and torrent import confirm failures also show error in correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)