### PR TITLE
Phase 6e: Remove member with encryption key rotation

### DIFF
--- a/bae-core/src/encryption.rs
+++ b/bae-core/src/encryption.rs
@@ -87,6 +87,11 @@ impl EncryptionService {
         Ok(EncryptionService { key })
     }
 
+    /// Create a new encryption service from a raw 32-byte key.
+    pub fn from_key(key: [u8; 32]) -> Self {
+        EncryptionService { key }
+    }
+
     /// SHA-256 fingerprint of the key, first 8 bytes hex-encoded (16 hex chars).
     /// Short enough to display in UI, long enough to detect wrong keys.
     pub fn fingerprint(&self) -> String {

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -489,7 +489,6 @@ async fn create_sync_handle(
         bucket_client,
         hlc,
         config.device_id.clone(),
-        encryption.clone(),
         raw_db,
         session,
         sync_trigger_tx,

--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -69,6 +69,10 @@ pub fn SyncSection() -> Element {
     let mut invite_pubkey = use_signal(String::new);
     let mut invite_role = use_signal(|| MemberRole::Member);
 
+    // --- Remove member state from store ---
+    let is_removing_member = *app.state.sync().removing_member().read();
+    let removing_member_error = app.state.sync().remove_member_error().read().clone();
+
     // Clone app for each closure that needs it
     let app_for_sync = app.clone();
     let app_for_edit = app.clone();
@@ -76,6 +80,7 @@ pub fn SyncSection() -> Element {
     let app_for_test = app.clone();
     let app_for_invite = app.clone();
     let app_for_dismiss = app.clone();
+    let app_for_remove = app.clone();
 
     rsx! {
         SyncSectionView {
@@ -88,7 +93,11 @@ pub fn SyncSection() -> Element {
             on_copy_pubkey: copy_pubkey,
             members,
             is_owner,
-            on_remove_member: |_pubkey: String| {},
+            on_remove_member: move |pubkey: String| {
+                app_for_remove.remove_member(pubkey);
+            },
+            is_removing_member,
+            removing_member_error,
             on_sync_now: move |_| app_for_sync.trigger_sync(),
 
             // Config display

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -100,6 +100,8 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             members: mock_members(),
                             is_owner: true,
                             on_remove_member: |_| {},
+                            is_removing_member: false,
+                            removing_member_error: None,
                             on_sync_now: |_| {},
                             sync_bucket: Some("my-sync-bucket".to_string()),
                             sync_region: Some("us-east-1".to_string()),

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -67,6 +67,8 @@ pub fn Settings() -> Element {
                         members: mock_members(),
                         is_owner: true,
                         on_remove_member: |_| {},
+                        is_removing_member: false,
+                        removing_member_error: None,
                         on_sync_now: |_| {},
                         sync_bucket: Some("my-sync-bucket".to_string()),
                         sync_region: Some("us-east-1".to_string()),

--- a/bae-ui/src/stores/sync.rs
+++ b/bae-ui/src/stores/sync.rs
@@ -79,4 +79,10 @@ pub struct SyncState {
     pub invite_status: Option<InviteStatus>,
     /// Share info shown after a successful invite.
     pub share_info: Option<ShareInfo>,
+
+    // Remove member flow state
+    /// Whether a member removal is in progress.
+    pub removing_member: bool,
+    /// Error from a member removal attempt.
+    pub remove_member_error: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Two-step inline confirmation for member removal ("Remove {name}? This will rotate the encryption key.")
- `remove_member()` in AppService: downloads chain, calls `revoke_member()`, persists new key, updates shared EncryptionService
- `EncryptionService` now shared via `Arc<RwLock<>>` between S3 bucket client and SyncHandle so key rotation is immediately visible to all consumers
- Added `EncryptionService::from_key()` constructor for key rotation
- S3SyncBucketClient updated to use read-locked encryption internally
- Removal status and error display in UI

## Test plan
- [ ] Verify all crates compile (bae-core, bae-desktop, bae-mocks, bae-server)
- [ ] Verify all tests pass (sync, encryption, invite/revoke)
- [ ] Verify Remove button shows confirmation dialog
- [ ] Verify key rotation updates both bucket client and sync handle encryption
- [ ] Verify membership list reloads after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)