### PR TITLE
Add sync, encryption, and sharing docs

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -32,6 +32,8 @@ export default defineConfig({
 					items: [
 						{ label: 'Overview', slug: 'storage/overview' },
 						{ label: 'Profiles', slug: 'storage/profiles' },
+						{ label: 'Sync', slug: 'storage/sync' },
+						{ label: 'Encryption', slug: 'storage/encryption' },
 					],
 				},
 				{
@@ -39,6 +41,8 @@ export default defineConfig({
 					items: [
 						{ label: 'Browsing', slug: 'library/browsing' },
 						{ label: 'Metadata', slug: 'library/metadata' },
+						{ label: 'Sharing', slug: 'library/sharing' },
+						{ label: 'Share Grants', slug: 'library/share-grants' },
 					],
 				},
 			],

--- a/website/src/content/docs/library/share-grants.mdx
+++ b/website/src/content/docs/library/share-grants.mdx
@@ -1,0 +1,48 @@
+---
+title: Share Grants
+description: Share individual releases across libraries
+---
+
+Share grants let you share a single release with someone without giving them access to your entire library.
+
+## How it works
+
+A share grant is a self-contained token that gives the recipient access to one release. It contains:
+
+- The release's per-release encryption key (derived via HKDF, not your master key)
+- Your sync bucket coordinates so they can fetch the files
+- Optionally, S3 credentials for bucket access
+- An expiration date (optional)
+- Your signature, so the recipient can verify it came from you
+
+The encryption key and any S3 credentials are sealed-box encrypted to the recipient's public key. Only they can open it.
+
+## Creating a grant
+
+To share a release:
+
+1. Open the release and choose **Share**
+2. Enter the recipient's public key
+3. Optionally set an expiration
+4. bae generates the grant token — copy it or export as a file
+
+The grant derives a per-release key from your library's master key. This key can only decrypt files belonging to that specific release. Your master key is never exposed.
+
+## Accepting a grant
+
+When you receive a share grant:
+
+1. Import it in bae (paste or open the file)
+2. bae verifies the signature and checks the expiration
+3. The encrypted payload is unwrapped with your private key
+4. The release becomes available in your library
+
+The shared release plays back directly from the sharer's sync bucket. You don't need to download or store the files yourself.
+
+## Security properties
+
+- Your master library key is never shared — only the derived per-release key
+- S3 credentials (if included) are encrypted end-to-end, never in the clear
+- The grant is signed, so it can't be tampered with or forged
+- Expiration is checked on accept — expired grants are rejected
+- Revoking access means rotating the release's encryption key (re-importing the release)

--- a/website/src/content/docs/library/sharing.mdx
+++ b/website/src/content/docs/library/sharing.mdx
@@ -1,0 +1,56 @@
+---
+title: Sharing a Library
+description: Invite others to your library
+---
+
+bae lets you share your entire library with other people. Everyone gets full read and write access — importing, editing, and deleting — with every change synced to all members.
+
+## Identity
+
+Each bae user has a global Ed25519 keypair — one identity across all libraries. The keypair is generated on first use and stored in your OS keyring. Your public key is how other members recognize you.
+
+## Membership
+
+A library's membership is tracked by an append-only chain of signed entries stored in the sync bucket. Each entry records an Add or Remove action, signed by a current owner.
+
+There are two roles:
+
+- **Owner** — can invite and revoke members, and make all edits
+- **Member** — can make all edits, but cannot manage membership
+
+The first entry in the chain is always the library creator adding themselves as owner.
+
+## Inviting someone
+
+To invite a new member:
+
+1. The invitee generates their keypair (happens automatically on first launch)
+2. They share their public key with you (copy-paste, QR code, etc.)
+3. You invite them from **Settings → Members** — this wraps your library's encryption key to their public key and creates a signed membership entry
+4. You share the sync bucket coordinates with them
+5. They connect, unwrap the key, download the library, and start syncing
+
+The library key is encrypted specifically to the invitee's key using a sealed box. Only they can decrypt it.
+
+## Signed changesets
+
+Every changeset pushed to the sync bucket is signed by its author. On pull, bae verifies that the author was a valid member at the time the changeset was created. Changesets from non-members or with invalid signatures are discarded.
+
+Unsigned changesets from before the membership chain was created are grandfathered — they predate the identity system and are trusted.
+
+## Revocation
+
+An owner can revoke any member:
+
+1. A signed Remove entry is added to the membership chain
+2. A new library encryption key is generated
+3. The new key is re-wrapped to all remaining members
+4. The revoked member's wrapped key is deleted
+
+After revocation, the removed member can no longer decrypt new data. Old data (encrypted with the previous key) remains accessible to them — they had legitimate access and could have downloaded everything.
+
+The last owner of a library cannot be revoked. At least one owner must always remain.
+
+## Attribution
+
+Every changeset carries the author's public key. bae maps public keys to display names locally, so you can see who imported a release or edited metadata. Display names are set during invitation and stored per-device.

--- a/website/src/content/docs/storage/encryption.mdx
+++ b/website/src/content/docs/storage/encryption.mdx
@@ -1,0 +1,48 @@
+---
+title: Encryption
+description: How bae encrypts your data
+---
+
+bae encrypts your music files and library metadata before they leave your machine. The bucket provider stores ciphertext only.
+
+## Library key
+
+Each library has a 256-bit master encryption key, generated when the library is created and stored in your OS keyring (macOS Keychain, Windows Credential Manager, or Linux Secret Service). The key never touches disk in plaintext.
+
+## File encryption
+
+Files are encrypted with XChaCha20-Poly1305 in 64 KB chunks. Each file gets a random nonce prepended to the encrypted blob. This means:
+
+- Identical files produce different ciphertext (random nonce)
+- Files can be decrypted independently (no dependency between files)
+- Chunk-based encryption supports efficient range requests for streaming
+
+## Per-release keys
+
+For sharing individual releases across libraries, bae derives a unique key for each release using HKDF-SHA256:
+
+```
+release_key = HKDF-SHA256(master_key, salt, "bae-release-v1:" + release_id)
+```
+
+The salt is deterministically derived from the master key, so it doesn't need to be distributed separately. Per-release keys allow sharing a single release without exposing the full library key.
+
+New imports use per-release derived keys by default. Legacy files encrypted with the master key continue to work — bae tracks the encryption scheme per file and uses the correct key automatically.
+
+## Sync bucket encryption
+
+Everything in the sync bucket is encrypted:
+
+- **Changesets** — encrypted with the library key
+- **Snapshots** — encrypted with the library key
+- **Images** — encrypted with the library key
+- **Membership entries** — encrypted with the library key
+- **Wrapped keys** — encrypted to individual members via sealed boxes (see [Sharing](/library/sharing))
+
+Head files (per-device sequence numbers) are also encrypted. The bucket provider sees only opaque blobs and key paths.
+
+## Key management
+
+Your library key is stored in the OS keyring under a library-specific namespace. If you use bae on multiple devices, the key is distributed via the membership system — encrypted to your personal public key using a sealed box, so only your devices can unwrap it.
+
+If you lose access to all devices and don't have a backup of your keyring, the library data in the bucket is unrecoverable. This is by design — there is no server-side recovery mechanism.

--- a/website/src/content/docs/storage/sync.mdx
+++ b/website/src/content/docs/storage/sync.mdx
@@ -1,0 +1,50 @@
+---
+title: Sync
+description: Sync your library across devices
+---
+
+bae can sync your library across multiple devices using a single S3-compatible bucket. Every edit, import, and deletion propagates automatically.
+
+## How it works
+
+When sync is enabled, bae records every change you make as a compact binary changeset. These changesets are encrypted and pushed to your sync bucket. Other devices pull and apply them.
+
+The sync bucket stores:
+
+- **Changesets** — incremental diffs of your database, one per edit session
+- **Snapshots** — periodic full copies for bootstrapping new devices
+- **Images** — album art and other library images
+- **Heads** — per-device sequence numbers for efficient polling
+
+Changesets are tiny (usually a few KB) compared to full database snapshots. A typical edit session produces one changeset covering all the changes you made.
+
+## Setting up sync
+
+1. Create an S3-compatible bucket (AWS S3, MinIO, Backblaze B2, etc.)
+2. Go to **Settings → Sync** and enter your bucket details
+3. bae generates a device ID and starts syncing
+
+Each device gets its own device ID. Changesets are namespaced by device, so multiple devices can push concurrently without conflicts.
+
+## Conflict resolution
+
+When two devices edit the same data, bae resolves conflicts automatically using last-writer-wins at the row level. Each row carries a hybrid logical clock (HLC) timestamp that's robust against clock skew.
+
+If two devices edit *different fields* of the same row, both changes survive — the changeset only contains the columns that actually changed. True conflicts (same field edited on both sides) are resolved by timestamp.
+
+Deletes win over concurrent edits. If one device deletes a release while another edits it, the deletion stands.
+
+## Snapshots
+
+Periodically, bae writes a full database snapshot to the sync bucket. New devices start from the latest snapshot and then apply only the changesets that came after it. This keeps initial sync fast regardless of how long the library has been active.
+
+## Schema versioning
+
+Every changeset carries a schema version number. When bae ships a database schema change:
+
+- **Additive changes** (new columns, new tables) are transparent — old and new clients interoperate without coordination
+- **Breaking changes** (column removal, reordering) bump a minimum version — older clients stop syncing until they upgrade, then bootstrap from a fresh snapshot
+
+## Encryption
+
+All data in the sync bucket is encrypted before upload using your library's encryption key. The bucket provider never sees plaintext metadata or images. See [Encryption](/storage/encryption) for details.


### PR DESCRIPTION
## Summary
- **Storage > Sync** — how sync works, setup, conflict resolution, snapshots, schema versioning
- **Storage > Encryption** — library key, file encryption, per-release keys, sync bucket encryption
- **Library > Sharing** — identity, membership chain, invitations, signed changesets, revocation, attribution
- **Library > Share Grants** — per-release sharing, creating/accepting grants, security properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)