### PR TITLE
Rate-limit MusicBrainz API to 1 req/sec

### DIFF
--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -75,6 +75,7 @@ bindgen = "0.69"
 [dev-dependencies]
 tempfile = "3.8"
 rusqlite = { version = "0.32.1", features = ["session", "bundled"] }
+tokio = { version = "1.0", features = ["test-util"] }
 
 [[test]]
 name = "test_playback_behavior"

--- a/bae-core/src/musicbrainz.rs
+++ b/bae-core/src/musicbrainz.rs
@@ -797,7 +797,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_rate_limiter_enforces_spacing() {
         // First call should return immediately
         let start = Instant::now();


### PR DESCRIPTION
## Summary
- Add a shared rate limiter (`tokio::sync::Mutex<Instant>`) ensuring at least 1 second between MusicBrainz API requests, preventing IP bans from their enforced rate limit
- Replace per-call `reqwest::Client` construction with a shared static client via `OnceLock`
- Apply rate limiting to all 4 HTTP request sites: `lookup_by_discid`, `lookup_release_by_id`, `fetch_release_group_with_relations`, `search_releases_with_params`

## Test plan
- [x] New `test_rate_limiter_enforces_spacing` verifies first call is instant and second call waits ~1s
- [x] `cargo clippy -p bae-core -- -D warnings` clean
- [x] `cargo clippy -p bae-desktop -- -D warnings` clean
- [x] `cargo test -p bae-core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)