### PR TITLE
Trim sync description on home page

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -78,7 +78,7 @@ import { Image } from 'astro:assets';
 			</div>
 			<div class="concept">
 				<h2>Sync across devices</h2>
-				<p>Connect a cloud provider. bae creates an encrypted cloud home that holds your files, metadata, and artwork. Changes sync automatically.</p>
+				<p>Connect a cloud provider. bae creates an encrypted cloud home. Changes sync automatically.</p>
 			</div>
 			<div class="concept">
 				<h2>Share tracks</h2>


### PR DESCRIPTION
Removes 'that holds your files, metadata, and artwork' from the sync concept description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)