### PR TITLE
Note that sqlx enables PRAGMA foreign_keys by default

### DIFF
--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -9,7 +9,10 @@ pub struct Database {
     pool: SqlitePool,
 }
 impl Database {
-    /// Initialize database connection and run migrations
+    /// Initialize database connection and run migrations.
+    ///
+    /// Note: sqlx enables `PRAGMA foreign_keys = ON` by default (since v0.4),
+    /// so FK constraints in the schema are enforced on every connection.
     pub async fn new(database_path: &str) -> Result<Self, sqlx::Error> {
         let database_url = format!("sqlite://{}?mode=rwc", database_path);
         info!("Connecting to {}", database_url);


### PR DESCRIPTION
## Summary
- Added doc comment on `Database::new` noting that sqlx enables `PRAGMA foreign_keys = ON` by default since v0.4, so FK constraints are enforced without explicit pragma calls

## Test plan
- [ ] Doc-only change, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)