### PR TITLE
Phase 5d: Manual sync trigger and post-pull UI refresh

### DIFF
--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -49,6 +49,7 @@ pub fn SyncSection() -> Element {
     let mut test_error = use_signal(|| Option::<String>::None);
 
     // Clone app for each closure that needs it
+    let app_for_sync = app.clone();
     let app_for_edit = app.clone();
     let app_for_save = app.clone();
     let app_for_test = app.clone();
@@ -62,6 +63,7 @@ pub fn SyncSection() -> Element {
             error,
             user_pubkey,
             on_copy_pubkey: copy_pubkey,
+            on_sync_now: move |_| app_for_sync.trigger_sync(),
 
             // Config display
             sync_bucket: sync_bucket.clone(),

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -96,6 +96,7 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             error: None,
                             user_pubkey: Some("a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string()),
                             on_copy_pubkey: |_| {},
+                            on_sync_now: |_| {},
                             sync_bucket: Some("my-sync-bucket".to_string()),
                             sync_region: Some("us-east-1".to_string()),
                             sync_endpoint: Some("https://s3.example.com".to_string()),

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -63,6 +63,7 @@ pub fn Settings() -> Element {
                         error: None,
                         user_pubkey: Some("a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string()),
                         on_copy_pubkey: |_| {},
+                        on_sync_now: |_| {},
                         sync_bucket: Some("my-sync-bucket".to_string()),
                         sync_region: Some("us-east-1".to_string()),
                         sync_endpoint: None,

--- a/bae-ui/src/components/settings/sync.rs
+++ b/bae-ui/src/components/settings/sync.rs
@@ -72,6 +72,7 @@ pub fn SyncSectionView(
     test_error: Option<String>,
 
     // --- Callbacks ---
+    on_sync_now: EventHandler<()>,
     on_edit_start: EventHandler<()>,
     on_cancel_edit: EventHandler<()>,
     on_save_config: EventHandler<SyncBucketConfig>,
@@ -160,6 +161,21 @@ pub fn SyncSectionView(
                     // Error display
                     if let Some(ref err) = error {
                         div { class: "text-red-400 text-sm", "{err}" }
+                    }
+                }
+
+                div { class: "mt-4",
+                    Button {
+                        variant: ButtonVariant::Secondary,
+                        size: ButtonSize::Small,
+                        disabled: syncing || !sync_configured,
+                        loading: syncing,
+                        onclick: move |_| on_sync_now.call(()),
+                        if syncing {
+                            "Syncing..."
+                        } else {
+                            "Sync Now"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add `on_sync_now` callback prop and "Sync Now" button to SyncSectionView (disabled when syncing or not configured)
- Add `trigger_sync()` method on AppService that sends on the sync trigger channel
- After pull with changesets applied: refresh album detail if open, emit AlbumsChanged
- Update mocks with new prop

## Test plan
- [ ] Verify bae-desktop and bae-mocks compile
- [ ] Verify "Sync Now" button appears in Sync settings when sync is configured
- [ ] Verify button is disabled during sync and when not configured
- [ ] Verify album grid and detail views refresh after incoming changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)