### PR TITLE
Add followed libraries and library switcher

### DIFF
--- a/bae-desktop/src/ui/components/album_detail/page.rs
+++ b/bae-desktop/src/ui/components/album_detail/page.rs
@@ -6,9 +6,10 @@ use super::AlbumDetailView;
 use crate::ui::app_service::use_app;
 use crate::ui::Route;
 use bae_ui::display_types::{CoverChange, PlaybackDisplay};
+use bae_ui::stores::config::LibrarySource;
 use bae_ui::stores::{
-    AlbumDetailStateStoreExt, AppStateStoreExt, ConfigStateStoreExt, PlaybackStatus,
-    PlaybackUiStateStoreExt, StorageProfilesStateStoreExt,
+    AlbumDetailStateStoreExt, AppStateStoreExt, ConfigStateStoreExt, LibraryStateStoreExt,
+    PlaybackStatus, PlaybackUiStateStoreExt, StorageProfilesStateStoreExt,
 };
 use bae_ui::{ErrorToast, SuccessToast};
 use dioxus::prelude::*;
@@ -349,6 +350,10 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
     // Show share link menu item only when base URL is configured
     let show_share_link = config_store.share_base_url().read().is_some();
 
+    // Check if viewing a followed library (read-only mode)
+    let active_source = app.state.library().active_source().read().clone();
+    let is_followed = matches!(active_source, LibrarySource::Followed(_));
+
     // Available storage profiles for transfer
     let available_profiles = app.state.storage_profiles().profiles().read().clone();
 
@@ -379,6 +384,7 @@ pub fn AlbumDetail(album_id: ReadSignal<String>, release_id: ReadSignal<String>)
                 tracks,
                 playback: playback_display(),
                 show_share_link,
+                read_only: is_followed,
                 on_release_select,
                 on_album_deleted,
                 on_export_release,

--- a/bae-desktop/src/ui/components/library.rs
+++ b/bae-desktop/src/ui/components/library.rs
@@ -6,7 +6,10 @@
 use crate::ui::app_service::use_app;
 use crate::ui::components::album_detail::utils::get_album_track_ids;
 use crate::ui::Route;
-use bae_ui::stores::{AppStateStoreExt, LibrarySortStateStoreExt, UiStateStoreExt};
+use bae_ui::stores::config::LibrarySource;
+use bae_ui::stores::{
+    AppStateStoreExt, LibrarySortStateStoreExt, LibraryStateStoreExt, UiStateStoreExt,
+};
 use bae_ui::LibraryView;
 use dioxus::prelude::*;
 
@@ -83,6 +86,15 @@ pub fn LibraryPage() -> Element {
         navigator().push(Route::ImportWorkflowManager {});
     };
 
+    // Check if viewing a followed library
+    let active_source = state.active_source().read().clone();
+    let is_followed = matches!(active_source, LibrarySource::Followed(_));
+    let header_badge = if is_followed {
+        Some("Following".to_string())
+    } else {
+        None
+    };
+
     rsx! {
         LibraryView {
             state,
@@ -94,6 +106,8 @@ pub fn LibraryPage() -> Element {
             on_play_album,
             on_add_album_to_queue,
             on_empty_action,
+            read_only: is_followed,
+            header_badge,
         }
     }
 }

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -393,6 +393,7 @@ async fn do_restore(
         share_base_url: None,
         share_default_expiry_days: None,
         share_signing_key_version: 1,
+        followed_libraries: vec![],
     };
     config.save_to_config_yaml()?;
 

--- a/bae-mocks/src/mocks/library.rs
+++ b/bae-mocks/src/mocks/library.rs
@@ -58,6 +58,7 @@ pub fn LibraryMock(initial_state: Option<String>) -> Element {
         artists_by_album,
         loading,
         error,
+        active_source: bae_ui::stores::config::LibrarySource::Local,
     });
 
     let sort_state = use_store(LibrarySortState::default);

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -1,6 +1,7 @@
 //! Settings mock component
 
 use super::framework::{ControlRegistryBuilder, MockPage, MockPanel};
