### PR TITLE
Add CloudHome trait for pluggable storage backends

### DIFF
--- a/bae-core/src/cloud_home/mod.rs
+++ b/bae-core/src/cloud_home/mod.rs
@@ -1,0 +1,62 @@
+//! CloudHome: low-level cloud storage abstraction.
+//!
+//! Each backend (S3, R2, B2, etc.) implements `CloudHome` -- 8 methods for
+//! raw bytes in/out. No encryption, no path layout knowledge, no sync
+//! semantics. Higher-level concerns live in `CloudHomeSyncBucket` which wraps
+//! any `dyn CloudHome`.
+
+pub mod s3;
+
+use async_trait::async_trait;
+
+/// Errors from raw cloud storage operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CloudHomeError {
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Information needed to join a cloud home from another device.
+pub enum JoinInfo {
+    S3 {
+        bucket: String,
+        region: String,
+        endpoint: Option<String>,
+    },
+}
+
+/// Low-level cloud storage. Implementations handle a single bucket/container.
+///
+/// All methods deal in raw bytes. No encryption or path layout logic.
+#[async_trait]
+pub trait CloudHome: Send + Sync {
+    /// Write bytes to a key, creating or overwriting.
+    async fn write(&self, key: &str, data: Vec<u8>) -> Result<(), CloudHomeError>;
+
+    /// Read the full contents of a key.
+    async fn read(&self, key: &str) -> Result<Vec<u8>, CloudHomeError>;
+
+    /// Read a byte range from a key. `start` is inclusive, `end` is exclusive.
+    async fn read_range(&self, key: &str, start: u64, end: u64) -> Result<Vec<u8>, CloudHomeError>;
+
+    /// List all keys under a prefix.
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, CloudHomeError>;
+
+    /// Delete a key. Not an error if the key does not exist.
+    async fn delete(&self, key: &str) -> Result<(), CloudHomeError>;
+
+    /// Check whether a key exists.
+    async fn exists(&self, key: &str) -> Result<bool, CloudHomeError>;
+
+    /// Return connection info that another device can use to access this
+    /// cloud home. For S3 this is bucket/region/endpoint.
+    fn join_info(&self) -> JoinInfo;
+
+    /// Revoke a previously granted access. No-op for backends where access
+    /// is controlled externally (e.g. S3 with pre-shared credentials).
+    async fn revoke_access(&self) -> Result<(), CloudHomeError>;
+}

