### PR TITLE
CI: unify the Android build into one reusable workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,158 @@
+name: Android build (reusable)
+
+# Shared Android build, called by android.yml (debug CI gate) and
+# release-android.yml (signed release). Cross-compiles bae-bridge for the NDK
+# targets, runs the app unit tests, and assembles the APK — debug or, with
+# profile=release, a signed APK uploaded as the `bae-android-release` artifact.
+#
+# Runs on macOS because build-android.sh / build-ffmpeg-android.sh resolve the
+# NDK toolchain at .../prebuilt/darwin-x86_64. The host ffmpeg from setup-macos
+# backs the `cargo run --bin uniffi-bindgen` host build, which builds
+# bae-bridge → bae-core for the host to read the cross-built .so's metadata.
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        description: 'debug or release. release passes --release to build-android.sh, assembles a signed APK, and uploads it.'
+        type: string
+        default: debug
+      version:
+        description: 'BAE_VERSION stamped into the build. Blank keeps build.gradle.kts / build.rs dev defaults.'
+        type: string
+        default: ''
+      version_code:
+        description: 'versionCode stamped into the build (monotonic run number for releases). Blank keeps the dev default.'
+        type: string
+        default: ''
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        required: false
+      ANDROID_KEYSTORE_PASSWORD:
+        required: false
+      ANDROID_KEY_ALIAS:
+        required: false
+      ANDROID_KEY_PASSWORD:
+        required: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Pinned NDK: build-android.sh and build-ffmpeg-android.sh default to this exact
+  # version and honor ANDROID_NDK_HOME. Keep in sync with both scripts.
+  NDK_VERSION: 29.0.14206865
+
+jobs:
+  build:
+    name: Android
+    runs-on: macos-26
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup macOS environment
+      # Host ffmpeg for the uniffi-bindgen host build.
+      uses: ./.github/actions/setup-macos
+
+    - name: Setup Rust environment
+      uses: ./.github/actions/setup-rust
+
+    - name: Setup JDK 17
+      # bae-android targets JavaVersion.VERSION_17 (app/build.gradle.kts).
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Install pinned Android NDK + SDK platform
+      # build-tools provides apksigner, used to verify the signed release APK.
+      run: |
+        SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+        yes | "$SDKMANAGER" --licenses >/dev/null
+        "$SDKMANAGER" "ndk;${NDK_VERSION}" "platforms;android-35" "build-tools;35.0.0"
+        echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+
+    - name: Cache cross-built Android FFmpeg
+      id: ffmpeg-cache
+      uses: actions/cache@v4
+      with:
+        path: third_party/ffmpeg-android
+        # Keyed on the build script + NDK version: rebuild only when the recipe
+        # or the toolchain that produced the libs changes.
+        key: ffmpeg-android-${{ env.NDK_VERSION }}-${{ hashFiles('scripts/build-ffmpeg-android.sh') }}
+
+    - name: Build Android FFmpeg (on cache miss)
+      if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
+      run: ./scripts/build-ffmpeg-android.sh
+
+    - name: Set release version + stamps
+      # Release stamps an explicit version/code and the source commits into the
+      # build; debug leaves these unset so build.gradle.kts / build.rs use their
+      # dev defaults.
+      if: inputs.profile == 'release'
+      run: |
+        {
+          echo "BAE_VERSION=${{ inputs.version }}"
+          echo "BAE_VERSION_CODE=${{ inputs.version_code }}"
+          echo "BAE_GIT_COMMIT=$(git rev-parse --short HEAD)"
+          echo "BAE_COVEN_REV=$(scripts/coven-rev.sh)"
+        } >> "$GITHUB_ENV"
+
+    - name: Cross-compile bae-bridge for Android
+      # Builds bae-bridge for aarch64 + x86_64 android, generates the Kotlin
+      # bindings, and stages the .so files into the app's jniLibs.
+      run: ./bae-bridge/build-android.sh ${{ inputs.profile == 'release' && '--release' || '' }}
+
+    - name: Run app unit tests
+      # Robolectric/JVM tests (no device) over the app's playback and reducer
+      # logic — including the audio-focus resume policy. Needs the generated
+      # bindings from the cross-compile step above to compile the test sources.
+      run: cd bae-android && ./gradlew testDebugUnitTest --no-daemon
+
+    - name: Decode signing keystore
+      if: inputs.profile == 'release'
+      env:
+        ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      run: |
+        echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/bae-release.jks"
+        echo "ANDROID_KEYSTORE_FILE=$RUNNER_TEMP/bae-release.jks" >> "$GITHUB_ENV"
+
+    - name: Assemble debug APK
+      if: inputs.profile != 'release'
+      # Compiles the Kotlin app against the generated bindings and staged .so's,
+      # catching binding drift on top of the Rust cross-compile.
+      run: cd bae-android && ./gradlew assembleDebug --no-daemon
+
+    - name: Assemble signed release APK
+      if: inputs.profile == 'release'
+      working-directory: bae-android
+      env:
+        ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+        ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      run: ./gradlew assembleRelease --no-daemon
+
+    - name: Locate and verify signed APK
+      if: inputs.profile == 'release'
+      run: |
+        # app-release.apk is the signed output; app-release-unsigned.apk means the
+        # signing config did not apply, so target the signed name explicitly and
+        # confirm the signature rather than shipping an uninstallable APK.
+        APK="bae-android/app/build/outputs/apk/release/app-release.apk"
+        if [[ ! -f "$APK" ]]; then
+          echo "no signed release APK at $APK — signing config did not apply" >&2
+          ls -la bae-android/app/build/outputs/apk/release || true
+          exit 1
+        fi
+        APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
+        "$APKSIGNER" verify --verbose "$APK"
+        cp "$APK" "bae-android.apk"
+        echo "Verified signed APK: $APK"
+
+    - name: Upload signed APK artifact
+      if: inputs.profile == 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: bae-android-release
+        path: bae-android.apk
+        retention-days: 30

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,16 +1,8 @@
 name: Android build
 
