### PR TITLE
Read OAuth client_id from env vars, implement Google Drive sign-in (#256)

### DIFF
--- a/bae-core/src/cloud_home/dropbox.rs
+++ b/bae-core/src/cloud_home/dropbox.rs
@@ -37,8 +37,7 @@ impl DropboxCloudHome {
 
     pub fn oauth_config() -> OAuthConfig {
         OAuthConfig {
-            // Placeholder: the actual client_id is set per-deployment.
-            client_id: String::new(),
+            client_id: std::env::var("BAE_DROPBOX_CLIENT_ID").unwrap_or_default(),
             client_secret: None,
             auth_url: "https://www.dropbox.com/oauth2/authorize".to_string(),
             token_url: "https://api.dropboxapi.com/oauth2/token".to_string(),

--- a/bae-core/src/cloud_home/google_drive.rs
+++ b/bae-core/src/cloud_home/google_drive.rs
@@ -33,11 +33,9 @@ impl GoogleDriveCloudHome {
         }
     }
 
-    fn oauth_config() -> OAuthConfig {
+    pub fn oauth_config() -> OAuthConfig {
         OAuthConfig {
-            // Placeholder: the actual client_id is set per-deployment.
-            // In production this comes from the app's Google Cloud Console project.
-            client_id: String::new(),
+            client_id: std::env::var("BAE_GOOGLE_DRIVE_CLIENT_ID").unwrap_or_default(),
             client_secret: None,
             auth_url: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
             token_url: "https://oauth2.googleapis.com/token".to_string(),

--- a/bae-core/src/cloud_home/onedrive.rs
+++ b/bae-core/src/cloud_home/onedrive.rs
@@ -42,8 +42,7 @@ impl OneDriveCloudHome {
 
     pub fn oauth_config() -> OAuthConfig {
         OAuthConfig {
-            // Placeholder: the actual client_id is set per-deployment.
-            client_id: String::new(),
+            client_id: std::env::var("BAE_ONEDRIVE_CLIENT_ID").unwrap_or_default(),
             client_secret: None,
             auth_url: "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize"
                 .to_string(),

--- a/bae-core/src/cloud_home/pcloud.rs
+++ b/bae-core/src/cloud_home/pcloud.rs
@@ -35,10 +35,8 @@ impl PCloudCloudHome {
 
     pub fn oauth_config() -> OAuthConfig {
         OAuthConfig {
-            // Placeholder: the actual client_id is set per-deployment.
-            client_id: String::new(),
-            // pCloud requires client_secret (no PKCE support). Set per-deployment.
-            client_secret: Some(String::new()),
+            client_id: std::env::var("BAE_PCLOUD_CLIENT_ID").unwrap_or_default(),
+            client_secret: Some(std::env::var("BAE_PCLOUD_CLIENT_SECRET").unwrap_or_default()),
             auth_url: "https://my.pcloud.com/oauth2/authorize".to_string(),
             // Token URL needs the api_host, but at OAuth time we don't know
             // the region yet. The authorize endpoint works from either host.


### PR DESCRIPTION
## Summary
- All 4 cloud providers (Google Drive, Dropbox, OneDrive, pCloud) now read OAuth client_id from environment variables (`BAE_GOOGLE_DRIVE_CLIENT_ID`, etc.)
- Implemented the full Google Drive sign-in flow in app_service.rs (was a no-op stub): OAuth authorize → create app folder → fetch user email → save tokens
- Added client_id.is_empty() validation to Dropbox and pCloud sign-in paths

Closes #256

## Test plan
- [ ] Set `BAE_GOOGLE_DRIVE_CLIENT_ID` env var and test Google Drive sign-in flow
- [ ] Verify other providers still work with their respective env vars
- [ ] Verify sign-in fails gracefully when client_id is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)