### PR TITLE
Embed provisioning profile and set bundle ID to fm.bae.desktop

### DIFF
--- a/bae-desktop/Dioxus.toml
+++ b/bae-desktop/Dioxus.toml
@@ -2,7 +2,7 @@
 name = "bae"
 
 [bundle]
-identifier = "fm.bae"
+identifier = "fm.bae.desktop"
 publisher = "bae"
 
 # Generated from /icon-source.png via:

--- a/bae-desktop/bae.entitlements
+++ b/bae-desktop/bae.entitlements
@@ -6,15 +6,15 @@
     <true/>
     <key>keychain-access-groups</key>
     <array>
-        <string>$(AppIdentifierPrefix)fm.bae</string>
+        <string>$(AppIdentifierPrefix)fm.bae.desktop</string>
     </array>
     <key>com.apple.developer.icloud-container-identifiers</key>
     <array>
-        <string>iCloud.fm.bae</string>
+        <string>iCloud.fm.bae.desktop</string>
     </array>
     <key>com.apple.developer.ubiquity-container-identifiers</key>
     <array>
-        <string>iCloud.fm.bae</string>
+        <string>iCloud.fm.bae.desktop</string>
     </array>
 </dict>
 </plist>

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -65,7 +65,7 @@ fn configure_logging() {
     // Always log to console. In release mode on macOS, also log to Console.app.
     #[cfg(target_os = "macos")]
     if !config::Config::is_dev_mode() {
-        let oslog_layer = tracing_oslog::OsLogger::new("fm.bae", "default");
+        let oslog_layer = tracing_oslog::OsLogger::new("fm.bae.desktop", "default");
 
         tracing_subscriber::registry()
             .with(env_filter)

--- a/bae-desktop/src/media_controls.rs
+++ b/bae-desktop/src/media_controls.rs
@@ -23,7 +23,7 @@ pub fn setup_media_controls(
     let current_state_for_controls = current_state.clone();
     let current_state_for_progress = current_state.clone();
     let config = PlatformConfig {
-        dbus_name: "fm.bae",
+        dbus_name: "fm.bae.desktop",
         display_name: "bae",
         hwnd: None,
     };


### PR DESCRIPTION
## Summary
- Embed base64-encoded provisioning profile into app bundle before codesign (fixes error 153 launch failure)
- Change bundle ID from `com.bae.app` to `fm.bae.desktop` across Dioxus.toml, entitlements, oslog, and dbus
- Update iCloud container IDs to `iCloud.fm.bae.desktop`
- Update keychain access group to `fm.bae.desktop`

Closes #281

## Test plan
- [ ] Add `PROVISIONING_PROFILE` secret with base64-encoded profile for `fm.bae.desktop`
- [ ] Trigger release workflow
- [ ] Verify app launches from Finder (no error 153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)