### PR TITLE
Add background sync loop and health endpoint to bae-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,8 +947,10 @@ version = "0.0.0-dev"
 dependencies = [
  "axum 0.7.9",
  "bae-core",
+ "chrono",
  "clap",
  "libsqlite3-sys",
+ "serde",
  "tokio",
  "tower-http 0.5.2",
  "tracing",

--- a/bae-server/Cargo.toml
+++ b/bae-server/Cargo.toml
@@ -10,8 +10,10 @@ path = "src/main.rs"
 
 [dependencies]
 bae-core = { path = "../bae-core" }
+chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
 libsqlite3-sys = { version = "0.30.1", features = ["session", "bundled"] }
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 axum = "0.7"
 tower-http = { version = "0.5", features = ["fs"] }


### PR DESCRIPTION
## Summary
- bae-server now re-syncs periodically instead of only at boot (configurable via `BAE_SYNC_INTERVAL`, default 30s)
- SQLite opened in WAL mode so the sync writer and Subsonic API reader operate concurrently
- Sync loop runs on a dedicated OS thread with single-threaded tokio runtime (avoids `Send` constraint on raw sqlite3 pointer held across await points)
- `GET /health` endpoint returns JSON with `last_sync` timestamp and `changesets_applied` count
- Image download logging quieted for sync cycles (only logs when images are actually downloaded or fail)

## Test plan
- [x] `cargo clippy -p bae-server` clean
- [ ] Manual: start bae-server, push a changeset from bae-desktop, verify it appears in Subsonic API within ~30s
- [ ] Manual: `curl /health` returns valid JSON with recent `last_sync`
- [ ] Manual: set `BAE_SYNC_INTERVAL=5`, verify faster sync cycles in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)