### PR TITLE
Remove per-release derived encryption keys

### DIFF
--- a/bae-core/migrations/003_encryption_scheme.sql
+++ b/bae-core/migrations/003_encryption_scheme.sql
@@ -1,1 +1,0 @@
-ALTER TABLE release_files ADD COLUMN encryption_scheme TEXT NOT NULL DEFAULT 'master';

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -190,9 +190,6 @@ impl Database {
             file_size: row.get("file_size"),
             content_type: ContentType::from_mime(&row.get::<String, _>("content_type")),
             encryption_nonce: row.get("encryption_nonce"),
-            encryption_scheme: EncryptionScheme::from_db_str(
-                &row.get::<String, _>("encryption_scheme"),
-            ),
             updated_at: DateTime::parse_from_rfc3339(&row.get::<String, _>("_updated_at"))
                 .unwrap()
                 .with_timezone(&Utc),
@@ -1033,8 +1030,8 @@ impl Database {
         sqlx::query(
             r#"
             INSERT INTO release_files (
-                id, release_id, original_filename, file_size, content_type, encryption_nonce, encryption_scheme, _updated_at, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                id, release_id, original_filename, file_size, content_type, encryption_nonce, _updated_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&file.id)
@@ -1043,7 +1040,6 @@ impl Database {
         .bind(file.file_size)
         .bind(file.content_type.as_str())
         .bind(&file.encryption_nonce)
-        .bind(file.encryption_scheme.as_str())
         .bind(file.updated_at.to_rfc3339())
         .bind(file.created_at.to_rfc3339())
         .execute(&mut *conn)
@@ -1153,8 +1149,8 @@ impl Database {
             sqlx::query(
                 r#"
                 INSERT INTO release_files (
-                    id, release_id, original_filename, file_size, content_type, encryption_nonce, encryption_scheme, _updated_at, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    id, release_id, original_filename, file_size, content_type, encryption_nonce, _updated_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
             )
             .bind(&file.id)
@@ -1163,7 +1159,6 @@ impl Database {
             .bind(file.file_size)
             .bind(file.content_type.as_str())
             .bind(&file.encryption_nonce)
-            .bind(file.encryption_scheme.as_str())
             .bind(file.updated_at.to_rfc3339())
             .bind(file.created_at.to_rfc3339())
             .execute(&mut *tx)

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -212,31 +212,6 @@ pub struct DbTrack {
     pub updated_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
 }
-/// Which encryption key was used for a release file.
-/// - `Master`: legacy, encrypted with the library master key directly
-/// - `Derived`: per-release key derived via HKDF from the master key
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum EncryptionScheme {
-    Master,
-    Derived,
-}
-
-impl EncryptionScheme {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            EncryptionScheme::Master => "master",
-            EncryptionScheme::Derived => "derived",
-        }
-    }
-
-    pub fn from_db_str(s: &str) -> Self {
-        match s {
-            "derived" => EncryptionScheme::Derived,
-            _ => EncryptionScheme::Master,
-        }
-    }
-}
-
 /// Physical file belonging to a release
 ///
 /// Stores original file information needed to reconstruct file structure for export
@@ -262,8 +237,6 @@ pub struct DbFile {
     /// Only set when file is encrypted with chunked encryption.
     /// Stored at import time, used during seek to avoid fetching nonce from cloud.
     pub encryption_nonce: Option<Vec<u8>>,
-    /// Which encryption scheme was used: master key directly, or HKDF-derived per-release key.
-    pub encryption_scheme: EncryptionScheme,
     pub updated_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
 }
@@ -593,7 +566,6 @@ impl DbFile {
             file_size,
             content_type,
             encryption_nonce: None,
-            encryption_scheme: EncryptionScheme::Master,
             updated_at: now,
             created_at: now,
         }
@@ -603,12 +575,6 @@ impl DbFile {
     /// The nonce is the first 24 bytes of the encrypted file.
     pub fn with_encryption_nonce(mut self, nonce: Vec<u8>) -> Self {
         self.encryption_nonce = Some(nonce);
-        self
-    }
-
-    /// Set the encryption scheme (master or derived).
-    pub fn with_encryption_scheme(mut self, scheme: EncryptionScheme) -> Self {
-        self.encryption_scheme = scheme;
         self
     }
 

--- a/bae-core/src/playback/track_loader.rs
+++ b/bae-core/src/playback/track_loader.rs
@@ -41,7 +41,7 @@ pub async fn create_shared_release_storage(
         .await
         .map_err(PlaybackError::cloud)?;
     let storage: Arc<dyn CloudStorage> = Arc::new(storage);
-    let encryption = Arc::new(EncryptionService::from_key(shared.release_key));
+    let encryption = Arc::new(EncryptionService::from_key(shared.library_key));
     let storage_key = crate::storage::storage_path(file_id);
 
     Ok(SharedReleaseStorage {

--- a/bae-core/src/sync/push.rs
+++ b/bae-core/src/sync/push.rs
@@ -5,7 +5,7 @@
 //! This module holds the shared types and the schema version constant.
 
 /// Current schema version -- matches the latest migration number.
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// An outgoing changeset ready to be pushed to the sync bucket.
 pub struct OutgoingChangeset {

--- a/bae-core/src/sync/test_helpers.rs
+++ b/bae-core/src/sync/test_helpers.rs
@@ -201,7 +201,6 @@ pub unsafe fn create_synced_schema(db: *mut ffi::sqlite3) {
             file_size INTEGER NOT NULL,
             content_type TEXT NOT NULL,
             encryption_nonce BLOB,
-            encryption_scheme TEXT NOT NULL DEFAULT 'master',
             _updated_at TEXT NOT NULL,
             created_at TEXT NOT NULL,
             FOREIGN KEY (release_id) REFERENCES releases (id) ON DELETE CASCADE


### PR DESCRIPTION
## Summary
- Delete per-release HKDF key derivation (`derive_release_key`, `encrypt_for_release`, `decrypt_for_release`) from `EncryptionService`, keeping `derive_key` which is still used by share tokens
- Remove `EncryptionScheme` enum and `encryption_scheme` column from `DbFile` / `release_files` table (migration 003 deleted)
- Simplify `decrypt_if_needed` to always use the master key
- Share grants now wrap the library key directly; rename `release_key` to `library_key` in `GrantPayload` and `SharedRelease`
- Reduce sync `SCHEMA_VERSION` from 3 to 2

Closes #273

## Test plan
- [x] `cargo clippy -p bae-core -p bae-ui -p bae-desktop -p bae-mocks -- -D warnings` passes
- [x] `cargo test -p bae-core` passes (493 tests)
- [x] Pre-commit hooks (fmt, clippy, tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)