### PR TITLE
Add recovery key display in sync settings (#251)

### DIFF
--- a/bae-desktop/src/ui/components/settings/sync.rs
+++ b/bae-desktop/src/ui/components/settings/sync.rs
@@ -128,6 +128,9 @@ pub fn SyncSection() -> Element {
     let mut is_accepting_grant = use_signal(|| false);
     let mut accept_grant_error = use_signal(|| Option::<String>::None);
 
+    // --- Recovery key state ---
+    let mut recovery_key = use_signal(|| Option::<String>::None);
+
     // Load membership and shared releases on mount
     let app_for_membership = app.clone();
     let app_for_load_shared = app.clone();
@@ -389,6 +392,19 @@ pub fn SyncSection() -> Element {
             },
             on_revoke_shared_release: move |grant_id: String| {
                 app_for_revoke.revoke_shared_release(grant_id);
+            },
+
+            // Recovery key
+            recovery_key: recovery_key.read().clone(),
+            on_reveal_recovery_key: move |_| {
+                if let Some(key) = app.key_service.get_encryption_key() {
+                    recovery_key.set(Some(key));
+                }
+            },
+            on_copy_recovery_key: move |_| {
+                if let Some(ref key) = *recovery_key.read() {
+                    let _ = arboard::Clipboard::new().and_then(|mut cb| cb.set_text(key));
+                }
             },
         }
     }

--- a/bae-mocks/src/mocks/settings.rs
+++ b/bae-mocks/src/mocks/settings.rs
@@ -118,6 +118,10 @@ pub fn SettingsMock(initial_state: Option<String>) -> Element {
                             on_accept_grant_text_change: |_| {},
                             on_accept_grant: |_| {},
                             on_revoke_shared_release: |_| {},
+                            // Recovery key
+                            recovery_key: None,
+                            on_reveal_recovery_key: |_| {},
+                            on_copy_recovery_key: |_| {},
                         }
                     },
                     SettingsTab::Discogs => rsx! {

--- a/bae-mocks/src/pages/settings.rs
+++ b/bae-mocks/src/pages/settings.rs
@@ -99,6 +99,10 @@ pub fn Settings() -> Element {
                         on_accept_grant_text_change: |_| {},
                         on_accept_grant: |_| {},
                         on_revoke_shared_release: |_| {},
+                        // Recovery key
+                        recovery_key: None,
+                        on_reveal_recovery_key: |_| {},
+                        on_copy_recovery_key: |_| {},
                     }
                 },
                 SettingsTab::Discogs => rsx! {


### PR DESCRIPTION
## Summary
- Adds a "Recovery key" card to the Sync settings tab so users can view and copy their library encryption key
- Solves the second-device setup problem when iCloud Keychain sync is disabled
- Key is hidden by default behind a "Show Recovery Key" button; once revealed, shows the full hex key with a copy button and security warning

## Test plan
- [ ] Open Settings > Sync, verify the "Recovery key" card appears at the bottom
- [ ] Click "Show Recovery Key", verify the hex key is displayed in a monospace box
- [ ] Click the copy icon, verify the key is copied to clipboard and the icon briefly shows a green checkmark
- [ ] On a second device, use the copied key in the unlock screen to verify it works

Generated with [Claude Code](https://claude.com/claude-code)