### PR TITLE
Use active-library pointer in dev mode instead of .env library ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,6 @@ BAE_ENCRYPTION_KEY=generate-a-new-key-here
 # Discogs API key - get from https://www.discogs.com/settings/developers
 BAE_DISCOGS_API_KEY=your-discogs-key-here
 
-# Library ID — auto-generated and persisted to .env on first run if missing
-# BAE_LIBRARY_ID=
-
 # Optional: Network interface to bind torrent clients to
 # Examples: "eth0", "tun0", "0.0.0.0:6881"
 # BAE_TORRENT_BIND_INTERFACE=

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -82,10 +82,6 @@ fn configure_logging() {
 }
 
 fn is_first_run() -> bool {
-    // In dev mode, Config::from_env() handles everything — no pointer file needed
-    if config::Config::is_dev_mode() {
-        return false;
-    }
     let home_dir = dirs::home_dir().expect("Failed to get home directory");
     !home_dir.join(".bae").join("active-library").exists()
 }


### PR DESCRIPTION
## Summary
- Dev mode now uses the same `~/.bae/active-library` pointer file as production for library selection
- `.env` only overlays secrets and dev-specific config (encryption key, discogs key, S3, etc.) on top of `config.yaml`
- Removes stale `BAE_LIBRARY_ID` / `BAE_DEVICE_ID` env var handling and dead `.env` writing code (-178/+52 lines)

Fixes a DX issue where a stale library ID in `.env` would silently create a ghost empty library instead of using the real one.

## Test plan
- [x] `cargo clippy` clean (bae-core, bae-desktop)
- [x] All 419 bae-core tests pass
- [ ] `rm -rf ~/.bae && cargo run -p bae-desktop` — welcome flow launches, creates library, app starts
- [ ] `cargo run -p bae-desktop` with existing library — picks up active library correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)