### PR TITLE
Rename CoverChange::ExistingImage to ReleaseImage { file_id }

### DIFF
--- a/bae-desktop/src/ui/app_service.rs
+++ b/bae-desktop/src/ui/app_service.rs
@@ -1476,11 +1476,10 @@ async fn change_cover_async(
     selection: bae_ui::display_types::CoverChange,
 ) -> Result<(), String> {
     match selection {
-        bae_ui::display_types::CoverChange::ExistingImage { image_id } => {
-            // image_id is a file ID -- get the file to read its bytes
+        bae_ui::display_types::CoverChange::ReleaseImage { file_id } => {
             let file = library_manager
                 .get()
-                .get_file_by_id(&image_id)
+                .get_file_by_id(&file_id)
                 .await
                 .map_err(|e| format!("Failed to get file: {}", e))?
                 .ok_or_else(|| "File not found".to_string())?;

--- a/bae-ui/src/components/album_detail/cover_picker.rs
+++ b/bae-ui/src/components/album_detail/cover_picker.rs
@@ -29,8 +29,8 @@ pub fn CoverPickerWrapper(
         if img.is_cover {
             cover_index = Some(gallery_items.len());
         }
-        change_map.push(CoverChange::ExistingImage {
-            image_id: img.id.clone(),
+        change_map.push(CoverChange::ReleaseImage {
+            file_id: img.id.clone(),
         });
         gallery_items.push(GalleryItem {
             label: img.filename.clone(),

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -161,7 +161,7 @@ pub struct RemoteCoverOption {
 /// Cover selection from the cover picker
 #[derive(Clone, Debug, PartialEq)]
 pub enum CoverChange {
-    ExistingImage { image_id: String },
+    ReleaseImage { file_id: String },
     RemoteCover { url: String, source: String },
 }
 


### PR DESCRIPTION
## Summary

- Rename `CoverChange::ExistingImage { image_id }` to `CoverChange::ReleaseImage { file_id }` — the variant holds a `DbFile.id` (not the deleted `DbImage.id`), and represents picking an image from the release's files

## Test plan

- [ ] Cover picker: select existing image from release files still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)