### PR TITLE
Fix iCloud container identifier to match entitlements

### DIFF
--- a/bae-desktop/src/ui/app_service.rs
+++ b/bae-desktop/src/ui/app_service.rs
@@ -3578,7 +3578,7 @@ fn detect_icloud_container() -> Option<std::path::PathBuf> {
 
         // Create NSString for the container identifier (needs null-terminated C string)
         let nsstring_class = Class::get("NSString")?;
-        let container_cstr = std::ffi::CString::new("iCloud.fm.bae").ok()?;
+        let container_cstr = std::ffi::CString::new("iCloud.fm.bae.desktop").ok()?;
         let container_nsstring: *mut Object = msg_send![
             nsstring_class,
             stringWithUTF8String: container_cstr.as_ptr()


### PR DESCRIPTION
The container identifier in `detect_icloud_container()` was `iCloud.fm.bae` but the entitlements file specifies `iCloud.fm.bae.desktop`. Without matching, `NSFileManager` returns nil and iCloud appears unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)