### PR TITLE
Remove redundant DetectedCandidate.status field (#19)

### DIFF
--- a/bae-desktop/src/ui/import_helpers/scan.rs
+++ b/bae-desktop/src/ui/import_helpers/scan.rs
@@ -78,7 +78,6 @@ pub async fn consume_scan_events(app: AppService, mut rx: broadcast::Receiver<Sc
                     let display_candidate = bae_ui::display_types::DetectedCandidate {
                         name: candidate.name.clone(),
                         path: key.clone(),
-                        status: bae_ui::display_types::DetectedCandidateStatus::Pending,
                     };
 
                     {

--- a/bae-mocks/src/mocks/folder_import.rs
+++ b/bae-mocks/src/mocks/folder_import.rs
@@ -6,10 +6,9 @@ use bae_ui::stores::import::{
     ManualSearchState, TabSearchState,
 };
 use bae_ui::{
-    AudioContentInfo, CategorizedFileInfo, CueFlacPairInfo, DetectedCandidate,
-    DetectedCandidateStatus, FileInfo, FolderImportView, FolderMetadata, IdentifyMode,
-    ImportSource, ImportStep, ImportView, MatchCandidate, MatchSourceType, SearchSource, SearchTab,
-    SelectedCover,
+    AudioContentInfo, CategorizedFileInfo, CueFlacPairInfo, DetectedCandidate, FileInfo,
+    FolderImportView, FolderMetadata, IdentifyMode, ImportSource, ImportStep, ImportView,
+    MatchCandidate, MatchSourceType, SearchSource, SearchTab, SelectedCover,
 };
 use dioxus::prelude::*;
 use std::collections::HashMap;
@@ -208,7 +207,6 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 name: "The Midnight Signal - Neon Frequencies (2023) [FLAC 24-96]".to_string(),
                 path: "/Users/demo/Music/Imports/The Midnight Signal - Neon Frequencies (2023) [FLAC 24-96]"
                     .to_string(),
-                status: DetectedCandidateStatus::Pending,
             },
             CategorizedFileInfo {
                 audio: AudioContentInfo::TrackFiles(vec![
@@ -239,7 +237,6 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 name: "Glass Harbor - 2022 - Pacific Standard".to_string(),
                 path: "/Users/demo/Music/Imports/Glass Harbor - 2022 - Pacific Standard"
                     .to_string(),
-                status: DetectedCandidateStatus::Pending,
             },
             CategorizedFileInfo {
                 audio: AudioContentInfo::CueFlacPairs(vec![mock_cue_flac(
@@ -259,7 +256,6 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 name: "Velvet_Mathematics-Proof_by_Induction-2021-FLAC".to_string(),
                 path: "/Users/demo/Music/Imports/Velvet_Mathematics-Proof_by_Induction-2021-FLAC"
                     .to_string(),
-                status: DetectedCandidateStatus::Pending,
             },
             CategorizedFileInfo {
                 audio: AudioContentInfo::TrackFiles(vec![
@@ -291,7 +287,6 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
             DetectedCandidate {
                 name: "Apartment Garden - Grow Light".to_string(),
                 path: "/Users/demo/Downloads/Apartment Garden - Grow Light".to_string(),
-                status: DetectedCandidateStatus::Pending,
             },
             CategorizedFileInfo {
                 audio: AudioContentInfo::TrackFiles(vec![
@@ -312,7 +307,6 @@ pub fn FolderImportMock(initial_state: Option<String>) -> Element {
                 name: "The Cold Equations - Fuel Weight (Vinyl Rip) [24-96]".to_string(),
                 path: "/Users/demo/Music/Vinyl Rips/The Cold Equations - Fuel Weight (Vinyl Rip) [24-96]"
                     .to_string(),
-                status: DetectedCandidateStatus::Pending,
             },
             CategorizedFileInfo {
                 audio: AudioContentInfo::TrackFiles(vec![

--- a/bae-ui/src/display_types.rs
+++ b/bae-ui/src/display_types.rs
@@ -413,9 +413,8 @@ impl SelectedCover {
 }
 
 /// Status of a detected candidate during import
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DetectedCandidateStatus {
-    #[default]
     Pending,
     /// Import in progress (preparing or importing)
     Importing,
@@ -441,8 +440,6 @@ pub struct DetectedCandidate {
     pub name: String,
     /// Full path to the candidate folder
     pub path: String,
-    /// Import status
-    pub status: DetectedCandidateStatus,
 }
 
 /// CD drive info for selection UI

--- a/bae-ui/src/stores/import.rs
+++ b/bae-ui/src/stores/import.rs
@@ -1013,48 +1013,6 @@ impl ImportState {
             .unwrap_or(true)
     }
 
-    /// Get detected candidates with status computed from state machine
-    pub fn get_detected_candidates_display(&self) -> Vec<DetectedCandidate> {
-        self.detected_candidates
-            .iter()
-            .map(|c| {
-                let status = self
-                    .candidate_states
-                    .get(&c.path)
-                    .map(|s| {
-                        let files = s.files();
-
-                        // Check for incomplete/corrupt files first
-                        if files.bad_audio_count > 0 || files.bad_image_count > 0 {
-                            let good_audio_count = match &files.audio {
-                                crate::display_types::AudioContentInfo::CueFlacPairs(p) => p.len(),
-                                crate::display_types::AudioContentInfo::TrackFiles(t) => t.len(),
-                            };
-                            return crate::display_types::DetectedCandidateStatus::Incomplete {
-                                bad_audio_count: files.bad_audio_count,
-                                total_audio_count: good_audio_count + files.bad_audio_count,
-                                bad_image_count: files.bad_image_count,
-                            };
-                        }
-
-                        if s.is_imported() {
-                            crate::display_types::DetectedCandidateStatus::Imported
-                        } else if s.is_importing() {
-                            crate::display_types::DetectedCandidateStatus::Importing
-                        } else {
-                            crate::display_types::DetectedCandidateStatus::Pending
-                        }
-                    })
-                    .unwrap_or(crate::display_types::DetectedCandidateStatus::Pending);
-                DetectedCandidate {
-                    name: c.name.clone(),
-                    path: c.path.clone(),
-                    status,
-                }
-            })
-            .collect()
-    }
-
     /// Get selected candidate index from current candidate key
     pub fn get_selected_candidate_index(&self) -> Option<usize> {
         self.current_candidate_key


### PR DESCRIPTION
## Summary
- Remove `status` field from `DetectedCandidate` struct — it was always hardcoded to `Pending` at creation and recomputed from `CandidateState` every time it was displayed
- Move status computation to `compute_status()` helper in `release_sidebar.rs`
- Remove dead `get_detected_candidates_display()` method from `ImportState`
- Remove `Default` derive from `DetectedCandidateStatus` (no longer needed)

Closes #19

## Test plan
- [x] `cargo clippy` passes for bae-ui, bae-desktop, bae-mocks
- [x] `cargo fmt --check` clean
- [ ] Import flow still shows correct status badges (Pending, Importing, Imported, Incomplete)

Generated with [Claude Code](https://claude.com/claude-code)