### PR TITLE
Phase 7b+7c: Accept share grant and view shared releases

### DIFF
--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -28,10 +28,20 @@ pub fn SyncSection() -> Element {
     let invite_status = app.state.sync().invite_status().read().clone();
     let share_info = app.state.sync().share_info().read().clone();
 
-    // Load membership on mount
+    // --- Shared releases from store ---
+    let shared_releases = app.state.sync().shared_releases().read().clone();
+
+    // --- Local accept form state ---
+    let mut accept_grant_text = use_signal(String::new);
+    let mut is_accepting_grant = use_signal(|| false);
+    let mut accept_grant_error = use_signal(|| Option::<String>::None);
+
+    // Load membership and shared releases on mount
     let app_for_membership = app.clone();
+    let app_for_load_shared = app.clone();
     use_effect(move || {
         app_for_membership.load_membership();
+        app_for_load_shared.load_shared_releases();
     });
 
     let copy_pubkey = {
@@ -81,6 +91,8 @@ pub fn SyncSection() -> Element {
     let app_for_invite = app.clone();
     let app_for_dismiss = app.clone();
     let app_for_remove = app.clone();
+    let app_for_accept = app.clone();
+    let app_for_revoke = app.clone();
 
     rsx! {
         SyncSectionView {
@@ -262,6 +274,54 @@ pub fn SyncSection() -> Element {
                 show_invite_form.set(false);
                 invite_pubkey.set(String::new());
                 invite_role.set(MemberRole::Member);
+            },
+
+            // Shared releases
+            shared_releases,
+            accept_grant_text: accept_grant_text.read().clone(),
+            is_accepting_grant: *is_accepting_grant.read(),
+            accept_grant_error: accept_grant_error.read().clone(),
+            on_accept_grant_text_change: move |v| accept_grant_text.set(v),
+            on_accept_grant: move |json: String| {
+                let app = app_for_accept.clone();
+                is_accepting_grant.set(true);
+                accept_grant_error.set(None);
+
+                spawn(async move {
+                    let result: Result<(), String> = async {
+                        let keypair = app
+                            .user_keypair
+                            .as_ref()
+                            .ok_or_else(|| "No user keypair available".to_string())?;
+
+                        let grant: bae_core::sync::share_grant::ShareGrant = serde_json::from_str(
+                                &json,
+                            )
+                            .map_err(|e| format!("Invalid JSON: {e}"))?;
+                        bae_core::sync::shared_release::accept_and_store_grant(
+                                app.library_manager.get().database(),
+                                &grant,
+                                keypair,
+                            )
+                            .await
+                            .map_err(|e| format!("{e}"))?;
+                        Ok(())
+                    }
+                        .await;
+                    match result {
+                        Ok(()) => {
+                            accept_grant_text.set(String::new());
+                            app.load_shared_releases();
+                        }
+                        Err(e) => {
+                            accept_grant_error.set(Some(e));
+                        }
+                    }
+                    is_accepting_grant.set(false);
+                });
+            },
+            on_revoke_shared_release: move |grant_id: String| {
+                app_for_revoke.revoke_shared_release(grant_id);
             },
         }
     }

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -1,7 +1,7 @@
 //! Settings mock component
 
 use super::framework::{ControlRegistryBuilder, MockPage, MockPanel};
-use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole};
+use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole, SharedReleaseDisplay};
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
     LibrarySectionView, SettingsTab, SettingsView, StorageLocation, StorageProfile,
@@ -138,6 +138,13 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             on_invite_member: |_| {},
                             on_copy_share_info: |_| {},
                             on_dismiss_share_info: |_| {},
+                            shared_releases: mock_shared_releases(),
+                            accept_grant_text: String::new(),
+                            is_accepting_grant: false,
+                            accept_grant_error: None,
+                            on_accept_grant_text_change: |_| {},
+                            on_accept_grant: |_| {},
+                            on_revoke_shared_release: |_| {},
                         }
                     },
                     SettingsTab::Discogs => rsx! {
@@ -252,6 +259,33 @@ fn mock_members() -> Vec<Member> {
             display_name: "ff00...ddee".to_string(),
             role: MemberRole::Member,
             is_self: false,
+        },
+    ]
+}
+
+fn mock_shared_releases() -> Vec<SharedReleaseDisplay> {
+    vec![
+        SharedReleaseDisplay {
+            grant_id: "grant-001".to_string(),
+            release_id: "rel-abc123".to_string(),
+            from_library_id: "lib-xyz789".to_string(),
+            from_user_pubkey: "ff00112233445566778899aabbccddeeff00112233445566778899aabbccddee"
+                .to_string(),
+            bucket: "shared-music-bucket".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint: None,
+            expires: Some("2026-06-01T00:00:00Z".to_string()),
+        },
+        SharedReleaseDisplay {
+            grant_id: "grant-002".to_string(),
+            release_id: "rel-def456".to_string(),
+            from_library_id: "lib-uvw321".to_string(),
+            from_user_pubkey: "aabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900"
+                .to_string(),
+            bucket: "another-bucket".to_string(),
+            region: "eu-west-1".to_string(),
+            endpoint: Some("https://s3.example.com".to_string()),
+            expires: None,
         },
     ]
 }

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -1,6 +1,6 @@
 //! Settings page
 