-# Cross-compiles bae-bridge for the Android NDK targets and assembles the debug
-# APK. The macOS test job only builds bae-bridge for the host, so a type that is
-# `#[cfg]`-gated away from `target_os = "android"` while a shared function calls
-# it unconditionally compiles on the host and breaks only here — exactly the gap
-# this job closes.
-#
-# Runs on macOS because build-android.sh / build-ffmpeg-android.sh resolve the
-# NDK toolchain at .../prebuilt/darwin-x86_64. The host-side deps (ffmpeg) come
-# from setup-macos because build-android.sh runs
-# `cargo run --bin uniffi-bindgen`, which builds bae-bridge → bae-core for the
-# host to read the cross-built .so's metadata.
+# Debug CI gate: on every push/PR, builds the Android app (cross-compile + unit
+# tests + debug APK) via the shared android-build reusable workflow. See
+# android-build.yml for what the build covers and why it runs on macOS.
 
 on:
   push:
@@ -25,68 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-  # Pinned NDK: build-android.sh and build-ffmpeg-android.sh default to this exact
-  # version and honor ANDROID_NDK_HOME. Keep in sync with both scripts.
-  NDK_VERSION: 29.0.14206865
-
 jobs:
   build:
-    name: Android
-    runs-on: macos-26
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup macOS environment
-      # Host ffmpeg for the uniffi-bindgen host build.
-      uses: ./.github/actions/setup-macos
-
-    - name: Setup Rust environment
-      uses: ./.github/actions/setup-rust
-
-    - name: Setup JDK 17
-      # bae-android targets JavaVersion.VERSION_17 (app/build.gradle.kts).
-      uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: '17'
-
-    - name: Install pinned Android NDK + SDK platform
-      run: |
-        SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
-        yes | "$SDKMANAGER" --licenses >/dev/null
-        "$SDKMANAGER" "ndk;${NDK_VERSION}" "platforms;android-35"
-        echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
-
-    - name: Cache cross-built Android FFmpeg
-      id: ffmpeg-cache
-      uses: actions/cache@v4
-      with:
-        path: third_party/ffmpeg-android
-        # Keyed on the build script + NDK version: rebuild only when the recipe
-        # or the toolchain that produced the libs changes.
-        key: ffmpeg-android-${{ env.NDK_VERSION }}-${{ hashFiles('scripts/build-ffmpeg-android.sh') }}
-
-    - name: Build Android FFmpeg (on cache miss)
-      if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
-      run: ./scripts/build-ffmpeg-android.sh
-
-    - name: Cross-compile bae-bridge for Android
-      # The actual gate: builds bae-bridge for aarch64 + x86_64 android, generates
-      # the Kotlin bindings, and stages the .so files into the app's jniLibs.
-      run: ./bae-bridge/build-android.sh
-
-    - name: Run app unit tests
-      # Robolectric/JVM tests (no device) over the app's playback and reducer
-      # logic — including the audio-focus resume policy. Needs the generated
-      # bindings from the cross-compile step above to compile the test sources.
-      run: cd bae-android && ./gradlew testDebugUnitTest --no-daemon
-
-    - name: Assemble debug APK
-      # Compiles the Kotlin app against the generated bindings and staged .so's,
-      # catching binding drift on top of the Rust cross-compile.
-      run: cd bae-android && ./gradlew assembleDebug --no-daemon
+    uses: ./.github/workflows/android-build.yml
+    with:
+      profile: debug

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,9 +1,9 @@
 name: Release Android
 
