### PR TITLE
Change active-library pointer from path to UUID

### DIFF
--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -91,7 +91,7 @@ fn is_first_run() -> bool {
         return false;
     }
     let home_dir = dirs::home_dir().expect("Failed to get home directory");
-    !home_dir.join(".bae").join("library").exists()
+    !home_dir.join(".bae").join("active-library").exists()
 }
 
 fn main() {

--- a/bae-desktop/src/ui/components/settings/library.rs
+++ b/bae-desktop/src/ui/components/settings/library.rs
@@ -29,10 +29,19 @@ pub fn LibrarySection() -> Element {
     let on_switch = {
         let app = app.clone();
         move |path: String| {
+            let library_path = PathBuf::from(&path);
+            let target_id = match Config::read_library_id(&library_path) {
+                Ok(id) => id,
+                Err(e) => {
+                    error!("Failed to read library ID at {path}: {e}");
+                    return;
+                }
+            };
+
             let mut config = app.config.clone();
-            config.library_dir = bae_core::library_dir::LibraryDir::new(PathBuf::from(&path));
-            if let Err(e) = config.save_library_path() {
-                error!("Failed to save library path: {e}");
+            config.library_id = target_id;
+            if let Err(e) = config.save_active_library() {
+                error!("Failed to save active library: {e}");
                 return;
             }
 
@@ -53,8 +62,8 @@ pub fn LibrarySection() -> Element {
                 }
             };
 
-            if let Err(e) = config.save_library_path() {
-                error!("Failed to save library pointer: {e}");
+            if let Err(e) = config.save_active_library() {
+                error!("Failed to save active library: {e}");
                 return;
             }
 
@@ -90,11 +99,19 @@ pub fn LibrarySection() -> Element {
                     return;
                 }
 
-                // Switch to the added library
+                // Read the added library's UUID and switch to it
+                let target_id = match Config::read_library_id(&path) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        error!("Failed to read library ID: {e}");
+                        return;
+                    }
+                };
+
                 let mut config = config;
-                config.library_dir = bae_core::library_dir::LibraryDir::new(path);
-                if let Err(e) = config.save_library_path() {
-                    error!("Failed to save library path: {e}");
+                config.library_id = target_id;
+                if let Err(e) = config.save_active_library() {
+                    error!("Failed to save active library: {e}");
                     return;
                 }
 

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -1,7 +1,7 @@
 //! Welcome screen for first-run setup
 //!
-//! Shown when no `~/.bae/library` pointer file exists. Offers two choices:
-//! - Create a new library (writes pointer file, re-execs binary)
+//! Shown when no `~/.bae/active-library` pointer file exists. Offers two choices:
+//! - Create a new library (writes pointer file with UUID, re-execs binary)
 //! - Restore from cloud (downloads encrypted DB + covers, then re-execs)
 
 use bae_core::keys::KeyService;
@@ -80,7 +80,7 @@ fn WelcomeScreen() -> Element {
             .expect("Failed to create new library");
 
         config
-            .save_library_path()
+            .save_active_library()
             .expect("Failed to write library pointer");
 
         relaunch();
@@ -406,7 +406,7 @@ async fn do_restore(
     }
 
     // Write pointer file last (makes this idempotent on failure)
-    config.save_library_path()?;
+    config.save_active_library()?;
 
     info!(
         "Cloud restore complete: library at {}",

--- a/bae-desktop/src/ui/window_activation/macos_window.rs
+++ b/bae-desktop/src/ui/window_activation/macos_window.rs
@@ -317,11 +317,19 @@ unsafe fn open_library_picker(create_new: bool) {
 
     info!("Switching library to: {}", path.display());
 
-    // Save the library path pointer (persists for future launches)
+    // Read the library UUID and save as active library
+    let target_id = match bae_core::config::Config::read_library_id(&path) {
+        Ok(id) => id,
+        Err(e) => {
+            error!("Failed to read library ID: {}", e);
+            return;
+        }
+    };
+
     let mut config = bae_core::config::Config::load();
-    config.library_dir = bae_core::library_dir::LibraryDir::new(path);
-    if let Err(e) = config.save_library_path() {
-        error!("Failed to save library path: {}", e);
+    config.library_id = target_id;
+    if let Err(e) = config.save_active_library() {
+        error!("Failed to save active library: {}", e);
         return;
     }
 


### PR DESCRIPTION
## Summary

- `~/.bae/library` (path) renamed to `~/.bae/active-library` (UUID)
- `save_library_path()` renamed to `save_active_library()`, now writes library UUID
- `Config::load()` reads UUID, resolves to path via `find_library_by_id()` which scans both `known_libraries.yaml` and `~/.bae/libraries/`
- `discover_libraries()` uses UUID comparison for `is_active` instead of path comparison
- Missing pointer file auto-selects first available library
- Library switching (`on_switch`) reads target library's UUID via `Config::read_library_id()`

## Phase 4 of storage roadmap

**Based on:** PR #154 (Phase 3: Reader instances)

## Test plan

- [ ] `cargo clippy -p bae-core -p bae-desktop -p bae-mocks -p bae-server -- -D warnings` clean
- [ ] `cargo test -p bae-core -p bae-desktop` pass (15 config tests + all others)
- [ ] Fresh start: `rm -rf ~/.bae`, create new library, verify `~/.bae/active-library` contains UUID
- [ ] Library switching: switch libraries, verify pointer file updates to new UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)