### PR TITLE
Import: overwrite a prior import on re-scan instead of duplicating

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -67,6 +67,11 @@ CREATE TABLE IF NOT EXISTS releases (
     -- lives in `release_local_copy`, NOT here — it must not sync.
     managed BOOLEAN NOT NULL,
     source_folder_name TEXT,
+    -- SHA-256 over the imported folder's categorized file structure (sorted
+    -- relative paths + sizes). Location-independent content fingerprint: the
+    -- same rip in any parent folder hashes the same. Used to recognize an
+    -- already-imported folder and to pick the overwrite target on re-import.
+    content_hash TEXT,
     _updated_at TEXT NOT NULL,
     created_at TEXT NOT NULL,
     FOREIGN KEY (album_id) REFERENCES albums (id) ON DELETE CASCADE

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -354,6 +354,7 @@ impl Database {
             metadata_source_release_id: row.get("metadata_source_release_id").unwrap(),
             managed: row.get("managed").unwrap(),
             source_folder_name: row.get("source_folder_name").unwrap(),
+            content_hash: row.get("content_hash").unwrap(),
             created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
                 .unwrap()
                 .with_timezone(&Utc),
@@ -2789,6 +2790,23 @@ impl Database {
             .await
     }
 
+    /// Release ids whose stored `content_hash` equals `hash`. Normally zero or
+    /// one (the import overwrite path keeps the hash unique), but returns all
+    /// matches so a re-import sweeps any pre-existing duplicates.
+    pub async fn release_ids_for_content_hash(&self, hash: &str) -> Result<Vec<String>, DbError> {
+        let hash = hash.to_string();
+        self.inner
+            .coven_db
+            .call(move |conn| {
+                let mut stmt = conn.prepare("SELECT id FROM releases WHERE content_hash = ?")?;
+                let ids = stmt
+                    .query_map(params![hash], |row| row.get::<_, String>(0))?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(ids)
+            })
+            .await
+    }
+
     /// Check, for each candidate in `checks`, whether the library already
     /// holds the same pressing or the same album (group). Drives the
     /// "in library" badges shown in the identify-pipeline result lists.
@@ -3153,8 +3171,8 @@ fn insert_release_row(conn: &Connection, release: &DbRelease, reg: &str) -> Resu
             disc_id, metadata_source, metadata_source_release_id,
             format, label, catalog_number, country, barcode,
             managed,
-            source_folder_name, _updated_at, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            source_folder_name, content_hash, _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
         params![
             release.id,
@@ -3171,6 +3189,7 @@ fn insert_release_row(conn: &Connection, release: &DbRelease, reg: &str) -> Resu
             release.pressing.barcode,
             release.managed,
             release.source_folder_name,
+            release.content_hash,
             reg,
             release.created_at.to_rfc3339(),
         ],

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -271,6 +271,13 @@ pub struct DbRelease {
     /// path component, not the full path). Used to detect likely duplicates when
     /// the user re-scans the same folder.
     pub source_folder_name: Option<String>,
+    /// SHA-256 over the imported folder's categorized file structure (sorted
+    /// relative paths + sizes) — a location-independent content fingerprint.
+    /// `None` for releases not created by a folder import. The import worker
+    /// populates it just before insert; metadata edits / re-identify preserve
+    /// it (the files didn't change). Used to recognize an already-imported
+    /// folder and to pick the overwrite target on re-import.
+    pub content_hash: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -561,6 +568,7 @@ impl DbRelease {
             metadata_source_release_id: None,
             managed: true,
             source_folder_name: None,
+            content_hash: None,
             created_at: now,
         }
     }
@@ -595,6 +603,7 @@ impl DbRelease {
             // once the release's audio is durably in the cloud.
             managed: false,
             source_folder_name: None,
+            content_hash: None,
             created_at: now,
         }
     }
@@ -638,6 +647,7 @@ impl DbRelease {
             // once the release's audio is durably in the cloud.
             managed: false,
             source_folder_name: None,
+            content_hash: None,
             created_at: now,
         }
     }

