### PR TITLE
Say "Copy to storage" for self-managed releases

### DIFF
--- a/bae-ui/src/components/album_detail/storage_modal.rs
+++ b/bae-ui/src/components/album_detail/storage_modal.rs
@@ -246,11 +246,16 @@ fn TransferActionsSection(
 
     rsx! {
         div { class: "space-y-3",
-            div { class: "text-sm font-medium text-gray-300",
+            div {
+                div { class: "text-sm font-medium text-gray-300",
+                    if is_self_managed {
+                        "Copy to storage"
+                    } else {
+                        "Transfer"
+                    }
+                }
                 if is_self_managed {
-                    "Move to storage"
-                } else {
-                    "Transfer"
+                    div { class: "text-xs text-gray-500 mt-1", "Original files will not be modified" }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Changed "Move to storage" → "Copy to storage" in the storage modal when the release is self-managed (unmanaged)
- Added subtitle "Original files will not be modified" to clarify behavior
- The transfer service already preserves originals (skips deletion queue for self-managed files) — label was just misleading

## Test plan
- [ ] Open storage modal for a self-managed release
- [ ] Verify it says "Copy to storage" with the subtitle
- [ ] Open storage modal for a managed release — verify it still says "Transfer" with no subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)