### PR TITLE
Add keychain access group entitlement for iCloud sync

### DIFF
--- a/bae-desktop/bae.entitlements
+++ b/bae-desktop/bae.entitlements
@@ -4,5 +4,9 @@
 <dict>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.fm.bae</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `keychain-access-groups` entitlement with `$(AppIdentifierPrefix)com.fm.bae` to `bae-desktop/bae.entitlements`
- Without this entitlement, keyring items (encryption keys, S3 credentials, user keypairs) stay local to the device and don't sync via iCloud Keychain

## Test plan
- [ ] Verify the app still launches and can read/write keyring entries
- [ ] Confirm keyring items sync between devices signed into the same iCloud account (requires two Macs with the same Apple ID)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)