### PR TITLE
Generate fun default library names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "libcdio-sys",
  "libsqlite3-sys",
  "nom",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "reqwest",

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -51,6 +51,7 @@ futures = "0.3.31"
 tokio-stream = "0.1.17"
 bincode = "1.3"
 cxx = { version = "1.0", optional = true }
+rand = "0.9"
 tracing = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -1,10 +1,156 @@
 use crate::library_dir::LibraryDir;
 use crate::sync::participation::{default_participation, ParticipationMode};
+use rand::prelude::IndexedRandom;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{info, warn};
+
+/// Generate a fun default library name like "groovin-coltrane" or "boppin-beethoven".
+fn generate_library_name() -> String {
+    const VERBS: &[&str] = &[
+        "boppin",
+        "groovin",
+        "swingin",
+        "rockin",
+        "jigging",
+        "vibin",
+        "jammin",
+        "funkin",
+        "chillin",
+        "cruisin",
+        "bumpin",
+        "rollin",
+        "flowin",
+        "blazin",
+        "rippin",
+        "shreddin",
+        "stompin",
+        "thumpin",
+        "bouncin",
+        "struttin",
+        "slidin",
+        "tappin",
+        "hummin",
+        "wailin",
+        "mixin",
+        "looping",
+        "droppin",
+        "spinnin",
+        "scratchin",
+        "ticklin",
+        "strummin",
+        "pluckin",
+        "beltin",
+        "snappin",
+        "poppin",
+        "buskin",
+        "noodlin",
+        "howlin",
+        "swooning",
+        "crooning",
+        "twangin",
+        "riffin",
+        "sampling",
+        "beatboxin",
+        "freestylin",
+        "headbangin",
+    ];
+    const MUSICIANS: &[&str] = &[
+        // classical
+        "bach",
+        "beethoven",
+        "brahms",
+        "chopin",
+        "debussy",
+        "gershwin",
+        "grieg",
+        "holst",
+        "liszt",
+        "mahler",
+        "mozart",
+        "paganini",
+        "ravel",
+        "satie",
+        "schubert",
+        "stravinsky",
+        "tchaikovsky",
+        "vivaldi",
+        // jazz
+        "coltrane",
+        "davis",
+        "dizzy",
+        "ella",
+        "ellington",
+        "mingus",
+        "monk",
+        // rock / pop / funk / electronic
+        "aretha",
+        "billie",
+        "bjork",
+        "bowie",
+        "dolly",
+        "elvis",
+        "etta",
+        "hendrix",
+        "marley",
+        "nina",
+        "otis",
+        "prince",
+        "sinatra",
+        "stevie",
+        "sting",
+        "waits",
+        "zappa",
+        // hip-hop / rap
+        "dilla",
+        "kendrick",
+        "lauryn",
+        "missy",
+        "nas",
+        "outkast",
+        "questlove",
+        "tupac",
+        // r&b / soul / gospel
+        "erykah",
+        "luther",
+        "sade",
+        "sam-cooke",
+        "whitney",
+        // country / folk
+        "cash",
+        "joni",
+        "woody",
+        // latin / brazilian
+        "celia",
+        "gilberto",
+        "jobim",
+        "piazzolla",
+        "santana",
+        "selena",
+        "shakira",
+        "tito",
+        // south asian
+        "bismillah",
+        "lata",
+        "nusrat",
+        "shankar",
+        "zakir",
+        // east asian
+        "kitaro",
+        "ryuichi",
+        "yo-yo",
+        // african
+        "fela",
+        "miriam",
+        "youssou",
+    ];
+    let mut rng = rand::rng();
+    let verb = VERBS.choose(&mut rng).unwrap();
+    let musician = MUSICIANS.choose(&mut rng).unwrap();
+    format!("{}-{}", verb, musician)
+}
 
 /// Initialize the keyring credential store.
 ///
