### PR TITLE
Only generate artist image URL when file exists on disk

### DIFF
--- a/bae-desktop/src/ui/display_types.rs
+++ b/bae-desktop/src/ui/display_types.rs
@@ -27,7 +27,7 @@ pub fn artist_from_db_ref(db: &DbArtist, imgs: &ImageServerHandle) -> Artist {
     Artist {
         id: db.id.clone(),
         name: db.name.clone(),
-        image_url: Some(imgs.image_url(&db.id)),
+        image_url: imgs.image_url_if_exists(&db.id),
     }
 }
 


### PR DESCRIPTION
## Summary
- `artist_from_db_ref` was unconditionally generating image URLs for all artists, causing 404s and broken image icons for artists without images
- Added `image_url_if_exists` to `ImageServerHandle` that checks file existence before generating a URL
- Artist images now only show when the file is actually on disk (e.g. fetched from Discogs)

## Test plan
- [ ] Navigate to an artist page — no broken image icon
- [ ] Artists with Discogs images still show their image

🤖 Generated with [Claude Code](https://claude.com/claude-code)