### PR TITLE
Add S3 key prefix support for shared buckets

### DIFF
--- a/bae-core/src/cloud_home/mod.rs
+++ b/bae-core/src/cloud_home/mod.rs
@@ -34,6 +34,8 @@ pub enum JoinInfo {
         endpoint: Option<String>,
         access_key: String,
         secret_key: String,
+        #[serde(default)]
+        key_prefix: Option<String>,
     },
     GoogleDrive {
         folder_id: String,
@@ -125,7 +127,10 @@ pub async fn create_cloud_home(
                 }
             };
 
-            let s3 = s3::S3CloudHome::new(bucket, region, endpoint, access_key, secret_key).await?;
+            let key_prefix = config.cloud_home_s3_key_prefix.clone();
+            let s3 =
+                s3::S3CloudHome::new(bucket, region, endpoint, access_key, secret_key, key_prefix)
+                    .await?;
             Ok(Box::new(s3))
         }
         Some(CloudProvider::GoogleDrive) => {

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -283,6 +283,9 @@ pub struct ConfigYaml {
     /// S3 endpoint for cloud home (for S3-compatible services)
     #[serde(default)]
     pub cloud_home_s3_endpoint: Option<String>,
+    /// S3 key prefix for cloud home (scopes keys under a path, e.g. "libraries/{id}")
+    #[serde(default)]
+    pub cloud_home_s3_key_prefix: Option<String>,
     /// Google Drive folder ID for the cloud home
     #[serde(default)]
     pub cloud_home_google_drive_folder_id: Option<String>,
@@ -378,6 +381,8 @@ pub struct Config {
     pub cloud_home_s3_region: Option<String>,
     /// S3 endpoint for cloud home (for S3-compatible services)
     pub cloud_home_s3_endpoint: Option<String>,
+    /// S3 key prefix for cloud home (scopes keys under a path)
+    pub cloud_home_s3_key_prefix: Option<String>,
     /// Google Drive folder ID for the cloud home
     pub cloud_home_google_drive_folder_id: Option<String>,
     /// Dropbox folder path for the cloud home
@@ -466,6 +471,13 @@ impl Config {
             .filter(|s| !s.is_empty())
         {
             config.cloud_home_s3_endpoint = Some(v);
+        }
+
+        if let Some(v) = std::env::var("BAE_CLOUD_HOME_S3_KEY_PREFIX")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            config.cloud_home_s3_key_prefix = Some(v);
         }
 
         if let Some(v) = std::env::var("BAE_SHARE_BASE_URL")
@@ -572,6 +584,7 @@ impl Config {
             cloud_home_s3_bucket: yaml_config.cloud_home_s3_bucket,
             cloud_home_s3_region: yaml_config.cloud_home_s3_region,
             cloud_home_s3_endpoint: yaml_config.cloud_home_s3_endpoint,
+            cloud_home_s3_key_prefix: yaml_config.cloud_home_s3_key_prefix,
             cloud_home_google_drive_folder_id: yaml_config.cloud_home_google_drive_folder_id,
             cloud_home_dropbox_folder_path: yaml_config.cloud_home_dropbox_folder_path,
             cloud_home_onedrive_drive_id: yaml_config.cloud_home_onedrive_drive_id,
@@ -662,6 +675,7 @@ impl Config {
             cloud_home_s3_bucket: self.cloud_home_s3_bucket.clone(),
             cloud_home_s3_region: self.cloud_home_s3_region.clone(),
             cloud_home_s3_endpoint: self.cloud_home_s3_endpoint.clone(),
+            cloud_home_s3_key_prefix: self.cloud_home_s3_key_prefix.clone(),
             cloud_home_google_drive_folder_id: self.cloud_home_google_drive_folder_id.clone(),
             cloud_home_dropbox_folder_path: self.cloud_home_dropbox_folder_path.clone(),
             cloud_home_onedrive_drive_id: self.cloud_home_onedrive_drive_id.clone(),
@@ -721,6 +735,7 @@ impl Config {
             cloud_home_s3_bucket: None,
             cloud_home_s3_region: None,
             cloud_home_s3_endpoint: None,
+            cloud_home_s3_key_prefix: None,
             cloud_home_google_drive_folder_id: None,
             cloud_home_dropbox_folder_path: None,
             cloud_home_onedrive_drive_id: None,
@@ -908,6 +923,7 @@ mod tests {
             cloud_home_s3_bucket: None,
             cloud_home_s3_region: None,
             cloud_home_s3_endpoint: None,
+            cloud_home_s3_key_prefix: None,
             cloud_home_google_drive_folder_id: None,
             cloud_home_dropbox_folder_path: None,
             cloud_home_onedrive_drive_id: None,

--- a/bae-core/src/join_code.rs
+++ b/bae-core/src/join_code.rs
@@ -47,6 +47,7 @@ mod tests {
                 endpoint: None,
                 access_key: "AKIAEXAMPLE".into(),
                 secret_key: "secret123".into(),
+                key_prefix: None,
             },
             owner_pubkey: "deadbeef".into(),
         };
@@ -62,12 +63,14 @@ mod tests {
                 endpoint,
                 access_key,
                 secret_key,
+                key_prefix,
             } => {
                 assert_eq!(bucket, "my-bucket");
                 assert_eq!(region, "us-east-1");
                 assert_eq!(endpoint, None);
                 assert_eq!(access_key, "AKIAEXAMPLE");
                 assert_eq!(secret_key, "secret123");
+                assert_eq!(key_prefix, None);
             }
             _ => panic!("expected S3 variant"),
         }
@@ -84,6 +87,7 @@ mod tests {
                 endpoint: Some("https://s3.example.com".into()),
                 access_key: "ak".into(),
                 secret_key: "sk".into(),
+                key_prefix: None,
             },
             owner_pubkey: "cafebabe".into(),
         };

--- a/bae-core/src/sync/invite.rs
+++ b/bae-core/src/sync/invite.rs
@@ -264,6 +264,7 @@ mod tests {
                 endpoint: None,
                 access_key: "test-access-key".to_string(),
                 secret_key: "test-secret-key".to_string(),
+                key_prefix: None,
             })
         }
         async fn revoke_access(&self, _member_id: &str) -> Result<(), CloudHomeError> {

--- a/bae-desktop/src/main.rs
+++ b/bae-desktop/src/main.rs
@@ -439,12 +439,14 @@ async fn create_sync_handle(
         _ => return None,
     };
 
+    let key_prefix = config.cloud_home_s3_key_prefix.clone();
     let cloud_home = match S3CloudHome::new(
         bucket.clone(),
         region.clone(),
         endpoint,
         access_key,
         secret_key,
+        key_prefix,
     )
     .await
     {

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -374,6 +374,7 @@ async fn do_restore(
         cloud_home_s3_bucket: None,
         cloud_home_s3_region: None,
         cloud_home_s3_endpoint: None,
+        cloud_home_s3_key_prefix: None,
         cloud_home_google_drive_folder_id: None,
         cloud_home_dropbox_folder_path: None,
         cloud_home_onedrive_drive_id: None,

--- a/bae-server/src/main.rs
+++ b/bae-server/src/main.rs
@@ -54,6 +54,10 @@ struct Args {
     #[arg(long, env = "BAE_S3_SECRET_KEY")]
     s3_secret_key: String,
 
+    /// S3 key prefix (scopes all keys under this path within the bucket).
+    #[arg(long, env = "BAE_S3_KEY_PREFIX")]
+    s3_key_prefix: Option<String>,
+
     /// Port for the Subsonic API server.
     #[arg(long, default_value = "4533", env = "BAE_PORT")]
     port: u16,
@@ -143,6 +147,7 @@ async fn main() {
         args.s3_endpoint.clone(),
         args.s3_access_key.clone(),
         args.s3_secret_key.clone(),
+        args.s3_key_prefix.clone(),
     )
     .await
     .unwrap_or_else(|e| {


### PR DESCRIPTION
## Summary
- Adds `key_prefix: Option<String>` to `S3CloudHome` — all keys scoped under the prefix when set, stripped on list
- Adds `key_prefix` to `JoinInfo::S3` (serde-default for backwards compat with existing invite codes)
- Adds `cloud_home_s3_key_prefix` to Config/ConfigYaml, wired through all construction sites
- bae-server gets `BAE_S3_KEY_PREFIX` / `--s3-key-prefix` CLI arg
- `key_prefix: None` preserves current behavior (no prefix)

Also solves #287 (multiple libraries on one S3 bucket).

## Test plan
- [x] `cargo clippy` clean across all crates
- [x] `cargo test -p bae-core` — all 488 tests pass including 3 new `apply_prefix` tests
- [ ] Manual: configure two libraries with different prefixes on the same bucket, verify isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)