### PR TITLE
Add HttpCloudHome backend for syncing through bae-server

### DIFF
--- a/bae-core/src/cloud_home/http.rs
+++ b/bae-core/src/cloud_home/http.rs
@@ -1,0 +1,348 @@
+//! HTTP-backed `CloudHome` implementation.
+//!
+//! Talks to a bae-server's `/cloud/*` write proxy endpoints.
+//! Requests are authenticated with Ed25519 signatures.
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::keys::UserKeypair;
+
+use super::{CloudHome, CloudHomeError, JoinInfo};
+
+/// HTTP-backed cloud home that proxies through a bae-server.
+pub struct HttpCloudHome {
+    base_url: String,
+    keypair: UserKeypair,
+    client: Client,
+}
+
+impl HttpCloudHome {
+    pub fn new(base_url: String, keypair: UserKeypair) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            keypair,
+            client: Client::new(),
+        }
+    }
+
+    /// Build the three auth headers for a request.
+    fn sign_request(&self, method: &str, path: &str) -> [(&'static str, String); 3] {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let message = format!("{}\n{}\n{}", method, path, timestamp);
+        let signature = self.keypair.sign(message.as_bytes());
+
+        [
+            ("X-Bae-Pubkey", hex::encode(self.keypair.public_key)),
+            ("X-Bae-Timestamp", timestamp.to_string()),
+            ("X-Bae-Signature", hex::encode(signature)),
+        ]
+    }
+
+    /// Map an HTTP response to a CloudHomeError for non-success status codes.
+    async fn map_error(key: &str, resp: reqwest::Response) -> CloudHomeError {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            CloudHomeError::NotFound(key.to_string())
+        } else if status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+        {
+            CloudHomeError::Storage(format!("unauthorized: {body}"))
+        } else {
+            CloudHomeError::Storage(format!("{status}: {body}"))
+        }
+    }
+}
+
+#[async_trait]
+impl CloudHome for HttpCloudHome {
+    async fn write(&self, key: &str, data: Vec<u8>) -> Result<(), CloudHomeError> {
+        let path = format!("/cloud/{key}");
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.sign_request("PUT", &path);
+
+        let resp = self
+            .client
+            .put(&url)
+            .header(headers[0].0, &headers[0].1)
+            .header(headers[1].0, &headers[1].1)
+            .header(headers[2].0, &headers[2].1)
+            .body(data)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("write {key}: {e}")))?;
+
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(Self::map_error(key, resp).await)
+        }
+    }
+
+    async fn read(&self, key: &str) -> Result<Vec<u8>, CloudHomeError> {
+        let path = format!("/cloud/{key}");
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.sign_request("GET", &path);
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(headers[0].0, &headers[0].1)
+            .header(headers[1].0, &headers[1].1)
+            .header(headers[2].0, &headers[2].1)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("read {key}: {e}")))?;
+
+        if resp.status().is_success() {
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| CloudHomeError::Storage(format!("read body {key}: {e}")))?;
+            Ok(bytes.to_vec())
+        } else {
+            Err(Self::map_error(key, resp).await)
+        }
+    }
+
+    async fn read_range(&self, key: &str, start: u64, end: u64) -> Result<Vec<u8>, CloudHomeError> {
+        let path = format!("/cloud/{key}");
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.sign_request("GET", &path);
+        let range_value = format!("bytes={}-{}", start, end.saturating_sub(1));
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(headers[0].0, &headers[0].1)
+            .header(headers[1].0, &headers[1].1)
+            .header(headers[2].0, &headers[2].1)
+            .header("Range", &range_value)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("read_range {key}: {e}")))?;
+
+        if resp.status().is_success() {
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| CloudHomeError::Storage(format!("read_range body {key}: {e}")))?;
+            Ok(bytes.to_vec())
+        } else {
+            Err(Self::map_error(key, resp).await)
+        }
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, CloudHomeError> {
+        let url = format!(
+            "{}/cloud?prefix={}",
+            self.base_url,
+            urlencoding::encode(prefix)
+        );
+        let headers = self.sign_request("GET", "/cloud");
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(headers[0].0, &headers[0].1)
+            .header(headers[1].0, &headers[1].1)
+            .header(headers[2].0, &headers[2].1)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("list {prefix}: {e}")))?;
+
+        if resp.status().is_success() {
+            let keys: Vec<String> = resp
+                .json()
+                .await
+                .map_err(|e| CloudHomeError::Storage(format!("list parse {prefix}: {e}")))?;
+            Ok(keys)
+        } else {
+            Err(Self::map_error(prefix, resp).await)
+        }
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), CloudHomeError> {
+        let path = format!("/cloud/{key}");
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.sign_request("DELETE", &path);
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(headers[0].0, &headers[0].1)
+            .header(headers[1].0, &headers[1].1)
+            .header(headers[2].0, &headers[2].1)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("delete {key}: {e}")))?;
+
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(Self::map_error(key, resp).await)
+        }
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, CloudHomeError> {
+        let path = format!("/cloud/{key}");
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.sign_request("HEAD", &path);
+
+        let resp = self
+            .client
+            .head(&url)
+            .header(headers[0].0, &headers[0].1)
+            .header(headers[1].0, &headers[1].1)
+            .header(headers[2].0, &headers[2].1)
+            .send()
+            .await
+            .map_err(|e| CloudHomeError::Storage(format!("exists {key}: {e}")))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            Ok(false)
+        } else if resp.status().is_success() {
+            Ok(true)
+        } else {
+            Err(Self::map_error(key, resp).await)
+        }
+    }
+
+    async fn grant_access(&self, _member_id: &str) -> Result<JoinInfo, CloudHomeError> {
+        Err(CloudHomeError::Storage(
+            "access is managed by the server".to_string(),
+        ))
+    }
+
+    async fn revoke_access(&self, _member_id: &str) -> Result<(), CloudHomeError> {
+        Err(CloudHomeError::Storage(
+            "access is managed by the server".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keys::{verify_signature, UserKeypair};
+
+    /// Helper to create a keypair for testing without going through KeyService.
+    fn test_keypair() -> UserKeypair {
+        crate::encryption::ensure_sodium_init();
+        let mut pk = [0u8; crate::sodium_ffi::SIGN_PUBLICKEYBYTES];
+        let mut sk = [0u8; crate::sodium_ffi::SIGN_SECRETKEYBYTES];
+        let ret = unsafe {
+            crate::sodium_ffi::crypto_sign_ed25519_keypair(pk.as_mut_ptr(), sk.as_mut_ptr())
+        };
+        assert_eq!(ret, 0);
+        UserKeypair {
+            signing_key: sk,
+            public_key: pk,
+        }
+    }
+
+    #[test]
+    fn sign_request_produces_three_headers() {
+        let kp = test_keypair();
+        let cloud_home = HttpCloudHome::new("https://example.com".to_string(), kp);
+        let headers = cloud_home.sign_request("PUT", "/cloud/changes/dev1/42.enc");
+
+        assert_eq!(headers[0].0, "X-Bae-Pubkey");
+        assert_eq!(headers[1].0, "X-Bae-Timestamp");
+        assert_eq!(headers[2].0, "X-Bae-Signature");
+
+        // Pubkey is hex-encoded 32-byte key = 64 hex chars
+        assert_eq!(headers[0].1.len(), 64);
+
+        // Timestamp is a valid u64
+        let ts: u64 = headers[1].1.parse().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(ts.abs_diff(now) < 5);
+
+        // Signature is hex-encoded 64-byte signature = 128 hex chars
+        assert_eq!(headers[2].1.len(), 128);
+    }
+
+    #[test]
+    fn sign_request_signature_verifies() {
+        let kp = test_keypair();
+        let cloud_home = HttpCloudHome::new("https://example.com".to_string(), kp.clone());
+        let headers = cloud_home.sign_request("GET", "/cloud/some/key");
+
+        let message = format!("GET\n/cloud/some/key\n{}", headers[1].1);
+        let sig_bytes: [u8; crate::sodium_ffi::SIGN_BYTES] =
+            hex::decode(&headers[2].1).unwrap().try_into().unwrap();
+
+        assert!(verify_signature(
+            &sig_bytes,
+            message.as_bytes(),
+            &kp.public_key
+        ));
+    }
+
+    #[test]
+    fn sign_request_different_methods_produce_different_signatures() {
+        let kp = test_keypair();
+        let cloud_home = HttpCloudHome::new("https://example.com".to_string(), kp);
+
+        let h1 = cloud_home.sign_request("GET", "/cloud/key");
+        let h2 = cloud_home.sign_request("PUT", "/cloud/key");
+
+        // Same timestamp is unlikely but possible; signatures should still differ
+        // because the method is part of the signed message.
+        // We can't guarantee different timestamps, but we can check the signatures
+        // are produced (non-empty).
+        assert_eq!(h1[2].1.len(), 128);
+        assert_eq!(h2[2].1.len(), 128);
+    }
+
+    #[test]
+    fn base_url_trailing_slash_stripped() {
+        let kp = test_keypair();
+        let cloud_home = HttpCloudHome::new("https://example.com/".to_string(), kp);
+        assert_eq!(cloud_home.base_url, "https://example.com");
+    }
+
+    #[test]
+    fn grant_access_returns_error() {
+        let kp = test_keypair();
+        let cloud_home = HttpCloudHome::new("https://example.com".to_string(), kp);
+
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(cloud_home.grant_access("some-member"));
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("access is managed by the server"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn revoke_access_returns_error() {
+        let kp = test_keypair();
+        let cloud_home = HttpCloudHome::new("https://example.com".to_string(), kp);
+
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(cloud_home.revoke_access("some-member"));
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("access is managed by the server"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -186,6 +186,7 @@ pub enum CloudProvider {
     GoogleDrive,
     Dropbox,
     OneDrive,
+    BaeServer,
 }
 
 /// Configuration errors
@@ -301,6 +302,9 @@ pub struct ConfigYaml {
     /// iCloud Drive ubiquity container path for cloud home
     #[serde(default)]
     pub cloud_home_icloud_container_path: Option<String>,
+    /// bae-server URL for cloud home (e.g. "https://alice.bae.fm")
+    #[serde(default)]
+    pub cloud_home_bae_server_url: Option<String>,
 
     /// Base URL for share links (e.g. "https://listen.example.com")
     #[serde(default)]
@@ -393,6 +397,8 @@ pub struct Config {
     pub cloud_home_onedrive_folder_id: Option<String>,
     /// iCloud Drive ubiquity container path for cloud home
     pub cloud_home_icloud_container_path: Option<String>,
+    /// bae-server URL for cloud home
+    pub cloud_home_bae_server_url: Option<String>,
     /// Base URL for share links (e.g. "https://listen.example.com")
     pub share_base_url: Option<String>,
     /// Default expiry for share links in days (None = never expires)
@@ -478,6 +484,13 @@ impl Config {
             .filter(|s| !s.is_empty())
         {
             config.cloud_home_s3_key_prefix = Some(v);
+        }
+
+        if let Some(v) = std::env::var("BAE_CLOUD_HOME_BAE_SERVER_URL")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            config.cloud_home_bae_server_url = Some(v);
         }
 
         if let Some(v) = std::env::var("BAE_SHARE_BASE_URL")
@@ -590,6 +603,7 @@ impl Config {
             cloud_home_onedrive_drive_id: yaml_config.cloud_home_onedrive_drive_id,
             cloud_home_onedrive_folder_id: yaml_config.cloud_home_onedrive_folder_id,
             cloud_home_icloud_container_path: yaml_config.cloud_home_icloud_container_path,
+            cloud_home_bae_server_url: yaml_config.cloud_home_bae_server_url,
             share_base_url: yaml_config.share_base_url,
             share_default_expiry_days: yaml_config.share_default_expiry_days,
             share_signing_key_version: yaml_config.share_signing_key_version,
@@ -625,6 +639,7 @@ impl Config {
                     && has_oauth
             }
             Some(CloudProvider::ICloud) => self.cloud_home_icloud_container_path.is_some(),
+            Some(CloudProvider::BaeServer) => self.cloud_home_bae_server_url.is_some(),
             None => {
                 // Backwards compat: check S3 fields directly (pre-cloud_provider configs)
                 self.cloud_home_s3_bucket.is_some() && self.cloud_home_s3_region.is_some() && has_s3
@@ -681,6 +696,7 @@ impl Config {
             cloud_home_onedrive_drive_id: self.cloud_home_onedrive_drive_id.clone(),
             cloud_home_onedrive_folder_id: self.cloud_home_onedrive_folder_id.clone(),
             cloud_home_icloud_container_path: self.cloud_home_icloud_container_path.clone(),
+            cloud_home_bae_server_url: self.cloud_home_bae_server_url.clone(),
             share_base_url: self.share_base_url.clone(),
             share_default_expiry_days: self.share_default_expiry_days,
             share_signing_key_version: self.share_signing_key_version,
@@ -741,6 +757,7 @@ impl Config {
             cloud_home_onedrive_drive_id: None,
             cloud_home_onedrive_folder_id: None,
             cloud_home_icloud_container_path: None,
+            cloud_home_bae_server_url: None,
             share_base_url: None,
             share_default_expiry_days: None,
             share_signing_key_version: 1,
@@ -929,6 +946,7 @@ mod tests {
             cloud_home_onedrive_drive_id: None,
             cloud_home_onedrive_folder_id: None,
             cloud_home_icloud_container_path: None,
+            cloud_home_bae_server_url: None,
             share_base_url: None,
             share_default_expiry_days: None,
             share_signing_key_version: 1,

--- a/bae-desktop/src/ui/app_service.rs
+++ b/bae-desktop/src/ui/app_service.rs
@@ -572,6 +572,9 @@ impl AppService {
                 bae_core::config::CloudProvider::OneDrive => {
                     bae_ui::stores::config::CloudProvider::OneDrive
                 }
+                bae_core::config::CloudProvider::BaeServer => {
+                    bae_ui::stores::config::CloudProvider::BaeServer
+                }
             });
             cs.cloud_account_display = if matches!(
                 config.cloud_provider,

--- a/bae-desktop/src/ui/components/settings/library.rs
+++ b/bae-desktop/src/ui/components/settings/library.rs
@@ -477,6 +477,7 @@ fn cloud_home_display(join_info: &JoinInfo) -> String {
         JoinInfo::GoogleDrive { .. } => "Google Drive".to_string(),
         JoinInfo::Dropbox { .. } => "Dropbox".to_string(),
         JoinInfo::OneDrive { .. } => "OneDrive".to_string(),
+        JoinInfo::BaeServer { url } => format!("bae server ({url})"),
     }
 }
 
@@ -720,6 +721,7 @@ async fn bootstrap_library(
         cloud_home_onedrive_drive_id: None,
         cloud_home_onedrive_folder_id: None,
         cloud_home_icloud_container_path: None,
+        cloud_home_bae_server_url: None,
         share_base_url: None,
         share_default_expiry_days: None,
         share_signing_key_version: 1,

--- a/bae-desktop/src/ui/components/welcome.rs
+++ b/bae-desktop/src/ui/components/welcome.rs
@@ -380,6 +380,7 @@ async fn do_restore(
         cloud_home_onedrive_drive_id: None,
         cloud_home_onedrive_folder_id: None,
         cloud_home_icloud_container_path: None,
+        cloud_home_bae_server_url: None,
         share_base_url: None,
         share_default_expiry_days: None,
         share_signing_key_version: 1,

--- a/bae-ui/src/stores/config.rs
+++ b/bae-ui/src/stores/config.rs
@@ -10,6 +10,7 @@ pub enum CloudProvider {
     GoogleDrive,
     Dropbox,
     OneDrive,
+    BaeServer,
 }
 
 /// Application configuration state


### PR DESCRIPTION
## Summary
- New `HttpCloudHome` backend in bae-core that implements `CloudHome` by calling bae-server's `/cloud/*` proxy endpoints
- Ed25519 request signing (same auth scheme the server verifies): `X-Bae-Pubkey`, `X-Bae-Timestamp`, `X-Bae-Signature`
- New `CloudProvider::BaeServer` variant and `cloud_home_bae_server_url` config field
- New `JoinInfo::BaeServer { url }` variant
- bae-desktop can now select "bae server" as a cloud home (config-only for now, no UI picker yet)

Depends on #294 (write proxy endpoints).

## Test plan
- [x] `cargo clippy` clean across bae-core, bae-desktop, bae-ui, bae-mocks
- [x] `cargo test -p bae-core` — all tests pass including 6 new HttpCloudHome tests
- [x] Auth protocol verified correct against server's `verify_auth` (message format, hex encoding, timestamp)
- [ ] Manual: configure `cloud_home_bae_server_url` in config.yaml, verify sync through bae-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)