### PR TITLE
Expand entitlements variable before codesign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,14 @@ jobs:
         find "$APP_PATH/Contents/Frameworks" -name "*.dylib" -exec \
           codesign --force --sign "$IDENTITY" --options runtime {} \;
         
+        # Expand $(AppIdentifierPrefix) in entitlements — codesign doesn't expand
+        # Xcode build variables, so the literal string ends up in the binary and
+        # AMFI rejects the launch via launchd.
+        ENTITLEMENTS=$(mktemp)
+        sed "s/\$(AppIdentifierPrefix)/${APPLE_TEAM_ID}./" bae-desktop/bae.entitlements > "$ENTITLEMENTS"
+
         # Finally sign the main app (with entitlements for protected keychain / iCloud sync)
-        codesign --force --sign "$IDENTITY" --options runtime --entitlements bae-desktop/bae.entitlements "$APP_PATH"
+        codesign --force --sign "$IDENTITY" --options runtime --entitlements "$ENTITLEMENTS" "$APP_PATH"
         
         codesign --verify --verbose "$APP_PATH"
 


### PR DESCRIPTION
## Summary
- `codesign` doesn't expand Xcode build variables like `$(AppIdentifierPrefix)` — it embeds the literal string in the binary's entitlements
- AMFI rejects the launch via launchd with error 153 ("Launchd job spawn failed")
- Fix: use `sed` to expand `$(AppIdentifierPrefix)` to `${APPLE_TEAM_ID}.` before passing entitlements to `codesign`

## Test plan
- [ ] Run release workflow
- [ ] Download DMG, drag to Applications
- [ ] Double-click app — should launch without "can't be opened" error
- [ ] Verify entitlements: `codesign -d --entitlements :- /Applications/bae.app` should show expanded team ID, not `$(AppIdentifierPrefix)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)