### PR TITLE
Consolidate cloud home credentials into single keyring entry (#242)

### DIFF
--- a/bae-core/src/cloud_home/dropbox.rs
+++ b/bae-core/src/cloud_home/dropbox.rs
@@ -94,7 +94,8 @@ impl DropboxCloudHome {
         // Persist to keyring
         let json = serde_json::to_string(&new_tokens)
             .map_err(|e| CloudHomeError::Storage(format!("serialize tokens: {e}")))?;
-        if let Err(e) = self.key_service.set_cloud_home_oauth_token(&json) {
+        let creds = crate::keys::CloudHomeCredentials::OAuth { token_json: json };
+        if let Err(e) = self.key_service.set_cloud_home_credentials(&creds) {
             warn!("Failed to persist refreshed OAuth tokens: {e}");
         }
 

--- a/bae-core/src/cloud_home/google_drive.rs
+++ b/bae-core/src/cloud_home/google_drive.rs
@@ -107,7 +107,8 @@ impl GoogleDriveCloudHome {
         // Persist to keyring
         let json = serde_json::to_string(&new_tokens)
             .map_err(|e| CloudHomeError::Storage(format!("serialize tokens: {e}")))?;
-        if let Err(e) = self.key_service.set_cloud_home_oauth_token(&json) {
+        let creds = crate::keys::CloudHomeCredentials::OAuth { token_json: json };
+        if let Err(e) = self.key_service.set_cloud_home_credentials(&creds) {
             warn!("Failed to persist refreshed OAuth tokens: {e}");
         }
 

--- a/bae-core/src/cloud_home/onedrive.rs
+++ b/bae-core/src/cloud_home/onedrive.rs
@@ -123,7 +123,8 @@ impl OneDriveCloudHome {
         // Persist to keyring
         let json = serde_json::to_string(&new_tokens)
             .map_err(|e| CloudHomeError::Storage(format!("serialize tokens: {e}")))?;
-        if let Err(e) = self.key_service.set_cloud_home_oauth_token(&json) {
+        let creds = crate::keys::CloudHomeCredentials::OAuth { token_json: json };
+        if let Err(e) = self.key_service.set_cloud_home_credentials(&creds) {
             warn!("Failed to persist refreshed OAuth tokens: {e}");
         }
 

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -420,8 +420,14 @@ async fn create_sync_handle(
     let bucket = config.cloud_home_s3_bucket.as_ref()?;
     let region = config.cloud_home_s3_region.as_ref()?;
     let endpoint = config.cloud_home_s3_endpoint.clone();
-    let access_key = key_service.get_cloud_home_access_key()?;
-    let secret_key = key_service.get_cloud_home_secret_key()?;
+
+    let (access_key, secret_key) = match key_service.get_cloud_home_credentials() {
+        Some(bae_core::keys::CloudHomeCredentials::S3 {
+            access_key,
+            secret_key,
+        }) => (access_key, secret_key),
+        _ => return None,
+    };
 
     let cloud_home = match S3CloudHome::new(
         bucket.clone(),

--- a/bae-desktop/src/ui/components/settings/library.rs
+++ b/bae-desktop/src/ui/components/settings/library.rs
@@ -622,12 +622,11 @@ async fn bootstrap_library(
 
     // Save sync bucket credentials to keyring.
     new_key_service
-        .set_cloud_home_access_key(access_key)
-        .map_err(|e| format!("Failed to save sync access key: {e}"))?;
-
-    new_key_service
-        .set_cloud_home_secret_key(secret_key)
-        .map_err(|e| format!("Failed to save sync secret key: {e}"))?;
+        .set_cloud_home_credentials(&bae_core::keys::CloudHomeCredentials::S3 {
+            access_key: access_key.to_string(),
+            secret_key: secret_key.to_string(),
+        })
+        .map_err(|e| format!("Failed to save sync credentials: {e}"))?;
 
     let config = Config {
         library_id: library_id.to_string(),

--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -273,14 +273,14 @@ pub fn SyncSection() -> Element {
                             .clone()
                             .unwrap_or_default(),
                     );
-                edit_access_key
-                    .set(
-                        app_for_edit.key_service.get_cloud_home_access_key().unwrap_or_default(),
-                    );
-                edit_secret_key
-                    .set(
-                        app_for_edit.key_service.get_cloud_home_secret_key().unwrap_or_default(),
-                    );
+                let (ak, sk) = match app_for_edit.key_service.get_cloud_home_credentials() {
+                    Some(bae_core::keys::CloudHomeCredentials::S3 { access_key, secret_key }) => {
+                        (access_key, secret_key)
+                    }
+                    _ => (String::new(), String::new()),
+                };
+                edit_access_key.set(ak);
+                edit_secret_key.set(sk);
                 is_editing.set(true);
             },
             on_cancel_edit: move |_| {

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -395,8 +395,11 @@ async fn do_restore(
 
     // Save cloud home S3 credentials
     {
-        key_service.set_cloud_home_access_key(&access_key)?;
-        key_service.set_cloud_home_secret_key(&secret_key)?;
+        let creds = bae_core::keys::CloudHomeCredentials::S3 {
+            access_key: access_key.clone(),
+            secret_key: secret_key.clone(),
+        };
+        key_service.set_cloud_home_credentials(&creds)?;
 
         info!("Saved cloud home S3 credentials");
     }


### PR DESCRIPTION
## Summary
- New `CloudHomeCredentials` enum: `S3 { access_key, secret_key }`, `OAuth { token_json }`, `None`
- Single keyring entry `cloud_home_credentials` replaces 3 separate entries
- Replaced 6 KeyService methods with 3 (`get/set/delete_cloud_home_credentials`)
- Updated all cloud home backends, config validation, settings UI, sign-in flows

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test -p bae-core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)