### PR TITLE
Show track listing in import search results and confirm screen

### DIFF
--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -375,6 +375,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
             discogs_release_id: None,
             discogs_master_id: None,
             existing_album_id: None,
+            tracks: vec![],
         },
         MatchCandidate {
             title: "Neon Frequencies (Deluxe)".to_string(),
@@ -393,6 +394,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
             discogs_release_id: None,
             discogs_master_id: None,
             existing_album_id: None,
+            tracks: vec![],
         },
     ];
 
@@ -563,6 +565,7 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                         discogs_release_id: None,
                         discogs_master_id: None,
                         existing_album_id: None,
+                        tracks: vec![],
                     }),
                 selected_cover: selected_cover(),
                 selected_profile_id: selected_profile_id(),

--- a/bae-ui/src/components/import/workflow/confirmation.rs
+++ b/bae-ui/src/components/import/workflow/confirmation.rs
@@ -1,6 +1,7 @@
 //! Confirmation view component
 
 use super::gallery_lightbox::{GalleryItem, GalleryItemContent, GalleryLightbox};
+use super::match_item::TrackListingCompact;
 use super::shared::ImportErrorDisplayView;
 use crate::components::icons::{CheckIcon, ImageIcon, PencilIcon};
 use crate::components::{
@@ -192,6 +193,11 @@ pub fn ConfirmationView(
                         "Change"
                     }
                 }
+            }
+
+            // Track listing
+            if !candidate.tracks.is_empty() {
+                TrackListingCompact { tracks: candidate.tracks.clone() }
             }
 
             // Import error (between release card and action row)

--- a/bae-ui/src/components/import/workflow/match_item.rs
+++ b/bae-ui/src/components/import/workflow/match_item.rs
@@ -2,7 +2,7 @@
 
 use crate::components::icons::{ImageIcon, RefreshIcon};
 use crate::components::{Button, ButtonSize, ButtonVariant};
-use crate::display_types::MatchCandidate;
+use crate::display_types::{CandidateTrack, MatchCandidate};
 use crate::stores::import::PrefetchState;
 use dioxus::prelude::*;
 
@@ -178,6 +178,35 @@ pub fn MatchItemView(
                             onclick: move |_| on_confirm.call(()),
                             "{confirm_button_text}"
                         }
