### PR TITLE
Switch to hash-based file and image layout

### DIFF
--- a/bae-core/src/cloud_storage.rs
+++ b/bae-core/src/cloud_storage.rs
@@ -211,14 +211,9 @@ impl S3CloudStorage {
             bucket_name,
         })
     }
-    /// Generate S3 key using hash-based partitioning for better distribution
+    /// S3 key — callers provide the full key (e.g. `storage/ab/cd/{file_id}`).
     fn object_key(&self, key: &str) -> String {
-        if key.len() < 4 {
-            return format!("files/misc/{}", key);
-        }
-        let prefix = &key[..2];
-        let subprefix = &key[2..4];
-        format!("files/{}/{}/{}", prefix, subprefix, key)
+        key.to_string()
     }
 }
 #[async_trait::async_trait]

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -906,14 +906,14 @@ impl ImportService {
         let content_type = ContentType::from_extension(ext);
         let source_url = format!("release://{}", relative_path);
 
-        // Copy cover to covers/{release_id}
-        let covers_dir = self.library_dir.covers_dir();
-        if let Err(e) = std::fs::create_dir_all(&covers_dir) {
-            error!("Failed to create covers directory: {}", e);
-            return Ok(());
+        // Copy cover to images/ab/cd/{release_id}
+        let cache_path = self.library_dir.image_path(release_id);
+        if let Some(parent) = cache_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                error!("Failed to create images directory: {}", e);
+                return Ok(());
+            }
         }
-
-        let cache_path = self.library_dir.cover_path(release_id);
         if let Err(e) = std::fs::copy(&cover_file.path, &cache_path) {
             error!("Failed to cache cover art: {}", e);
             return Ok(());
@@ -973,20 +973,20 @@ impl ImportService {
             }
         };
 
-        let cover_path = self.library_dir.cover_path(release_id);
-        if let Some(parent) = cover_path.parent() {
+        let image_path = self.library_dir.image_path(release_id);
+        if let Some(parent) = image_path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
-                error!("Failed to create covers directory: {}", e);
+                error!("Failed to create images directory: {}", e);
                 return false;
             }
         }
 
