### PR TITLE
Phase 4b: DHT integration for peer discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2",
  "sqlx",
  "tempfile",

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -21,6 +21,7 @@ keyring-core = "0.7"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"] }
 uuid = { version = "1.0", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+sha1 = "0.10"
 sha2 = "0.10"
 hmac = "0.12"
 hkdf = "0.12"

--- a/bae-core/cpp/bae_storage_cxx_wrappers.cpp
+++ b/bae-core/cpp/bae_storage_cxx_wrappers.cpp
@@ -264,8 +264,26 @@ rust::Vec<AlertData> session_pop_alerts(Session* sess) {
         rust_alert.file_path = rust::String(cpp_alert.file_path.data(), cpp_alert.file_path.size());
         rust_alert.progress = cpp_alert.progress;
         rust_alert.error_message = rust::String(cpp_alert.error_message.data(), cpp_alert.error_message.size());
+        rust::Vec<rust::String> peers;
+        for (const auto& peer : cpp_alert.peers) {
+            peers.push_back(rust::String(peer.data(), peer.size()));
+        }
+        rust_alert.peers = peers;
         rust_alerts.push_back(rust_alert);
     }
     return rust_alerts;
+}
+
+// DHT wrappers
+void session_dht_announce(Session* sess, rust::Str info_hash_hex, int32_t port) {
+    libtorrent::session_dht_announce(sess, std::string(info_hash_hex), static_cast<int>(port));
+}
+
+void session_dht_get_peers(Session* sess, rust::Str info_hash_hex) {
+    libtorrent::session_dht_get_peers(sess, std::string(info_hash_hex));
+}
+
+void set_enable_dht(SessionParams* params, bool enable) {
+    libtorrent::set_enable_dht(params, enable);
 }
 

--- a/bae-core/cpp/bae_storage_helpers.h
+++ b/bae-core/cpp/bae_storage_helpers.h
@@ -175,6 +175,9 @@ enum AlertType {
     ALERT_TORRENT_RESUMED = 9,
     ALERT_STATE_CHANGED = 10,
     ALERT_STATS = 11,
+    ALERT_DHT_GET_PEERS_REPLY = 12,
+    ALERT_DHT_ANNOUNCE = 13,
+    ALERT_DHT_BOOTSTRAP = 14,
     ALERT_UNKNOWN = 99,
 };
 
@@ -189,10 +192,20 @@ struct AlertData {
     std::string file_path;
     float progress;
     std::string error_message;
+    std::vector<std::string> peers;
 };
 
 /// Pop all pending alerts from session
 std::vector<AlertData> session_pop_alerts(session* sess);
+
+/// Announce on the DHT for a given info hash (20-byte SHA-1 as 40-char hex string)
+void session_dht_announce(session* sess, const std::string& info_hash_hex, int port);
+
+/// Request peers from the DHT for a given info hash (20-byte SHA-1 as 40-char hex string)
+void session_dht_get_peers(session* sess, const std::string& info_hash_hex);
+
+/// Enable or disable DHT on session_params
+void set_enable_dht(session_params* params, bool enable);
 
 } // namespace libtorrent
 
@@ -239,6 +252,11 @@ void torrent_resume(TorrentHandle* handle);
 // Alert handling (implemented in bae_storage_helpers.cpp)
 struct AlertData;
 rust::Vec<AlertData> session_pop_alerts(Session* sess);