+                    }
+                }
+            }
+
+            // Track listing (shown when selected and prefetch returned tracks)
+            if is_selected {
+                if let Some(PrefetchState::Valid { tracks }) = &prefetch_state {
+                    if !tracks.is_empty() {
+                        TrackListingCompact { tracks: tracks.clone() }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Compact track listing for display in match items and confirmation views
+#[component]
+pub fn TrackListingCompact(tracks: Vec<CandidateTrack>) -> Element {
+    rsx! {
+        div { class: "mt-2 ml-7 border-t border-gray-700/50 pt-2",
+            div { class: "grid grid-cols-[auto_1fr_auto] gap-x-3 gap-y-0.5 text-xs text-gray-400",
+                for track in tracks.iter() {
+                    span { class: "text-gray-500 tabular-nums text-right", "{track.position}" }
+                    span { class: "truncate", "{track.title}" }
+                    if let Some(ref dur) = track.duration {
+                        span { class: "text-gray-500 tabular-nums", "{dur}" }
+                    } else {
+                        span {}
                     }
                 }
             }

--- a/bae-ui/src/components/import/workflow/mod.rs
+++ b/bae-ui/src/components/import/workflow/mod.rs
@@ -30,7 +30,7 @@ pub use file_list::FileListView;
 pub use folder_import::{FolderImportView, FolderImportViewProps};
 pub use gallery_lightbox::{GalleryItem, GalleryItemContent, GalleryLightbox};
 pub use manual_search_panel::ManualSearchPanelView;
-pub use match_item::MatchItemView;
+pub use match_item::{MatchItemView, TrackListingCompact};
 pub use match_results_panel::MatchResultsPanel;
 pub use metadata_display::MetadataDisplayView;
 pub use multiple_exact_matches::MultipleExactMatchesView;

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -240,6 +240,14 @@ impl SearchSource {
     }
 }
 
+/// A track from a remote release (MusicBrainz or Discogs)
+#[derive(Clone, Debug, PartialEq)]
+pub struct CandidateTrack {
+    pub position: String,
+    pub title: String,
+    pub duration: Option<String>,
+}
+
 /// Match candidate source type
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MatchSourceType {
@@ -274,6 +282,8 @@ pub struct MatchCandidate {
     pub discogs_master_id: Option<String>,
     /// ID of existing album in library (duplicate detection)
     pub existing_album_id: Option<String>,
+    /// Tracks from the full release (populated after prefetch)
+    pub tracks: Vec<CandidateTrack>,
 }
 
 /// Detected folder metadata for UI display

--- a/website/src/content/docs/importing/local-files.mdx
+++ b/website/src/content/docs/importing/local-files.mdx
@@ -26,14 +26,14 @@ bae scans the folder, detects audio files and artwork, and moves to the identify
 
 bae needs to match your files to a known release so it can pull in proper metadata. A few ways this happens:
 
-- **Disc ID** -- if your folder has a LOG file (from EAC, XLD, etc.), bae calculates a MusicBrainz disc ID from the track offsets and lead-out sector. If there's no LOG, it falls back to computing the disc ID from a CUE sheet + FLAC file. Either way, the disc ID is looked up on MusicBrainz automatically, and this often finds an exact match with no manual effort.
-- **Manual search** -- search by artist and album name, barcode, or catalog number across both MusicBrainz and Discogs.
+- **Automatically** -- if your folder has a LOG file (from EAC, XLD, etc.), bae calculates a <a href="https://musicbrainz.org/doc/Disc_ID" target="_blank">MusicBrainz disc ID</a> from the track offsets and lead-out sector. If there's no LOG, it falls back to computing the disc ID from a CUE sheet + FLAC file. Either way, the disc ID is looked up on MusicBrainz automatically, and this often finds an exact match with no manual effort.
+- **Manually** -- search by artist and album name, barcode, or catalog number across both MusicBrainz and Discogs.
 
 When you select a result, bae checks that the release's track count matches your local files. If there's a mismatch, the result is flagged and you can't accidentally import the wrong release.
 
 ### Confirm
 
-Once matched, you see the full track listing alongside your files. This is where you:
+Once matched, you review the release details. This is where you:
 
 - **Pick artwork** -- bae fetches cover art from MusicBrainz's Cover Art Archive and Discogs. If your folder has image files (cover.jpg, front.png, etc.), those show up too. Choose whichever looks best.
 - **Choose storage** -- select a [storage profile](/storage/profiles) or leave as self-managed. This determines whether bae copies the files or just indexes them in place.

--- a/website/src/content/docs/library/metadata.mdx
+++ b/website/src/content/docs/library/metadata.mdx
@@ -9,7 +9,7 @@ bae enriches your library with detailed metadata from online databases.
 
 ### Discogs
 
-[Discogs](https://www.discogs.com) is a music database and marketplace. It's especially strong for:
+<a href="https://www.discogs.com" target="_blank">Discogs</a> is a music database and marketplace. It's especially strong for:
 
 - Vinyl releases and pressings
 - Detailed credits (producer, engineer, etc.)
@@ -18,7 +18,7 @@ bae enriches your library with detailed metadata from online databases.
 
 ### MusicBrainz
 
-[MusicBrainz](https://musicbrainz.org) is an open music encyclopedia. It provides:
+<a href="https://musicbrainz.org" target="_blank">MusicBrainz</a> is an open music encyclopedia. It provides:
 
 - Comprehensive track listings
 - Release group information


### PR DESCRIPTION
## Summary
- Show track listing (position, title, duration) in selected search results once prefetch completes
- Show same track listing on the confirm screen
- Carry track data through `PrefetchState::Valid { tracks }` from prefetch validation
- For single disc ID matches, fetch full MB release for track listing before auto-confirming
- Fix website docs: accurate FLAC-only format support, disc ID calculation description, external links open in new tabs

## Test plan
- [ ] Select a search result, wait for prefetch, track list appears inline
- [ ] Confirm screen shows track listing
- [ ] Switch between results — old tracks disappear, new prefetch starts
- [ ] Single disc ID match auto-confirms with tracks shown on confirm screen
- [ ] Track count mismatch still disables Select button
- [ ] `cargo clippy -p bae-desktop -p bae-ui -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)