### PR TITLE
Detect compilations and group Various Artists at end of artist list

### DIFF
--- a/bae-core/src/discogs/models.rs
+++ b/bae-core/src/discogs/models.rs
@@ -22,6 +22,7 @@ pub struct DiscogsRelease {
     pub artists: Vec<DiscogsArtist>,
     pub tracklist: Vec<DiscogsTrack>,
     pub master_id: Option<String>,
+    pub is_compilation: bool,
 }
 /// Represents a track from Discogs
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/bae-core/src/import/discogs_parser.rs
+++ b/bae-core/src/import/discogs_parser.rs
@@ -22,7 +22,7 @@ pub fn parse_discogs_release(
     release: &DiscogsRelease,
     master_year: u32,
 ) -> Result<ParsedAlbum, String> {
-    let album = DbAlbum::from_discogs_release(release, master_year);
+    let album = DbAlbum::from_discogs_release(release, master_year, release.is_compilation);
     let db_release = DbRelease::from_discogs_release(&album.id, release);
     let mut artists = Vec::new();
     let mut album_artists = Vec::new();

--- a/bae-core/src/import/musicbrainz_parser.rs
+++ b/bae-core/src/import/musicbrainz_parser.rs
@@ -61,14 +61,15 @@ fn parse_mb_release_from_json(
     discogs_release: Option<crate::discogs::DiscogsRelease>,
 ) -> Result<ParsedMbAlbum, String> {
     let album = if let Some(ref discogs_rel) = discogs_release {
-        let mut album = DbAlbum::from_mb_release(mb_release, master_year);
+        let mut album =
+            DbAlbum::from_mb_release(mb_release, master_year, mb_release.is_compilation);
         album.discogs_release = Some(crate::db::DiscogsMasterRelease {
             master_id: discogs_rel.master_id.clone(),
             release_id: discogs_rel.id.clone(),
         });
         album
     } else {
-        DbAlbum::from_mb_release(mb_release, master_year)
+        DbAlbum::from_mb_release(mb_release, master_year, mb_release.is_compilation)
     };
     let db_release = DbRelease::from_mb_release(&album.id, mb_release);
     let mut artists = Vec::new();

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -1417,5 +1417,6 @@ fn create_test_discogs_release() -> DiscogsRelease {
             },
         ],
         master_id: Some("test-master".to_string()),
+        is_compilation: false,
     }
 }

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -219,6 +219,7 @@ fn create_test_album() -> DiscogsRelease {
             },
         ],
         master_id: Some("test-master-123".to_string()),
+        is_compilation: false,
     }
 }
 /// Copy pre-generated FLAC fixtures to test directory
@@ -325,6 +326,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
             },
         ],
         master_id: Some("test-master-cue-flac".to_string()),
+        is_compilation: false,
     }
 }
 
@@ -2001,6 +2003,7 @@ impl HighSampleRateTestFixture {
                 duration: Some("0:03".to_string()),
             }],
             master_id: Some("test-master-96khz".to_string()),
+            is_compilation: false,
         };
 
         let import_handle = bae_core::import::ImportService::start(

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -132,6 +132,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
             },
         ],
         master_id: Some("test-master".to_string()),
+        is_compilation: false,
     }
 }
 

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -660,6 +660,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
             },
         ],
         master_id: Some("test-master-storage".to_string()),
+        is_compilation: false,
     }
 }
 

--- a/bae-desktop/src/ui/import_helpers.rs
+++ b/bae-desktop/src/ui/import_helpers.rs
@@ -837,6 +837,9 @@ pub async fn confirm_and_start_import(
                     label: candidate.label.clone(),
                     catalog_number: candidate.catalog_number.clone(),
                     barcode: None,
+                    // The full release is re-fetched in fetch_and_parse_mb_release,
+                    // which reads is_compilation from the API response.
+                    is_compilation: false,
                 };
 
                 ImportRequest::Folder {

--- a/bae-ui/src/components/library.rs
+++ b/bae-ui/src/components/library.rs
@@ -449,11 +449,18 @@ fn derive_artist_list(
     items
 }
 
-/// Group a sorted list of artists by their first letter (# for non-alpha)
+/// Group a sorted list of artists by their first letter (# for non-alpha).
+/// "Various Artists" goes into its own group at the end instead of under "V".
 fn group_artists_by_letter(items: Vec<ArtistListItem>) -> Vec<ArtistGroup> {
     let mut groups: Vec<ArtistGroup> = Vec::new();
+    let mut various_artists: Vec<ArtistListItem> = Vec::new();
 
     for item in items {
+        if item.artist.name.eq_ignore_ascii_case("various artists") {
+            various_artists.push(item);
+            continue;
+        }
+
         let first_char = item
             .artist
             .name
@@ -478,6 +485,13 @@ fn group_artists_by_letter(items: Vec<ArtistListItem>) -> Vec<ArtistGroup> {
         groups.push(ArtistGroup {
             letter,
             artists: vec![item],
+        });
+    }
+
+    if !various_artists.is_empty() {
+        groups.push(ArtistGroup {
+            letter: "Various Artists".to_string(),
+            artists: various_artists,
         });
     }
 


### PR DESCRIPTION
## Summary
- Read `formats[].descriptions` from Discogs API to detect "Compilation" flag
- Read `release-group.secondary-types` from MusicBrainz API to detect "Compilation"
- Fallback: artist name "Various"/"Various Artists" forces `is_compilation = true`
- UI: "Various Artists" entries get their own group at the end of the artist list instead of appearing under "V"

## Test plan
- [x] `cargo clippy` clean across bae-core, bae-desktop, bae-ui, bae-mocks
- [x] All 399 bae-core tests pass
- [ ] Import a known VA compilation from Discogs — verify `is_compilation` is set
- [ ] Import a known VA compilation from MB — verify `is_compilation` is set
- [ ] Check artist list groups VA at end, not under "V"

🤖 Generated with [Claude Code](https://claude.com/claude-code)