### PR TITLE
Add storage_dir() and storage_file_path() to LibraryDir (#239)

### DIFF
--- a/bae-core/src/library_dir.rs
+++ b/bae-core/src/library_dir.rs
@@ -34,6 +34,19 @@ impl LibraryDir {
         self.images_dir().join(&hex[..2]).join(&hex[2..4]).join(id)
     }
 
+    pub fn storage_dir(&self) -> PathBuf {
+        self.path.join("storage")
+    }
+
+    /// Hash-based storage path: `storage/{ab}/{cd}/{file_id}`
+    pub fn storage_file_path(&self, file_id: &str) -> PathBuf {
+        let hex = file_id.replace('-', "");
+        self.storage_dir()
+            .join(&hex[..2])
+            .join(&hex[2..4])
+            .join(file_id)
+    }
+
     pub fn manifest_path(&self) -> PathBuf {
         self.path.join("manifest.json")
     }
@@ -44,7 +57,7 @@ impl LibraryDir {
 
     /// All asset directories that should be synced/created.
     pub fn asset_dirs(&self) -> Vec<PathBuf> {
-        vec![self.images_dir()]
+        vec![self.images_dir(), self.storage_dir()]
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `storage_dir()` method to `LibraryDir` (mirrors `images_dir()`)
- Added `storage_file_path(file_id)` for hash-based path resolution (mirrors `image_path()`)
- Added `storage_dir()` to `asset_dirs()` so the directory gets created automatically

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test -p bae-core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)