--- a/bae-core/src/cloud_home/s3.rs
+++ b/bae-core/src/cloud_home/s3.rs
@@ -1,0 +1,210 @@
+//! S3-backed `CloudHome` implementation.
+//!
+//! Wraps `aws-sdk-s3` to provide raw storage operations against any
+//! S3-compatible endpoint.
+
+use async_trait::async_trait;
+use aws_config::{BehaviorVersion, Region};
+use aws_credential_types::Credentials;
+use aws_sdk_s3::Client;
+
+use super::{CloudHome, CloudHomeError, JoinInfo};
+
+/// S3-backed cloud home.
+pub struct S3CloudHome {
+    client: Client,
+    bucket: String,
+    region: String,
+    endpoint: Option<String>,
+}
+
+impl S3CloudHome {
+    pub async fn new(
+        bucket: String,
+        region: String,
+        endpoint: Option<String>,
+        access_key: String,
+        secret_key: String,
+    ) -> Result<Self, CloudHomeError> {
+        let credentials = Credentials::new(access_key, secret_key, None, None, "bae-cloud-home");
+
+        let mut builder = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(region.clone()))
+            .credentials_provider(credentials);
+
+        if let Some(ref ep) = endpoint {
+            builder = builder.endpoint_url(ep.trim_end_matches('/'));
+        }
+
+        let aws_config = builder.load().await;
+        let s3_config = aws_sdk_s3::config::Builder::from(&aws_config)
+            .force_path_style(true)
+            .build();
+        let client = Client::from_conf(s3_config);
+
+        Ok(S3CloudHome {
+            client,
+            bucket,
+            region,
+            endpoint,
+        })
+    }
+}
+
+#[async_trait]
+impl CloudHome for S3CloudHome {
+    async fn write(&self, key: &str, data: Vec<u8>) -> Result<(), CloudHomeError> {
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .body(data.into())
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("put {key}: {e}")))?;
+        Ok(())
+    }
+
+    async fn read(&self, key: &str) -> Result<Vec<u8>, CloudHomeError> {
+        let resp = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| {
+                let msg = format!("{e}");
+                if msg.contains("NoSuchKey") || msg.contains("not found") || msg.contains("404") {
+                    CloudHomeError::NotFound(key.to_string())
+                } else {
+                    CloudHomeError::Storage(format!("get {key}: {e}"))
+                }
+            })?;
+
+        let bytes = resp
+            .body
+            .collect()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("read body for {key}: {e}")))?
+            .into_bytes()
+            .to_vec();
+
+        Ok(bytes)
+    }
+
+    async fn read_range(&self, key: &str, start: u64, end: u64) -> Result<Vec<u8>, CloudHomeError> {
+        let range = format!("bytes={start}-{}", end.saturating_sub(1));
+        let resp = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .range(range)
+            .send()
+            .await
+            .map_err(|e| {
+                let msg = format!("{e}");
+                if msg.contains("NoSuchKey") || msg.contains("not found") || msg.contains("404") {
+                    CloudHomeError::NotFound(key.to_string())
+                } else {
+                    CloudHomeError::Storage(format!("get range {key}: {e}"))
+                }
+            })?;
+
+        let bytes = resp
+            .body
+            .collect()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("read range body for {key}: {e}")))?
+            .into_bytes()
+            .to_vec();
+
+        Ok(bytes)
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, CloudHomeError> {
+        let mut keys = Vec::new();
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let mut req = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .prefix(prefix);
+
+            if let Some(token) = continuation_token.take() {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .map_err(|e| CloudHomeError::Storage(format!("list {prefix}: {e}")))?;
+
+            for obj in resp.contents() {
+                if let Some(key) = obj.key() {
+                    keys.push(key.to_string());
+                }
+            }
+
+            if resp.is_truncated() == Some(true) {
+                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        Ok(keys)
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), CloudHomeError> {
+        self.client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("delete {key}: {e}")))?;
+        Ok(())
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, CloudHomeError> {
+        match self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                let msg = format!("{e}");
+                if msg.contains("NotFound")
+                    || msg.contains("not found")
+                    || msg.contains("404")
+                    || msg.contains("NoSuchKey")
+                {
+                    Ok(false)
+                } else {
+                    Err(CloudHomeError::Storage(format!("head {key}: {e}")))
+                }
+            }
+        }
+    }
+
+    fn join_info(&self) -> JoinInfo {
+        JoinInfo::S3 {
+            bucket: self.bucket.clone(),
+            region: self.region.clone(),
+            endpoint: self.endpoint.clone(),
+        }
+    }
+
+    async fn revoke_access(&self) -> Result<(), CloudHomeError> {
+        // S3 access is managed externally (IAM/pre-shared credentials).
+        Ok(())
+    }
+}

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audio_codec;
 pub mod cache;
 #[cfg(feature = "cd-rip")]
 pub mod cd;
+pub mod cloud_home;
 pub mod cloud_storage;
 #[doc(hidden)]
 pub mod config;

--- a/bae-core/src/sync/bucket.rs
+++ b/bae-core/src/sync/bucket.rs
@@ -39,6 +39,18 @@ pub enum BucketError {
     Decryption(String),
 }
 
