### PR TITLE
Populate discogs_artist_id on MB imports for artist image fetching

### DIFF
--- a/bae-core/src/import/musicbrainz_parser.rs
+++ b/bae-core/src/import/musicbrainz_parser.rs
@@ -106,11 +106,17 @@ fn parse_mb_release_from_json(
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| artist_name.clone());
+                let discogs_artist_id = discogs_release.as_ref().and_then(|dr| {
+                    dr.artists
+                        .iter()
+                        .find(|da| da.name.eq_ignore_ascii_case(&artist_name))
+                        .map(|da| da.id.clone())
+                });
                 let artist = DbArtist {
                     id: Uuid::new_v4().to_string(),
                     name: artist_name,
                     sort_name: Some(sort_name),
-                    discogs_artist_id: None,
+                    discogs_artist_id,
                     bandcamp_artist_id: None,
                     musicbrainz_artist_id: mb_artist_id,
 


### PR DESCRIPTION
## Summary
- When a MusicBrainz release has a linked Discogs release (via URL relationships), match artist names to extract Discogs artist IDs
- This lets the existing `fetch_artist_images` flow pick up artists from MB-sourced imports — previously it skipped them because `discogs_artist_id` was always `None`
- 5-line change in `musicbrainz_parser.rs`, no new deps

## Test plan
- [ ] Import via MB search for an artist with a Discogs-linked release (e.g. Led Zeppelin)
- [ ] Verify artist image appears on artist detail page
- [ ] Verify Discogs-only imports still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)