@@ -477,7 +623,7 @@ impl Config {
             library_id: id,
             device_id,
             library_dir: library_dir.clone(),
-            library_name: None,
+            library_name: Some(generate_library_name()),
             keys_migrated: true,
             discogs_key_stored: false,
             encryption_key_stored: true,

--- a/notes/02-storage-profiles.md
+++ b/notes/02-storage-profiles.md
@@ -6,6 +6,16 @@ How bae manages where release files live. Storage profiles are file storage loca
 
 A release's files can exist on one or more profiles, or be unmanaged. Each copy is in one of these modes:
 
+|                          | Unmanaged        | Local profile      | Cloud profile        |
+|--------------------------|------------------|--------------------|----------------------|
+| Files live at            | User's location  | Profile directory   | S3 bucket            |
+| Copies files on import   | No               | Yes                | Yes (upload)         |
+| Encrypted at rest        | No               | No                 | Yes (XChaCha20)      |
+| Transfer between profiles| No               | Yes                | Yes                  |
+| Sync across devices      | No               | No                 | Yes                  |
+| User manages files       | Yes              | No (bae owns them) | No (bae owns them)   |
+| Delete release removes files | No (DB only) | Yes (deferred)     | Yes (deferred)       |
+
 ### Unmanaged (no profile)
 
 Files stay wherever the user has them. bae records each file's location in `release_files.source_path` but doesn't copy, move, or touch anything. Deleting a release from the library removes DB records but leaves files on disk.

--- a/website/src/content/docs/storage/overview.mdx
+++ b/website/src/content/docs/storage/overview.mdx
@@ -5,26 +5,46 @@ description: How bae stores your music files
 
 bae gives you full control over where your music is stored. You can manage storage yourself, or let bae handle it for you.
 
-## Storage Options
+## At a Glance
 
-**Self-managed storage**: Point bae at files you already have organized. bae indexes them but doesn't move or copy anything.
+|                          | Self-managed     | Local profile      | Cloud profile        |
+|--------------------------|------------------|--------------------|----------------------|
+| Files live at            | Your location    | bae-managed folder | S3 bucket            |
+| Copies files on import   | No               | Yes                | Yes (upload)         |
+| Encrypted at rest        | No               | No                 | Yes                  |
+| Transfer between storage | No               | Yes                | Yes                  |
+| Sync across devices      | No               | No                 | Yes                  |
+| You manage the files     | Yes              | No                 | No                   |
+| Delete release removes files | No           | Yes                | Yes                  |
 
-**bae-managed storage**: Let bae organize and store your files. When you import music, bae copies it to your configured storage location.
+## Self-managed Storage
 
-## Storage Locations
+Point bae at files you already have organized. bae indexes them but doesn't move, copy, or touch anything. If you already have terabytes of music arranged your way, this lets you catalog it without duplicating a single byte.
 
-Storage can be:
+The tradeoff: bae can't encrypt, transfer, or sync self-managed files. If you move or rename them outside bae, it loses track.
 
-- **Local**: A folder on your computer or external drive
-- **Remote**: S3-compatible cloud storage (AWS S3, MinIO, Backblaze B2, etc.)
+## bae-managed Storage
 
-Both options support optional encryption—your files are encrypted before they leave your machine.
+Let bae organize and store your files. When you import music, bae copies it to your configured storage location. Your originals are untouched -- you can delete them after import if you want.
+
+Managed storage supports:
+- **Transfer** -- move releases between profiles (local to cloud, cloud to local, etc.)
+- **Encryption** -- cloud files are always encrypted before leaving your machine
+- **Sync** -- cloud-stored files can be accessed from other devices
+
+### Local Profiles
+
+A folder on your computer or external drive. bae copies files into a hash-based layout. Not encrypted.
+
+### Cloud Profiles
+
+S3-compatible cloud storage (AWS S3, MinIO, Backblaze B2, etc.). Files are encrypted with XChaCha20-Poly1305 before upload. See [Encryption](/storage/encryption) for details.
 
 ## How It Works
 
 1. You create **storage profiles** in Settings
-2. When importing a release, you pick which profile to use
+2. When importing a release, you pick which profile to use (or "None" for self-managed)
 3. bae copies the files to that storage location
-4. The release is now associated with that storage configuration
+4. The release is linked to that profile
 
-Each release stores its own copy of the storage settings. This means you can have different releases in different locations—some local, some in the cloud, some unmanaged.
+You can have different releases in different places -- some local, some in the cloud, some self-managed.


### PR DESCRIPTION
## Summary
- New libraries get a random name like `groovin-coltrane` or `headbangin-bach` instead of showing a bare UUID
- 46 music verbs x 58 musicians across genres and cultures = 2,668 combos
- Adds `rand` dependency to bae-core

## Test plan
- [x] `cargo test -p bae-core --lib -- config` (16 tests pass)
- [ ] `rm -rf ~/.bae && cargo run` — verify new library shows a fun name in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)