+use bae_ui::stores::config::{FollowedLibraryInfo, LibrarySource};
 use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole, SharedReleaseDisplay};
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
@@ -46,9 +47,14 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                     SettingsTab::Library => rsx! {
                         LibrarySectionView {
                             libraries: mock_libraries(),
+                            followed_libraries: mock_followed_libraries(),
+                            active_source: LibrarySource::Local,
                             on_switch: |_| {},
                             on_create: |_| {},
                             on_join: |_| {},
+                            on_follow: |_| {},
+                            on_unfollow: |_| {},
+                            on_switch_source: |_| {},
                             on_rename: |_| {},
                             on_remove: |_| {},
                         }
@@ -273,6 +279,15 @@ fn mock_libraries() -> Vec<LibraryInfo> {
             is_active: false,
         },
     ]
+}
+
+fn mock_followed_libraries() -> Vec<FollowedLibraryInfo> {
+    vec![FollowedLibraryInfo {
+        id: "follow-1".to_string(),
+        name: "Friend's Library".to_string(),
+        server_url: "http://192.168.1.50:4533".to_string(),
+        username: "listener".to_string(),
+    }]
 }
 
 fn mock_members() -> Vec<Member> {

--- a/bae-mocks/src/pages/library.rs
+++ b/bae-mocks/src/pages/library.rs
@@ -19,6 +19,7 @@ pub fn Library() -> Element {
         artists_by_album,
         loading: false,
         error: None,
+        active_source: bae_ui::stores::config::LibrarySource::Local,
     });
 
     let sort_state = use_store(LibrarySortState::default);

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -1,5 +1,6 @@
 //! Settings page
 
+use bae_ui::stores::config::{FollowedLibraryInfo, LibrarySource};
 use bae_ui::stores::{DeviceActivityInfo, Member, MemberRole, SharedReleaseDisplay};
 use bae_ui::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView, LibraryInfo,
