### PR TITLE
Phase 6a: User keypair initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
  "dirs 5.0.1",
  "dispatch",
  "futures",
+ "hex",
  "objc",
  "reqwest",
  "rfd",

--- a/bae-core/src/keys.rs
+++ b/bae-core/src/keys.rs
@@ -17,6 +17,7 @@ pub enum KeyError {
 ///
 /// This is a global identity (not per-library) so attestations accumulate
 /// under one pubkey across all libraries.
+#[derive(Clone)]
 pub struct UserKeypair {
     pub signing_key: [u8; sodium_ffi::SIGN_SECRETKEYBYTES], // Ed25519 secret key (64 bytes)
     pub public_key: [u8; sodium_ffi::SIGN_PUBLICKEYBYTES],  // Ed25519 public key (32 bytes)

--- a/bae-desktop/Cargo.toml
+++ b/bae-desktop/Cargo.toml
@@ -22,6 +22,7 @@ rfd = "0.17"
 tokio = { version = "1.0", features = ["full"] }
 tracing = { workspace = true }
 arboard = "3.4"
+hex = "0.4"
 urlencoding = "2.1"
 axum = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -131,6 +131,21 @@ fn main() {
         }
     }
 
+    // Load or generate user Ed25519 keypair (global identity for sync signing and invitations)
+    let user_keypair = match key_service.get_or_create_user_keypair() {
+        Ok(kp) => {
+            info!(
+                "User keypair loaded (pubkey: {}...)",
+                &hex::encode(kp.public_key)[..8]
+            );
+            Some(kp)
+        }
+        Err(e) => {
+            error!("Failed to load/create user keypair: {e}");
+            None
+        }
+    };
+
     // If config says we have an encryption key but it's missing from the keyring,
     // show the unlock screen so the user can paste their recovery key.
     if config.encryption_key_stored {
@@ -273,6 +288,7 @@ fn main() {
         cache: cache_manager.clone(),
         key_service,
         image_server,
+        user_keypair,
     };
 
     // Initialize auto-updater (checks for updates on launch)

--- a/bae-desktop/src/ui/app.rs
+++ b/bae-desktop/src/ui/app.rs
@@ -66,6 +66,7 @@ pub fn launch_app(context: super::app_context::AppContext) {
         torrent_manager: context.torrent_manager.clone(),
         key_service: context.key_service.clone(),
         image_server: context.image_server.clone(),
+        user_keypair: context.user_keypair.clone(),
     };
     #[cfg(not(feature = "torrent"))]
     let services = super::app_context::AppServices {
@@ -76,6 +77,7 @@ pub fn launch_app(context: super::app_context::AppContext) {
         cache: context.cache.clone(),
         key_service: context.key_service.clone(),
         image_server: context.image_server.clone(),
+        user_keypair: context.user_keypair.clone(),
     };
 
     LaunchBuilder::desktop()

--- a/bae-desktop/src/ui/app_context.rs
+++ b/bae-desktop/src/ui/app_context.rs
@@ -8,7 +8,7 @@ use bae_core::cache;
 use bae_core::config;
 use bae_core::image_server::ImageServerHandle;
 use bae_core::import;
-use bae_core::keys::KeyService;
+use bae_core::keys::{KeyService, UserKeypair};
 use bae_core::library::SharedLibraryManager;
 use bae_core::playback;
 #[cfg(feature = "torrent")]
@@ -38,6 +38,8 @@ pub struct AppServices {
     pub key_service: KeyService,
     /// Image server connection handle
     pub image_server: ImageServerHandle,
+    /// User's Ed25519 keypair for signing and key exchange
+    pub user_keypair: Option<UserKeypair>,
 }
 
 #[derive(Clone)]
@@ -51,4 +53,5 @@ pub struct AppContext {
     pub torrent_manager: torrent::LazyTorrentManager,
     pub key_service: KeyService,
     pub image_server: ImageServerHandle,
+    pub user_keypair: Option<UserKeypair>,
 }

--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -5,7 +5,7 @@ use bae_ui::stores::{AppStateStoreExt, SyncStateStoreExt};
 use bae_ui::SyncSectionView;
 use dioxus::prelude::*;
 
-/// Sync section - shows sync status and other devices
+/// Sync section - shows sync status, other devices, and user identity
 #[component]
 pub fn SyncSection() -> Element {
     let app = use_app();
@@ -14,6 +14,16 @@ pub fn SyncSection() -> Element {
     let other_devices = app.state.sync().other_devices().read().clone();
     let syncing = *app.state.sync().syncing().read();
     let error = app.state.sync().error().read().clone();
+    let user_pubkey = app.state.sync().user_pubkey().read().clone();
+
+    let copy_pubkey = {
+        let user_pubkey = user_pubkey.clone();
+        move |_| {
+            if let Some(ref pk) = user_pubkey {
+                let _ = arboard::Clipboard::new().and_then(|mut cb| cb.set_text(pk));
+            }
+        }
+    };
 
     rsx! {
         SyncSectionView {
@@ -21,6 +31,8 @@ pub fn SyncSection() -> Element {
             other_devices,
             syncing,
             error,
+            user_pubkey,
+            on_copy_pubkey: copy_pubkey,
         }
     }
 }

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -94,6 +94,8 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             ],
                             syncing: false,
                             error: None,
+                            user_pubkey: Some("a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string()),
+                            on_copy_pubkey: |_| {},
                         }
                     },
                     SettingsTab::Discogs => rsx! {

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -61,6 +61,8 @@ pub fn Settings() -> Element {
                         ],
                         syncing: false,
                         error: None,
+                        user_pubkey: Some("a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string()),
+                        on_copy_pubkey: |_| {},
                     }
                 },
                 SettingsTab::Discogs => rsx! {

--- a/bae-ui/src/stores/sync.rs
+++ b/bae-ui/src/stores/sync.rs
@@ -22,4 +22,6 @@ pub struct SyncState {
     pub syncing: bool,
     /// Last sync error message, if any.
     pub error: Option<String>,
+    /// User's Ed25519 public key (hex-encoded). None if no keypair exists.
+    pub user_pubkey: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Generate or load Ed25519 `UserKeypair` on app startup via `KeyService`
- Store in `AppServices`/`AppContext` for downstream sync signing, invitations, and share grants
- Display truncated public key in Settings > Sync with copy-to-clipboard
- Add `user_pubkey: Option<String>` to `SyncState` store

## Test plan
- [ ] App launches and generates keypair on first run (check log for pubkey)
- [ ] Subsequent launches load existing keypair from keyring
- [ ] Settings > Sync shows "Your Identity" card with truncated pubkey
- [ ] Copy button copies full hex pubkey to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)