### PR TITLE
Emit LibraryEvent::AlbumsChanged after import and cover changes (#250)

### DIFF
--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -570,6 +570,8 @@ impl ImportService {
             import_id: import_id.map(|s| s.to_string()),
         });
 
+        self.library_manager.notify_albums_changed();
+
         Ok(())
     }
 

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -411,6 +411,9 @@ impl LibraryManager {
         self.database
             .set_album_cover_release(album_id, cover_release_id)
             .await?;
+
+        self.notify_albums_changed();
+
         Ok(())
     }
 

--- a/bae-desktop/src/ui/app_service.rs
+++ b/bae-desktop/src/ui/app_service.rs
@@ -378,20 +378,11 @@ impl AppService {
     fn subscribe_import_progress(&self) {
         let state = self.state;
         let import_handle = self.import_handle.clone();
-        let library_manager = self.library_manager.clone();
-        let imgs = self.image_server.clone();
 
         spawn(async move {
             let mut progress_rx = import_handle.subscribe_all_imports();
             while let Some(event) = progress_rx.recv().await {
-                // Reload library when import completes
-                let should_reload = matches!(event, ImportProgress::Complete { .. });
-
                 handle_import_progress(&state, event);
-
-                if should_reload {
-                    load_library(&state, &library_manager, &imgs).await;
-                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- Add `notify_albums_changed()` call at end of `finalize_import()` — all import paths funnel through here, so this covers every import
- Add `notify_albums_changed()` in `set_album_cover_release()` — triggers sync when cover art changes
- Remove redundant `load_library()` from `subscribe_import_progress()` — the existing `subscribe_library_events` handler already reloads on AlbumsChanged

## Test plan
- [ ] Import an album → verify AlbumsChanged event fires (sync push triggered after 2s debounce)
- [ ] Change album cover → verify AlbumsChanged event fires
- [ ] Delete a release → verify AlbumsChanged event still fires (existing behavior)
- [ ] Verify no double-reload after import completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)