### PR TITLE
Move S3 storage profile credentials from DB to OS keyring

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -170,8 +170,6 @@ CREATE TABLE storage_profiles (
     cloud_bucket TEXT,
     cloud_region TEXT,
     cloud_endpoint TEXT,
-    cloud_access_key TEXT,
-    cloud_secret_key TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/bae-core/src/cloud_storage.rs
+++ b/bae-core/src/cloud_storage.rs
@@ -53,6 +53,25 @@ impl S3Config {
         Ok(())
     }
 }
+/// Build an S3Config from a cloud storage profile by reading credentials from the keyring.
+///
+/// Returns None if the profile is not a cloud profile or if credentials are missing.
+pub fn s3_config_from_profile(
+    profile: &crate::db::DbStorageProfile,
+    key_service: &crate::keys::KeyService,
+) -> Option<S3Config> {
+    if profile.location != crate::db::StorageLocation::Cloud {
+        return None;
+    }
+    Some(S3Config {
+        bucket_name: profile.cloud_bucket.clone()?,
+        region: profile.cloud_region.clone()?,
+        access_key_id: key_service.get_profile_access_key(&profile.id)?,
+        secret_access_key: key_service.get_profile_secret_key(&profile.id)?,
+        endpoint_url: profile.cloud_endpoint.clone(),
+    })
+}
+
 /// Trait for cloud storage operations (allows mocking for tests)
 #[async_trait::async_trait]
 pub trait CloudStorage: Send + Sync {

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -1515,9 +1515,9 @@ impl Database {
             r#"
             INSERT INTO storage_profiles (
                 id, name, location, location_path, encrypted, is_default,
-                cloud_bucket, cloud_region, cloud_endpoint, cloud_access_key, cloud_secret_key,
+                cloud_bucket, cloud_region, cloud_endpoint,
                 created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&profile.id)
@@ -1529,8 +1529,6 @@ impl Database {
         .bind(&profile.cloud_bucket)
         .bind(&profile.cloud_region)
         .bind(&profile.cloud_endpoint)
-        .bind(&profile.cloud_access_key)
-        .bind(&profile.cloud_secret_key)
         .bind(profile.created_at.to_rfc3339())
         .bind(profile.updated_at.to_rfc3339())
         .execute(&self.pool)
@@ -1584,7 +1582,6 @@ impl Database {
                 name = ?, location = ?, location_path = ?, encrypted = ?,
                 is_default = ?,
                 cloud_bucket = ?, cloud_region = ?, cloud_endpoint = ?,
-                cloud_access_key = ?, cloud_secret_key = ?,
                 updated_at = ?
             WHERE id = ?
             "#,
@@ -1597,8 +1594,6 @@ impl Database {
         .bind(&profile.cloud_bucket)
         .bind(&profile.cloud_region)
         .bind(&profile.cloud_endpoint)
-        .bind(&profile.cloud_access_key)
-        .bind(&profile.cloud_secret_key)
         .bind(profile.updated_at.to_rfc3339())
         .bind(&profile.id)
         .execute(&self.pool)
@@ -1653,8 +1648,6 @@ impl Database {
             cloud_bucket: row.get("cloud_bucket"),
             cloud_region: row.get("cloud_region"),
             cloud_endpoint: row.get("cloud_endpoint"),
-            cloud_access_key: row.get("cloud_access_key"),
-            cloud_secret_key: row.get("cloud_secret_key"),
             created_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("created_at"))
                 .unwrap()
                 .with_timezone(&Utc),

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -868,10 +868,6 @@ pub struct DbStorageProfile {
     pub cloud_region: Option<String>,
     /// Custom endpoint URL for S3-compatible services (MinIO, etc.)
     pub cloud_endpoint: Option<String>,
-    /// Access key ID
-    pub cloud_access_key: Option<String>,
-    /// Secret access key
-    pub cloud_secret_key: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -889,8 +885,6 @@ impl DbStorageProfile {
             cloud_bucket: None,
             cloud_region: None,
             cloud_endpoint: None,
-            cloud_access_key: None,
-            cloud_secret_key: None,
             created_at: now,
             updated_at: now,
         }
@@ -901,8 +895,6 @@ impl DbStorageProfile {
         bucket: &str,
         region: &str,
         endpoint: Option<&str>,
-        access_key: &str,
-        secret_key: &str,
         encrypted: bool,
     ) -> Self {
         let now = Utc::now();
@@ -916,8 +908,6 @@ impl DbStorageProfile {
             cloud_bucket: Some(bucket.to_string()),
             cloud_region: Some(region.to_string()),
             cloud_endpoint: endpoint.map(|s| s.to_string()),
-            cloud_access_key: Some(access_key.to_string()),
-            cloud_secret_key: Some(secret_key.to_string()),
             created_at: now,
             updated_at: now,
         }
@@ -925,21 +915,6 @@ impl DbStorageProfile {
     pub fn with_default(mut self, is_default: bool) -> Self {
         self.is_default = is_default;
         self
-    }
-
-    /// Convert cloud storage fields to S3Config for creating a client.
-    /// Returns None if this is not a cloud profile or credentials are missing.
-    pub fn to_s3_config(&self) -> Option<crate::cloud_storage::S3Config> {
-        if self.location != StorageLocation::Cloud {
-            return None;
-        }
-        Some(crate::cloud_storage::S3Config {
-            bucket_name: self.cloud_bucket.clone()?,
-            region: self.cloud_region.clone()?,
-            access_key_id: self.cloud_access_key.clone()?,
-            secret_access_key: self.cloud_secret_key.clone()?,
-            endpoint_url: self.cloud_endpoint.clone(),
-        })
     }
 }
 /// Links a release to its storage profile

--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -1,6 +1,7 @@
 use crate::cache::CacheManager;
 use crate::cloud_storage::CloudStorage;
 use crate::encryption::EncryptionService;
+use crate::keys::KeyService;
 use crate::library::LibraryManager;
 use crate::playback::track_loader::load_track_audio;
 use crate::storage::create_storage_reader;
@@ -22,6 +23,7 @@ impl ExportService {
         library_manager: &LibraryManager,
         _cache: &CacheManager,
         encryption_service: Option<&EncryptionService>,
+        key_service: &KeyService,
     ) -> Result<(), String> {
         info!(
             "Exporting release {} to {}",
@@ -36,7 +38,7 @@ impl ExportService {
             .map_err(|e| format!("Failed to get storage profile: {}", e))?
             .ok_or_else(|| "No storage profile found for release".to_string())?;
 
-        let storage = create_storage_reader(&storage_profile)
+        let storage = create_storage_reader(&storage_profile, key_service)
             .await
             .map_err(|e| format!("Failed to create storage reader: {}", e))?;
 

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -523,6 +523,7 @@ impl LibraryManager {
         release_id: &str,
         target_dir: &Path,
         cache: &CacheManager,
+        key_service: &crate::keys::KeyService,
     ) -> Result<(), LibraryError> {
         ExportService::export_release(
             release_id,
@@ -530,6 +531,7 @@ impl LibraryManager {
             self,
             cache,
             self.encryption_service.as_ref(),
+            key_service,
         )
         .await
         .map_err(LibraryError::Import)
@@ -543,6 +545,7 @@ impl LibraryManager {
         track_id: &str,
         output_path: &Path,
         cache: &CacheManager,
+        key_service: &crate::keys::KeyService,
     ) -> Result<(), LibraryError> {
         // Get storage profile for track's release
         let track = self
@@ -554,7 +557,7 @@ impl LibraryManager {
             .get_storage_profile_for_release(&track.release_id)
             .await?
             .ok_or_else(|| LibraryError::Import("No storage profile for release".to_string()))?;
-        let storage = crate::storage::create_storage_reader(&storage_profile)
+        let storage = crate::storage::create_storage_reader(&storage_profile, key_service)
             .await
             .map_err(LibraryError::CloudStorage)?;
 

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -15,6 +15,7 @@ use bae_core::db::{Database, ImportStatus};
 use bae_core::discogs::models::{DiscogsRelease, DiscogsTrack};
 use bae_core::encryption::EncryptionService;
 use bae_core::import::{ImportProgress, ImportRequest, ImportService};
+use bae_core::keys::KeyService;
 use bae_core::library::{LibraryManager, SharedLibraryManager};
 use std::path::Path;
 use std::sync::Arc;
@@ -263,6 +264,7 @@ async fn test_cue_flac_playback_uses_track_positions() {
     let playback_handle = bae_core::playback::PlaybackService::start(
         library_manager.as_ref().clone(),
         encryption_service,
+        KeyService::new(true, "test".to_string()),
         runtime_handle,
     );
     playback_handle.set_volume(0.0);
@@ -395,6 +397,7 @@ async fn test_cue_flac_decoded_duration_matches_cue_timing() {
     let playback_handle = bae_core::playback::PlaybackService::start(
         library_manager.as_ref().clone(),
         encryption_service,
+        KeyService::new(true, "test".to_string()),
         runtime_handle,
     );
     playback_handle.set_volume(0.0);

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -6,6 +6,7 @@ use bae_core::db::{Database, DbStorageProfile};
 use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::encryption::EncryptionService;
 use bae_core::import::ImportRequest;
+use bae_core::keys::KeyService;
 use bae_core::library::{LibraryManager, SharedLibraryManager};
 use bae_core::playback::{PlaybackProgress, PlaybackState};
 use std::sync::Arc;
@@ -99,6 +100,7 @@ impl PlaybackTestFixture {
         let playback_handle = bae_core::playback::PlaybackService::start(
             library_manager_arc.as_ref().clone(),
             encryption_service,
+            KeyService::new(true, "test".to_string()),
             runtime_handle,
         );
         playback_handle.set_volume(0.0);
@@ -413,6 +415,7 @@ impl CueFlacTestFixture {
         let playback_handle = bae_core::playback::PlaybackService::start(
             library_manager_arc.as_ref().clone(),
             encryption_service,
+            KeyService::new(true, "test".to_string()),
             runtime_handle,
         );
         playback_handle.set_volume(0.0);
@@ -2055,6 +2058,7 @@ impl HighSampleRateTestFixture {
         let playback_handle = bae_core::playback::PlaybackService::start(
             library_manager_arc.as_ref().clone(),
             encryption_service,
+            KeyService::new(true, "test".to_string()),
             runtime_handle,
         );
         playback_handle.set_volume(0.0);
@@ -2459,6 +2463,7 @@ async fn test_real_library_cpu_usage() {
     let playback_handle = bae_core::playback::PlaybackService::start(
         library_manager.clone(),
         encryption_service,
+        KeyService::new(true, "test".to_string()),
         runtime_handle,
     );
     let mut progress_rx = playback_handle.subscribe_progress();
@@ -2632,6 +2637,7 @@ async fn test_pause_seek_cue_flac() {
     let playback_handle = bae_core::playback::PlaybackService::start(
         library_manager.clone(),
         encryption_service,
+        KeyService::new(true, "test".to_string()),
         runtime_handle,
     );
     playback_handle.set_volume(0.0); // Mute for test
@@ -2855,6 +2861,7 @@ async fn test_playing_seek_cue_flac() {
     let playback_handle = bae_core::playback::PlaybackService::start(
         library_manager.clone(),
         encryption_service,
+        KeyService::new(true, "test".to_string()),
         runtime_handle,
     );
     playback_handle.set_volume(0.0);

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -10,6 +10,7 @@ use bae_core::db::Database;
 use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::encryption::EncryptionService;
 use bae_core::import::ImportRequest;
+use bae_core::keys::KeyService;
 use bae_core::library::{LibraryManager, SharedLibraryManager};
 use bae_core::playback::{PlaybackProgress, PlaybackState};
 use std::sync::Arc;
@@ -221,6 +222,7 @@ impl CueFlacTestFixture {
         let playback_handle = bae_core::playback::PlaybackService::start(
             library_manager_arc.as_ref().clone(),
             encryption_service,
+            KeyService::new(true, "test".to_string()),
             runtime_handle,
         );
         playback_handle.set_volume(0.0);

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -622,15 +622,9 @@ fn create_storage_profile(
     );
     match location {
         StorageLocation::Local => DbStorageProfile::new_local(&name, storage_path, encrypted),
-        StorageLocation::Cloud => DbStorageProfile::new_cloud(
-            &name,
-            "test-bucket",
-            "us-east-1",
-            None,
-            "test-access-key",
-            "test-secret-key",
-            encrypted,
-        ),
+        StorageLocation::Cloud => {
+            DbStorageProfile::new_cloud(&name, "test-bucket", "us-east-1", None, encrypted)
+        }
     }
 }
 

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -13,6 +13,7 @@ use bae_core::content_type::ContentType;
 use bae_core::db::{
     Database, DbAlbum, DbFile, DbRelease, DbReleaseStorage, DbStorageProfile, ImportStatus,
 };
+use bae_core::keys::KeyService;
 use bae_core::library::LibraryManager;
 use bae_core::library_dir::LibraryDir;
 use bae_core::storage::cleanup::PendingDeletion;
@@ -198,6 +199,7 @@ async fn test_transfer_self_managed_to_local_profile() {
         shared_mgr.clone(),
         None,
         LibraryDir::new(library_path.clone()),
+        KeyService::new(true, "test".to_string()),
     );
     let rx = service.transfer(
         release_id.clone(),
@@ -308,6 +310,7 @@ async fn test_transfer_local_profile_to_local_profile() {
         shared_mgr.clone(),
         None,
         LibraryDir::new(library_path.clone()),
+        KeyService::new(true, "test".to_string()),
     );
     let rx = service.transfer(
         release_id.clone(),
@@ -393,6 +396,7 @@ async fn test_eject_from_local_profile() {
         shared_mgr.clone(),
         None,
         LibraryDir::new(library_path.clone()),
+        KeyService::new(true, "test".to_string()),
     );
     let rx = service.transfer(release_id.clone(), TransferTarget::Eject(eject_dir.clone()));
     let events = collect_progress(rx).await;
@@ -465,7 +469,12 @@ async fn test_transfer_empty_release_fails() {
     db.insert_storage_profile(&dest_profile).await.unwrap();
 
     let shared_mgr = bae_core::library::SharedLibraryManager::new(mgr);
-    let service = TransferService::new(shared_mgr, None, LibraryDir::new(library_path));
+    let service = TransferService::new(
+        shared_mgr,
+        None,
+        LibraryDir::new(library_path),
+        KeyService::new(true, "test".to_string()),
+    );
     let rx = service.transfer(release_id.clone(), TransferTarget::Profile(dest_profile));
     let events = collect_progress(rx).await;
 

--- a/bae-desktop/src/ui/components/album_detail/page.rs
+++ b/bae-desktop/src/ui/components/album_detail/page.rs
@@ -101,9 +101,11 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
     let on_track_export = EventHandler::new({
         let library_manager = library_manager.clone();
         let cache = cache.clone();
+        let key_service = app.key_service.clone();
         move |track_id: String| {
             let library_manager = library_manager.clone();
             let cache = cache.clone();
+            let key_service = key_service.clone();
             spawn(async move {
                 if let Some(file_handle) = AsyncFileDialog::new()
                     .set_title("Export Track")
@@ -115,7 +117,7 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
                     let output_path = file_handle.path().to_path_buf();
                     if let Err(e) = library_manager
                         .get()
-                        .export_track(&track_id, &output_path, &cache)
+                        .export_track(&track_id, &output_path, &cache, &key_service)
                         .await
                     {
                         error!("Failed to export track: {}", e);
@@ -143,9 +145,11 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
     let on_export_release = EventHandler::new({
         let library_manager = library_manager.clone();
         let cache = cache.clone();
+        let key_service = app.key_service.clone();
         move |release_id: String| {
             let library_manager = library_manager.clone();
             let cache = cache.clone();
+            let key_service = key_service.clone();
             spawn(async move {
                 if let Some(folder_handle) = AsyncFileDialog::new()
                     .set_title("Select Export Directory")
@@ -155,7 +159,7 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
                     let target_dir = folder_handle.path().to_path_buf();
                     if let Err(e) = library_manager
                         .get()
-                        .export_release(&release_id, &target_dir, &cache)
+                        .export_release(&release_id, &target_dir, &cache, &key_service)
                         .await
                     {
                         error!("Failed to export release: {}", e);

--- a/notes/00-data-model.md
+++ b/notes/00-data-model.md
@@ -69,6 +69,8 @@ Managed by `KeyService`. On macOS, uses the protected data store with iCloud Key
 
 - `encryption_master_key` — one per library, used for all file and metadata encryption
 - `discogs_api_key`
+- `s3_access_key:{profile_id}` — per-profile S3 access key (cloud profiles only)
+- `s3_secret_key:{profile_id}` — per-profile S3 secret key (cloud profiles only)
 
 ### Storage profile layout
 

--- a/notes/02-storage-profiles.md
+++ b/notes/02-storage-profiles.md
@@ -171,7 +171,7 @@ Metadata replicas on cloud profiles are encrypted (DB as a blob, images individu
 
 Two tables:
 
-**`storage_profiles`** — profile configuration. `location` is "local" or "cloud". Local profiles have `location_path`. Cloud profiles have `cloud_bucket`, `cloud_region`, `cloud_endpoint`, `cloud_access_key`, `cloud_secret_key`. `encrypted` flag (always false for local, always true for cloud). `is_default` marks the profile pre-selected in import.
+**`storage_profiles`** — profile configuration. `location` is "local" or "cloud". Local profiles have `location_path`. Cloud profiles have `cloud_bucket`, `cloud_region`, `cloud_endpoint`. S3 credentials (access key, secret key) are stored in the OS keyring per profile ID, not in the DB — see `00-data-model.md` keyring section. `encrypted` flag (always false for local, always true for cloud). `is_default` marks the profile pre-selected in import.
 
 **`release_storage`** — links a release to a profile. One row per release-profile pair, FK to both `releases` and `storage_profiles`. A release can be on multiple profiles. A release with no `release_storage` rows is unmanaged.
 


### PR DESCRIPTION
## Summary

S3 credentials (`cloud_access_key`, `cloud_secret_key`) were stored as plaintext in the `storage_profiles` SQLite table. Any process that could read `library.db` got S3 bucket access. This moves them to the OS keyring via `KeyService`, matching how the encryption key is already stored.

- Remove `cloud_access_key`/`cloud_secret_key` columns from `storage_profiles` table
- Add 5 per-profile credential methods to `KeyService` (get/set/delete for access key and secret key)
- New `s3_config_from_profile(profile, key_service)` free function replaces `DbStorageProfile::to_s3_config()`
- Thread `KeyService` through all storage callsites (reader, traits, transfer, cleanup, subsonic, playback, import, export)
- Desktop bridge: save writes to keyring, load reads from keyring, delete cleans up keyring
- bae-server: creates dev-mode `KeyService`, bridges CLI args to env vars
- Specs updated to reflect new keyring entries

## Plan

<details>
<summary>Phase 0.4 plan (from storage roadmap)</summary>

**Why:** `cloud_access_key` and `cloud_secret_key` are stored as plaintext in `storage_profiles` table. Spec says "credentials go in the keyring" (`00-data-model.md:64`). Any process that reads `library.db` gets S3 bucket access.

**Approach:** Store per-profile S3 credentials in OS keyring via `KeyService`, keyed by profile_id. Keep bucket/region/endpoint in DB (not secrets).

**KeyService additions:**
- Dev mode: `BAE_S3_ACCESS_KEY_{profile_id}` then `BAE_S3_ACCESS_KEY` fallback
- Prod mode: keyring entries `s3_access_key:{profile_id}` / `s3_secret_key:{profile_id}`

**bae-server:** Creates `KeyService::new(true, library_id)` (dev mode). CLI args bridged to `BAE_S3_ACCESS_KEY`/`BAE_S3_SECRET_KEY` env vars before KeyService creation.

**bae-ui unchanged:** Keeps credential fields as editor form transport. Cannot depend on keyring (wasm target).
</details>

## Test plan

- [x] `cargo clippy -p bae-core -p bae-desktop -p bae-mocks -p bae-server` clean
- [x] `cargo test -p bae-core` — all 216 tests pass
- [x] No `cloud_access_key`/`cloud_secret_key` in SQL or model code (only UI types, KeyService, specs)
- [ ] Manual: `rm -rf ~/.bae`, create library, add cloud profile, verify credentials stored in keyring not DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)