-use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole};
+use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole, SharedReleaseDisplay};
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
     LibrarySectionView, SettingsTab, SettingsView, StorageLocation, StorageProfile,
@@ -105,6 +105,13 @@ pub fn Settings() -> Element {
                         on_invite_member: |_| {},
                         on_copy_share_info: |_| {},
                         on_dismiss_share_info: |_| {},
+                        shared_releases: mock_shared_releases(),
+                        accept_grant_text: String::new(),
+                        is_accepting_grant: false,
+                        accept_grant_error: None,
+                        on_accept_grant_text_change: |_| {},
+                        on_accept_grant: |_| {},
+                        on_revoke_shared_release: |_| {},
                     }
                 },
                 SettingsTab::Discogs => rsx! {
@@ -223,6 +230,20 @@ fn mock_members() -> Vec<Member> {
             is_self: false,
         },
     ]
+}
+
+fn mock_shared_releases() -> Vec<SharedReleaseDisplay> {
+    vec![SharedReleaseDisplay {
+        grant_id: "grant-001".to_string(),
+        release_id: "rel-abc123".to_string(),
+        from_library_id: "lib-xyz789".to_string(),
+        from_user_pubkey: "ff00112233445566778899aabbccddeeff00112233445566778899aabbccddee"
+            .to_string(),
+        bucket: "shared-music-bucket".to_string(),
+        region: "us-east-1".to_string(),
+        endpoint: None,
+        expires: Some("2026-06-01T00:00:00Z".to_string()),
+    }]
 }
 
 fn mock_storage_profiles() -> Vec<StorageProfile> {

--- a/bae-ui/src/components/settings/sync.rs
+++ b/bae-ui/src/components/settings/sync.rs
@@ -5,7 +5,9 @@ use crate::components::{
     Button, ButtonSize, ButtonVariant, ChromelessButton, SettingsCard, SettingsSection, TextInput,
     TextInputSize, TextInputType,
 };
-use crate::stores::{DeviceActivityInfo, InviteStatus, Member, MemberRole, ShareInfo};
+use crate::stores::{
+    DeviceActivityInfo, InviteStatus, Member, MemberRole, ShareInfo, SharedReleaseDisplay,
+};
 use dioxus::prelude::*;
 
 /// Data bundle for sync bucket configuration fields (avoids 5 separate EventHandler props for save).
@@ -120,6 +122,22 @@ pub fn SyncSectionView(
     on_copy_share_info: EventHandler<String>,
     /// Dismiss the share info panel.
     on_dismiss_share_info: EventHandler<()>,
+
+    // --- Shared releases props ---
+    /// Releases shared with us via accepted share grants.
+    shared_releases: Vec<SharedReleaseDisplay>,
+    /// Accept form: JSON text input.
+    accept_grant_text: String,
+    /// Whether an accept operation is in progress.
+    is_accepting_grant: bool,
+    /// Error from a grant accept attempt.
+    accept_grant_error: Option<String>,
+    /// Called when the accept textarea content changes.
+    on_accept_grant_text_change: EventHandler<String>,
+    /// Called when the user clicks Accept.
+    on_accept_grant: EventHandler<String>,
+    /// Called when the user clicks Remove on a shared release.
+    on_revoke_shared_release: EventHandler<String>,
 ) -> Element {
     let mut copied = use_signal(|| false);
     let mut share_copied = use_signal(|| false);
@@ -317,8 +335,12 @@ pub fn SyncSectionView(
 
         
                 
-        
+                
 
+                
+        
+                
+                
                                                             if let Some(ref err) = removing_member_error {
                                                                 div { class: "text-sm text-red-400 mb-3", "{err}" }
                                                             }
@@ -476,6 +498,7 @@ pub fn SyncSectionView(
                                         }
                                     }
 
+        
         
                                     div { class: "flex gap-3 mt-3",
                                         Button {
@@ -698,7 +721,96 @@ pub fn SyncSectionView(
                     }
                 }
             }
+
+            // Shared with Me
+            SettingsCard {
+                h3 { class: "text-lg font-medium text-white mb-4", "Shared with Me" }
+
+                // Accept grant form
+                div { class: "space-y-3 mb-4",
+                    label { class: "block text-sm text-gray-400",
+                        "Paste a share grant JSON token to gain access to a shared release."
+                    }
+                    textarea {
+                        class: "w-full h-24 bg-gray-700 text-white text-sm font-mono rounded-lg p-3 border border-gray-600 focus:border-blue-500 focus:outline-none resize-none placeholder-gray-500",
+                        placeholder: "Paste share grant JSON here...",
+                        value: "{accept_grant_text}",
+                        oninput: move |e| on_accept_grant_text_change.call(e.value()),
+                    }
+
+                    if let Some(ref err) = accept_grant_error {
+                        div { class: "p-3 bg-red-900/30 border border-red-700 rounded-lg text-sm text-red-300",
+                            "{err}"
+                        }
+                    }
+
+                    {
+                        let text = accept_grant_text.clone();
+                        rsx! {
+                            Button {
+                                variant: ButtonVariant::Primary,
+                                size: ButtonSize::Small,
+                                disabled: text.trim().is_empty() || is_accepting_grant,
+                                loading: is_accepting_grant,
+                                onclick: move |_| on_accept_grant.call(text.clone()),
+                                if is_accepting_grant {
+                                    "Accepting..."
+                                } else {
+                                    "Accept"
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Shared releases list
+                if shared_releases.is_empty() {
+                    p { class: "text-sm text-gray-500", "No shared releases yet." }
+                } else {
+                    div { class: "space-y-2",
+                        for release in shared_releases.iter() {
+                            {
+                                let grant_id = release.grant_id.clone();
+                                rsx! {
+                                    div {
+                                        key: "{release.grant_id}",
+                                        class: "flex items-center justify-between p-3 bg-gray-700/50 rounded-lg",
+                                        div { class: "min-w-0 flex-1",
+                                            div { class: "flex items-center gap-2 text-sm",
+                                                span { class: "text-gray-200 font-mono truncate", {truncate_id(&release.release_id)} }
+                                                span { class: "text-gray-500", "from" }
+                                                span { class: "text-gray-400 font-mono", {truncate_pubkey(&release.from_user_pubkey)} }
+                                            }
+                                            div { class: "flex items-center gap-3 mt-1 text-xs text-gray-500",
+                                                span { "Bucket: {release.bucket}" }
+                                                if let Some(ref exp) = release.expires {
+                                                    span { "Expires: {exp}" }
+                                                }
+                                            }
+                                        }
+                                        Button {
+                                            variant: ButtonVariant::Secondary,
+                                            size: ButtonSize::Small,
+                                            onclick: move |_| on_revoke_shared_release.call(grant_id.clone()),
+                                            "Remove"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
+    }
+}
+
+/// Truncate an ID for display: first 8 characters.
+fn truncate_id(id: &str) -> String {
+    if id.len() > 12 {
+        format!("{}...", &id[..8])
+    } else {
+        id.to_string()
     }
 }
 

--- a/bae-ui/src/stores/sync.rs
+++ b/bae-ui/src/stores/sync.rs
@@ -48,6 +48,19 @@ pub struct ShareInfo {
     pub invitee_pubkey: String,
 }
 
+/// A release shared with us via a share grant (display-only).
+#[derive(Clone, Debug, PartialEq)]
+pub struct SharedReleaseDisplay {
+    pub grant_id: String,
+    pub release_id: String,
+    pub from_library_id: String,
+    pub from_user_pubkey: String,
+    pub bucket: String,
+    pub region: String,
+    pub endpoint: Option<String>,
+    pub expires: Option<String>,
+}
+
 /// Sync status state for the UI.
 #[derive(Clone, Debug, Default, PartialEq, Store)]
 pub struct SyncState {
@@ -85,4 +98,8 @@ pub struct SyncState {
     pub removing_member: bool,
     /// Error from a member removal attempt.
     pub remove_member_error: Option<String>,
+
+    // Shared releases
+    /// Releases shared with us via accepted share grants.
+    pub shared_releases: Vec<SharedReleaseDisplay>,
 }


### PR DESCRIPTION
## Summary
- `SharedReleaseDisplay` type in bae-ui stores for shared release display
- "Shared with Me" section in Sync settings: paste JSON textarea + Accept button, shared releases list with Remove
- `accept_share_grant()`: deserializes JSON, calls `accept_and_store_grant()`, refreshes list
- `load_shared_releases()`: loads from DB on settings mount
- `revoke_shared_release()`: removes from DB and updates store optimistically

## Test plan
- [ ] Verify bae-desktop and bae-mocks compile
- [ ] Verify shared releases section appears in Sync settings
- [ ] Verify accepting a valid grant JSON adds to the list
- [ ] Verify removing a shared release works
- [ ] Verify error display for invalid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)