--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -303,6 +303,7 @@ mod tests {
             metadata_source_release_id: None,
             managed: false,
             source_folder_name: None,
+            content_hash: None,
             created_at: Utc::now(),
         };
         database.insert_release(&release).await.unwrap();

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -155,6 +155,7 @@ pub fn map_file_tags_to_db(
         // the release's audio is durably in the cloud.
         managed: false,
         source_folder_name: None,
+        content_hash: None,
         created_at: now,
     };
 

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -10,6 +10,7 @@
 use super::file_validation;
 use crate::cue_flac::CueFlacProcessor;
 use crate::util::content_type_hint::ContentTypeHint;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -146,6 +147,49 @@ pub struct CategorizedFiles {
     /// catalog/performer/title harvesting reads parsed data instead of
     /// re-reading the file.
     pub unpaired_cue_sheets: Vec<(PathBuf, crate::cue_flac::CueSheet)>,
+}
+
+impl CategorizedFiles {
+    /// Stable content fingerprint of this release's file structure: a SHA-256
+    /// over every audio, artwork, and document file's relative path + size,
+    /// sorted so the digest is independent of discovery order. Relative (not
+    /// absolute) paths make it location-independent — the same rip under any
+    /// parent folder hashes identically. Drives "already imported?" detection
+    /// and selects the overwrite target on re-import.
+    ///
+    /// Paired CUE files live on `audio` (not `documents`); unpaired CUE files
+    /// are in `documents`. Together with `artwork` that's every on-disk file,
+    /// each counted once. `unpaired_cue_sheets` is parsed-signal data, not a
+    /// file — its CUE is already covered as a document, so it's excluded.
+    pub fn content_hash(&self) -> String {
+        let mut entries: Vec<(&str, u64)> = Vec::new();
+        match &self.audio {
+            AudioContent::CueFlacPairs { pairs, .. } => {
+                for pair in pairs {
+                    entries.push((&pair.cue_file.relative_path, pair.cue_file.size));
+                    entries.push((&pair.audio_file.relative_path, pair.audio_file.size));
+                }
+            }
+            AudioContent::TrackFiles { tracks, .. } => {
+                for track in tracks {
+                    entries.push((&track.relative_path, track.size));
+                }
+            }
+        }
+        for file in self.artwork.iter().chain(&self.documents) {
+            entries.push((&file.relative_path, file.size));
+        }
+        entries.sort_unstable();
+
+        let mut hasher = Sha256::new();
+        for (path, size) in entries {
+            hasher.update(path.as_bytes());
+            hasher.update([0u8]);
+            hasher.update(size.to_le_bytes());
+            hasher.update([b'\n']);
+        }
+        format!("{:x}", hasher.finalize())
+    }
 }
 
 /// Commit-ready release data: the parsed DB-shape album/release/tracks plus