+
+// DHT functions (implemented in bae_storage_cxx_wrappers.cpp)
+void session_dht_announce(Session* sess, rust::Str info_hash_hex, int32_t port);
+void session_dht_get_peers(Session* sess, rust::Str info_hash_hex);
+void set_enable_dht(SessionParams* params, bool enable);
 
 std::unique_ptr<BaeStorageConstructor> create_bae_storage_constructor(
     rust::Fn<rust::Vec<uint8_t>(int32_t, int32_t, int32_t, int32_t)> read_cb,

--- a/bae-core/migrations/010_dht_announcements.sql
+++ b/bae-core/migrations/010_dht_announcements.sql
@@ -1,0 +1,7 @@
+CREATE TABLE dht_announcements (
+    release_id TEXT PRIMARY KEY,
+    mbid TEXT NOT NULL,
+    rendezvous_key TEXT NOT NULL,
+    last_announced_at TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT 1
+);

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -1725,7 +1725,7 @@ impl ImportService {
             storage_profile,
             cover_image_path.as_deref(),
             &import_id,
-            None,
+            false,
         )
         .await?;
 

--- a/bae-core/src/torrent/dht.rs
+++ b/bae-core/src/torrent/dht.rs
@@ -1,0 +1,94 @@
+use sha1::{Digest, Sha1};
+
+use crate::torrent::client::{TorrentClient, TorrentError};
+
+/// Alert type constants matching the C++ AlertType enum
+pub const ALERT_DHT_GET_PEERS_REPLY: i32 = 12;
+pub const ALERT_DHT_BOOTSTRAP: i32 = 14;
+
+/// Compute the DHT rendezvous key for a MusicBrainz ID.
+///
+/// The key is SHA-1("bae:mbid:" + mbid), producing a 20-byte hash
+/// compatible with libtorrent's sha1_hash / Kademlia node IDs.
+pub fn compute_rendezvous_key(mbid: &str) -> [u8; 20] {
+    let mut hasher = Sha1::new();
+    hasher.update(b"bae:mbid:");
+    hasher.update(mbid.as_bytes());
+    hasher.finalize().into()
+}
+
+/// Encode a 20-byte hash as a 40-character uppercase hex string.
+fn to_hex(hash: &[u8; 20]) -> String {
+    hash.iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<String>()
+}
+
+/// DHT operations built on top of TorrentClient.
+///
+/// Wraps the raw FFI DHT calls with MBID-based rendezvous keys.
+pub struct DhtService {
+    client: TorrentClient,
+}
+
+impl DhtService {
+    pub fn new(client: TorrentClient) -> Self {
+        Self { client }
+    }
+
+    /// Announce this peer on the DHT for a release identified by its MusicBrainz ID.
+    pub async fn announce(&self, mbid: &str, port: u16) -> Result<(), TorrentError> {
+        let key = compute_rendezvous_key(mbid);
+        let hex = to_hex(&key);
+        self.client.dht_announce(&hex, port).await
+    }
+
+    /// Look up peers on the DHT for a release identified by its MusicBrainz ID.
+    ///
+    /// This is asynchronous -- results arrive via `dht_get_peers_reply_alert`
+    /// when polling alerts from the TorrentClient.
+    pub async fn get_peers(&self, mbid: &str) -> Result<(), TorrentError> {
+        let key = compute_rendezvous_key(mbid);
+        let hex = to_hex(&key);
+        self.client.dht_get_peers(&hex).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendezvous_key_is_deterministic() {
+        let mbid = "12345678-1234-1234-1234-123456789012";
+        let key1 = compute_rendezvous_key(mbid);
+        let key2 = compute_rendezvous_key(mbid);
+        assert_eq!(key1, key2);
+        assert_eq!(key1.len(), 20);
+    }
+
+    #[test]
+    fn different_mbids_produce_different_keys() {
+        let key1 = compute_rendezvous_key("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        let key2 = compute_rendezvous_key("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn rendezvous_key_matches_expected_sha1() {
+        // SHA-1("bae:mbid:test") should be a known value
+        let key = compute_rendezvous_key("test");
+        let hex = to_hex(&key);
+
+        // Verify via manual computation:
+        // echo -n "bae:mbid:test" | shasum -a 1
+        let mut hasher = Sha1::new();
+        hasher.update(b"bae:mbid:test");
+        let expected: [u8; 20] = hasher.finalize().into();
+        assert_eq!(key, expected);
+
+        // Hex is 40 chars, uppercase
+        assert_eq!(hex.len(), 40);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/bae-core/src/torrent/ffi.rs
+++ b/bae-core/src/torrent/ffi.rs
@@ -193,6 +193,23 @@ mod ffi {
         /// Parses the torrent file and returns all available metadata.
         /// Returns an empty struct if the file cannot be parsed.
         fn get_torrent_info(file_path: &str) -> TorrentInfo;
+        /// Announce on the DHT for a given info hash (40-char hex string)
+        ///
+        /// # Safety
+        /// `sess` must be a valid pointer to a Session that outlives the call.
+        unsafe fn session_dht_announce(sess: *mut Session, info_hash_hex: &str, port: i32);
+        /// Request peers from the DHT for a given info hash (40-char hex string)
+        ///
+        /// Results arrive asynchronously via `dht_get_peers_reply_alert`.
+        ///
+        /// # Safety
+        /// `sess` must be a valid pointer to a Session that outlives the call.
+        unsafe fn session_dht_get_peers(sess: *mut Session, info_hash_hex: &str);
+        /// Enable or disable DHT on session_params
+        ///
+        /// # Safety
+        /// `params` must be a valid pointer to SessionParams that outlives the call.
+        unsafe fn set_enable_dht(params: *mut SessionParams, enable: bool);
     }
     /// File info from torrent (shared between Rust and C++)
     struct TorrentFileInfo {
@@ -224,13 +241,15 @@ mod ffi {
         file_path: String,
         progress: f32,
         error_message: String,
+        peers: Vec<String>,
     }
 }
 pub use ffi::{
     create_bae_storage_constructor, create_session_params_default,
     create_session_params_with_storage, create_session_with_params, get_session_ptr,
-    get_torrent_info, load_torrent_file, parse_magnet_uri, session_add_torrent, session_pop_alerts,
-    session_remove_torrent, set_connections_limit, set_enable_natpmp, set_enable_upnp,
+    get_torrent_info, load_torrent_file, parse_magnet_uri, session_add_torrent,
+    session_dht_announce, session_dht_get_peers, session_pop_alerts, session_remove_torrent,
+    set_connections_limit, set_enable_dht, set_enable_natpmp, set_enable_upnp,
     set_listen_interfaces, set_paused, set_seed_mode, set_unchoke_slots_limit,
     torrent_get_file_list, torrent_get_name, torrent_get_num_peers, torrent_get_num_pieces,
     torrent_get_num_seeds, torrent_get_piece_length, torrent_get_progress,

--- a/bae-core/src/torrent/mod.rs
+++ b/bae-core/src/torrent/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod dht;
 pub mod ffi;
 pub mod lazy;
 pub mod manager;
@@ -7,6 +8,7 @@ pub mod parser;
 pub mod piece_mapper;
 pub mod progress;
 pub mod storage;
+pub use dht::DhtService;
 pub use lazy::LazyTorrentManager;
 pub use metadata_detector::detect_metadata_from_torrent_file;
 pub use parser::parse_torrent_info;


### PR DESCRIPTION
## Summary
- Add C++ FFI functions for libtorrent DHT operations:
  - `session_dht_announce` — announce on a SHA-1 rendezvous key
  - `session_dht_get_peers` — lookup peers for a rendezvous key
  - `set_enable_dht` — enable/disable DHT on session params
  - DHT alert handling (`dht_get_peers_reply_alert`, `dht_bootstrap_alert`)
- Add Rust `DhtService` with MBID-based rendezvous keys: `SHA-1("bae:mbid:" + mbid)`
- Add `dht_announcements` table (migration 010) for per-release DHT opt-in tracking
- Wire DHT enable/disable into `TorrentClientOptions`
- 3 new unit tests for rendezvous key determinism and correctness

## Test plan
- [x] All 374 unit tests pass + 3 new DHT tests
- [x] Clippy clean (only pre-existing warnings in import/service.rs)
- [x] Pre-commit hooks pass
- [x] C++ compiles cleanly with libtorrent headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)