### PR TITLE
Replace 5-field join form with single invite code paste

### DIFF
--- a/bae-core/src/cloud_home/mod.rs
+++ b/bae-core/src/cloud_home/mod.rs
@@ -28,6 +28,8 @@ pub enum JoinInfo {
         bucket: String,
         region: String,
         endpoint: Option<String>,
+        access_key: String,
+        secret_key: String,
     },
     GoogleDrive {
         folder_id: String,

--- a/bae-core/src/cloud_home/s3.rs
+++ b/bae-core/src/cloud_home/s3.rs
@@ -16,6 +16,8 @@ pub struct S3CloudHome {
     bucket: String,
     region: String,
     endpoint: Option<String>,
+    access_key: String,
+    secret_key: String,
 }
 
 impl S3CloudHome {
@@ -26,7 +28,7 @@ impl S3CloudHome {
         access_key: String,
         secret_key: String,
     ) -> Result<Self, CloudHomeError> {
-        let credentials = Credentials::new(access_key, secret_key, None, None, "bae-cloud-home");
+        let credentials = Credentials::new(&access_key, &secret_key, None, None, "bae-cloud-home");
 
         let mut builder = aws_config::defaults(BehaviorVersion::latest())
             .region(Region::new(region.clone()))
@@ -47,6 +49,8 @@ impl S3CloudHome {
             bucket,
             region,
             endpoint,
+            access_key,
+            secret_key,
         })
     }
 }
@@ -197,10 +201,13 @@ impl CloudHome for S3CloudHome {
 
     async fn grant_access(&self, _member_id: &str) -> Result<JoinInfo, CloudHomeError> {
         // S3 access is managed externally (IAM/pre-shared credentials).
+        // Return the owner's credentials so they can be embedded in the invite code.
         Ok(JoinInfo::S3 {
             bucket: self.bucket.clone(),
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
+            access_key: self.access_key.clone(),
+            secret_key: self.secret_key.clone(),
         })
     }
 

--- a/bae-core/src/join_code.rs
+++ b/bae-core/src/join_code.rs
@@ -1,0 +1,151 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+use crate::cloud_home::JoinInfo;
+
+#[derive(Serialize, Deserialize)]
+pub struct InviteCode {
+    pub library_id: String,
+    pub library_name: String,
+    pub join_info: JoinInfo,
+    pub owner_pubkey: String,
+}
+
+pub fn encode(code: &InviteCode) -> String {
+    let json = serde_json::to_vec(code).expect("InviteCode is always serializable");
+    URL_SAFE_NO_PAD.encode(&json)
+}
+
+pub fn decode(s: &str) -> Result<InviteCode, JoinCodeError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(s.trim())
+        .map_err(|_| JoinCodeError::InvalidBase64)?;
+    serde_json::from_slice(&bytes).map_err(|e| JoinCodeError::InvalidJson(e.to_string()))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JoinCodeError {
+    #[error("invalid base64url encoding")]
+    InvalidBase64,
+    #[error("invalid invite code payload: {0}")]
+    InvalidJson(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_s3() {
+        let code = InviteCode {
+            library_id: "lib-123".into(),
+            library_name: "My Library".into(),
+            join_info: JoinInfo::S3 {
+                bucket: "my-bucket".into(),
+                region: "us-east-1".into(),
+                endpoint: None,
+                access_key: "AKIAEXAMPLE".into(),
+                secret_key: "secret123".into(),
+            },
+            owner_pubkey: "deadbeef".into(),
+        };
+        let encoded = encode(&code);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.library_id, "lib-123");
+        assert_eq!(decoded.library_name, "My Library");
+        assert_eq!(decoded.owner_pubkey, "deadbeef");
+        match decoded.join_info {
+            JoinInfo::S3 {
+                bucket,
+                region,
+                endpoint,
+                access_key,
+                secret_key,
+            } => {
+                assert_eq!(bucket, "my-bucket");
+                assert_eq!(region, "us-east-1");
+                assert_eq!(endpoint, None);
+                assert_eq!(access_key, "AKIAEXAMPLE");
+                assert_eq!(secret_key, "secret123");
+            }
+            _ => panic!("expected S3 variant"),
+        }
+    }
+
+    #[test]
+    fn round_trip_s3_with_endpoint() {
+        let code = InviteCode {
+            library_id: "lib-456".into(),
+            library_name: "Shared".into(),
+            join_info: JoinInfo::S3 {
+                bucket: "bucket".into(),
+                region: "eu-west-1".into(),
+                endpoint: Some("https://s3.example.com".into()),
+                access_key: "ak".into(),
+                secret_key: "sk".into(),
+            },
+            owner_pubkey: "cafebabe".into(),
+        };
+        let encoded = encode(&code);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.library_id, "lib-456");
+        match decoded.join_info {
+            JoinInfo::S3 { endpoint, .. } => {
+                assert_eq!(endpoint, Some("https://s3.example.com".to_string()));
+            }
+            _ => panic!("expected S3 variant"),
+        }
+    }
+
+    #[test]
+    fn round_trip_google_drive() {
+        let code = InviteCode {
+            library_id: "lib-789".into(),
+            library_name: "Cloud Shared".into(),
+            join_info: JoinInfo::GoogleDrive {
+                folder_id: "abc123".into(),
+            },
+            owner_pubkey: "cafebabe".into(),
+        };
+        let encoded = encode(&code);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.library_id, "lib-789");
+        match decoded.join_info {
+            JoinInfo::GoogleDrive { folder_id } => assert_eq!(folder_id, "abc123"),
+            _ => panic!("expected GoogleDrive variant"),
+        }
+    }
+
+    #[test]
+    fn decode_invalid_base64() {
+        assert!(matches!(
+            decode("not-valid!!!"),
+            Err(JoinCodeError::InvalidBase64)
+        ));
+    }
+
+    #[test]
+    fn decode_invalid_json() {
+        let encoded = URL_SAFE_NO_PAD.encode(b"not json");
+        assert!(matches!(
+            decode(&encoded),
+            Err(JoinCodeError::InvalidJson(_))
+        ));
+    }
+
+    #[test]
+    fn decode_trims_whitespace() {
+        let code = InviteCode {
+            library_id: "lib-ws".into(),
+            library_name: "Trimmed".into(),
+            join_info: JoinInfo::Dropbox {
+                shared_folder_id: "sf1".into(),
+            },
+            owner_pubkey: "aabb".into(),
+        };
+        let encoded = format!("  {} \n", encode(&code));
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.library_id, "lib-ws");
+    }
+}

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod encryption;
 pub mod hmac_utils;
 pub mod image_server;
 pub mod import;