@@ -1098,6 +1142,65 @@ mod tests {
         assert_eq!(artwork_paths, vec!["cover.jpg"]);
 
         assert!(files.documents.is_empty());
+    }
+
+    #[test]
+    fn content_hash_is_location_independent_and_size_sensitive() {
+        let make = |root: &str, second_size: u64| CategorizedFiles {
+            audio: AudioContent::TrackFiles {
+                tracks: vec![
+                    ScannedFile::new(
+                        PathBuf::from(format!("{root}/01.flac")),
+                        "01.flac".to_string(),
+                        1000,
+                    ),
+                    ScannedFile::new(
+                        PathBuf::from(format!("{root}/02.flac")),
+                        "02.flac".to_string(),
+                        second_size,
+                    ),
+                ],
+                format_label: "FLAC".to_string(),
+            },
+            artwork: vec![],
+            documents: vec![],
+            unpaired_cue_sheets: vec![],
+        };
+
+        // The same relative structure under two different parent folders hashes
+        // identically — the fingerprint follows the rip, not where it sits.
+        let a = make("/Volumes/Music/Release", 2000);
+        let b = make("/Users/sam/Downloads/Release", 2000);
+        assert_eq!(a.content_hash(), b.content_hash());
+
+        // A single differing file size flips the hash.
+        let c = make("/Volumes/Music/Release", 2001);
+        assert_ne!(a.content_hash(), c.content_hash());
+    }
+
+    #[test]
+    fn content_hash_is_independent_of_discovery_order() {
+        let file =
+            |name: &str, size: u64| ScannedFile::new(PathBuf::from(name), name.to_string(), size);
+        let forward = CategorizedFiles {
+            audio: AudioContent::TrackFiles {
+                tracks: vec![file("01.flac", 1), file("02.flac", 2)],
+                format_label: "FLAC".to_string(),
+            },
+            artwork: vec![file("cover.jpg", 3)],
+            documents: vec![file("notes.txt", 4)],
+            unpaired_cue_sheets: vec![],
+        };
+        let shuffled = CategorizedFiles {
+            audio: AudioContent::TrackFiles {
+                tracks: vec![file("02.flac", 2), file("01.flac", 1)],
+                format_label: "FLAC".to_string(),
+            },
+            artwork: vec![file("cover.jpg", 3)],
+            documents: vec![file("notes.txt", 4)],
+            unpaired_cue_sheets: vec![],
+        };
+        assert_eq!(forward.content_hash(), shuffled.content_hash());
     }
 
     /// Creates a minimal CUE file content that references the given FLAC filename

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1248,6 +1248,7 @@ mod tests {
             metadata_source_release_id: None,
             managed: true,
             source_folder_name: None,
+            content_hash: None,
             created_at: now,
         }
     }

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -682,6 +682,10 @@ impl ImportService {
         .await
         .map_err(|e| format!("Folder scan task failed: {e}"))??;
 
+        // Content fingerprint of the folder tree. Used below to overwrite a
+        // prior import of the same files, then stamped onto the new release row.
+        let content_hash = categorized.content_hash();
+
         // Phase 0a: Reconcile the prepared release with existing library state
         send_event(
             &self.event_tx,
@@ -727,6 +731,19 @@ impl ImportService {
                 (parsed, Vec::new())
             }
         };
+
+        // Overwrite a prior import of the same folder tree: re-importing
+        // replaces rather than duplicates. Remove the existing release(s)
+        // carrying this content hash (and their managed files, via the library
+        // remove path) before reconciling, so the new import builds against
+        // post-removal state — a single-release album is freshly recreated; a
+        // multi-release album keeps its siblings and reassigns its primary. The
+        // source-metadata fetch above already ran, so the window between this
+        // removal and the new insert holds no fallible network step.
+        library_manager
+            .delete_releases_with_content_hash(&content_hash)
+            .await
+            .map_err(|e| format!("Failed to overwrite prior import: {e}"))?;
 
         let PreparedMetadata {
             db_album,
@@ -781,6 +798,7 @@ impl ImportService {
             .file_name()
             .and_then(|n| n.to_str())
             .map(|s| s.to_string());
+        db_release.content_hash = Some(content_hash);
 
         // Phase 0b: Remote cover art is downloaded through the
         // session-wide LRU cache. The UI may have pre-fetched the URL
@@ -2170,6 +2188,7 @@ mod tests {
             metadata_source_release_id: Some("rel-mb".to_string()),
             managed: true,
             source_folder_name: None,
+            content_hash: None,
             created_at: now,
         };
         let track = crate::db::DbTrack {
@@ -2379,6 +2398,7 @@ mod tests {
             metadata_source_release_id: Some("rel-mb".to_string()),
             managed: true,
             source_folder_name: None,
+            content_hash: None,
             created_at: now,
         };
         let track = crate::db::DbTrack {

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -4148,6 +4148,19 @@ impl LibraryManager {
         Ok(())
     }
 
+    /// Remove any releases whose stored content hash equals `hash` — full
+    /// managed-file cleanup, primary-release reassignment, album cascade, and
+    /// removal events, via [`delete_release`](Self::delete_release) per match.
+    /// The import worker calls this before inserting a re-import of the same
+    /// folder tree, so the re-import overwrites the prior release(s) instead of
+    /// duplicating them.
+    pub async fn delete_releases_with_content_hash(&self, hash: &str) -> Result<(), LibraryError> {
+        for release_id in self.database.release_ids_for_content_hash(hash).await? {
+            self.delete_release(&release_id).await?;
+        }
+        Ok(())
+    }
+
     /// Delete an album and all its associated data
     ///
     /// This will:
@@ -5020,6 +5033,7 @@ mod tests {
             metadata_source_release_id: None,
             managed: true,
             source_folder_name: None,
+            content_hash: None,
             created_at: Utc::now(),
         }
     }
@@ -5067,6 +5081,39 @@ mod tests {
             .unwrap();
         assert_eq!(releases.len(), 1);
         assert_eq!(releases[0].id, release2.id);
+    }
+
+    #[tokio::test]
+    async fn delete_releases_with_content_hash_removes_only_matching() {
+        let (manager, _temp_dir) = setup_test_manager().await;
+        let album = create_test_album();
+        let mut matching1 = create_test_release(&album.id);
+        matching1.content_hash = Some("hash-shared".to_string());
+        let mut matching2 = create_test_release(&album.id);
+        matching2.content_hash = Some("hash-shared".to_string());
+        let mut other = create_test_release(&album.id);
+        other.content_hash = Some("hash-other".to_string());
+
+        manager.database.insert_album(&album).await.unwrap();
+        manager.database.insert_release(&matching1).await.unwrap();
+        manager.database.insert_release(&matching2).await.unwrap();
+        manager.database.insert_release(&other).await.unwrap();
+
+        manager
+            .delete_releases_with_content_hash("hash-shared")
+            .await
+            .unwrap();
+
+        // Both releases carrying the re-imported folder's hash are gone; the
+        // unrelated release survives. This is the overwrite the import worker
+        // performs before inserting a re-import of the same folder tree.
+        let remaining = manager
+            .database
+            .get_releases_for_album(&album.id)
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, other.id);
     }
 
     /// Deleting one release of a multi-release album must drain the pinned

--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -74,6 +74,7 @@ fn create_test_release(album_id: &str) -> DbRelease {
         metadata_source_release_id: None,
         managed: true,
         source_folder_name: None,
+        content_hash: None,
         created_at: Utc::now(),
     }
 }

--- a/bae-core/tests/test_library_events.rs
+++ b/bae-core/tests/test_library_events.rs
@@ -78,6 +78,7 @@ fn make_release(album_id: &str) -> DbRelease {
         metadata_source_release_id: None,
         managed: true,
         source_folder_name: None,
+        content_hash: None,
         created_at: Utc::now(),
     }
 }

--- a/bae-core/tests/test_reset_metadata.rs
+++ b/bae-core/tests/test_reset_metadata.rs
@@ -81,6 +81,7 @@ fn make_release(album_id: &str) -> DbRelease {
         metadata_source_release_id: None,
         managed: true,
         source_folder_name: None,
+        content_hash: None,
         created_at: Utc::now(),
     }
 }

