### PR TITLE
Use deferred cleanup for release/album deletion

### DIFF
--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -81,7 +81,11 @@ async fn test_delete_album_integration() {
     database.insert_track(&track1).await.unwrap();
     database.insert_track(&track2).await.unwrap();
 
-    library_manager.get().delete_album(&album.id).await.unwrap();
+    library_manager
+        .get()
+        .delete_album(&album.id, _temp_dir.path())
+        .await
+        .unwrap();
 
     let album_result = library_manager
         .get()
@@ -118,7 +122,7 @@ async fn test_delete_release_integration() {
 
     library_manager
         .get()
-        .delete_release(&release1.id)
+        .delete_release(&release1.id, _temp_dir.path())
         .await
         .unwrap();
 
@@ -163,7 +167,7 @@ async fn test_delete_last_release_deletes_album() {
 
     library_manager
         .get()
-        .delete_release(&release.id)
+        .delete_release(&release.id, _temp_dir.path())
         .await
         .unwrap();
 

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -310,7 +310,7 @@ async fn test_storageless_delete_preserves_files() {
     info!("Deleting release {}", release_id);
     shared_library_manager
         .get()
-        .delete_release(&release_id)
+        .delete_release(&release_id, &db_dir)
         .await
         .expect("delete release");
 

--- a/bae-desktop/src/ui/components/album_detail/page.rs
+++ b/bae-desktop/src/ui/components/album_detail/page.rs
@@ -168,6 +168,7 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
     // Delete release callback
     let on_delete_release = EventHandler::new({
         let library_manager = library_manager.clone();
+        let library_dir = app.config.library_dir.clone();
         let playback = playback.clone();
         move |release_id: String| {
             // Stop playback if current track belongs to the release being deleted
@@ -181,8 +182,13 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
             }
 
             let library_manager = library_manager.clone();
+            let library_dir = library_dir.clone();
             spawn(async move {
-                if let Err(e) = library_manager.get().delete_release(&release_id).await {
+                if let Err(e) = library_manager
+                    .get()
+                    .delete_release(&release_id, &library_dir)
+                    .await
+                {
                     error!("Failed to delete release: {}", e);
                 }
             });
@@ -200,6 +206,7 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
     // Delete album callback
     let on_delete_album = EventHandler::new({
         let library_manager = library_manager.clone();
+        let library_dir = app.config.library_dir.clone();
         let playback = playback.clone();
         move |album_id: String| {
             // Stop playback if current track belongs to the album being deleted
@@ -214,8 +221,13 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
             }
 
             let library_manager = library_manager.clone();
+            let library_dir = library_dir.clone();
             spawn(async move {
-                if let Err(e) = library_manager.get().delete_album(&album_id).await {
+                if let Err(e) = library_manager
+                    .get()
+                    .delete_album(&album_id, &library_dir)
+                    .await
+                {
                     error!("Failed to delete album: {}", e);
                 }
             });


### PR DESCRIPTION
## Summary
- `delete_release()` and `delete_album()` previously attempted synchronous cloud file deletion, then deleted DB records regardless of outcome. Failed cloud deletes left orphaned objects in S3 with no record pointing to them.
- Now queues files into `pending_deletions.json` manifest **before** deleting DB records, reusing the existing deferred cleanup pattern from the transfer service. The cleanup service (runs on startup, retries failures) handles actual file deletion.
- Extracted shared `queue_release_files_for_deletion()` helper that builds `PendingDeletion` entries from files + storage profile, matching the same local/cloud distinction used by the transfer service.

## Test plan
- [x] Existing unit tests in `manager.rs` pass (updated to pass `library_path`)
- [x] Integration tests in `test_delete.rs` pass
- [x] `test_storageless_delete_preserves_files` in `test_storage.rs` passes (self-managed files still untouched)
- [x] Clippy clean on bae-core, bae-desktop, bae-mocks, bae-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)