### PR TITLE
Fix Phase 4a audit: attestation uniqueness + author index

### DIFF
--- a/bae-core/migrations/009_attestation_indexes.sql
+++ b/bae-core/migrations/009_attestation_indexes.sql
@@ -1,0 +1,7 @@
+-- Prevent duplicate attestations from the same author for the same mbid+infohash.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attestations_unique
+    ON attestations (mbid, infohash, author_pubkey);
+
+-- Support get_attestations_by_author queries.
+CREATE INDEX IF NOT EXISTS idx_attestations_author_pubkey
+    ON attestations (author_pubkey);

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -2234,7 +2234,7 @@ impl Database {
         let mut conn = self.writer()?.lock().await;
         sqlx::query(
             r#"
-            INSERT INTO attestations (
+            INSERT OR REPLACE INTO attestations (
                 id, mbid, infohash, content_hash, format,
                 author_pubkey, timestamp, signature, created_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## Summary
- Add UNIQUE index on `(mbid, infohash, author_pubkey)` to prevent duplicate attestations
- Add index on `author_pubkey` for `get_attestations_by_author` queries
- Change INSERT to INSERT OR REPLACE for natural deduplication on re-attestation

## Test plan
- [x] All 386 tests pass (`cargo test -p bae-core`)
- [x] Clippy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)