--- a/bae-core/tests/test_storage_state_machine.rs
+++ b/bae-core/tests/test_storage_state_machine.rs
@@ -107,6 +107,7 @@ async fn create_pinned_release(mgr: &LibraryManager, filenames: &[&str]) -> Stri
         // drain the uploads exercise that real flip.
         managed: false,
         source_folder_name: None,
+        content_hash: None,
         created_at: now,
     };
     let release_id = release.id.clone();
@@ -315,6 +316,7 @@ async fn create_unmanaged_release(
         metadata_source_release_id: None,
         managed: true,
         source_folder_name: None,
+        content_hash: None,
         created_at: now,
     };
     let release_id = release.id.clone();
@@ -615,6 +617,7 @@ async fn create_cloud_only_release(
         metadata_source_release_id: None,
         managed: true,
         source_folder_name: None,
+        content_hash: None,
         created_at: now,
     };
     let release_id = release.id.clone();

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -161,6 +161,7 @@ async fn create_album_and_release(
         // Unmanaged when an in-place path is given; otherwise managed (cloud).
         managed: unmanaged_path.is_none(),
         source_folder_name: None,
+        content_hash: None,
         created_at: now,
     };
     db.insert_release(&release).await.unwrap();
@@ -441,6 +442,7 @@ async fn test_read_release_file_bytes_rejects_short_read() {
         metadata_source_release_id: None,
         managed: true,
         source_folder_name: None,
+        content_hash: None,
         created_at: Utc::now(),
     };
     // This device pins the release: reads come from the staged `storage/` copy.


### PR DESCRIPTION
Re-importing a folder that's already in the library has been creating a duplicate release. The library only knew a rip by its source-folder *name* — a fuzzy guess used for the "Likely imported" hint — so the import pipeline had no way to recognize "these are the same files" and always inserted fresh.

This adds a content fingerprint for a release: a SHA-256 over the candidate's categorized file structure (sorted relative paths + file sizes, covering audio/artwork/documents). It uses relative paths, so the same rip under any parent folder hashes identically. The hash is stored on the `releases` row, and at import-commit the worker removes any existing release carrying the same hash — through the library's managed-file-aware remove path, so encrypted/pinned blobs, the cover image, primary-release reassignment, and the album cascade are all handled — before inserting the new one. The removal runs after the source-metadata fetch, so the window before the new insert holds no fallible network step. A re-import now overwrites rather than duplicates.

The fingerprint is the content identity the upcoming New/Added/Skipped import tabs will use to recognize an already-imported folder; in this change it only drives overwrite-on-reimport.

## Test plan
- [x] `content_hash` unit tests: location-independent, size-sensitive, order-independent
- [x] `delete_releases_with_content_hash` removes only matching releases, leaves others
- [ ] Manual: import a folder, then re-import it → exactly one release; the first import's managed files are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)