### PR TITLE
Add confirmation prompt and return-to-settings for library switch

### DIFF
--- a/bae-desktop/src/ui/components/app_layout.rs
+++ b/bae-desktop/src/ui/components/app_layout.rs
@@ -13,6 +13,14 @@ use dioxus::prelude::*;
 /// Layout component that includes title bar, content, playback bar, and sidebar
 #[component]
 pub fn AppLayout() -> Element {
+    // If we were relaunched after a library switch, navigate to Settings
+    use_effect(|| {
+        if std::env::var("BAE_OPEN_SETTINGS").is_ok() {
+            unsafe { std::env::remove_var("BAE_OPEN_SETTINGS") };
+            navigator().replace(Route::Settings {});
+        }
+    });
+
     rsx! {
         ShortcutsHandler {
             AppLayoutView {

--- a/bae-desktop/src/ui/components/settings/library.rs
+++ b/bae-desktop/src/ui/components/settings/library.rs
@@ -64,6 +64,9 @@ pub fn LibrarySection() -> Element {
             }
 
             info!("Switching to library at {path}");
+
+            // Tell the re-exec'd process to open Settings instead of the main view
+            unsafe { std::env::set_var("BAE_OPEN_SETTINGS", "1") };
             super::super::welcome::relaunch();
         }
     };

--- a/bae-ui/src/components/settings/library.rs
+++ b/bae-ui/src/components/settings/library.rs
@@ -24,6 +24,7 @@ pub fn LibrarySectionView(
 ) -> Element {
     let mut renaming_path = use_signal(|| None::<String>);
     let mut rename_value = use_signal(String::new);
+    let mut confirming_switch = use_signal(|| None::<String>);
     let mut confirming_delete = use_signal(|| None::<String>);
 
     let mut start_rename = move |lib: &LibraryInfo| {
@@ -67,9 +68,11 @@ pub fn LibrarySectionView(
                     {
                         let lib_path_rename = lib.path.clone();
                         let lib_path_switch = lib.path.clone();
+                        let lib_path_confirm_switch = lib.path.clone();
                         let lib_path_remove = lib.path.clone();
                         let lib_path_confirm = lib.path.clone();
                         let is_renaming = renaming_path.read().as_ref() == Some(&lib.path);
+                        let is_confirming_switch = confirming_switch.read().as_ref() == Some(&lib.path);
                         let is_confirming = confirming_delete.read().as_ref() == Some(&lib.path);
 
                         rsx! {
@@ -120,10 +123,27 @@ pub fn LibrarySectionView(
                                         }
                                     }
                                     if !lib.is_active {
-                                        button {
-                                            class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors",
-                                            onclick: move |_| on_switch.call(lib_path_switch.clone()),
-                                            "Switch"
+                                        if is_confirming_switch {
+                                            span { class: "text-xs text-gray-400 mr-1", "App will restart. Switch?" }
+                                            button {
+                                                class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors",
+                                                onclick: move |_| {
+                                                    confirming_switch.set(None);
+                                                    on_switch.call(lib_path_switch.clone());
+                                                },
+                                                "Yes"
+                                            }
+                                            button {
+                                                class: "px-2 py-1 text-xs text-gray-400 hover:text-white transition-colors",
+                                                onclick: move |_| confirming_switch.set(None),
+                                                "No"
+                                            }
+                                        } else {
+                                            button {
+                                                class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors",
+                                                onclick: move |_| confirming_switch.set(Some(lib_path_confirm_switch.clone())),
+                                                "Switch"
+                                            }
                                         }
                                         if is_confirming {
                                             span { class: "text-xs text-red-400 mr-1", "Delete?" }


### PR DESCRIPTION
## Summary
- Adds inline "Switch? Yes / No" confirmation before switching libraries (mirrors existing delete confirmation pattern)
- After switching, app relaunches to Settings > Library instead of the main view (via `BAE_OPEN_SETTINGS` env var)

## Test plan
- [ ] Click Switch on a non-active library — confirmation prompt appears
- [ ] Click No — confirmation dismisses, nothing happens
- [ ] Click Yes — app relaunches and lands on Settings > Library tab
- [ ] Create new library — still opens to main view (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)