### PR TITLE
AAudio: drop the unreachable granted-format warning

### DIFF
--- a/bae-core/src/playback/aaudio_output.rs
+++ b/bae-core/src/playback/aaudio_output.rs
@@ -47,9 +47,8 @@ impl AAudioOutput {
 }
 
 /// Build and start an AAudio output stream for the given format, logging the
-/// rate and channel count AAudio actually granted (which can differ from the
-/// request). Called on the writer thread at startup and again to recover from a
-/// disconnect/route change.
+/// rate and channel count the stream actually opened with. Called on the writer
+/// thread at startup and again to recover from a disconnect/route change.
 ///
 /// Uses the default performance mode, not `LowLatency`: a music player wants the
 /// normal mixer path, which honors the requested sample rate and resamples to the
@@ -68,25 +67,11 @@ fn open_output_stream(sample_rate: u32, channels: u32) -> Result<NdkAudioStream,
         .open_stream()?;
     stream.request_start()?;
 
-    let granted_rate = stream.sample_rate() as u32;
-    let granted_channels = stream.channel_count() as u32;
-    if granted_rate != sample_rate || granted_channels != channels {
-        warn!(
-            requested_rate = sample_rate,
-            requested_channels = channels,
-            granted_rate,
-            granted_channels,
-            "AAudio granted a different format than requested; the sink feeds the \
-             requested format, so playback will be wrong until it resamples to the \
-             granted format"
-        );
-    } else {
-        info!(
-            sample_rate = granted_rate,
-            channels = granted_channels,
-            "AAudio output stream opened"
-        );
-    }
+    info!(
+        sample_rate = stream.sample_rate() as u32,
+        channels = stream.channel_count() as u32,
+        "AAudio output stream opened"
+    );
     Ok(stream)
 }
 


### PR DESCRIPTION
The Android output sink opens its AAudio stream in the default performance mode, which forces AAudio onto the legacy AudioTrack path. On that path an explicitly requested sample rate and channel count are honored — AudioFlinger inserts a resampler down to the device's rate beneath the app — or the open fails outright; AAudio never silently substitutes a different format. `open_output_stream` nonetheless read the granted rate/channels back and, on any mismatch, warned that "playback will be wrong until it resamples to the granted format" before playing anyway. That branch could never fire on this path, and its message was backwards on top of that: it told the sink to resample when the framework already does. This removes the dead branch and keeps one info log of the configuration the stream actually opened with.

The contract was confirmed against three sources before cutting it: the AAudio NDK guide ("if you specified sample format, sample rate, or samples per frame they will not change"), the AAudio.h header ("if an exact value is specified then an opened stream will use that value ... if a stream cannot be opened with the specified value then the open will fail"), and an AOSP frameworks/av trace — a non-low-latency performance mode forces `allowMMap=false`, the legacy `AudioStreamTrack` passes the requested rate straight into `AudioTrack`, and `createTrack_l` only overrides the rate when it is left unspecified (0).

## Test plan
- [x] Android arm64-v8a cross-compile of bae-bridge (compiles the changed, android-gated file) — passes, no new warnings.