### PR TITLE
Remove cover_art_url from DbAlbum and all persistence

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -16,7 +16,6 @@ CREATE TABLE albums (
     year INTEGER,
     bandcamp_album_id TEXT,
     cover_release_id TEXT,
-    cover_art_url TEXT,
     is_compilation BOOLEAN NOT NULL DEFAULT FALSE,
     _updated_at TEXT NOT NULL,
     created_at TEXT NOT NULL

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -353,7 +353,7 @@ impl Database {
         let rows = sqlx::query(
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -394,7 +394,6 @@ impl Database {
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
                 cover_release_id: row.get("cover_release_id"),
-                cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 updated_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("_updated_at"))
                     .unwrap()
@@ -444,7 +443,7 @@ impl Database {
         // Search albums by title, with primary artist name
         let album_rows = sqlx::query(
             r#"
-            SELECT a.id, a.title, a.year, a.cover_art_url,
+            SELECT a.id, a.title, a.year, a.cover_release_id,
                    COALESCE(art.name, 'Unknown Artist') as artist_name
             FROM albums a
             LEFT JOIN album_artists aa ON a.id = aa.album_id AND aa.position = 0
@@ -465,7 +464,7 @@ impl Database {
                 id: row.get("id"),
                 title: row.get("title"),
                 year: row.get("year"),
-                cover_art_url: row.get("cover_art_url"),
+                cover_release_id: row.get("cover_release_id"),
                 artist_name: row.get("artist_name"),
             })
             .collect();
@@ -517,8 +516,8 @@ impl Database {
         sqlx::query(
             r#"
             INSERT INTO albums (
-                id, title, year, bandcamp_album_id, cover_release_id, cover_art_url, is_compilation, _updated_at, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                id, title, year, bandcamp_album_id, cover_release_id, is_compilation, _updated_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&album.id)
@@ -526,7 +525,6 @@ impl Database {
         .bind(album.year)
         .bind(&album.bandcamp_album_id)
         .bind(&album.cover_release_id)
-        .bind(&album.cover_art_url)
         .bind(album.is_compilation)
         .bind(album.updated_at.to_rfc3339())
         .bind(album.created_at.to_rfc3339())
@@ -639,8 +637,8 @@ impl Database {
         sqlx::query(
             r#"
             INSERT INTO albums (
-                id, title, year, bandcamp_album_id, cover_release_id, cover_art_url, is_compilation, _updated_at, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                id, title, year, bandcamp_album_id, cover_release_id, is_compilation, _updated_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&album.id)
@@ -648,7 +646,6 @@ impl Database {
         .bind(album.year)
         .bind(&album.bandcamp_album_id)
         .bind(&album.cover_release_id)
-        .bind(&album.cover_art_url)
         .bind(album.is_compilation)
         .bind(album.updated_at.to_rfc3339())
         .bind(album.created_at.to_rfc3339())
@@ -790,7 +787,7 @@ impl Database {
         let rows = sqlx::query(
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -828,7 +825,6 @@ impl Database {
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
                 cover_release_id: row.get("cover_release_id"),
-                cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 updated_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("_updated_at"))
                     .unwrap()
@@ -845,7 +841,7 @@ impl Database {
         let row = sqlx::query(
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -883,7 +879,6 @@ impl Database {
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
                 cover_release_id: row.get("cover_release_id"),
-                cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 updated_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("_updated_at"))
                     .unwrap()
@@ -1349,7 +1344,7 @@ impl Database {
         let query = if master_id.is_some() && release_id.is_some() {
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1362,7 +1357,7 @@ impl Database {
         } else if master_id.is_some() {
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1375,7 +1370,7 @@ impl Database {
         } else if release_id.is_some() {
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1435,7 +1430,6 @@ impl Database {
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
                 cover_release_id: row.get("cover_release_id"),
-                cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 updated_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("_updated_at"))
                     .unwrap()
@@ -1458,7 +1452,7 @@ impl Database {
         let query = if release_id.is_some() && release_group_id.is_some() {
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1471,7 +1465,7 @@ impl Database {
         } else if release_id.is_some() {
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1484,7 +1478,7 @@ impl Database {
         } else if release_group_id.is_some() {
             r#"
             SELECT
-                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id, a.cover_art_url,
+                a.id, a.title, a.year, a.bandcamp_album_id, a.cover_release_id,
                 a.is_compilation, a._updated_at, a.created_at,
                 ad.discogs_master_id, ad.discogs_release_id,
                 amb.musicbrainz_release_group_id, amb.musicbrainz_release_id
@@ -1544,7 +1538,6 @@ impl Database {
                 musicbrainz_release,
                 bandcamp_album_id: row.get("bandcamp_album_id"),
                 cover_release_id: row.get("cover_release_id"),
-                cover_art_url: row.get("cover_art_url"),
                 is_compilation: row.get("is_compilation"),
                 updated_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("_updated_at"))
                     .unwrap()

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -131,9 +131,6 @@ pub struct DbAlbum {
     pub bandcamp_album_id: Option<String>,
     /// Release ID whose cover art is used for this album
     pub cover_release_id: Option<String>,
-    /// Cover art URL for immediate display (remote URL)
-    /// Used before import completes and cover_release_id is set
-    pub cover_art_url: Option<String>,
     /// True for "Various Artists" compilation albums
     pub is_compilation: bool,
     pub created_at: DateTime<Utc>,
@@ -373,7 +370,6 @@ impl DbAlbum {
             musicbrainz_release: None,
             bandcamp_album_id: None,
             cover_release_id: None,
-            cover_art_url: None,
             is_compilation: false,
             created_at: now,
             updated_at: now,
@@ -384,11 +380,9 @@ impl DbAlbum {
     ///
     /// master_id and master_year are always provided for releases imported from Discogs.
     /// The master year is used for the album year (not the release year).
-    /// cover_art_url is for immediate display before import completes.
     pub fn from_discogs_release(
         release: &crate::discogs::DiscogsRelease,
         master_year: u32,
-        cover_art_url: Option<String>,
     ) -> Self {
         let now = Utc::now();
         let discogs_release = DiscogsMasterRelease {
@@ -403,18 +397,12 @@ impl DbAlbum {
             musicbrainz_release: None,
             bandcamp_album_id: None,
             cover_release_id: None,
-            cover_art_url,
             is_compilation: false,
             created_at: now,
             updated_at: now,
         }
     }
-    /// cover_art_url is for immediate display before import completes.
-    pub fn from_mb_release(
-        release: &crate::musicbrainz::MbRelease,
-        master_year: u32,
-        cover_art_url: Option<String>,
-    ) -> Self {
+    pub fn from_mb_release(release: &crate::musicbrainz::MbRelease, master_year: u32) -> Self {
         let now = Utc::now();
         let musicbrainz_release = crate::db::MusicBrainzRelease {
             release_group_id: release.release_group_id.clone(),
@@ -433,7 +421,6 @@ impl DbAlbum {
             musicbrainz_release: Some(musicbrainz_release),
             bandcamp_album_id: None,
             cover_release_id: None,
-            cover_art_url,
             is_compilation: false,
             created_at: now,
             updated_at: now,
@@ -1083,7 +1070,7 @@ pub struct AlbumSearchResult {
     pub id: String,
     pub title: String,
     pub year: Option<i32>,
-    pub cover_art_url: Option<String>,
+    pub cover_release_id: Option<String>,
     pub artist_name: String,
 }
 

--- a/bae-core/src/import/discogs_parser.rs
+++ b/bae-core/src/import/discogs_parser.rs
@@ -16,15 +16,13 @@ pub type ParsedAlbum = (
 /// generates IDs, and links all entities together.
 ///
 /// master_year is always provided and used for the album year (not the release year).
-/// cover_art_url is for immediate display before import completes.
 ///
 /// Returns: (album, release, tracks, artists, album_artists)
 pub fn parse_discogs_release(
     release: &DiscogsRelease,
     master_year: u32,
-    cover_art_url: Option<String>,
 ) -> Result<ParsedAlbum, String> {
-    let album = DbAlbum::from_discogs_release(release, master_year, cover_art_url);
+    let album = DbAlbum::from_discogs_release(release, master_year);
     let db_release = DbRelease::from_discogs_release(&album.id, release);
     let mut artists = Vec::new();
     let mut album_artists = Vec::new();

--- a/bae-core/src/import/progress/handle.rs
+++ b/bae-core/src/import/progress/handle.rs
@@ -206,7 +206,6 @@ mod tests {
             step: PrepareStep::ParsingMetadata,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
     }
     #[test]
@@ -255,7 +254,6 @@ mod tests {
             step: PrepareStep::ParsingMetadata,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
     }
     #[test]
@@ -268,21 +266,18 @@ mod tests {
             step: PrepareStep::ParsingMetadata,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
         assert!(filter.matches(&ImportProgress::Preparing {
             import_id: "import-1".to_string(),
             step: PrepareStep::DownloadingCoverArt,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
         assert!(!filter.matches(&ImportProgress::Preparing {
             import_id: "import-2".to_string(),
             step: PrepareStep::ParsingMetadata,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
     }
     #[test]
@@ -332,14 +327,12 @@ mod tests {
             step: PrepareStep::ParsingMetadata,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
         assert!(filter.matches(&ImportProgress::Preparing {
             import_id: "import-2".to_string(),
             step: PrepareStep::DownloadingCoverArt,
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
-            cover_art_url: None,
         },),);
         assert!(filter.matches(&ImportProgress::Started {
             id: "release-1".to_string(),
@@ -395,7 +388,6 @@ mod tests {
                 step,
                 album_title: "Test".to_string(),
                 artist_name: "Artist".to_string(),
-                cover_art_url: None,
             };
             let filter = SubscriptionFilter::Import {
                 import_id: "test".to_string(),

--- a/bae-core/src/import/types.rs
+++ b/bae-core/src/import/types.rs
@@ -101,7 +101,6 @@ pub enum ImportProgress {
         step: PrepareStep,
         album_title: String,
         artist_name: String,
-        cover_art_url: Option<String>,
     },
     Started {
         id: String,

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -739,7 +739,6 @@ mod tests {
             musicbrainz_release: None,
             bandcamp_album_id: None,
             cover_release_id: None,
-            cover_art_url: None,
             is_compilation: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/bae-core/src/sync/test_helpers.rs
+++ b/bae-core/src/sync/test_helpers.rs
@@ -96,7 +96,6 @@ pub unsafe fn create_synced_schema(db: *mut ffi::sqlite3) {
             year INTEGER,
             bandcamp_album_id TEXT,
             cover_release_id TEXT,
-            cover_art_url TEXT,
             is_compilation BOOLEAN NOT NULL DEFAULT FALSE,
             _updated_at TEXT NOT NULL,
             created_at TEXT NOT NULL

--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -28,7 +28,6 @@ fn create_test_album() -> DbAlbum {
         musicbrainz_release: None,
         bandcamp_album_id: None,
         cover_release_id: None,
-        cover_art_url: None,
         is_compilation: false,
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/bae-core/tests/test_storage_profile_flow.rs
+++ b/bae-core/tests/test_storage_profile_flow.rs
@@ -328,7 +328,6 @@ fn create_test_album(title: &str) -> DbAlbum {
         musicbrainz_release: None,
         bandcamp_album_id: None,
         cover_release_id: None,
-        cover_art_url: None,
         is_compilation: false,
         created_at: now,
         updated_at: now,

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -53,7 +53,6 @@ async fn create_album_and_release(db: &Database) -> (String, String) {
         musicbrainz_release: None,
         bandcamp_album_id: None,
         cover_release_id: None,
-        cover_art_url: None,
         is_compilation: false,
         created_at: now,
         updated_at: now,

--- a/bae-desktop/src/media_controls.rs
+++ b/bae-desktop/src/media_controls.rs
@@ -245,27 +245,23 @@ async fn update_media_metadata(
         }
     };
 
-    let (album_name, cover_release_id, cover_art_url) = match library_manager
+    let (album_name, cover_release_id) = match library_manager
         .get()
         .get_album_id_for_release(&track.release_id)
         .await
     {
         Ok(album_id) => match library_manager.get().get_album_by_id(&album_id).await {
-            Ok(Some(album)) => (
-                Some(album.title),
-                album.cover_release_id,
-                album.cover_art_url,
-            ),
+            Ok(Some(album)) => (Some(album.title), album.cover_release_id),
             Ok(None) => {
                 error!(
                     "Album {} not found for release {}",
                     album_id, track.release_id
                 );
-                (None, None, None)
+                (None, None)
             }
             Err(e) => {
                 error!("Failed to fetch album {}: {}", album_id, e);
-                (None, None, None)
+                (None, None)
             }
         },
         Err(e) => {
@@ -273,13 +269,11 @@ async fn update_media_metadata(
                 "Failed to get album ID for release {}: {}",
                 track.release_id, e
             );
-            (None, None, None)
+            (None, None)
         }
     };
 
-    let cover_url = cover_release_id
-        .map(|rid| imgs.image_url(&rid))
-        .or(cover_art_url);
+    let cover_url = cover_release_id.map(|rid| imgs.image_url(&rid));
     let title = track.title.clone();
     let artist_str = artist_name.as_deref();
     let album_str = album_name.as_deref();

--- a/bae-desktop/src/ui/app_service.rs
+++ b/bae-desktop/src/ui/app_service.rs
@@ -218,8 +218,7 @@ impl AppService {
                                                 let cover = album
                                                     .cover_release_id
                                                     .as_ref()
-                                                    .map(|rid| imgs.image_url(rid))
-                                                    .or(album.cover_art_url.clone());
+                                                    .map(|rid| imgs.image_url(rid));
                                                 (album.title, cover)
                                             } else {
                                                 ("Unknown Album".to_string(), None)
@@ -315,8 +314,7 @@ impl AppService {
                                         let cover = album
                                             .cover_release_id
                                             .as_ref()
-                                            .map(|rid| imgs.image_url(rid))
-                                            .or(album.cover_art_url.clone());
+                                            .map(|rid| imgs.image_url(rid));
                                         (album.title, cover)
                                     } else {
                                         ("Unknown Album".to_string(), None)
@@ -611,7 +609,6 @@ impl AppService {
                             current_step: None,
                             progress_percent: None,
                             release_id: db.release_id,
-                            cover_art_url: None,
                         })
                         .collect();
                     state.active_imports().imports().set(imports);
@@ -2319,7 +2316,6 @@ fn handle_import_progress(state: &Store<AppState>, event: ImportProgress) {
             step,
             album_title,
             artist_name,
-            cover_art_url,
         } => {
             state.active_imports().imports().with_mut(|list| {
                 if let Some(import) = list.iter_mut().find(|i| i.import_id == import_id) {
@@ -2334,7 +2330,6 @@ fn handle_import_progress(state: &Store<AppState>, event: ImportProgress) {
                         current_step: Some(convert_prepare_step(step)),
                         progress_percent: None,
                         release_id: None,
-                        cover_art_url,
                     });
                 }
             });

--- a/bae-desktop/src/ui/components/imports_dropdown.rs
+++ b/bae-desktop/src/ui/components/imports_dropdown.rs
@@ -20,25 +20,20 @@ pub fn ImportsDropdown(dropdown_open: Signal<bool>) -> Element {
     // Convert to display types
     let display_imports: Vec<DisplayActiveImport> = imports
         .iter()
-        .map(|i| {
-            let cover_url = i.cover_art_url.clone();
-
-            DisplayActiveImport {
-                import_id: i.import_id.clone(),
-                album_title: i.album_title.clone(),
-                artist_name: i.artist_name.clone(),
-                status: match i.status {
-                    ImportOperationStatus::Pending => ImportStatus::Preparing,
-                    ImportOperationStatus::Preparing => ImportStatus::Preparing,
-                    ImportOperationStatus::Importing => ImportStatus::Importing,
-                    ImportOperationStatus::Complete => ImportStatus::Complete,
-                    ImportOperationStatus::Failed => ImportStatus::Failed,
-                },
-                current_step_text: i.current_step.map(|s| format!("{:?}", s)),
-                progress_percent: i.progress_percent,
-                release_id: i.release_id.clone(),
-                cover_url,
-            }
+        .map(|i| DisplayActiveImport {
+            import_id: i.import_id.clone(),
+            album_title: i.album_title.clone(),
+            artist_name: i.artist_name.clone(),
+            status: match i.status {
+                ImportOperationStatus::Pending => ImportStatus::Preparing,
+                ImportOperationStatus::Preparing => ImportStatus::Preparing,
+                ImportOperationStatus::Importing => ImportStatus::Importing,
+                ImportOperationStatus::Complete => ImportStatus::Complete,
+                ImportOperationStatus::Failed => ImportStatus::Failed,
+            },
+            current_step_text: i.current_step.map(|s| format!("{:?}", s)),
+            progress_percent: i.progress_percent,
+            release_id: i.release_id.clone(),
         })
         .collect();
 

--- a/bae-desktop/src/ui/components/title_bar.rs
+++ b/bae-desktop/src/ui/components/title_bar.rs
@@ -78,6 +78,7 @@ pub fn TitleBar() -> Element {
                 }
             } else {
                 let library_manager = library_manager.clone();
+                let imgs = app.image_server.clone();
                 let query = query.clone();
                 spawn(async move {
                     match library_manager.search_library(&query, 5).await {
@@ -100,7 +101,9 @@ pub fn TitleBar() -> Element {
                                         title: a.title,
                                         artist_name: a.artist_name,
                                         year: a.year,
-                                        cover_url: a.cover_art_url,
+                                        cover_url: a
+                                            .cover_release_id
+                                            .map(|rid| imgs.image_url(&rid)),
                                     })
                                     .collect(),
                                 tracks: db_results

--- a/bae-desktop/src/ui/display_types.rs
+++ b/bae-desktop/src/ui/display_types.rs
@@ -10,8 +10,7 @@ pub fn album_from_db_ref(db: &DbAlbum, imgs: &ImageServerHandle) -> Album {
     let cover = db
         .cover_release_id
         .as_ref()
-        .map(|release_id| imgs.image_url(release_id))
-        .or_else(|| db.cover_art_url.clone());
+        .map(|release_id| imgs.image_url(release_id));
 
     Album {
         id: db.id.clone(),

--- a/bae-mocks/src/mocks/title_bar.rs
+++ b/bae-mocks/src/mocks/title_bar.rs
@@ -114,7 +114,6 @@ fn mock_active_imports() -> Vec<ActiveImport> {
             current_step_text: None,
             progress_percent: Some(65),
             release_id: None,
-            cover_url: Some("/covers/glass-harbor_pacific-standard.png".to_string()),
         },
         ActiveImport {
             import_id: "imp-2".to_string(),
@@ -124,7 +123,6 @@ fn mock_active_imports() -> Vec<ActiveImport> {
             current_step_text: None,
             progress_percent: None,
             release_id: Some("release-3".to_string()),
-            cover_url: Some("/covers/apartment-garden_grow-light.png".to_string()),
         },
         ActiveImport {
             import_id: "imp-3".to_string(),
@@ -134,7 +132,6 @@ fn mock_active_imports() -> Vec<ActiveImport> {
             current_step_text: Some("Parsing metadata...".to_string()),
             progress_percent: None,
             release_id: None,
-            cover_url: None,
         },
     ]
 }

--- a/bae-mocks/src/pages/layout.rs
+++ b/bae-mocks/src/pages/layout.rs
@@ -32,7 +32,6 @@ fn mock_active_imports() -> Vec<ActiveImport> {
             current_step_text: None,
             progress_percent: Some(67),
             release_id: Some("release-1".to_string()),
-            cover_url: Some("/covers/the-midnight-signal_neon-frequencies.png".to_string()),
         },
         ActiveImport {
             import_id: "import-2".to_string(),
@@ -42,7 +41,6 @@ fn mock_active_imports() -> Vec<ActiveImport> {
             current_step_text: Some("Downloading cover art...".to_string()),
             progress_percent: None,
             release_id: None,
-            cover_url: None,
         },
         ActiveImport {
             import_id: "import-3".to_string(),
@@ -52,7 +50,6 @@ fn mock_active_imports() -> Vec<ActiveImport> {
             current_step_text: None,
             progress_percent: Some(100),
             release_id: Some("release-3".to_string()),
-            cover_url: Some("/covers/velvet-mathematics_proof-by-induction.png".to_string()),
         },
     ]
 }

--- a/bae-ui/src/components/imports/dropdown.rs
+++ b/bae-ui/src/components/imports/dropdown.rs
@@ -116,16 +116,8 @@ fn ImportItemView(
                 // Cover art
                 div {
                     class: "flex-shrink-0 w-10 h-10 bg-gray-700 rounded overflow-clip relative",
-                    if let Some(ref url) = import.cover_url {
-                        img {
-                            src: "{url}",
-                            alt: "Album cover",
-                            class: "w-full h-full object-cover",
-                        }
-                    } else {
-                        div { class: "w-full h-full flex items-center justify-center text-gray-500",
-                            ImageIcon { class: "w-5 h-5" }
-                        }
+                    div { class: "w-full h-full flex items-center justify-center text-gray-500",
+                        ImageIcon { class: "w-5 h-5" }
                     }
 
                     // Status badge

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -183,7 +183,6 @@ pub struct ActiveImport {
     pub current_step_text: Option<String>,
     pub progress_percent: Option<u8>,
     pub release_id: Option<String>,
-    pub cover_url: Option<String>,
 }
 
 // ============================================================================

--- a/bae-ui/src/stores/active_imports.rs
+++ b/bae-ui/src/stores/active_imports.rs
@@ -34,8 +34,6 @@ pub struct ActiveImport {
     pub current_step: Option<PrepareStep>,
     pub progress_percent: Option<u8>,
     pub release_id: Option<String>,
-    /// External cover art URL (ephemeral, shown during import)
-    pub cover_art_url: Option<String>,
 }
 
 /// UI state for active imports (shown in toolbar dropdown)


### PR DESCRIPTION
## Summary
- Removed `cover_art_url` column from DB schema and `DbAlbum` model
- Removed from all SELECT/INSERT queries (~12 locations in client.rs)
- Removed from import parsers (discogs, musicbrainz), import handle (3 paths), and progress events
- Changed `AlbumSearchResult.cover_art_url` → `cover_release_id` so title bar search computes local image URLs
- Removed fallback logic in display_types, app_service, media_controls
- Removed dead `cover_url` field from display `ActiveImport` and dropdown view branch
- `MatchCandidate.cover_art_url` (pre-import search previews) intentionally kept — different concern

## Test plan
- [ ] `rm -rf ~/.bae` (schema changed)
- [ ] Import an album via Discogs — verify cover art displays correctly
- [ ] Import an album via MusicBrainz — verify cover art displays correctly
- [ ] Search for an album in title bar — verify cover thumbnails appear
- [ ] Verify media controls show album art during playback
- [ ] Verify import dropdown shows placeholder icon (no cover thumbnails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)