### PR TITLE
Stream local tracks directly from disk instead of buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -49,6 +49,7 @@ urlencoding = "2.1"
 rtrb = "0.3.2"
 futures = "0.3.31"
 tokio-stream = "0.1.17"
+tokio-util = { version = "0.7", features = ["io"] }
 bincode = "1.3"
 cxx = { version = "1.0", optional = true }
 rand = "0.9"


### PR DESCRIPTION
## Summary
- Local unencrypted standalone tracks now stream directly from disk via `tokio::fs::File` → `ReaderStream`, never loading the full file into memory
- Encrypted, cloud, and CUE/FLAC tracks (needing decryption/slicing/headers) still buffer and process as before
- Extracted `lookup_track()` to do all DB queries once — shared between fast path (direct stream) and slow path (buffer), eliminating duplicate queries
- `Content-Length` set via `file.metadata()` on the direct path for Subsonic client seek/progress support

Part of share links roadmap Phase 1c. Chains on #212 and #213.

## Test plan
- [x] `cargo clippy -p bae-core -- -D warnings` clean
- [x] Existing `test_subsonic_stream_cue_flac_track2_correct_range` passes (exercises buffered path)
- [ ] Manual: stream a standalone FLAC track, verify chunked streaming (no full buffer)
- [ ] Manual: stream a CUE/FLAC track, verify correct byte range served

🤖 Generated with [Claude Code](https://claude.com/claude-code)