### PR TITLE
Add per-device snapshot cursors and safe GC (#252)

### DIFF
--- a/bae-core/src/sync/bucket.rs
+++ b/bae-core/src/sync/bucket.rs
@@ -6,6 +6,7 @@
 /// heads/{device_id}.json.enc             -- encrypted head pointers
 /// images/{ab}/{cd}/{id}                  -- encrypted library images
 /// snapshot.db.enc                        -- full DB snapshot for bootstrapping
+/// snapshot_meta.json.enc                 -- per-device cursors at snapshot time
 /// membership/{author_pubkey}/{seq}.enc   -- encrypted membership entries
 /// keys/{user_pubkey}.enc                 -- wrapped library keys per member
 /// ```
@@ -153,4 +154,12 @@ pub trait SyncBucketClient: Send + Sync {
     /// Delete a wrapped library key.
     /// Removes `keys/{user_pubkey_hex}.enc`.
     async fn delete_wrapped_key(&self, user_pubkey: &str) -> Result<(), BucketError>;
+
+    /// Upload snapshot metadata (plaintext -- the implementation encrypts it).
+    /// Writes to `snapshot_meta.json.enc`.
+    async fn put_snapshot_meta(&self, data: Vec<u8>) -> Result<(), BucketError>;
+
+    /// Download snapshot metadata (decrypted).
+    /// Reads from `snapshot_meta.json.enc`. Returns NotFound if no metadata exists.
+    async fn get_snapshot_meta(&self) -> Result<Vec<u8>, BucketError>;
 }

--- a/bae-core/src/sync/cloud_home_bucket.rs
+++ b/bae-core/src/sync/cloud_home_bucket.rs
@@ -300,4 +300,17 @@ impl SyncBucketClient for CloudHomeSyncBucket {
         self.home.delete(&key).await?;
         Ok(())
     }
+
+    async fn put_snapshot_meta(&self, data: Vec<u8>) -> Result<(), BucketError> {
+        let encrypted = self.enc().encrypt(&data);
+        self.home.write("snapshot_meta.json.enc", encrypted).await?;
+        Ok(())
+    }
+
+    async fn get_snapshot_meta(&self) -> Result<Vec<u8>, BucketError> {
+        let encrypted = self.home.read("snapshot_meta.json.enc").await?;
+        self.enc()
+            .decrypt(&encrypted)
+            .map_err(|e| BucketError::Decryption(format!("snapshot_meta: {e}")))
+    }
 }

--- a/bae-core/src/sync/test_helpers.rs
+++ b/bae-core/src/sync/test_helpers.rs
@@ -495,4 +495,12 @@ impl SyncBucketClient for MockBucket {
         self.objects.lock().unwrap().remove(&key);
         Ok(())
     }
+
+    async fn put_snapshot_meta(&self, _data: Vec<u8>) -> Result<(), BucketError> {
+        Ok(())
+    }
+
+    async fn get_snapshot_meta(&self) -> Result<Vec<u8>, BucketError> {
+        Err(BucketError::NotFound("snapshot_meta.json.enc".into()))
+    }
 }


### PR DESCRIPTION
## Summary
- Store per-device cursor metadata in `snapshot_meta.json.enc` alongside snapshots
- GC now only deletes changesets the snapshot covers for each device (per-device thresholds instead of a single global `snapshot_seq`)
- `bootstrap_from_snapshot` returns per-device cursors so new devices start pulling from the correct position per remote device
- Falls back gracefully when no snapshot metadata exists (old snapshots)

## Test plan
- [x] All 19 snapshot tests pass (6 updated + 3 new safety tests)
- [x] `gc_does_not_delete_post_snapshot_changesets` — verifies changesets pushed after snapshot are preserved
- [x] `gc_ignores_device_not_in_snapshot_meta` — verifies new devices' changesets are untouched
- [x] `bootstrap_without_metadata_falls_back` — verifies backward compat with old snapshots
- [x] Clippy clean across all crates
- [x] bae-server and bae-desktop callers updated and compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)