### PR TITLE
Add iCloud Drive entitlements (#278)

### DIFF
--- a/bae-desktop/bae.entitlements
+++ b/bae-desktop/bae.entitlements
@@ -8,5 +8,13 @@
     <array>
         <string>$(AppIdentifierPrefix)com.fm.bae</string>
     </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.fm.bae</string>
+    </array>
+    <key>com.apple.developer.ubiquity-container-identifiers</key>
+    <array>
+        <string>iCloud.com.fm.bae</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` with `iCloud.com.fm.bae`
- Without these, `detect_icloud_container()` always returns `None` even in signed builds
- **Manual step needed**: Register `iCloud.com.fm.bae` in Apple Developer Portal

Closes #278

## Test plan
- [ ] Register container in Apple Developer Portal
- [ ] Build signed release
- [ ] "Use iCloud Drive" detects the ubiquity container

🤖 Generated with [Claude Code](https://claude.com/claude-code)