### PR TITLE
Phase 6d: Accept invitation flow

### DIFF
--- a/bae-desktop/src/ui/components/settings/library.rs
+++ b/bae-desktop/src/ui/components/settings/library.rs
@@ -1,8 +1,17 @@
 //! Library settings section — business logic wrapper
 
 use bae_core::config::Config;
-use bae_ui::LibrarySectionView;
+use bae_core::encryption::EncryptionService;
+use bae_core::keys::KeyService;
+use bae_core::library_dir::LibraryDir;
+use bae_core::sync::bucket::SyncBucketClient;
+use bae_core::sync::pull::pull_changes;
+use bae_core::sync::s3_bucket::S3SyncBucketClient;
+use bae_core::sync::snapshot::bootstrap_from_snapshot;
+use bae_ui::{JoinLibraryView, JoinStatus, LibrarySectionView};
 use dioxus::prelude::*;
+use std::collections::HashMap;
+use std::ffi::CString;
 use std::path::PathBuf;
 use tracing::{error, info};
 
@@ -25,6 +34,15 @@ fn discover_ui_libraries() -> Vec<bae_ui::LibraryInfo> {
 pub fn LibrarySection() -> Element {
     let app = use_app();
     let mut libraries = use_signal(discover_ui_libraries);
+    let mut showing_join = use_signal(|| false);
+
+    // Join form state
+    let mut join_bucket = use_signal(String::new);
+    let mut join_region = use_signal(String::new);
+    let mut join_endpoint = use_signal(String::new);
+    let mut join_access_key = use_signal(String::new);
+    let mut join_secret_key = use_signal(String::new);
+    let mut join_status = use_signal(|| Option::<JoinStatus>::None);
 
     let on_switch = {
         let app = app.clone();
@@ -121,6 +139,65 @@ pub fn LibrarySection() -> Element {
         }
     };
 
+    let on_join_start = move |_| {
+        // Reset join form state and show the form
+        join_bucket.set(String::new());
+        join_region.set(String::new());
+        join_endpoint.set(String::new());
+        join_access_key.set(String::new());
+        join_secret_key.set(String::new());
+        join_status.set(None);
+        showing_join.set(true);
+    };
+
+    let on_join_cancel = move |_| {
+        showing_join.set(false);
+    };
+
+    let on_join_submit = {
+        let app = app.clone();
+        move |_| {
+            let bucket = join_bucket.read().clone();
+            let region = join_region.read().clone();
+            let endpoint = join_endpoint.read().clone();
+            let access_key = join_access_key.read().clone();
+            let secret_key = join_secret_key.read().clone();
+            let key_service = app.key_service.clone();
+
+            join_status.set(Some(JoinStatus::Joining(
+                "Connecting to sync bucket...".to_string(),
+            )));
+
+            spawn(async move {
+                match join_shared_library(
+                    bucket,
+                    region,
+                    endpoint,
+                    access_key,
+                    secret_key,
+                    key_service,
+                    join_status,
+                )
+                .await
+                {
+                    Ok(config) => {
+                        join_status.set(Some(JoinStatus::Success));
+
+                        if let Err(e) = config.save_active_library() {
+                            error!("Failed to save active library: {e}");
+                        }
+
+                        super::super::welcome::relaunch();
+                    }
+                    Err(e) => {
+                        error!("Failed to join shared library: {e}");
+                        join_status.set(Some(JoinStatus::Error(e)));
+                    }
+                }
+            });
+        }
+    };
+
     let on_rename = move |(path, new_name): (String, String)| {
         let library_path = PathBuf::from(&path);
         if let Err(e) = Config::rename_library(&library_path, &new_name) {
@@ -143,14 +220,277 @@ pub fn LibrarySection() -> Element {
         libraries.set(discover_ui_libraries());
     };
 
-    rsx! {
-        LibrarySectionView {
-            libraries: libraries.read().clone(),
-            on_switch,
-            on_create,
-            on_add_existing,
-            on_rename,
-            on_remove,
+    if *showing_join.read() {
+        rsx! {
+            JoinLibraryView {
+                bucket: join_bucket.read().clone(),
+                region: join_region.read().clone(),
+                endpoint: join_endpoint.read().clone(),
+                access_key: join_access_key.read().clone(),
+                secret_key: join_secret_key.read().clone(),
+                status: join_status.read().clone(),
+                on_bucket_change: move |v| join_bucket.set(v),
+                on_region_change: move |v| join_region.set(v),
+                on_endpoint_change: move |v| join_endpoint.set(v),
+                on_access_key_change: move |v| join_access_key.set(v),
+                on_secret_key_change: move |v| join_secret_key.set(v),
+                on_join: on_join_submit,
+                on_cancel: on_join_cancel,
+            }
+        }
+    } else {
+        rsx! {
+            LibrarySectionView {
+                libraries: libraries.read().clone(),
+                on_switch,
+                on_create,
+                on_add_existing,
+                on_join: on_join_start,
+                on_rename,
+                on_remove,
+            }
         }
     }
+}
+
+/// Perform the full join-shared-library bootstrap sequence.
+///
+/// Steps:
+/// 1. Load the user's Ed25519 keypair (must exist -- Phase 6a).
+/// 2. Create an S3SyncBucketClient with a dummy encryption key (only used
+///    to access the wrapped key, which is stored as raw sealed-box bytes).
+/// 3. `accept_invitation()` to unwrap the library encryption key.
+/// 4. Recreate the bucket client with the real encryption key.
+/// 5. Create a new library directory and config.
+/// 6. `bootstrap_from_snapshot()` to get the initial database.
+/// 7. Pull any changesets since the snapshot.
+/// 8. Save sync bucket config and credentials.
+/// 9. Return the Config so the caller can switch to it.
+async fn join_shared_library(
+    bucket: String,
+    region: String,
+    endpoint: String,
+    access_key: String,
+    secret_key: String,
+    key_service: KeyService,
+    mut status: Signal<Option<JoinStatus>>,
+) -> Result<Config, String> {
+    use bae_core::sync::invite::accept_invitation;
+
+    // Step 1: Load user keypair.
+    let user_keypair = key_service
+        .get_or_create_user_keypair()
+        .map_err(|e| format!("Failed to load user keypair: {e}"))?;
+
+    // Step 2: Create bucket client with a dummy encryption key.
+    // We only need get_wrapped_key() which stores sealed-box bytes raw (no library-key encryption).
+    let ep = if endpoint.is_empty() {
+        None
+    } else {
+        Some(endpoint.clone())
+    };
+    let dummy_key = [0u8; 32];
+    let dummy_encryption = EncryptionService::new(&hex::encode(dummy_key))
+        .map_err(|e| format!("Failed to create encryption service: {e}"))?;
+
+    let dummy_bucket = S3SyncBucketClient::new(
+        bucket.clone(),
+        region.clone(),
+        ep.clone(),
+        access_key.clone(),
+        secret_key.clone(),
+        dummy_encryption,
+    )
+    .await
+    .map_err(|e| format!("Failed to connect to sync bucket: {e}"))?;
+
+    // Step 3: Accept invitation to get the library encryption key.
+    status.set(Some(JoinStatus::Joining(
+        "Accepting invitation...".to_string(),
+    )));
+
+    let encryption_key = accept_invitation(&dummy_bucket, &user_keypair)
+        .await
+        .map_err(|e| format!("Failed to accept invitation: {e}"))?;
+
+    let encryption_key_hex = hex::encode(encryption_key);
+
+    // Step 4: Create the real bucket client with the actual encryption key.
+    status.set(Some(JoinStatus::Joining(
+        "Downloading library snapshot...".to_string(),
+    )));
+
+    let encryption = EncryptionService::new(&encryption_key_hex)
+        .map_err(|e| format!("Invalid encryption key: {e}"))?;
+
+    let real_bucket = S3SyncBucketClient::new(
+        bucket.clone(),
+        region.clone(),
+        ep,
+        access_key.clone(),
+        secret_key.clone(),
+        encryption.clone(),
+    )
+    .await
+    .map_err(|e| format!("Failed to reconnect to sync bucket: {e}"))?;
+
+    // Step 5: Create a new library directory.
+    let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
+    let bae_dir = home_dir.join(".bae");
+    let library_id = uuid::Uuid::new_v4().to_string();
+    let device_id = uuid::Uuid::new_v4().to_string();
+    let library_dir = LibraryDir::new(bae_dir.join("libraries").join(&library_id));
+
+    std::fs::create_dir_all(&*library_dir)
+        .map_err(|e| format!("Failed to create library directory: {e}"))?;
+
+    // All steps after directory creation are wrapped so we can clean up on failure.
+    let result = bootstrap_library(
+        &real_bucket,
+        &encryption,
+        &encryption_key_hex,
+        &library_dir,
+        &library_id,
+        &device_id,
+        &bucket,
+        &region,
+        &endpoint,
+        &access_key,
+        &secret_key,
+        &key_service,
+        &mut status,
+    )
+    .await;
+
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&*library_dir);
+    }
+
+    result
+}
+
+/// Inner bootstrap logic — separated so the caller can clean up the library directory on failure.
+async fn bootstrap_library(
+    real_bucket: &S3SyncBucketClient,
+    encryption: &EncryptionService,
+    encryption_key_hex: &str,
+    library_dir: &LibraryDir,
+    library_id: &str,
+    device_id: &str,
+    bucket: &str,
+    region: &str,
+    endpoint: &str,
+    access_key: &str,
+    secret_key: &str,
+    key_service: &KeyService,
+    status: &mut Signal<Option<JoinStatus>>,
+) -> Result<Config, String> {
+    // Step 6: Bootstrap from snapshot.
+    let db_path = library_dir.db_path();
+    let bucket_dyn: &dyn SyncBucketClient = real_bucket;
+    let snapshot_seq = bootstrap_from_snapshot(bucket_dyn, encryption, &db_path)
+        .await
+        .map_err(|e| format!("Failed to bootstrap from snapshot: {e}"))?;
+
+    info!("Bootstrapped from snapshot (snapshot_seq: {snapshot_seq})");
+
+    // Step 7: Pull changesets since the snapshot.
+    status.set(Some(JoinStatus::Joining(
+        "Applying recent changes...".to_string(),
+    )));
+
+    // Build cursors before opening the raw connection to avoid leaking the handle.
+    let heads = bucket_dyn
+        .list_heads()
+        .await
+        .map_err(|e| format!("Failed to list heads: {e}"))?;
+
+    let mut cursors = HashMap::new();
+    for head in &heads {
+        cursors.insert(head.device_id.clone(), snapshot_seq);
+    }
+
+    let changesets_applied = unsafe {
+        let c_path = CString::new(db_path.to_str().unwrap()).unwrap();
+        let mut db: *mut libsqlite3_sys::sqlite3 = std::ptr::null_mut();
+        let rc = libsqlite3_sys::sqlite3_open(c_path.as_ptr(), &mut db);
+        if rc != libsqlite3_sys::SQLITE_OK {
+            return Err("Failed to open database for changeset application".to_string());
+        }
+
+        let result = match pull_changes(db, bucket_dyn, device_id, &cursors, None).await {
+            Ok((_updated_cursors, pull_result)) => pull_result.changesets_applied,
+            Err(e) => {
+                libsqlite3_sys::sqlite3_close(db);
+                return Err(format!("Failed to pull changesets: {e}"));
+            }
+        };
+
+        libsqlite3_sys::sqlite3_close(db);
+        result
+    };
+
+    if changesets_applied > 0 {
+        info!("Applied {changesets_applied} changesets since snapshot");
+    }
+
+    // Step 8: Save encryption key to keyring and create config.
+    status.set(Some(JoinStatus::Joining(
+        "Saving configuration...".to_string(),
+    )));
+
+    let new_key_service = KeyService::new(key_service.is_dev_mode(), library_id.to_string());
+    new_key_service
+        .set_encryption_key(encryption_key_hex)
+        .map_err(|e| format!("Failed to save encryption key: {e}"))?;
+
+    // Save sync bucket credentials to keyring.
+    new_key_service
+        .set_sync_access_key(access_key)
+        .map_err(|e| format!("Failed to save sync access key: {e}"))?;
+
+    new_key_service
+        .set_sync_secret_key(secret_key)
+        .map_err(|e| format!("Failed to save sync secret key: {e}"))?;
+
+    let config = Config {
+        library_id: library_id.to_string(),
+        device_id: device_id.to_string(),
+        library_dir: library_dir.clone(),
+        library_name: None,
+        keys_migrated: true,
+        discogs_key_stored: false,
+        encryption_key_stored: true,
+        encryption_key_fingerprint: Some(encryption.fingerprint()),
+        torrent_bind_interface: None,
+        torrent_listen_port: None,
+        torrent_enable_upnp: true,
+        torrent_enable_natpmp: true,
+        torrent_enable_dht: false,
+        torrent_max_connections: None,
+        torrent_max_connections_per_torrent: None,
+        torrent_max_uploads: None,
+        torrent_max_uploads_per_torrent: None,
+        network_participation: bae_core::sync::participation::ParticipationMode::Off,
+        subsonic_enabled: true,
+        subsonic_port: 4533,
+        sync_s3_bucket: Some(bucket.to_string()),
+        sync_s3_region: Some(region.to_string()),
+        sync_s3_endpoint: if endpoint.is_empty() {
+            None
+        } else {
+            Some(endpoint.to_string())
+        },
+    };
+
+    config
+        .save_to_config_yaml()
+        .map_err(|e| format!("Failed to save config: {e}"))?;
+
+    Config::add_known_library(library_dir)
+        .map_err(|e| format!("Failed to register library: {e}"))?;
+
+    info!("Joined shared library: {}", library_dir.display());
+
+    Ok(config)
 }

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -45,6 +45,7 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             on_switch: |_| {},
                             on_create: |_| {},
                             on_add_existing: |_| {},
+                            on_join: |_| {},
                             on_rename: |_| {},
                             on_remove: |_| {},
                         }

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -24,6 +24,7 @@ pub fn Settings() -> Element {
                         on_switch: |_| {},
                         on_create: |_| {},
                         on_add_existing: |_| {},
+                        on_join: |_| {},
                         on_rename: |_| {},
                         on_remove: |_| {},
                     }

--- a/bae-ui/src/components/mod.rs
+++ b/bae-ui/src/components/mod.rs
@@ -72,10 +72,10 @@ pub use resizable_panel::{GrabBar, PanelPosition, ResizablePanel, ResizeDirectio
 pub use segmented_control::{Segment, SegmentedControl};
 pub use select::{Select, SelectOption};
 pub use settings::{
-    AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
-    LibrarySectionView, SettingsCard, SettingsSection, SettingsTab, SettingsView, StorageLocation,
-    StorageProfile, StorageProfileEditorView, StorageProfilesSectionView, SubsonicSectionView,
-    SyncBucketConfig, SyncSectionView,
+    AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView,
+    JoinLibraryView, JoinStatus, LibraryInfo, LibrarySectionView, SettingsCard, SettingsSection,
+    SettingsTab, SettingsView, StorageLocation, StorageProfile, StorageProfileEditorView,
+    StorageProfilesSectionView, SubsonicSectionView, SyncBucketConfig, SyncSectionView,
 };
 pub use text_input::{TextInput, TextInputSize, TextInputType};
 pub use text_link::TextLink;

--- a/bae-ui/src/components/settings/join_library.rs
+++ b/bae-ui/src/components/settings/join_library.rs
@@ -1,0 +1,201 @@
+//! Join shared library view -- form for accepting an invitation to a shared library.
+
+use crate::components::{
+    Button, ButtonSize, ButtonVariant, LoadingSpinner, SettingsSection, TextInput, TextInputSize,
+    TextInputType,
+};
+use dioxus::prelude::*;
+
+/// Status of the join operation.
+#[derive(Clone, Debug, PartialEq)]
+pub enum JoinStatus {
+    /// Currently joining.
+    Joining(String),
+    /// Join succeeded.
+    Success,
+    /// Join failed with an error.
+    Error(String),
+}
+
+/// Pure view component for joining a shared library.
+///
+/// The user pastes sync bucket coordinates (received out-of-band from the owner)
+/// and clicks Join. The desktop wrapper handles the actual bootstrap flow.
+#[component]
+pub fn JoinLibraryView(
+    /// Bucket name input value.
+    bucket: String,
+    /// Region input value.
+    region: String,
+    /// Endpoint input value (optional).
+    endpoint: String,
+    /// Access key input value.
+    access_key: String,
+    /// Secret key input value.
+    secret_key: String,
+    /// Current status of the join operation.
+    status: Option<JoinStatus>,
+
+    // --- Callbacks ---
+    on_bucket_change: EventHandler<String>,
+    on_region_change: EventHandler<String>,
+    on_endpoint_change: EventHandler<String>,
+    on_access_key_change: EventHandler<String>,
+    on_secret_key_change: EventHandler<String>,
+    /// Called when the user clicks "Join". The desktop wrapper performs the actual work.
+    on_join: EventHandler<()>,
+    /// Called when the user clicks "Cancel" to go back.
+    on_cancel: EventHandler<()>,
+) -> Element {
+    let is_joining = matches!(status, Some(JoinStatus::Joining(_)));
+    let is_success = matches!(status, Some(JoinStatus::Success));
+    let can_join = !is_joining
+        && !is_success
+        && !bucket.is_empty()
+        && !region.is_empty()
+        && !access_key.is_empty()
+        && !secret_key.is_empty();
+
+    rsx! {
+        SettingsSection {
+            div {
+                h2 { class: "text-xl font-semibold text-white", "Join Shared Library" }
+                p { class: "text-sm text-gray-400 mt-1",
+                    "Enter the sync bucket details shared with you by the library owner."
+                }
+            }
+
+            if is_success {
+                div { class: "p-4 rounded-lg bg-green-900/30 border border-green-700",
+                    p { class: "text-sm text-green-300",
+                        "Successfully joined the library. Restarting..."
+                    }
+                }
+            } else {
+                div { class: "space-y-4 mt-4",
+                    // Bucket
+                    div {
+                        label { class: "block text-sm font-medium text-gray-300 mb-1",
+                            "Bucket "
+                            span { class: "text-red-400", "*" }
+                        }
+                        TextInput {
+                            value: bucket,
+                            on_input: move |v| on_bucket_change.call(v),
+                            size: TextInputSize::Medium,
+                            input_type: TextInputType::Text,
+                            placeholder: "my-sync-bucket",
+                            disabled: is_joining,
+                        }
+                    }
+
+                    // Region
+                    div {
+                        label { class: "block text-sm font-medium text-gray-300 mb-1",
+                            "Region "
+                            span { class: "text-red-400", "*" }
+                        }
+                        TextInput {
+                            value: region,
+                            on_input: move |v| on_region_change.call(v),
+                            size: TextInputSize::Medium,
+                            input_type: TextInputType::Text,
+                            placeholder: "us-east-1",
+                            disabled: is_joining,
+                        }
+                    }
+
+                    // Endpoint (optional)
+                    div {
+                        label { class: "block text-sm font-medium text-gray-300 mb-1",
+                            "Endpoint "
+                            span { class: "text-xs text-gray-500",
+                                "(optional, for S3-compatible services)"
+                            }
+                        }
+                        TextInput {
+                            value: endpoint,
+                            on_input: move |v| on_endpoint_change.call(v),
+                            size: TextInputSize::Medium,
+                            input_type: TextInputType::Text,
+                            placeholder: "https://s3.example.com",
+                            disabled: is_joining,
+                        }
+                    }
+
+                    // Access Key
+                    div {
+                        label { class: "block text-sm font-medium text-gray-300 mb-1",
+                            "Access Key "
+                            span { class: "text-red-400", "*" }
+                        }
+                        TextInput {
+                            value: access_key,
+                            on_input: move |v| on_access_key_change.call(v),
+                            size: TextInputSize::Medium,
+                            input_type: TextInputType::Text,
+                            placeholder: "AKIAIOSFODNN7EXAMPLE",
+                            disabled: is_joining,
+                        }
+                    }
+
+                    // Secret Key
+                    div {
+                        label { class: "block text-sm font-medium text-gray-300 mb-1",
+                            "Secret Key "
+                            span { class: "text-red-400", "*" }
+                        }
+                        TextInput {
+                            value: secret_key,
+                            on_input: move |v| on_secret_key_change.call(v),
+                            size: TextInputSize::Medium,
+                            input_type: TextInputType::Password,
+                            placeholder: "",
+                            disabled: is_joining,
+                        }
+                    }
+                }
+
+                // Status display
+                if let Some(ref status) = status {
+                    match status {
+                        JoinStatus::Joining(msg) => rsx! {
+                            div { class: "flex items-center gap-2 mt-4 p-3 rounded-lg bg-gray-800",
+                                LoadingSpinner {}
+                                p { class: "text-sm text-gray-300", "{msg}" }
+                            }
+                        },
+                        JoinStatus::Error(err) => rsx! {
+                            div { class: "mt-4 p-3 rounded-lg bg-red-900/30 border border-red-700",
+                                p { class: "text-sm text-red-300", "{err}" }
+                            }
+                        },
+                        JoinStatus::Success => rsx! {},
+                    }
+                }
+
+                // Buttons
+                div { class: "flex justify-end gap-3 mt-6",
+                    Button {
+                        variant: ButtonVariant::Ghost,
+                        size: ButtonSize::Medium,
+                        disabled: is_joining,
+                        onclick: move |_| on_cancel.call(()),
+                        "Cancel"
+                    }
+                    Button {
+                        variant: ButtonVariant::Primary,
+                        size: ButtonSize::Medium,
+                        disabled: !can_join,
+                        onclick: move |_| on_join.call(()),
+                        if is_joining {
+                            "Joining..."
+                        } else {
+                            "Join Library"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bae-ui/src/components/settings/library.rs
+++ b/bae-ui/src/components/settings/library.rs
@@ -19,6 +19,7 @@ pub fn LibrarySectionView(
     on_switch: EventHandler<String>,
     on_create: EventHandler<()>,
     on_add_existing: EventHandler<()>,
+    on_join: EventHandler<()>,
     on_rename: EventHandler<(String, String)>,
     on_remove: EventHandler<String>,
 ) -> Element {
@@ -57,6 +58,11 @@ pub fn LibrarySectionView(
                         class: "px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-md transition-colors",
                         onclick: move |_| on_add_existing.call(()),
                         "Add Existing..."
+                    }
+                    button {
+                        class: "px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-md transition-colors",
+                        onclick: move |_| on_join.call(()),
+                        "Join Shared..."
                     }
                 }
             }

--- a/bae-ui/src/components/settings/mod.rs
+++ b/bae-ui/src/components/settings/mod.rs
@@ -6,6 +6,7 @@ mod about;
 mod bittorrent;
 mod card;
 mod discogs;
+mod join_library;
 mod library;
 mod storage_profiles;
 mod subsonic;
@@ -16,6 +17,7 @@ pub use about::AboutSectionView;
 pub use bittorrent::{BitTorrentSectionView, BitTorrentSettings};
 pub use card::{SettingsCard, SettingsSection};
 pub use discogs::DiscogsSectionView;
+pub use join_library::{JoinLibraryView, JoinStatus};
 pub use library::{LibraryInfo, LibrarySectionView};
 pub use storage_profiles::{
     StorageLocation, StorageProfile, StorageProfileEditorView, StorageProfilesSectionView,


### PR DESCRIPTION
## Summary
- New `JoinLibraryView` component in bae-ui with S3 bucket coordinate form
- "Join Shared..." button added to Library settings section
- Full bootstrap flow in bae-desktop: accept invitation, unwrap encryption key, bootstrap from snapshot, pull changesets, save config, register and relaunch
- Handles the encryption key chicken-and-egg by creating a temporary S3 client with dummy key for membership operations, then creating real client after key unwrap

## Test plan
- [ ] Verify bae-desktop and bae-mocks compile
- [ ] Verify "Join Shared..." button appears in Library settings
- [ ] Verify join form validates required fields
- [ ] Verify full bootstrap flow: accept invitation -> snapshot -> pull -> register
- [ ] Verify error handling for invalid credentials, missing invitation, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)