-# Builds a signed release APK with an independent 0.N version line (android-v*
-# tags) and a monotonic versionCode (the run number). Mirrors android.yml's
-# cross-compile setup (NDK toolchain + host ffmpeg for uniffi-bindgen) and adds
-# release signing + GitHub release publishing.
+# Cuts a signed Android release: an independent 0.N version line (android-v*
+# tags) and a monotonic versionCode (the run number). The build itself is the
+# shared android-build reusable workflow (same cross-compile + tests as CI) in
+# release mode; this workflow only computes the version and publishes the result.
 
 on:
   workflow_dispatch:
@@ -16,12 +16,6 @@ on:
 concurrency:
   group: release-android
   cancel-in-progress: true
-
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-  # Keep in sync with android.yml and build-android.sh / build-ffmpeg-android.sh.
-  NDK_VERSION: 29.0.14206865
 
 jobs:
   calculate-version:
@@ -54,92 +48,34 @@ jobs:
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "::notice::Android release version $VERSION (build ${{ github.run_number }})"
 
-  release:
-    name: Build and Release Android
-    runs-on: macos-26
+  build:
+    name: Build signed APK
     needs: calculate-version
+    uses: ./.github/workflows/android-build.yml
+    with:
+      profile: release
+      version: ${{ needs.calculate-version.outputs.version }}
+      version_code: ${{ github.run_number }}
+    secrets: inherit
+
+  publish:
+    name: Publish release
+    needs: [calculate-version, build]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
-    - name: Checkout code
+    - name: Checkout the built commit
+      # github.sha is fixed for the whole run, so the tag points at exactly the
+      # commit the build job assembled the APK from.
       uses: actions/checkout@v4
-
-    - name: Setup macOS environment
-      # Host ffmpeg for the uniffi-bindgen host build.
-      uses: ./.github/actions/setup-macos
-
-    - name: Setup Rust environment
-      uses: ./.github/actions/setup-rust
-
-    - name: Setup JDK 17
-      uses: actions/setup-java@v4
       with:
-        distribution: temurin
-        java-version: '17'
+        ref: ${{ github.sha }}
 
-    - name: Install pinned Android NDK + SDK platform
-      run: |
-        SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
-        yes | "$SDKMANAGER" --licenses >/dev/null
-        "$SDKMANAGER" "ndk;${NDK_VERSION}" "platforms;android-35" "build-tools;35.0.0"
-        echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
-
-    - name: Cache cross-built Android FFmpeg
-      id: ffmpeg-cache
-      uses: actions/cache@v4
+    - name: Download signed APK
+      uses: actions/download-artifact@v4
       with:
