### PR TITLE
Replace native title tooltips with custom Tooltip component (#56)

### DIFF
--- a/bae-ui/src/components/album_card.rs
+++ b/bae-ui/src/components/album_card.rs
@@ -1,5 +1,6 @@
 //! Album card component - pure view with callbacks
 
+use crate::components::helpers::Tooltip;
 use crate::components::icons::{EllipsisIcon, ImageIcon, PlayIcon, PlusIcon};
 use crate::components::{MenuDropdown, MenuItem, Placement, TextLink};
 use crate::display_types::{Album, Artist};
@@ -85,10 +86,11 @@ pub fn AlbumCard(
                 }
             }
             div { class: "p-4",
-                h3 {
-                    class: "font-bold text-white text-lg mb-1 truncate",
-                    title: "{album_title}",
-                    "{album_title}"
+                Tooltip {
+                    text: album_title.clone(),
+                    placement: Placement::Bottom,
+                    nowrap: true,
+                    h3 { class: "font-bold text-white text-lg mb-1 truncate", "{album_title}" }
                 }
                 p { class: "text-gray-400 text-sm truncate",
                     if artists.is_empty() {

--- a/bae-ui/src/components/import/workflow/folder_import.rs
+++ b/bae-ui/src/components/import/workflow/folder_import.rs
@@ -22,12 +22,14 @@ use super::{
     ConfirmationView, DiscIdPill, DiscIdSource, LoadingIndicator, ManualSearchPanelView,
     MultipleExactMatchesView, SmartFileDisplayView,
 };
+use crate::components::helpers::Tooltip;
 use crate::components::icons::{CloudOffIcon, LoaderIcon};
 use crate::components::{Button, ButtonSize, ButtonVariant};
 use crate::components::{PanelPosition, ResizablePanel, ResizeDirection};
 use crate::display_types::{
     IdentifyMode, ImportStep, MatchCandidate, SearchSource, SearchTab, SelectedCover,
 };
+use crate::floating_ui::Placement;
 use crate::stores::import::{CandidateState, ConfirmPhase, ImportState, ImportStateStoreExt};
 use dioxus::prelude::*;
 
@@ -470,9 +472,11 @@ fn DetailHeader(state: ReadStore<ImportState>) -> Element {
 
     rsx! {
         div { class: "flex-shrink-0 px-4 py-4 bg-gray-800/30",
-            div { class: "cursor-default", title: "{tooltip}",
-                span { class: "text-[0.9375rem] font-medium text-gray-300 truncate select-text",
-                    "{name}"
+            Tooltip { text: tooltip, placement: Placement::Bottom, nowrap: false,
+                div { class: "cursor-default",
+                    span { class: "text-[0.9375rem] font-medium text-gray-300 truncate select-text",
+                        "{name}"
+                    }
                 }
             }
         }

--- a/bae-ui/src/components/import/workflow/match_item.rs
+++ b/bae-ui/src/components/import/workflow/match_item.rs
@@ -1,10 +1,12 @@
 //! Match item view component
 
+use crate::components::helpers::Tooltip;
 use crate::components::icons::{
     ChevronDownIcon, ChevronRightIcon, ImageIcon, LoaderIcon, RefreshIcon,
 };
 use crate::components::{Button, ButtonSize, ButtonVariant};
 use crate::display_types::{CandidateTrack, MatchCandidate};
+use crate::floating_ui::Placement;
 use crate::stores::import::PrefetchState;
 use dioxus::prelude::*;
 
@@ -100,14 +102,18 @@ pub fn MatchItemView(
                             class: "w-full h-full object-cover text-transparent",
                         }
                     } else if candidate.cover_fetch_failed {
-                        div {
-                            class: "w-full h-full flex items-center justify-center text-gray-500 hover:text-gray-300 cursor-pointer",
-                            title: "Cover art failed to load. Click to retry.",
-                            onclick: move |e| {
-                                e.stop_propagation();
-                                on_retry_cover.call(());
-                            },
-                            RefreshIcon { class: "w-4 h-4" }
+                        Tooltip {
+                            text: "Cover art failed to load. Click to retry.",
+                            placement: Placement::Top,
+                            nowrap: true,
+                            div {
+                                class: "w-full h-full flex items-center justify-center text-gray-500 hover:text-gray-300 cursor-pointer",
+                                onclick: move |e| {
+                                    e.stop_propagation();
+                                    on_retry_cover.call(());
+                                },
+                                RefreshIcon { class: "w-4 h-4" }
+                            }
                         }
                     } else {
                         div { class: "w-full h-full flex items-center justify-center text-gray-500",

--- a/bae-ui/src/components/import/workflow/release_sidebar.rs
+++ b/bae-ui/src/components/import/workflow/release_sidebar.rs
@@ -127,22 +127,30 @@ pub fn ReleaseSidebarView(
                             LoaderIcon { class: "w-3.5 h-3.5 text-gray-400 animate-spin" }
                         }
                         if detected.is_empty() {
-                            button {
-                                class: "p-1.5 text-gray-400 hover:text-white transition-colors rounded-md hover:bg-white/5",
-                                onclick: move |_| on_add_folder.call(()),
-                                title: "Scan folder",
-                                PlusIcon { class: "w-4 h-4" }
+                            Tooltip {
+                                text: "Scan folder",
+                                placement: Placement::Top,
+                                nowrap: true,
+                                button {
+                                    class: "p-1.5 text-gray-400 hover:text-white transition-colors rounded-md hover:bg-white/5",
+                                    onclick: move |_| on_add_folder.call(()),
+                                    PlusIcon { class: "w-4 h-4" }
+                                }
                             }
                         } else {
-                            button {
-                                id: "{anchor_id}",
-                                class: "p-1.5 text-gray-400 hover:text-white transition-colors rounded-md hover:bg-white/5",
-                                onclick: move |evt| {
-                                    evt.stop_propagation();
-                                    show_menu.set(!show_menu());
-                                },
-                                title: "More",
-                                EllipsisIcon { class: "w-4 h-4" }
+                            Tooltip {
+                                text: "More",
+                                placement: Placement::Top,
+                                nowrap: true,
+                                button {
+                                    id: "{anchor_id}",
+                                    class: "p-1.5 text-gray-400 hover:text-white transition-colors rounded-md hover:bg-white/5",
+                                    onclick: move |evt| {
+                                        evt.stop_propagation();
+                                        show_menu.set(!show_menu());
+                                    },
+                                    EllipsisIcon { class: "w-4 h-4" }
+                                }
                             }
                         }
                     }
@@ -358,14 +366,15 @@ fn CandidateRow(
             }
 
             if is_removable {
-                button {
-                    class: "flex-shrink-0 opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-white rounded transition-opacity",
-                    title: "Remove",
-                    onclick: move |e: MouseEvent| {
-                        e.stop_propagation();
-                        on_remove.call(index);
-                    },
-                    XIcon { class: "w-3.5 h-3.5" }
+                Tooltip { text: "Remove", placement: Placement::Top, nowrap: true,
+                    button {
+                        class: "flex-shrink-0 opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-white rounded transition-opacity",
+                        onclick: move |e: MouseEvent| {
+                            e.stop_propagation();
+                            on_remove.call(index);
+                        },
+                        XIcon { class: "w-3.5 h-3.5" }
+                    }
                 }
             }
         }

--- a/bae-ui/src/components/import/workflow/shared/selected_source.rs
+++ b/bae-ui/src/components/import/workflow/shared/selected_source.rs
@@ -1,6 +1,8 @@
 //! Selected source display view
 
+use crate::components::helpers::Tooltip;
 use crate::components::icons::{FolderIcon, XIcon};
+use crate::floating_ui::Placement;
 use dioxus::prelude::*;
 use std::path::PathBuf;
 
@@ -27,19 +29,27 @@ pub fn SelectedSourceView(
             div { class: "flex items-center justify-between gap-2 px-3 py-2 bg-gray-900/50 rounded",
                 div { class: "flex items-center gap-2 min-w-0",
                     // Folder icon - clickable to reveal in Finder
-                    button {
-                        class: "text-gray-400 hover:text-gray-200 flex-shrink-0 transition-colors",
-                        title: crate::platform::reveal_in_file_manager(),
-                        onclick: move |_| on_reveal.call(()),
-                        FolderIcon { class: "w-4 h-4" }
+                    Tooltip {
+                        text: crate::platform::reveal_in_file_manager().to_string(),
+                        placement: Placement::Top,
+                        nowrap: true,
+                        button {
+                            class: "text-gray-400 hover:text-gray-200 flex-shrink-0 transition-colors",
+                            onclick: move |_| on_reveal.call(()),
+                            FolderIcon { class: "w-4 h-4" }
+                        }
                     }
                     span { class: "text-sm text-gray-100 truncate", {display_name} }
                 }
-                button {
-                    class: "p-1 text-gray-400 hover:text-gray-200 flex-shrink-0 rounded hover:bg-gray-700/50 transition-colors",
-                    title: "Clear selection",
-                    onclick: move |_| on_clear.call(()),
-                    XIcon { class: "w-4 h-4" }
+                Tooltip {
+                    text: "Clear selection",
+                    placement: Placement::Top,
+                    nowrap: true,
+                    button {
+                        class: "p-1 text-gray-400 hover:text-gray-200 flex-shrink-0 rounded hover:bg-gray-700/50 transition-colors",
+                        onclick: move |_| on_clear.call(()),
+                        XIcon { class: "w-4 h-4" }
+                    }
                 }
             }
 

--- a/bae-ui/src/components/imports/dropdown.rs
+++ b/bae-ui/src/components/imports/dropdown.rs
@@ -3,8 +3,10 @@
 //! Pure, props-based content for the imports dropdown.
 //! Positioning and visibility are handled by the Dropdown component in the title bar.
 
+use crate::components::helpers::Tooltip;
 use crate::components::icons::{CheckIcon, DownloadIcon, FileTextIcon, ImageIcon, XIcon};
 use crate::display_types::{ActiveImport, ImportStatus};
+use crate::floating_ui::Placement;
 use dioxus::prelude::*;
 
 /// Content for the imports dropdown: header + items list
@@ -174,14 +176,18 @@ fn ImportItemView(
                 }
 
                 // Dismiss button
-                button {
-                    class: "flex-shrink-0 p-1.5 text-gray-600 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-0 group-hover:opacity-100",
-                    onclick: move |e: Event<MouseData>| {
-                        e.stop_propagation();
-                        on_dismiss.call(import_id_for_dismiss.clone());
-                    },
-                    title: "Dismiss",
-                    XIcon { class: "h-4 w-4" }
+                Tooltip {
+                    text: "Dismiss",
+                    placement: Placement::Top,
+                    nowrap: true,
+                    button {
+                        class: "flex-shrink-0 p-1.5 text-gray-600 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-0 group-hover:opacity-100",
+                        onclick: move |e: Event<MouseData>| {
+                            e.stop_propagation();
+                            on_dismiss.call(import_id_for_dismiss.clone());
+                        },
+                        XIcon { class: "h-4 w-4" }
+                    }
                 }
             }
         }

--- a/bae-ui/src/components/settings/sync.rs
+++ b/bae-ui/src/components/settings/sync.rs
@@ -1,11 +1,13 @@
 //! Sync status and configuration section view
 
+use crate::components::helpers::Tooltip;
 use crate::components::icons::{CheckIcon, CopyIcon};
 use crate::components::settings::cloud_provider::{CloudProviderOption, CloudProviderPicker};
 use crate::components::{
     Button, ButtonSize, ButtonVariant, ChromelessButton, SettingsCard, SettingsSection, TextInput,
     TextInputSize, TextInputType,
 };
+use crate::floating_ui::Placement;
 use crate::stores::config::CloudProvider;
 use crate::stores::{
     DeviceActivityInfo, InviteStatus, Member, MemberRole, ShareInfo, SharedReleaseDisplay,
@@ -169,15 +171,19 @@ pub fn SyncSectionView(
                         span { class: "text-gray-400 font-mono text-sm truncate",
                             {truncate_pubkey(pubkey)}
                         }
-                        ChromelessButton {
-                            class: Some("text-gray-400 hover:text-white transition-colors".to_string()),
-                            title: Some("Copy public key to clipboard".to_string()),
-                            aria_label: Some("Copy public key to clipboard".to_string()),
-                            onclick: handle_copy,
-                            if *copied.read() {
-                                CheckIcon { class: "w-4 h-4 text-green-400" }
-                            } else {
-                                CopyIcon { class: "w-4 h-4" }
+                        Tooltip {
+                            text: "Copy public key to clipboard",
+                            placement: Placement::Top,
+                            nowrap: true,
+                            ChromelessButton {
+                                class: Some("text-gray-400 hover:text-white transition-colors".to_string()),
+                                aria_label: Some("Copy public key to clipboard".to_string()),
+                                onclick: handle_copy,
+                                if *copied.read() {
+                                    CheckIcon { class: "w-4 h-4 text-green-400" }
+                                } else {
+                                    CopyIcon { class: "w-4 h-4" }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Replaced all 10 native HTML `title:` attributes with the custom `Tooltip` component across 7 files in bae-ui
- Each tooltip uses the popover API + floating-ui positioning with a 700ms hover delay, matching existing tooltip behavior elsewhere in the app

## Files changed
- `album_card.rs` - album title truncation tooltip
- `imports/dropdown.rs` - dismiss button
- `import/workflow/release_sidebar.rs` - scan folder, more, and remove buttons
- `import/workflow/folder_import.rs` - folder path in detail header
- `import/workflow/match_item.rs` - cover art retry
- `import/workflow/shared/selected_source.rs` - reveal in file manager and clear selection buttons
- `settings/sync.rs` - copy public key button

## Test plan
- [ ] Hover over album card titles on the library grid -- tooltip appears after 700ms delay
- [ ] Hover over dismiss button in imports dropdown
- [ ] Hover over scan folder / more / remove buttons in import sidebar
- [ ] Hover over folder name in import detail header
- [ ] Hover over failed cover art retry icon in match results
- [ ] Hover over folder icon and clear button in selected source
- [ ] Hover over copy pubkey button in sync settings
- [ ] Verify tooltips position correctly and don't clip at edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)