@@ -21,9 +22,14 @@ pub fn Settings() -> Element {
                 SettingsTab::Library => rsx! {
                     LibrarySectionView {
                         libraries: mock_libraries(),
+                        followed_libraries: mock_followed_libraries(),
+                        active_source: LibrarySource::Local,
                         on_switch: |_| {},
                         on_create: |_| {},
                         on_join: |_| {},
+                        on_follow: |_| {},
+                        on_unfollow: |_| {},
+                        on_switch_source: |_| {},
                         on_rename: |_| {},
                         on_remove: |_| {},
                     }
@@ -238,6 +244,15 @@ fn mock_libraries() -> Vec<LibraryInfo> {
             is_active: false,
         },
     ]
+}
+
+fn mock_followed_libraries() -> Vec<FollowedLibraryInfo> {
+    vec![FollowedLibraryInfo {
+        id: "follow-1".to_string(),
+        name: "Friend's Library".to_string(),
+        server_url: "http://192.168.1.50:4533".to_string(),
+        username: "listener".to_string(),
+    }]
 }
 
 fn mock_members() -> Vec<Member> {

--- a/bae-ui/src/components/album_detail/album_cover_section.rs
+++ b/bae-ui/src/components/album_detail/album_cover_section.rs
@@ -15,6 +15,9 @@ pub fn AlbumCoverSection(
     is_exporting: bool,
     first_release_id: Option<String>,
     has_single_release: bool,
+    /// When true, hides edit/delete/export/storage/share actions
+    #[props(default)]
+    read_only: bool,
     // Callbacks - all required
     on_export: EventHandler<String>,
     on_delete_album: EventHandler<String>,
@@ -61,8 +64,8 @@ pub fn AlbumCoverSection(
                 }
             }
 
-            // Show dropdown button on hover
-            if hover_cover() || show_dropdown() {
+            // Show dropdown button on hover (hidden in read-only mode)
+            if !read_only && (hover_cover() || show_dropdown()) {
                 div { class: "absolute top-2 right-2 z-10",
                     button {
                         id: "{anchor_id}",

--- a/bae-ui/src/components/album_detail/track_row.rs
+++ b/bae-ui/src/components/album_detail/track_row.rs
@@ -25,6 +25,9 @@ pub fn TrackRow(
     show_spinner: bool,
     /// Whether to show the "Copy Share Link" menu item
     show_share_link: bool,
+    /// When true, hides export and other local-only actions
+    #[props(default)]
+    read_only: bool,
     // Callbacks
     on_play: EventHandler<String>,
     on_pause: EventHandler<()>,
@@ -180,6 +183,7 @@ pub fn TrackRow(
                 TrackMenu {
                     track_id: track_id_for_menu,
                     show_share_link,
+                    read_only,
                     on_export,
                     on_add_next,
                     on_add_to_queue,
@@ -195,6 +199,7 @@ pub fn TrackRow(
 fn TrackMenu(
     track_id: String,
     show_share_link: bool,
+    read_only: bool,
     on_export: EventHandler<String>,
     on_add_next: EventHandler<String>,
     on_add_to_queue: EventHandler<String>,
@@ -227,15 +232,17 @@ fn TrackMenu(
             on_close: move |_| show_menu.set(false),
             placement: Placement::BottomEnd,
 
-            MenuItem {
-                onclick: {
-                    let track_id = track_id.clone();
-                    move |_| {
-                        show_menu.set(false);
-                        on_export.call(track_id.clone());
-                    }
-                },
-                "Export File"
+            if !read_only {
+                MenuItem {
+                    onclick: {
+                        let track_id = track_id.clone();
+                        move |_| {
+                            show_menu.set(false);
+                            on_export.call(track_id.clone());
+                        }
+                    },
+                    "Export File"
+                }
             }
             MenuItem {
                 onclick: {

--- a/bae-ui/src/components/album_detail/view.rs
+++ b/bae-ui/src/components/album_detail/view.rs
@@ -38,6 +38,9 @@ pub fn AlbumDetailView(
     /// Whether to show the "Copy Share Link" menu item
     #[props(default)]
     show_share_link: bool,
+    /// When true, hides edit/delete/export/storage/share actions (used for followed libraries)
+    #[props(default)]
+    read_only: bool,
     on_release_select: EventHandler<String>,
     on_album_deleted: EventHandler<()>,
     on_export_release: EventHandler<String>,
@@ -93,6 +96,7 @@ pub fn AlbumDetailView(
                 div { class: "w-full lg:flex-shrink-0 lg:w-[360px] lg:self-start lg:sticky lg:top-6",
                     AlbumInfoSection {
                         state,
+                        read_only,
                         is_deleting,
                         is_exporting,
                         on_export: on_export_release,
@@ -125,6 +129,7 @@ pub fn AlbumDetailView(
                 div { class: "flex-1 min-w-0",
                     ReleaseTabsSectionWrapper {
                         state,
+                        read_only,
                         is_deleting,
                         is_exporting,
                         export_error,
@@ -143,7 +148,8 @@ pub fn AlbumDetailView(
                         state,
                         tracks,
                         playback,
-                        show_share_link,
+                        show_share_link: show_share_link && !read_only,
+                        read_only,
                         on_track_play,
                         on_track_pause,
                         on_track_resume,
@@ -207,6 +213,7 @@ pub fn AlbumDetailView(
 #[component]
 fn AlbumInfoSection(
     state: ReadStore<AlbumDetailState>,
+    read_only: bool,
     is_deleting: Signal<bool>,
     is_exporting: Signal<bool>,
     on_export: EventHandler<String>,
@@ -249,6 +256,7 @@ fn AlbumInfoSection(
             is_exporting: *is_exporting.read(),
             first_release_id: releases.first().map(|r| r.id.clone()),
             has_single_release: releases.len() == 1,
+            read_only,
             on_export,
             on_delete_album,
             on_view_release_info,
@@ -280,6 +288,7 @@ fn AlbumInfoSection(
 #[component]
 fn ReleaseTabsSectionWrapper(
     state: ReadStore<AlbumDetailState>,
+    read_only: bool,
     is_deleting: Signal<bool>,
     is_exporting: Signal<bool>,
     export_error: Signal<Option<String>>,
@@ -312,6 +321,7 @@ fn ReleaseTabsSectionWrapper(
             releases,
             selected_release_id,
             on_release_select,
+            read_only,
             is_deleting,
             is_exporting,
             export_error,
@@ -335,6 +345,7 @@ fn TrackListSection(
     tracks: ReadStore<Vec<Track>>,
     playback: PlaybackDisplay,
     show_share_link: bool,
+    read_only: bool,
     on_track_play: EventHandler<String>,
     on_track_pause: EventHandler<()>,
     on_track_resume: EventHandler<()>,
@@ -431,6 +442,7 @@ fn TrackListSection(
                                 is_loading,
                                 show_spinner: is_loading,
                                 show_share_link,
+                                read_only,
                                 on_play: on_track_play,
                                 on_pause: on_track_pause,
                                 on_resume: on_track_resume,

--- a/bae-ui/src/components/library.rs
+++ b/bae-ui/src/components/library.rs
@@ -102,6 +102,12 @@ pub fn LibraryView(
     on_add_album_to_queue: EventHandler<String>,
     // Empty state action (e.g., navigate to import)
     on_empty_action: EventHandler<()>,
+    /// When true, hides import/edit actions (used when viewing a followed library)
+    #[props(default)]
+    read_only: bool,
+    /// Optional label to show next to the header (e.g. "Following")
+    #[props(default)]
+    header_badge: Option<String>,
 ) -> Element {
     // Use lenses to subscribe only to specific fields for routing decisions
     let loading = *state.loading().read();
@@ -122,7 +128,14 @@ pub fn LibraryView(
             div { class: "container mx-auto flex flex-col flex-1",
                 // Header row: title + controls on same line
                 div { class: "flex items-center justify-between mb-6",
-                    h1 { class: "text-3xl font-bold text-white", "Music Library" }
+                    div { class: "flex items-center gap-3",
+                        h1 { class: "text-3xl font-bold text-white", "Music Library" }
+                        if let Some(ref badge) = header_badge {
+                            span { class: "text-xs font-medium bg-accent/20 text-accent-soft px-2 py-0.5 rounded",
+                                "{badge}"
+                            }
+                        }
+                    }
 
                     if !loading && error.is_none() && !albums.is_empty() {
                         SortToolbar {
@@ -143,12 +156,16 @@ pub fn LibraryView(
                     }
                 } else if albums.is_empty() {
                     div { class: "flex-1 flex flex-col items-center justify-center",
-                        p { class: "text-gray-500 mb-4", "No albums in your library" }
-                        Button {
-                            variant: ButtonVariant::Primary,
-                            size: ButtonSize::Medium,
-                            onclick: move |_| on_empty_action.call(()),
-                            "Import"
+                        if read_only {
+                            p { class: "text-gray-500", "No albums available" }
+                        } else {
+                            p { class: "text-gray-500 mb-4", "No albums in your library" }
+                            Button {
+                                variant: ButtonVariant::Primary,
+                                size: ButtonSize::Medium,
+                                onclick: move |_| on_empty_action.call(()),
+                                "Import"
+                            }
                         }
                     }
                 } else {

--- a/bae-ui/src/components/mod.rs
+++ b/bae-ui/src/components/mod.rs
@@ -74,9 +74,10 @@ pub use segmented_control::{Segment, SegmentedControl};
 pub use select::{Select, SelectOption};
 pub use settings::{
     AboutSectionView, BitTorrentSectionView, BitTorrentSettings, DiscogsSectionView,
-    JoinLibraryView, JoinStatus, LibraryInfo, LibrarySectionView, SettingsCard, SettingsSection,
-    SettingsTab, SettingsView, StorageLocation, StorageProfile, StorageProfileEditorView,
-    StorageProfilesSectionView, SubsonicSectionView, SyncBucketConfig, SyncSectionView,
+    FollowLibraryView, FollowTestStatus, JoinLibraryView, JoinStatus, LibraryInfo,
+    LibrarySectionView, SettingsCard, SettingsSection, SettingsTab, SettingsView, StorageLocation,
+    StorageProfile, StorageProfileEditorView, StorageProfilesSectionView, SubsonicSectionView,
+    SyncBucketConfig, SyncSectionView,
 };
 pub use success_toast::SuccessToast;
 pub use text_input::{TextInput, TextInputSize, TextInputType};

--- a/bae-ui/src/components/settings/follow_library.rs
+++ b/bae-ui/src/components/settings/follow_library.rs
@@ -1,0 +1,184 @@
+//! Follow library view -- form for adding a remote Subsonic server to follow.
+
+use crate::components::{
+    Button, ButtonSize, ButtonVariant, LoadingSpinner, SettingsSection, TextInput, TextInputSize,
+    TextInputType,
+};
+use dioxus::prelude::*;
+
+/// Status of the follow test/save operation.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FollowTestStatus {
+    /// Connection test in progress.
+    Testing,
+    /// Connection test succeeded.
+    Success,
+    /// Connection test failed.
+    Error(String),
+}
+
+/// Pure view component for following a remote Subsonic server.
+#[component]
+pub fn FollowLibraryView(
+    name: String,
+    server_url: String,
+    username: String,
+    password: String,
+    test_status: Option<FollowTestStatus>,
+    is_saving: bool,
+
+    on_name_change: EventHandler<String>,
+    on_server_url_change: EventHandler<String>,
+    on_username_change: EventHandler<String>,
+    on_password_change: EventHandler<String>,
+    on_test: EventHandler<()>,
+    on_save: EventHandler<()>,
+    on_cancel: EventHandler<()>,
+) -> Element {
+    let is_testing = matches!(test_status, Some(FollowTestStatus::Testing));
+    let test_succeeded = matches!(test_status, Some(FollowTestStatus::Success));
+    let can_test = !is_testing
+        && !is_saving
+        && !server_url.is_empty()
+        && !username.is_empty()
+        && !password.is_empty();
+    let can_save = !is_testing
+        && !is_saving
+        && test_succeeded
+        && !name.is_empty()
+        && !server_url.is_empty()
+        && !username.is_empty()
+        && !password.is_empty();
+
+    rsx! {
+        SettingsSection {
+            div {
+                h2 { class: "text-xl font-semibold text-white", "Follow Server" }
+                p { class: "text-sm text-gray-400 mt-1",
+                    "Connect to a remote Subsonic-compatible server to browse and stream its library."
+                }
+            }
+
+            div { class: "space-y-4 mt-4",
+                // Display name
+                div {
+                    label { class: "block text-sm font-medium text-gray-300 mb-1",
+                        "Name "
+                        span { class: "text-red-400", "*" }
+                    }
+                    TextInput {
+                        value: name,
+                        on_input: move |v| on_name_change.call(v),
+                        size: TextInputSize::Medium,
+                        input_type: TextInputType::Text,
+                        placeholder: "Friend's Library",
+                        disabled: is_saving,
+                    }
+                }
+
+                // Server URL
+                div {
+                    label { class: "block text-sm font-medium text-gray-300 mb-1",
+                        "Server URL "
+                        span { class: "text-red-400", "*" }
+                    }
+                    TextInput {
+                        value: server_url,
+                        on_input: move |v| on_server_url_change.call(v),
+                        size: TextInputSize::Medium,
+                        input_type: TextInputType::Text,
+                        placeholder: "http://192.168.1.100:4533",
+                        disabled: is_saving,
+                    }
+                }
+
+                // Username
+                div {
+                    label { class: "block text-sm font-medium text-gray-300 mb-1",
+                        "Username "
+                        span { class: "text-red-400", "*" }
+                    }
+                    TextInput {
+                        value: username,
+                        on_input: move |v| on_username_change.call(v),
+                        size: TextInputSize::Medium,
+                        input_type: TextInputType::Text,
+                        placeholder: "listener",
+                        disabled: is_saving,
+                    }
+                }
+
+                // Password
+                div {
+                    label { class: "block text-sm font-medium text-gray-300 mb-1",
+                        "Password "
+                        span { class: "text-red-400", "*" }
+                    }
+                    TextInput {
+                        value: password,
+                        on_input: move |v| on_password_change.call(v),
+                        size: TextInputSize::Medium,
+                        input_type: TextInputType::Password,
+                        placeholder: "",
+                        disabled: is_saving,
+                    }
+                }
+            }
+
+            // Test status
+            if let Some(ref status) = test_status {
+                match status {
+                    FollowTestStatus::Testing => rsx! {
+                        div { class: "flex items-center gap-2 mt-4 p-3 rounded-lg bg-gray-800",
+                            LoadingSpinner {}
+                            p { class: "text-sm text-gray-300", "Testing connection..." }
+                        }
+                    },
+                    FollowTestStatus::Success => rsx! {
+                        div { class: "mt-4 p-3 rounded-lg bg-green-900/30 border border-green-700",
+                            p { class: "text-sm text-green-300", "Connection successful." }
+                        }
+                    },
+                    FollowTestStatus::Error(err) => rsx! {
+                        div { class: "mt-4 p-3 rounded-lg bg-red-900/30 border border-red-700",
+                            p { class: "text-sm text-red-300", "{err}" }
+                        }
+                    },
+                }
+            }
+
+            // Buttons
+            div { class: "flex justify-end gap-3 mt-6",
+                Button {
+                    variant: ButtonVariant::Ghost,
+                    size: ButtonSize::Medium,
+                    disabled: is_testing || is_saving,
+                    onclick: move |_| on_cancel.call(()),
+                    "Cancel"
+                }
+                Button {
+                    variant: ButtonVariant::Ghost,
+                    size: ButtonSize::Medium,
+                    disabled: !can_test,
+                    onclick: move |_| on_test.call(()),
+                    if is_testing {
+                        "Testing..."
+                    } else {
+                        "Test Connection"
+                    }
+                }
+                Button {
+                    variant: ButtonVariant::Primary,
+                    size: ButtonSize::Medium,
+                    disabled: !can_save,
+                    onclick: move |_| on_save.call(()),
+                    if is_saving {
+                        "Saving..."
+                    } else {
+                        "Save"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bae-ui/src/components/settings/mod.rs
+++ b/bae-ui/src/components/settings/mod.rs
@@ -6,6 +6,7 @@ mod about;
 mod bittorrent;
 mod card;
 mod discogs;
+mod follow_library;
 mod join_library;
 mod library;
 mod storage_profiles;
@@ -17,6 +18,7 @@ pub use about::AboutSectionView;
 pub use bittorrent::{BitTorrentSectionView, BitTorrentSettings};
 pub use card::{SettingsCard, SettingsSection};
 pub use discogs::DiscogsSectionView;
+pub use follow_library::{FollowLibraryView, FollowTestStatus};
 pub use join_library::{JoinLibraryView, JoinStatus};
 pub use library::{LibraryInfo, LibrarySectionView};
 pub use storage_profiles::{

--- a/bae-ui/src/stores/config.rs
+++ b/bae-ui/src/stores/config.rs
@@ -49,4 +49,31 @@ pub struct ConfigState {
     pub share_default_expiry_days: Option<u32>,
     /// Signing key version for share tokens
     pub share_signing_key_version: u32,
+    /// Followed remote Subsonic libraries
+    pub followed_libraries: Vec<FollowedLibraryInfo>,
+}
+
+/// Info about a followed remote Subsonic library (UI display type)
+#[derive(Clone, Debug, PartialEq)]
+pub struct FollowedLibraryInfo {
+    pub id: String,
+    pub name: String,
+    pub server_url: String,
+    pub username: String,
+}
+
+/// Which library source is currently active
+#[derive(Clone, Debug, PartialEq)]
+pub enum LibrarySource {
+    /// The local library (default)
+    Local,
+    /// A followed remote Subsonic library, by ID
+    Followed(String),
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for LibrarySource {
+    fn default() -> Self {
+        Self::Local
+    }
 }

--- a/bae-ui/src/stores/library.rs
+++ b/bae-ui/src/stores/library.rs
@@ -1,6 +1,7 @@
 //! Library state store
 
 use crate::display_types::{Album, Artist};
+use crate::stores::config::LibrarySource;
 use dioxus::prelude::*;
 use std::collections::HashMap;
 
@@ -15,4 +16,6 @@ pub struct LibraryState {
     pub loading: bool,
     /// Error message if loading failed
     pub error: Option<String>,
+    /// Which library source is currently active (local or followed)
+    pub active_source: LibrarySource,
 }


### PR DESCRIPTION
## Summary

- Follow remote Subsonic-compatible servers to browse and stream their libraries
- Add "Follow Server..." form in library settings (name, URL, credentials, test connection)
- Library source switching between local and followed libraries
- Read-only mode hides edit/delete/export/storage/share actions for followed libraries
- "Following" badge shown on library and settings views when browsing a followed library
- Followed library passwords stored securely in OS keyring

## Technical details

- `FollowedLibrary` config struct with `add`/`remove` methods and YAML persistence
- `LibrarySource` enum (`Local` | `Followed(id)`) on `LibraryState` for source switching
- `load_followed_library()` and `load_followed_album_detail()` fetch via `SubsonicClient`
- Connection details read from Store (not stale boot config) for correct same-session behavior
- `read_only` prop threaded through album detail views to conditionally hide write actions

## Test plan

- [x] `cargo clippy -p bae-core -p bae-ui -p bae-desktop -p bae-mocks -- -D warnings`
- [x] `cargo test -p bae-core` — 465 tests pass including 3 new followed library config tests
- [ ] Manual: add a followed library in settings → test connection succeeds
- [ ] Manual: click "Browse" → library view shows followed library albums with "Following" badge
- [ ] Manual: click album → album detail loads from followed server, write actions hidden
- [ ] Manual: switch back to local → local library data reloads
- [ ] Manual: unfollow while browsing → switches back to local automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)