+pub mod join_code;
 pub mod keys;
 pub mod library;
 pub mod library_dir;

--- a/bae-core/src/sync/invite.rs
+++ b/bae-core/src/sync/invite.rs
@@ -262,6 +262,8 @@ mod tests {
                 bucket: "test-bucket".to_string(),
                 region: "us-east-1".to_string(),
                 endpoint: None,
+                access_key: "test-access-key".to_string(),
+                secret_key: "test-secret-key".to_string(),
             })
         }
         async fn revoke_access(&self, _member_id: &str) -> Result<(), CloudHomeError> {

--- a/bae-ui/src/components/settings/sync.rs
+++ b/bae-ui/src/components/settings/sync.rs
@@ -335,8 +335,12 @@ pub fn SyncSectionView(
 
         
                 
-        
+                
 
+                
+        
+                
+                
                                                             if let Some(ref err) = removing_member_error {
                                                                 div { class: "text-sm text-red-400 mb-3", "{err}" }
                                                             }
@@ -469,29 +473,19 @@ pub fn SyncSectionView(
                     // Share info panel (shown after successful invite)
                     if let Some(ref info) = share_info {
                         {
-                            let share_text = format_share_text(info);
+                            let code = info.invite_code.clone();
                             rsx! {
                                 div { class: "mt-4 pt-4 border-t border-gray-700",
-                                    h4 { class: "text-sm font-medium text-gray-300 mb-3", "Share these details with the invitee" }
-                                    div { class: "p-3 bg-gray-700/50 rounded-lg space-y-2 text-sm",
-                                        div { class: "flex justify-between",
-                                            span { class: "text-gray-400", "Bucket" }
-                                            span { class: "text-gray-200 font-mono", "{info.cloud_home_bucket}" }
-                                        }
-                                        div { class: "flex justify-between",
-                                            span { class: "text-gray-400", "Region" }
-                                            span { class: "text-gray-200 font-mono", "{info.cloud_home_region}" }
-                                        }
-                                        if let Some(ref ep) = info.cloud_home_endpoint {
-                                            div { class: "flex justify-between",
-                                                span { class: "text-gray-400", "Endpoint" }
-                                                span { class: "text-gray-200 font-mono", "{ep}" }
-                                            }
-                                        }
-                                        div { class: "flex justify-between",
-                                            span { class: "text-gray-400", "Invitee key" }
-                                            span { class: "text-gray-200 font-mono", {truncate_pubkey(&info.invitee_pubkey)} }
-                                        }
+                                    h4 { class: "text-sm font-medium text-gray-300 mb-3",
+                                        "Send this invite code to {info.invitee_display}:"
+                                    }
+                                    textarea {
+                                        class: "w-full h-24 bg-gray-700 text-white text-sm font-mono rounded-lg p-3 border border-gray-600 focus:outline-none resize-none",
+                                        readonly: true,
+                                        value: "{info.invite_code}",
+                                    }
+                                    p { class: "text-xs text-gray-500 mt-2",
+                                        "The code contains cloud home connection info. The encryption key is delivered separately via the membership chain."
                                     }
 
         
@@ -500,7 +494,7 @@ pub fn SyncSectionView(
                                             variant: ButtonVariant::Secondary,
                                             size: ButtonSize::Small,
                                             onclick: {
-                                                let text = share_text.clone();
+                                                let text = code.clone();
                                                 move |_| {
                                                     on_copy_share_info.call(text.clone());
                                                     share_copied.set(true);
@@ -520,7 +514,7 @@ pub fn SyncSectionView(
                                             variant: ButtonVariant::Secondary,
                                             size: ButtonSize::Small,
                                             onclick: move |_| on_dismiss_share_info.call(()),
-                                            "Dismiss"
+                                            "Done"
                                         }
                                     }
                                 }
@@ -826,19 +820,6 @@ fn short_device_id(id: &str) -> String {
     } else {
         clean
     }
-}
-
-/// Format share info as a text block for clipboard copy.
-fn format_share_text(info: &ShareInfo) -> String {
-    let mut lines = vec![
-        format!("Bucket: {}", info.cloud_home_bucket),
-        format!("Region: {}", info.cloud_home_region),
-    ];
-    if let Some(ref ep) = info.cloud_home_endpoint {
-        lines.push(format!("Endpoint: {ep}"));
-    }
-    lines.push(format!("Invitee key: {}", info.invitee_pubkey));
-    lines.join("\n")
 }
 
 /// Format an RFC 3339 timestamp as a relative time string.

--- a/bae-ui/src/stores/sync.rs
+++ b/bae-ui/src/stores/sync.rs
@@ -39,13 +39,11 @@ pub enum InviteStatus {
     Error(String),
 }
 
-/// Cloud home coordinates to share with an invitee after a successful invite.
+/// Invite code to share with an invitee after a successful invite.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ShareInfo {
-    pub cloud_home_bucket: String,
-    pub cloud_home_region: String,
-    pub cloud_home_endpoint: Option<String>,
-    pub invitee_pubkey: String,
+    pub invite_code: String,
+    pub invitee_display: String,
 }
 
 /// A release shared with us via a share grant (display-only).


### PR DESCRIPTION
## Summary
- Add `InviteCode` struct + `encode`/`decode` functions in `bae-core/src/join_code.rs` (base64url JSON)
- Extend `JoinInfo::S3` with `access_key` and `secret_key` fields so credentials travel in the invite code
- Simplify `ShareInfo` from 6 fields to `invite_code` + `invitee_display`
- Rewrite `JoinLibraryView` as single textarea with live decode preview (library name, owner, cloud home type)
- Update desktop join handler to decode invite code and construct `S3CloudHome` from embedded fields
- Update `invite_member` in `AppService` to encode `JoinInfo` into `InviteCode` string

## Test plan
- [x] `cargo test -p bae-core` — all 456 tests pass (including 6 new join_code tests)
- [x] `cargo clippy -p bae-core -p bae-ui -p bae-desktop -p bae-mocks -- -D warnings` — clean
- [ ] Manual: invite member → copy invite code → paste in new instance → verify decode preview shows library info
- [ ] Manual: paste invalid string → verify inline error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)