-        path: third_party/ffmpeg-android
-        key: ffmpeg-android-${{ env.NDK_VERSION }}-${{ hashFiles('scripts/build-ffmpeg-android.sh') }}
-
-    - name: Build Android FFmpeg (on cache miss)
-      if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
-      run: ./scripts/build-ffmpeg-android.sh
-
-    - name: Set build version + stamps
-      run: |
-        VERSION="${{ needs.calculate-version.outputs.version }}"
-        {
-          echo "BAE_VERSION=$VERSION"
-          echo "BAE_VERSION_CODE=${{ github.run_number }}"
-          echo "BAE_GIT_COMMIT=$(git rev-parse --short HEAD)"
-          echo "BAE_COVEN_REV=$(scripts/coven-rev.sh)"
-        } >> "$GITHUB_ENV"
-
-    - name: Cross-compile bae-bridge for Android (release)
-      # Reads BAE_VERSION from the env above into bae-core's build.rs.
-      run: ./bae-bridge/build-android.sh --release
-
-    - name: Decode signing keystore
-      env:
-        ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-      run: |
-        echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/bae-release.jks"
-        echo "ANDROID_KEYSTORE_FILE=$RUNNER_TEMP/bae-release.jks" >> "$GITHUB_ENV"
-
-    - name: Assemble signed release APK
-      working-directory: bae-android
-      env:
-        ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-        ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-        ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-      run: ./gradlew assembleRelease --no-daemon
-
-    - name: Locate and verify signed APK
-      run: |
-        # app-release.apk is the signed output; app-release-unsigned.apk means the
-        # signing config did not apply, so target the signed name explicitly and
-        # confirm the signature rather than shipping an uninstallable APK.
-        APK="bae-android/app/build/outputs/apk/release/app-release.apk"
-        if [[ ! -f "$APK" ]]; then
-          echo "no signed release APK at $APK — signing config did not apply" >&2
-          ls -la bae-android/app/build/outputs/apk/release || true
-          exit 1
-        fi
-        APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
-        "$APKSIGNER" verify --verbose "$APK"
-        cp "$APK" "bae-android.apk"
-        echo "Verified signed APK: $APK"
+        name: bae-android-release
 
     - name: Create git tag
       run: |
@@ -150,13 +86,6 @@ jobs:
           git tag "android-v$VERSION"
           git push origin "android-v$VERSION"
         fi
-
-    - name: Upload APK artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: bae-android-release
-        path: bae-android.apk
-        retention-days: 30
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
`android.yml` and `release-android.yml` each carried their own copy of the entire Android build setup — install the pinned NDK, cache/build the cross-compiled ffmpeg, run `build-android.sh` — so the two drifted (the release path, for instance, never ran the unit tests). This pulls that shared build into one reusable workflow, `android-build.yml` (`on: workflow_call`), parameterized by a `profile` input.

`android.yml` becomes a thin caller that invokes it with `profile: debug` (assembles the debug APK, runs the unit tests). `release-android.yml` keeps only the parts that are actually release-specific — computing the `android-v0.N` version and publishing the GitHub Release — and calls the same reusable workflow with `profile: release`, which stamps the version, passes `--release`, signs, verifies, and uploads the APK as an artifact the publish job attaches to the release. The release now builds the exact same way CI does, unit tests included.

Two intentional deltas: the debug path now also installs `build-tools` (cheap; the shared release path needs `apksigner`), and the release path now runs the unit tests it previously skipped.

## Test plan
- [x] `actionlint` clean on all three workflows.
- [x] Behavior-preservation audit against the originals (signing, version stamps, tag, artifact, release-notes, triggers, concurrency).
- [ ] This PR's own `Android` check exercises the debug path end-to-end through the reusable workflow. The release path is exercised at the next `android-v0.N` release.