-        if let Err(e) = std::fs::write(&cover_path, &bytes) {
+        if let Err(e) = std::fs::write(&image_path, &bytes) {
             error!("Failed to write cover: {}", e);
             return false;
         }
 
-        info!("Wrote remote cover art to {}", cover_path.display());
+        info!("Wrote remote cover art to {}", image_path.display());
         let source = if url.contains("musicbrainz") || url.contains("coverartarchive") {
             "musicbrainz"
         } else {

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -387,6 +387,14 @@ impl LibraryManager {
         Ok(self.database.get_library_image(id, image_type).await?)
     }
 
+    /// Get a library image by ID (regardless of type)
+    pub async fn get_library_image_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<DbLibraryImage>, LibraryError> {
+        Ok(self.database.get_library_image_by_id(id).await?)
+    }
+
     /// Delete a library image by ID and type
     pub async fn delete_library_image(
         &self,

--- a/bae-core/src/library_dir.rs
+++ b/bae-core/src/library_dir.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 /// Typed wrapper for a library directory path.
 ///
 /// Centralizes the on-disk layout so callers use methods instead of
-/// ad-hoc `path.join("covers")` etc.
+/// ad-hoc `path.join("images")` etc.
 #[derive(Clone, Debug)]
 pub struct LibraryDir {
     path: PathBuf,
@@ -23,20 +23,14 @@ impl LibraryDir {
         self.path.join("config.yaml")
     }
 
-    pub fn covers_dir(&self) -> PathBuf {
-        self.path.join("covers")
+    pub fn images_dir(&self) -> PathBuf {
+        self.path.join("images")
     }
 
-    pub fn artists_dir(&self) -> PathBuf {
-        self.path.join("artists")
-    }
-
-    pub fn cover_path(&self, release_id: &str) -> PathBuf {
-        self.covers_dir().join(release_id)
-    }
-
-    pub fn artist_image_path(&self, artist_id: &str) -> PathBuf {
-        self.artists_dir().join(artist_id)
+    /// Hash-based image path: `images/{ab}/{cd}/{id}`
+    pub fn image_path(&self, id: &str) -> PathBuf {
+        let hex = id.replace('-', "");
+        self.images_dir().join(&hex[..2]).join(&hex[2..4]).join(id)
     }
 
     pub fn pending_deletions_path(&self) -> PathBuf {
@@ -45,7 +39,7 @@ impl LibraryDir {
 
     /// All asset directories that should be synced/created.
     pub fn asset_dirs(&self) -> Vec<PathBuf> {
-        vec![self.covers_dir(), self.artists_dir()]
+        vec![self.images_dir()]
     }
 }
 

--- a/bae-core/src/storage/mod.rs
+++ b/bae-core/src/storage/mod.rs
@@ -10,3 +10,34 @@ pub mod transfer;
 
 pub use reader::create_storage_reader;
 pub use traits::{ReleaseStorage, ReleaseStorageImpl};
+
+/// Hash-based storage path for a file: `storage/{ab}/{cd}/{file_id}`
+///
+/// Deterministic from the file_id alone. Used for both local profiles
+/// (relative to `location_path`) and cloud profiles (S3 key).
+pub fn storage_path(file_id: &str) -> String {
+    let hex = file_id.replace('-', "");
+    format!("storage/{}/{}/{}", &hex[..2], &hex[2..4], file_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_path_uses_first_four_hex_chars() {
+        let id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let path = storage_path(id);
+        assert_eq!(path, format!("storage/a1/b2/{}", id));
+    }
+
+    #[test]
+    fn storage_path_preserves_original_id_with_dashes() {
+        let id = "12345678-aaaa-bbbb-cccc-ddddeeeeaaaa";
+        let path = storage_path(id);
+        // prefix from dashless hex: "12" and "34"
+        assert_eq!(path, format!("storage/12/34/{}", id));
+        // The full id with dashes is the filename
+        assert!(path.ends_with(id));
+    }
+}

--- a/bae-desktop/src/media_controls.rs
+++ b/bae-desktop/src/media_controls.rs
@@ -278,7 +278,7 @@ async fn update_media_metadata(
     };
 
     let cover_url = cover_release_id
-        .map(|rid| imgs.cover_url(&rid))
+        .map(|rid| imgs.image_url(&rid))
         .or(cover_art_url);
     let title = track.title.clone();
     let artist_str = artist_name.as_deref();

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -310,12 +310,9 @@ async fn do_restore(
     let db_path = library_dir.db_path();
     sync_service.download_db(&db_path).await?;
 
-    // Download covers + artist images
-    let covers_dir = library_dir.covers_dir();
-    sync_service.download_covers(&covers_dir).await?;
-
-    let artists_dir = library_dir.artists_dir();
-    sync_service.download_artists(&artists_dir).await?;
+    // Download library images (covers + artist photos)
+    let images_dir = library_dir.images_dir();
+    sync_service.download_images(&images_dir).await?;
 
     // Write config.yaml with cloud sync settings already populated
     let config = bae_core::config::Config {

--- a/bae-desktop/src/ui/display_types.rs
+++ b/bae-desktop/src/ui/display_types.rs
@@ -10,7 +10,7 @@ pub fn album_from_db_ref(db: &DbAlbum, imgs: &ImageServerHandle) -> Album {
     let cover = db
         .cover_release_id
         .as_ref()
-        .map(|release_id| imgs.cover_url(release_id))
+        .map(|release_id| imgs.image_url(release_id))
         .or_else(|| db.cover_art_url.clone());
 
     Album {
@@ -27,7 +27,7 @@ pub fn artist_from_db_ref(db: &DbArtist, imgs: &ImageServerHandle) -> Artist {
     Artist {
         id: db.id.clone(),
         name: db.name.clone(),
-        image_url: Some(imgs.artist_image_url(&db.id)),
+        image_url: Some(imgs.image_url(&db.id)),
     }
 }
 

--- a/bae-server/src/main.rs
+++ b/bae-server/src/main.rs
@@ -269,14 +269,14 @@ async fn download_from_cloud(args: &Args, library_dir: &LibraryDir, config: &Con
         std::process::exit(1);
     });
 
-    // Download and decrypt covers
-    let covers_path = library_dir.covers_dir();
-    info!("Downloading covers...");
+    // Download and decrypt library images
+    let images_path = library_dir.images_dir();
+    info!("Downloading images...");
     cloud
-        .download_covers(&covers_path)
+        .download_images(&images_path)
         .await
         .unwrap_or_else(|e| {
-            error!("Failed to download covers: {e}");
+            error!("Failed to download images: {e}");
             std::process::exit(1);
         });
 


### PR DESCRIPTION
## Summary

- Release files now stored at `storage/ab/cd/{file_id}` (was `{release_id}/{filename}`)
- Library images now stored at `images/ab/cd/{id}` (was flat `covers/` + `artists/` dirs)
- Image server unified to single `/image/:id` route (was separate `/cover/:release_id` + `/artist-image/:artist_id`)
- Cloud sync uses recursive directory walking for the nested image layout
- `write_file` restructured: creates DbFile first (for UUID), then computes storage path from file_id

18 files changed across bae-core, bae-desktop, bae-server. Net zero lines (270 added, 284 removed).

## Plan

**Phase 1 of the storage roadmap** ([full plan](/plans/storage/indexed-chasing-clover.md))

### 1a: Release file layout

**Was:** `{location_path}/{release_id}/{filename}` (local), `s3://bucket/files/{prefix}/{subprefix}/{release_id}/{filename}` (cloud)
**Now:** `{location_path}/storage/ab/cd/{file_id}` (local), `s3://bucket/storage/ab/cd/{file_id}` (cloud)

- `storage_path(file_id)` helper strips UUID dashes, uses first 4 hex chars as `ab/cd` prefix
- `write_file` creates `DbFile` first to get UUID, then uses `storage_path(file_id)` for the path
- `cloud_storage.rs` `object_key()` simplified to pass-through (callers provide full key)
- `source_path` in DB stores absolute local path or full S3 URI
- Subsonic and playback read `source_path` from DB directly
- Transfer/eject path unchanged (eject writes human-readable filenames)

### 1b: Image layout

**Was:** `covers/{release_id}` and `artists/{artist_id}` (flat, separate)
**Now:** `images/ab/cd/{id}` (unified, hash-based)

- `image_path(id)` on `LibraryDir` mirrors `storage_path` pattern
- Removed `covers_dir()`, `artists_dir()`, `cover_path()`, `artist_image_path()`
- Image server: merged two routes into `/image/:id` with `get_library_image_by_id`
- `ImageServerHandle`: merged `cover_url()`/`artist_image_url()` into `image_url(id)`
- Cloud sync: unified `upload_images`/`download_images` with recursive dir walking

## Test plan

- [x] `cargo clippy -p bae-core -p bae-desktop -p bae-mocks -p bae-server -- -D warnings` clean
- [x] `cargo test -p bae-core -p bae-desktop` all pass
- [x] Pre-commit hooks pass (fmt, clippy, tests)
- [ ] Manual test: `rm -rf ~/.bae`, fresh library, import album, verify files at `storage/ab/cd/` and images at `images/ab/cd/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)