### PR TITLE
Android: don't resume a user-paused stream when audio focus returns

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,6 +80,12 @@ jobs:
       # the Kotlin bindings, and stages the .so files into the app's jniLibs.
       run: ./bae-bridge/build-android.sh
 
+    - name: Run app unit tests
+      # Robolectric/JVM tests (no device) over the app's playback and reducer
+      # logic — including the audio-focus resume policy. Needs the generated
+      # bindings from the cross-compile step above to compile the test sources.
+      run: cd bae-android && ./gradlew testDebugUnitTest --no-daemon
+
     - name: Assemble debug APK
       # Compiles the Kotlin app against the generated bindings and staged .so's,
       # catching binding drift on top of the Rust cross-compile.

--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -319,18 +319,19 @@ class BaeCorePlayer(
                     .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
                     .build(),
             )
-            .setOnAudioFocusChangeListener { focusChange ->
-                when (focusChange) {
-                    AudioManager.AUDIOFOCUS_LOSS,
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK,
-                    -> appHandle.pause()
-                    AudioManager.AUDIOFOCUS_GAIN -> appHandle.resume()
-                }
-            }
+            .setOnAudioFocusChangeListener(::onAudioFocusChange)
             .build()
 
     private var hasFocus: Boolean = false
+
+    /**
+     * Whether a transient focus loss paused *active* playback, so the matching
+     * [AudioManager.AUDIOFOCUS_GAIN] should resume it. Left false when the loss
+     * lands on an already-paused stream (e.g. dictation grabbing focus over a
+     * track the user paused), so regaining focus never resumes a stream the user
+     * stopped. Cleared on an explicit user pause.
+     */
+    private var resumeOnFocusGain: Boolean = false
 
     private val becomingNoisyReceiver = object : BroadcastReceiver() {
         override fun onReceive(c: Context?, intent: Intent?) {
@@ -627,7 +628,14 @@ class BaeCorePlayer(
     // ── Transport commands (forward to core; no local state change) ──────────
 
     override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
-        if (playWhenReady) appHandle.resume() else appHandle.pause()
+        if (playWhenReady) {
+            appHandle.resume()
+        } else {
+            // An explicit user pause must survive a later focus regain (e.g. a
+            // dictation session ending), so disarm any transient-loss resume.
+            resumeOnFocusGain = false
+            appHandle.pause()
+        }
         return Futures.immediateVoidFuture()
     }
 
@@ -737,6 +745,35 @@ class BaeCorePlayer(
     }
 
     // ── Audio focus ──────────────────────────────────────────────────────
+
+    /**
+     * React to a system audio-focus change. Any loss pauses playback. A
+     * *transient* loss (dictation, a navigation prompt, a notification chime)
+     * arms [resumeOnFocusGain] only when it interrupted active playback, so the
+     * matching [AudioManager.AUDIOFOCUS_GAIN] resumes a stream the loss itself
+     * paused — but not one the user had already paused, which would otherwise
+     * restart music the moment the interrupting app released focus. A permanent
+     * loss never auto-resumes.
+     */
+    internal fun onAudioFocusChange(focusChange: Int) {
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_LOSS -> {
+                resumeOnFocusGain = false
+                appHandle.pause()
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK,
+            -> {
+                resumeOnFocusGain = _isPlaying.value
+                appHandle.pause()
+            }
+            AudioManager.AUDIOFOCUS_GAIN ->
+                if (resumeOnFocusGain) {
+                    resumeOnFocusGain = false
+                    appHandle.resume()
+                }
+        }
+    }
 
     private fun requestFocus() {
         if (hasFocus) return

--- a/bae-android/app/src/test/java/fm/bae/app/playback/AudioFocusResumeTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/AudioFocusResumeTest.kt
@@ -1,0 +1,115 @@
+package fm.bae.app.playback
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Looper
+import fm.bae.app.data.Library
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Audio-focus pause/resume policy. A transient focus loss (a dictation session,
+ * a navigation prompt) pauses playback, and the matching regain resumes it — but
+ * only when the loss interrupted *active* playback. A loss that arrives over a
+ * stream the user already paused must not resume on regain, or toggling
+ * dictation over a paused track would restart music the user had stopped.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class AudioFocusResumeTest {
+    private fun player(context: Context, handle: FakeAppHandle): BaeCorePlayer =
+        BaeCorePlayer(
+            applicationLooper = Looper.getMainLooper(),
+            appHandle = handle,
+            library = Library(handle),
+            context = context,
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+            isAppForeground = { false },
+        )
+
+    private fun BaeCorePlayer.startPlaying() =
+        onPlaying("t1", "Track Title", "Artist Name", "Album Title", null, 200_000L)
+
+    private fun BaeCorePlayer.reportPaused() =
+        onPaused("t1", "Track Title", "Artist Name", "Album Title", null, 200_000L)
+
+    @Test
+    fun transientLossWhileUserPausedDoesNotResumeOnRegain() {
+        val context = RuntimeEnvironment.getApplication()
+        val handle = FakeAppHandle(emptyMap())
+        val player = player(context, handle)
+
+        player.startPlaying()
+        player.reportPaused() // the user paused
+        shadowOf(Looper.getMainLooper()).idle()
+        val resumesBeforeFocusChurn = handle.resumeCount
+
+        // Dictation grabs focus, then releases it.
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+
+        assertEquals(resumesBeforeFocusChurn, handle.resumeCount)
+    }
+
+    @Test
+    fun transientLossWhilePlayingResumesOnRegain() {
+        val context = RuntimeEnvironment.getApplication()
+        val handle = FakeAppHandle(emptyMap())
+        val player = player(context, handle)
+
+        player.startPlaying()
+        shadowOf(Looper.getMainLooper()).idle()
+        val resumesBeforeFocusChurn = handle.resumeCount
+
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+
+        assertEquals(resumesBeforeFocusChurn + 1, handle.resumeCount)
+    }
+
+    @Test
+    fun permanentLossDoesNotResumeOnRegain() {
+        val context = RuntimeEnvironment.getApplication()
+        val handle = FakeAppHandle(emptyMap())
+        val player = player(context, handle)
+
+        player.startPlaying()
+        shadowOf(Looper.getMainLooper()).idle()
+        val resumesBeforeFocusChurn = handle.resumeCount
+
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+
+        assertEquals(resumesBeforeFocusChurn, handle.resumeCount)
+    }
+
+    @Test
+    fun userPauseDuringTransientLossDisarmsResume() {
+        val context = RuntimeEnvironment.getApplication()
+        val handle = FakeAppHandle(emptyMap())
+        val player = player(context, handle)
+
+        player.startPlaying()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // A transient loss while playing arms resume...
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+        // ...but the user pauses during the interruption (lock screen / notification),
+        // which must disarm it.
+        player.pause()
+        shadowOf(Looper.getMainLooper()).idle()
+        val resumesBeforeRegain = handle.resumeCount
+
+        player.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+
+        assertEquals(resumesBeforeRegain, handle.resumeCount)
+    }
+}

--- a/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackServiceTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackServiceTest.kt
@@ -113,9 +113,16 @@ class PlaybackServiceTest {
 }
 
 internal class FakeAppHandle(private val imagePaths: Map<String, String>) : AppHandle(NoHandle) {
-    override fun pause() {}
+    var pauseCount = 0
+    var resumeCount = 0
 
-    override fun resume() {}
+    override fun pause() {
+        pauseCount++
+    }
+
+    override fun resume() {
+        resumeCount++
+    }
 
     override fun savePlaybackState() {}
 


### PR DESCRIPTION
On Android, a stream you've paused can start playing on its own: pause bae, toggle the keyboard's dictation on and off, and playback resumes. The cause is in `BaeCorePlayer`'s audio-focus handling. The focus listener resumed on any `AUDIOFOCUS_GAIN`, and `onPaused` never abandons focus — only `onStopped` does — so bae stays the registered focus owner while paused. Dictation requests *transient* focus (bae gets `LOSS_TRANSIENT`, already paused, a no-op), and when dictation ends it abandons that focus, so the system hands focus back to bae and the listener resumes a stream the user had stopped. The listener couldn't tell "I paused myself for a transient loss" (resume is right) from "the user paused me" (resume is wrong).

The fix tracks a `resumeOnFocusGain` flag: a transient loss arms it only when it interrupted active playback, a gain resumes only when it's armed, and an explicit user pause clears it. In the repro bae is already paused when dictation grabs focus, so the flag stays disarmed and the regain doesn't resume. The listener body moves into an `onAudioFocusChange` method so the policy can be exercised directly.

`AudioFocusResumeTest` drives the real `BaeCorePlayer` (Robolectric, no device) through a `FakeAppHandle` that counts pause/resume calls, covering the reported case, the legitimate duck-and-resume, a permanent loss (never resumes), and a user pause landing mid-interruption.

These app unit tests had no CI runner — `android.yml` only assembled the APK and `ci.yml` runs only `cargo test` — so a regression test would have guarded nothing. This adds a `testDebugUnitTest` step to `android.yml`, which now also gates the existing playback/reducer tests.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — full app suite green (24 tests, incl. the 4 new focus cases).
- [ ] CI: Android job runs the new unit-test step + assembles the debug APK.