### PR TITLE
Fix import dropdown navigation and close behavior

### DIFF
--- a/bae-desktop/src/ui/components/title_bar.rs
+++ b/bae-desktop/src/ui/components/title_bar.rs
@@ -226,7 +226,7 @@ pub fn TitleBar() -> Element {
             on_imports_dropdown_toggle: Some(EventHandler::new(move |_| imports_dropdown_open.toggle())),
             on_imports_dropdown_close: Some(EventHandler::new(move |_| imports_dropdown_open.set(false))),
             imports_dropdown_content: rsx! {
-                ImportsDropdown {}
+                ImportsDropdown { dropdown_open: imports_dropdown_open }
             },
             left_padding,
         }


### PR DESCRIPTION
## Summary
- Clicking completed import was passing release_id as album_id, causing "Album not found"
- Now looks up album_id from release_id via get_album_id_for_release
- Also passes release_id to the route so the correct release is selected
- Dropdown closes on navigation (passes dropdown_open signal to ImportsDropdown)

## Test plan
- [ ] Click completed import in dropdown — navigates to correct album detail
- [ ] Dropdown closes after clicking
- [ ] Dismiss and clear all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)