### PR TITLE
Phase 6b: Membership display in sync settings

### DIFF
--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -1,7 +1,7 @@
 //! Settings mock component
 
 use super::framework::{ControlRegistryBuilder, MockPage, MockPanel};
-use bae_ui::stores::DeviceActivityInfo;
+use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole};
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
     LibrarySectionView, SettingsTab, SettingsView, StorageLocation, StorageProfile,
@@ -96,6 +96,9 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             error: None,
                             user_pubkey: Some("a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string()),
                             on_copy_pubkey: |_| {},
+                            members: mock_members(),
+                            is_owner: true,
+                            on_remove_member: |_| {},
                             on_sync_now: |_| {},
                             sync_bucket: Some("my-sync-bucket".to_string()),
                             sync_region: Some("us-east-1".to_string()),
@@ -218,6 +221,23 @@ fn mock_libraries() -> Vec<LibraryInfo> {
             name: Some("Jazz Collection".to_string()),
             path: "/Users/demo/.bae/libraries/def-456".to_string(),
             is_active: false,
+        },
+    ]
+}
+
+fn mock_members() -> Vec<Member> {
+    vec![
+        Member {
+            pubkey: "a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string(),
+            display_name: "a1b2...7890".to_string(),
+            role: MemberRole::Owner,
+            is_self: true,
+        },
+        Member {
+            pubkey: "ff00112233445566778899aabbccddeeff00112233445566778899aabbccddee".to_string(),
+            display_name: "ff00...ddee".to_string(),
+            role: MemberRole::Member,
+            is_self: false,
         },
     ]
 }

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -1,6 +1,6 @@
 //! Settings page
 
-use bae_ui::stores::DeviceActivityInfo;
+use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole};
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
     LibrarySectionView, SettingsTab, SettingsView, StorageLocation, StorageProfile,
@@ -63,6 +63,9 @@ pub fn Settings() -> Element {
                         error: None,
                         user_pubkey: Some("a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string()),
                         on_copy_pubkey: |_| {},
+                        members: mock_members(),
+                        is_owner: true,
+                        on_remove_member: |_| {},
                         on_sync_now: |_| {},
                         sync_bucket: Some("my-sync-bucket".to_string()),
                         sync_region: Some("us-east-1".to_string()),
@@ -187,6 +190,23 @@ fn mock_libraries() -> Vec<LibraryInfo> {
             name: None,
             path: "/Volumes/External/bae-library".to_string(),
             is_active: false,
+        },
+    ]
+}
+
+fn mock_members() -> Vec<Member> {
+    vec![
+        Member {
+            pubkey: "a1b2c3d4e5f67890abcdef1234567890a1b2c3d4e5f67890abcdef1234567890".to_string(),
+            display_name: "a1b2...7890".to_string(),
+            role: MemberRole::Owner,
+            is_self: true,
+        },
+        Member {
+            pubkey: "ff00112233445566778899aabbccddeeff00112233445566778899aabbccddee".to_string(),
+            display_name: "ff00...ddee".to_string(),
+            role: MemberRole::Member,
+            is_self: false,
         },
     ]
 }

--- a/bae-ui/src/stores/sync.rs
+++ b/bae-ui/src/stores/sync.rs
@@ -11,6 +11,26 @@ pub struct DeviceActivityInfo {
     pub last_sync: Option<String>,
 }
 
+/// Role of a library member (display-only, shadows bae-core's MemberRole).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MemberRole {
+    Owner,
+    Member,
+}
+
+/// A library member for display in the sync settings.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Member {
+    /// Ed25519 public key (hex-encoded).
+    pub pubkey: String,
+    /// Display name (or truncated pubkey if no name is set).
+    pub display_name: String,
+    /// Role in the library.
+    pub role: MemberRole,
+    /// Whether this member is the current user.
+    pub is_self: bool,
+}
+
 /// Sync status state for the UI.
 #[derive(Clone, Debug, Default, PartialEq, Store)]
 pub struct SyncState {
@@ -24,6 +44,8 @@ pub struct SyncState {
     pub error: Option<String>,
     /// User's Ed25519 public key (hex-encoded). None if no keypair exists.
     pub user_pubkey: Option<String>,
+    /// Current library members (from membership chain). Empty if solo or not syncing.
+    pub members: Vec<Member>,
 
     // Sync bucket configuration (mirrors Config, for UI display)
     /// S3 bucket name for sync.


### PR DESCRIPTION
## Summary
- Add `Member` and `MemberRole` display types to bae-ui sync store
- Add "Members" card to SyncSectionView showing member list with role badges and Remove buttons
- Add `load_membership()` to AppService: downloads membership entries from bucket, builds chain, updates store
- Membership refreshed after each sync cycle and on settings mount
- Remove button shown only for owners viewing non-self, non-last-owner members (actual removal in Phase 6e)

## Test plan
- [ ] Verify bae-desktop and bae-mocks compile
- [ ] Verify Members card appears in Sync settings when sync is configured
- [ ] Verify solo library shows no Members card (empty list)
- [ ] Verify role badges render correctly (Owner=amber, Member=gray)

🤖 Generated with [Claude Code](https://claude.com/claude-code)