+impl From<crate::cloud_home::CloudHomeError> for BucketError {
+    fn from(e: crate::cloud_home::CloudHomeError) -> Self {
+        match e {
+            crate::cloud_home::CloudHomeError::NotFound(key) => BucketError::NotFound(key),
+            crate::cloud_home::CloudHomeError::Storage(msg) => BucketError::S3(msg),
+            crate::cloud_home::CloudHomeError::Io(io_err) => {
+                BucketError::S3(format!("I/O error: {io_err}"))
+            }
+        }
+    }
+}
+
 #[async_trait]
 pub trait SyncBucketClient: Send + Sync {
     /// List all device heads (one LIST call to `heads/`).

--- a/bae-core/src/sync/cloud_home_bucket.rs
+++ b/bae-core/src/sync/cloud_home_bucket.rs
@@ -1,16 +1,15 @@
-/// S3-backed implementation of `SyncBucketClient`.
-///
-/// Uses `aws-sdk-s3` to talk to an S3-compatible bucket. Handles
-/// encryption/decryption for changesets, heads, and images.
-/// Snapshot blobs are stored/returned encrypted (the caller handles that).
+//! `SyncBucketClient` implementation backed by any `CloudHome`.
+//!
+//! Handles the cloud home path layout (where keys, heads, images, etc. live)
+//! and encryption/decryption. The underlying `CloudHome` only deals in raw
+//! bytes and flat keys.
+
 use async_trait::async_trait;
-use aws_config::{BehaviorVersion, Region};
-use aws_credential_types::Credentials;
-use aws_sdk_s3::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 
 use super::bucket::{BucketError, DeviceHead, SyncBucketClient};
+use crate::cloud_home::CloudHome;
 use crate::encryption::EncryptionService;
 
 /// Serialized form of a device head stored in `heads/{device_id}.json.enc`.
@@ -30,49 +29,19 @@ struct MinSchemaVersionJson {
     min_schema_version: u32,
 }
 
-/// S3-backed sync bucket client.
-///
-/// Encryption semantics match the `SyncBucketClient` trait:
-/// - `get_changeset` / `download_image`: returns decrypted bytes
-/// - `put_changeset` / `upload_image`: caller passes already-encrypted bytes
-/// - `get_snapshot` / `put_snapshot`: raw encrypted bytes (caller handles crypto)
-/// - `list_heads` / `put_head`: head JSON is encrypted/decrypted internally
-pub struct S3SyncBucketClient {
-    client: Client,
-    bucket: String,
+/// `SyncBucketClient` that delegates raw I/O to a `CloudHome` and handles
+/// the path layout and encryption layer.
+pub struct CloudHomeSyncBucket {
+    home: Box<dyn CloudHome>,
     encryption: Arc<RwLock<EncryptionService>>,
 }
 
-impl S3SyncBucketClient {
-    pub async fn new(
-        bucket: String,
-        region: String,
-        endpoint: Option<String>,
-        access_key: String,
-        secret_key: String,
-        encryption: EncryptionService,
-    ) -> Result<Self, BucketError> {
-        let credentials = Credentials::new(access_key, secret_key, None, None, "bae-sync-bucket");
-
-        let mut builder = aws_config::defaults(BehaviorVersion::latest())
-            .region(Region::new(region))
-            .credentials_provider(credentials);
-
-        if let Some(ref ep) = endpoint {
-            builder = builder.endpoint_url(ep.trim_end_matches('/'));
-        }
-
-        let aws_config = builder.load().await;
-        let s3_config = aws_sdk_s3::config::Builder::from(&aws_config)
-            .force_path_style(true)
-            .build();
-        let client = Client::from_conf(s3_config);
-
-        Ok(S3SyncBucketClient {
-            client,
-            bucket,
+impl CloudHomeSyncBucket {
+    pub fn new(home: Box<dyn CloudHome>, encryption: EncryptionService) -> Self {
+        CloudHomeSyncBucket {
+            home,
             encryption: Arc::new(RwLock::new(encryption)),
-        })
+        }
     }
 
     /// Return a shared reference to the encryption lock for external use
@@ -86,108 +55,26 @@ impl S3SyncBucketClient {
         self.encryption.read().unwrap()
     }
 
-    /// Download an object by key. Returns raw bytes.
-    async fn get_object(&self, key: &str) -> Result<Vec<u8>, BucketError> {
-        let resp = self
-            .client
-            .get_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .send()
-            .await
-            .map_err(|e| {
-                let msg = format!("{e}");
-                if msg.contains("NoSuchKey") || msg.contains("not found") || msg.contains("404") {
-                    BucketError::NotFound(key.to_string())
-                } else {
-                    BucketError::S3(format!("get {key}: {e}"))
-                }
-            })?;
-
-        let bytes = resp
-            .body
-            .collect()
-            .await
-            .map_err(|e| BucketError::S3(format!("read body for {key}: {e}")))?
-            .into_bytes()
-            .to_vec();
-
-        Ok(bytes)
-    }
-
-    /// Upload bytes to a key.
-    async fn put_object(&self, key: &str, data: Vec<u8>) -> Result<(), BucketError> {
-        self.client
-            .put_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .body(data.into())
-            .send()
-            .await
-            .map_err(|e| BucketError::S3(format!("put {key}: {e}")))?;
-        Ok(())
-    }
-
-    /// Delete an object by key.
-    async fn delete_object(&self, key: &str) -> Result<(), BucketError> {
-        self.client
-            .delete_object()
-            .bucket(&self.bucket)
-            .key(key)
-            .send()
-            .await
-            .map_err(|e| BucketError::S3(format!("delete {key}: {e}")))?;
-        Ok(())
-    }
-
-    /// List all keys under a prefix.
-    async fn list_keys(&self, prefix: &str) -> Result<Vec<String>, BucketError> {
-        let mut keys = Vec::new();
-        let mut continuation_token: Option<String> = None;
-
-        loop {
-            let mut req = self
-                .client
-                .list_objects_v2()
-                .bucket(&self.bucket)
-                .prefix(prefix);
-
-            if let Some(token) = continuation_token.take() {
-                req = req.continuation_token(token);
-            }
-
-            let resp = req
-                .send()
-                .await
-                .map_err(|e| BucketError::S3(format!("list {prefix}: {e}")))?;
-
-            for obj in resp.contents() {
-                if let Some(key) = obj.key() {
-                    keys.push(key.to_string());
-                }
-            }
-
-            if resp.is_truncated() == Some(true) {
-                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
-            } else {
-                break;
-            }
-        }
-
-        Ok(keys)
-    }
-
     /// Image key from ID: `images/{ab}/{cd}/{id}`.
     fn image_key(id: &str) -> String {
         let hex = id.replace('-', "");
         format!("images/{}/{}/{id}", &hex[..2], &hex[2..4])
     }
+
+    /// List all image keys in the cloud home.
+    ///
+    /// Separate from `SyncBucketClient` because only bae-server needs to
+    /// enumerate all images for bulk download. Returns keys like
+    /// `images/ab/cd/{id}`.
+    pub async fn list_image_keys(&self) -> Result<Vec<String>, BucketError> {
+        self.home.list("images/").await.map_err(BucketError::from)
+    }
 }
 
 #[async_trait]
-impl SyncBucketClient for S3SyncBucketClient {
+impl SyncBucketClient for CloudHomeSyncBucket {
     async fn list_heads(&self) -> Result<Vec<DeviceHead>, BucketError> {
-        let keys = self.list_keys("heads/").await?;
+        let keys = self.home.list("heads/").await?;
         let mut heads = Vec::new();
 
         for key in &keys {
@@ -197,7 +84,7 @@ impl SyncBucketClient for S3SyncBucketClient {
                 .and_then(|s| s.strip_suffix(".json.enc"))
                 .ok_or_else(|| BucketError::S3(format!("unexpected head key format: {key}")))?;
 
-            let encrypted = self.get_object(key).await?;
+            let encrypted = self.home.read(key).await?;
             let decrypted = self
                 .enc()
                 .decrypt(&encrypted)
@@ -219,7 +106,7 @@ impl SyncBucketClient for S3SyncBucketClient {
 
     async fn get_changeset(&self, device_id: &str, seq: u64) -> Result<Vec<u8>, BucketError> {
         let key = format!("changes/{device_id}/{seq}.enc");
-        let encrypted = self.get_object(&key).await?;
+        let encrypted = self.home.read(&key).await?;
         self.enc()
             .decrypt(&encrypted)
             .map_err(|e| BucketError::Decryption(format!("changeset {device_id}/{seq}: {e}")))
@@ -233,7 +120,8 @@ impl SyncBucketClient for S3SyncBucketClient {
     ) -> Result<(), BucketError> {
         let key = format!("changes/{device_id}/{seq}.enc");
         let encrypted = self.enc().encrypt(&data);
-        self.put_object(&key, encrypted).await
+        self.home.write(&key, encrypted).await?;
+        Ok(())
     }
 
     async fn put_head(
@@ -252,39 +140,46 @@ impl SyncBucketClient for S3SyncBucketClient {
             .map_err(|e| BucketError::S3(format!("serialize head: {e}")))?;
         let encrypted = self.enc().encrypt(&json);
         let key = format!("heads/{device_id}.json.enc");
-        self.put_object(&key, encrypted).await
+        self.home.write(&key, encrypted).await?;
+        Ok(())
     }
 
     async fn upload_image(&self, id: &str, data: Vec<u8>) -> Result<(), BucketError> {
         let key = Self::image_key(id);
         let encrypted = self.enc().encrypt(&data);
-        self.put_object(&key, encrypted).await
+        self.home.write(&key, encrypted).await?;
+        Ok(())
     }
 
     async fn download_image(&self, id: &str) -> Result<Vec<u8>, BucketError> {
         let key = Self::image_key(id);
-        let encrypted = self.get_object(&key).await?;
+        let encrypted = self.home.read(&key).await?;
         self.enc()
             .decrypt(&encrypted)
             .map_err(|e| BucketError::Decryption(format!("image {id}: {e}")))
     }
 
     async fn put_snapshot(&self, data: Vec<u8>) -> Result<(), BucketError> {
-        self.put_object("snapshot.db.enc", data).await
+        self.home.write("snapshot.db.enc", data).await?;
+        Ok(())
     }
 
     async fn get_snapshot(&self) -> Result<Vec<u8>, BucketError> {
-        self.get_object("snapshot.db.enc").await
+        self.home
+            .read("snapshot.db.enc")
+            .await
+            .map_err(BucketError::from)
     }
 
     async fn delete_changeset(&self, device_id: &str, seq: u64) -> Result<(), BucketError> {
         let key = format!("changes/{device_id}/{seq}.enc");
-        self.delete_object(&key).await
+        self.home.delete(&key).await?;
+        Ok(())
     }
 
     async fn list_changesets(&self, device_id: &str) -> Result<Vec<u64>, BucketError> {
         let prefix = format!("changes/{device_id}/");
-        let keys = self.list_keys(&prefix).await?;
+        let keys = self.home.list(&prefix).await?;
 
         let mut seqs: Vec<u64> = keys
             .iter()
@@ -300,10 +195,10 @@ impl SyncBucketClient for S3SyncBucketClient {
 
     async fn get_min_schema_version(&self) -> Result<Option<u32>, BucketError> {
         let key = "min_schema_version.json.enc";
-        let encrypted = match self.get_object(key).await {
+        let encrypted = match self.home.read(key).await {
             Ok(data) => data,
-            Err(BucketError::NotFound(_)) => return Ok(None),
-            Err(e) => return Err(e),
+            Err(crate::cloud_home::CloudHomeError::NotFound(_)) => return Ok(None),
+            Err(e) => return Err(BucketError::from(e)),
         };
 
         let decrypted = self
@@ -324,8 +219,10 @@ impl SyncBucketClient for S3SyncBucketClient {
         let json = serde_json::to_vec(&payload)
             .map_err(|e| BucketError::S3(format!("serialize min_schema_version: {e}")))?;
         let encrypted = self.enc().encrypt(&json);
-        self.put_object("min_schema_version.json.enc", encrypted)
-            .await
+        self.home
+            .write("min_schema_version.json.enc", encrypted)
+            .await?;
+        Ok(())
     }
 
     async fn put_membership_entry(
@@ -336,7 +233,8 @@ impl SyncBucketClient for S3SyncBucketClient {
     ) -> Result<(), BucketError> {
         let key = format!("membership/{author_pubkey}/{seq}.enc");
         let encrypted = self.enc().encrypt(&data);
-        self.put_object(&key, encrypted).await
+        self.home.write(&key, encrypted).await?;
+        Ok(())
     }
 
     async fn get_membership_entry(
@@ -345,14 +243,14 @@ impl SyncBucketClient for S3SyncBucketClient {
         seq: u64,
     ) -> Result<Vec<u8>, BucketError> {
         let key = format!("membership/{author_pubkey}/{seq}.enc");
-        let encrypted = self.get_object(&key).await?;
+        let encrypted = self.home.read(&key).await?;
         self.enc()
             .decrypt(&encrypted)
             .map_err(|e| BucketError::Decryption(format!("membership {author_pubkey}/{seq}: {e}")))
     }
 
     async fn list_membership_entries(&self) -> Result<Vec<(String, u64)>, BucketError> {
-        let keys = self.list_keys("membership/").await?;
+        let keys = self.home.list("membership/").await?;
         let mut entries = Vec::new();
 
         for key in &keys {
@@ -382,28 +280,19 @@ impl SyncBucketClient for S3SyncBucketClient {
     async fn put_wrapped_key(&self, user_pubkey: &str, data: Vec<u8>) -> Result<(), BucketError> {
         let key = format!("keys/{user_pubkey}.enc");
         // Wrapped keys are already encrypted (sealed box), store as-is.
-        self.put_object(&key, data).await
+        self.home.write(&key, data).await?;
+        Ok(())
     }
 
     async fn get_wrapped_key(&self, user_pubkey: &str) -> Result<Vec<u8>, BucketError> {
         let key = format!("keys/{user_pubkey}.enc");
         // Wrapped keys are already encrypted (sealed box), return as-is.
-        self.get_object(&key).await
+        self.home.read(&key).await.map_err(BucketError::from)
     }
 
     async fn delete_wrapped_key(&self, user_pubkey: &str) -> Result<(), BucketError> {
         let key = format!("keys/{user_pubkey}.enc");
-        self.delete_object(&key).await
-    }
-}
-
-/// List all image keys in the sync bucket.
-///
-/// Separate from `SyncBucketClient` because only bae-server needs to
-/// enumerate all images for bulk download. Returns keys like
-/// `images/ab/cd/{id}`.
-impl S3SyncBucketClient {
-    pub async fn list_image_keys(&self) -> Result<Vec<String>, BucketError> {
-        self.list_keys("images/").await
+        self.home.delete(&key).await?;
+        Ok(())
     }
 }

--- a/bae-core/src/sync/mod.rs
+++ b/bae-core/src/sync/mod.rs
@@ -3,6 +3,7 @@ pub mod attestation;
 pub mod attestation_cache;
 pub mod attribution;
 pub mod bucket;
+pub mod cloud_home_bucket;
 pub mod conflict;
 pub mod envelope;
 #[cfg(feature = "torrent")]
@@ -16,7 +17,6 @@ pub mod pull;
 mod pull_tests;
 pub mod push;
 pub mod reverse_lookup;
-pub mod s3_bucket;
 pub mod service;
 pub mod session;
 pub mod session_ext;

--- a/bae-desktop/src/ui/app_context.rs
+++ b/bae-desktop/src/ui/app_context.rs
@@ -14,8 +14,8 @@ use bae_core::import;
 use bae_core::keys::{KeyService, UserKeypair};
 use bae_core::library::SharedLibraryManager;
 use bae_core::playback;
+use bae_core::sync::cloud_home_bucket::CloudHomeSyncBucket;
 use bae_core::sync::hlc::Hlc;
-use bae_core::sync::s3_bucket::S3SyncBucketClient;
 use bae_core::sync::session::SyncSession;
 #[cfg(feature = "torrent")]
 use bae_core::torrent;
@@ -30,8 +30,8 @@ use bae_core::torrent;
 /// connection is heap-allocated and never moved.
 #[derive(Clone)]
 pub struct SyncHandle {
-    /// S3 sync bucket client for pushing/pulling changesets
-    pub bucket_client: Arc<S3SyncBucketClient>,
+    /// Sync bucket client for pushing/pulling changesets
+    pub bucket_client: Arc<CloudHomeSyncBucket>,
     /// Hybrid logical clock for causal ordering of writes
     pub hlc: Arc<Hlc>,
     /// Device ID for this device (used in push, cursors, and SyncService)
@@ -60,7 +60,7 @@ unsafe impl Sync for SyncHandle {}
 
 impl SyncHandle {
     pub fn new(
-        bucket_client: S3SyncBucketClient,
+        bucket_client: CloudHomeSyncBucket,
         hlc: Hlc,
         device_id: String,
         raw_db: *mut libsqlite3_sys::sqlite3,

--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -201,16 +201,19 @@ pub fn SyncSection() -> Element {
                                     .to_string()
                             })?;
                         let ep = if endpoint.is_empty() { None } else { Some(endpoint) };
-                        let client = bae_core::sync::s3_bucket::S3SyncBucketClient::new(
+                        let cloud_home = bae_core::cloud_home::s3::S3CloudHome::new(
                                 bucket,
                                 region,
                                 ep,
                                 access_key,
                                 secret_key,
-                                encryption,
                             )
                             .await
                             .map_err(|e| format!("Failed to create S3 client: {}", e))?;
+                        let client = bae_core::sync::cloud_home_bucket::CloudHomeSyncBucket::new(
+                            Box::new(cloud_home),
+                            encryption,
+                        );
                         use bae_core::sync::bucket::SyncBucketClient;
                         let heads = client.list_heads().await.map_err(|e| format!("{}", e))?;
                         Ok(heads.len())


### PR DESCRIPTION
## Summary
- Introduces `CloudHome` trait (8 methods) as a low-level storage abstraction for cloud home backends
- Implements `S3CloudHome` for S3-compatible storage
- Replaces monolithic `S3SyncBucketClient` with `CloudHomeSyncBucket` that wraps any `dyn CloudHome` + encryption
- Adding a new backend now requires implementing only 8 methods; sync works automatically

## Changes
- New: `bae-core/src/cloud_home/mod.rs` (trait + error types)
- New: `bae-core/src/cloud_home/s3.rs` (S3 implementation)
- New: `bae-core/src/sync/cloud_home_bucket.rs` (generic SyncBucketClient adapter)
- Deleted: `bae-core/src/sync/s3_bucket.rs` (replaced by above)
- Updated all call sites in bae-desktop, bae-server

## Test plan
- [x] `cargo clippy -p bae-core -p bae-desktop -p bae-server -- -D warnings` clean
- [x] `cargo test -p bae-core` — all tests pass (SyncBucketClient trait + MockBucket unchanged)
- [x] All existing sync tests pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)