### PR TITLE
Website: resolve downloads from versioned releases, drop rolling -latest

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -110,22 +110,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Refresh the per-edition -latest downloads
+  refresh-website:
+    # Republish the website so its build-time latest.json and download buttons
+    # resolve to this new release. Replaces the old rolling `-latest` releases:
+    # immutable releases make those impossible to update — a tag, once used by an
+    # immutable release, can't be reused, and an immutable release's assets can't
+    # be replaced — so the site resolves the newest versioned release instead.
+    name: Refresh website downloads
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+    - name: Trigger website deploy
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Stable per-edition download links for the website:
-        #   releases/download/android-latest/bae-android.apk        (full)
-        #   releases/download/baeium-android-latest/baeium-android.apk (baeium)
-        # Each rolling release is created once and never moves; only its asset is
-        # replaced. --latest=false keeps the global "Latest" badge on the real
-        # versioned releases.
-        gh release view android-latest >/dev/null 2>&1 \
-          || gh release create android-latest --latest=false --title "Android — latest (bae)" \
-               --notes "Stable download link that always serves the newest full bae Android build."
-        gh release upload android-latest bae-android.apk --clobber
-
-        gh release view baeium-android-latest >/dev/null 2>&1 \
-          || gh release create baeium-android-latest --latest=false --title "Android — latest (baeium)" \
-               --notes "Stable download link that always serves the newest baeium baeium Android build."
-        gh release upload baeium-android-latest baeium-android.apk --clobber
+      run: gh workflow run deploy-website.yml --repo ${{ github.repository }} --ref main

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -90,8 +90,6 @@ jobs:
             echo "PRODUCT_NAME=baeium"
             echo "IPA_NAME=baeium-ios.ipa"
             echo "ARTIFACT_NAME=baeium-iOS-unsigned"
-            echo "LATEST_RELEASE=baeium-ios-latest"
-            echo "LATEST_TITLE=iOS — latest (baeium)"
           } >> "$GITHUB_ENV"
         else
           {
@@ -100,8 +98,6 @@ jobs:
             echo "PRODUCT_NAME=bae"
             echo "IPA_NAME=bae-ios.ipa"
             echo "ARTIFACT_NAME=bae-iOS-unsigned"
-            echo "LATEST_RELEASE=ios-latest"
-            echo "LATEST_TITLE=iOS — latest (bae)"
           } >> "$GITHUB_ENV"
         fi
 
@@ -220,14 +216,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Refresh the per-edition -latest download
+  refresh-website:
+    # Republish the website so its build-time latest.json and download buttons
+    # resolve to this new release. Replaces the old rolling `-latest` releases:
+    # immutable releases make those impossible to update — a tag, once used by an
+    # immutable release, can't be reused, and an immutable release's assets can't
+    # be replaced — so the site resolves the newest versioned release instead.
+    name: Refresh website downloads
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+    - name: Trigger website deploy
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Stable per-edition sideload link for the website, e.g.
-        #   releases/download/ios-latest/bae-ios.ipa          (full)
-        #   releases/download/baeium-ios-latest/baeium-ios.ipa (baeium)
-        gh release view "$LATEST_RELEASE" >/dev/null 2>&1 \
-          || gh release create "$LATEST_RELEASE" --latest=false --title "$LATEST_TITLE" \
-               --notes "Stable sideload link that always serves the newest $PRODUCT_NAME iOS build (unsigned .ipa)."
-        gh release upload "$LATEST_RELEASE" "$IPA_NAME" --clobber
+      run: gh workflow run deploy-website.yml --repo ${{ github.repository }} --ref main

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -95,8 +95,6 @@ jobs:
             echo "APPCAST_FILE=appcast-baeium.xml"
             echo "APPCAST_TITLE=baeium Updates"
             echo "ARTIFACT_NAME=baeium-macOS-native-signed"
-            echo "LATEST_RELEASE=baeium-macos-latest"
-            echo "LATEST_TITLE=macOS — latest (baeium)"
             echo "SUFEED_URL=https://raw.githubusercontent.com/${{ github.repository }}/appcast/appcast-baeium.xml"
           } >> "$GITHUB_ENV"
         else
@@ -109,8 +107,6 @@ jobs:
             echo "APPCAST_FILE=appcast.xml"
             echo "APPCAST_TITLE=bae Updates"
             echo "ARTIFACT_NAME=bae-macOS-native-signed"
-            echo "LATEST_RELEASE=macos-latest"
-            echo "LATEST_TITLE=macOS — latest (bae)"
             echo "SUFEED_URL=https://raw.githubusercontent.com/${{ github.repository }}/appcast/appcast.xml"
           } >> "$GITHUB_ENV"
         fi
@@ -371,21 +367,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Refresh the per-edition -latest download
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Stable per-edition download link for the website, e.g.
-        # releases/download/macos-latest/bae-macos.dmg (full) and
-        # releases/download/baeium-macos-latest/baeium-macos.dmg (baeium). Each
-        # rolling release is created once and never moves; only its asset is
-        # replaced. --latest=false keeps the global "Latest" badge on the real
-        # versioned releases.
-        gh release view "$LATEST_RELEASE" >/dev/null 2>&1 \
-          || gh release create "$LATEST_RELEASE" --latest=false --title "$LATEST_TITLE" \
-               --notes "Stable download link that always serves the newest $PRODUCT_NAME macOS build."
-        gh release upload "$LATEST_RELEASE" "target/$DMG_NAME" --clobber
-
     - name: Publish appcast to the appcast branch
       run: |
         # The Sparkle feed lives on a dedicated, orphan `appcast` branch — the app's
@@ -421,3 +402,20 @@ jobs:
         else
           echo "::warning::appcast pushed to branch but raw feed not yet showing $VERSION (CDN lag); it will catch up"
         fi
+
+  refresh-website:
+    # Republish the website so its build-time latest.json and download buttons
+    # resolve to this new release. Replaces the old rolling `-latest` releases:
+    # immutable releases make those impossible to update — a tag, once used by an
+    # immutable release, can't be reused, and an immutable release's assets can't
+    # be replaced — so the site resolves the newest versioned release instead.
+    name: Refresh website downloads
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+    - name: Trigger website deploy
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh workflow run deploy-website.yml --repo ${{ github.repository }} --ref main

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -225,19 +225,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Refresh the per-edition -latest downloads
+  refresh-website:
+    # Republish the website so its build-time latest.json and download buttons
+    # resolve to this new release. Replaces the old rolling `-latest` releases:
+    # immutable releases make those impossible to update — a tag, once used by an
+    # immutable release, can't be reused, and an immutable release's assets can't
+    # be replaced — so the site resolves the newest versioned release instead.
+    name: Refresh website downloads
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+    - name: Trigger website deploy
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Stable per-edition download links for the website:
-        #   releases/download/windows-latest/bae-windows-x64.zip        (full)
-        #   releases/download/baeium-windows-latest/baeium-windows-x64.zip (baeium)
-        gh release view windows-latest >/dev/null 2>&1 \
-          || gh release create windows-latest --latest=false --title "Windows — latest (bae)" \
-               --notes "Stable download link that always serves the newest full bae Windows build."
-        gh release upload windows-latest bae-windows-x64.zip --clobber
-
-        gh release view baeium-windows-latest >/dev/null 2>&1 \
-          || gh release create baeium-windows-latest --latest=false --title "Windows — latest (baeium)" \
-               --notes "Stable download link that always serves the newest baeium baeium Windows build."
-        gh release upload baeium-windows-latest baeium-windows-x64.zip --clobber
+      run: gh workflow run deploy-website.yml --repo ${{ github.repository }} --ref main

--- a/website/src/components/DownloadButton.astro
+++ b/website/src/components/DownloadButton.astro
@@ -1,0 +1,28 @@
+---
+// A download button whose href is resolved at build time to the latest
+// versioned release asset for this platform/edition (see ../lib/releases). When
+// that platform hasn't shipped yet, it renders as a disabled "coming soon"
+// affordance instead of a link to a non-existent asset.
+import { getLatest, type Platform, type Edition } from '../lib/releases';
+
+interface Props {
+  platform: Platform;
+  edition: Edition;
+  class?: string;
+}
+
+const { platform, edition, class: className = 'sl-button' } = Astro.props;
+const download = (await getLatest())[platform]?.[edition];
+---
+
+{
+  download ? (
+    <a href={download.url} class={className}>
+      <slot />
+    </a>
+  ) : (
+    <span class={`${className} download-unavailable`} aria-disabled="true">
+      <slot /> (coming soon)
+    </span>
+  )
+}

--- a/website/src/content/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/getting-started/installation.mdx
@@ -3,6 +3,8 @@ title: Installation
 description: Download and install bae or baeium on every platform
 ---
 
+import DownloadButton from '../../../components/DownloadButton.astro';
+
 ## Two editions
 
 Every platform ships in two editions, built from the same source:
@@ -14,8 +16,8 @@ They install side by side, each with its own library and its own (iCloud-Keychai
 
 ## macOS
 
-<a href="https://github.com/bae-fm/bae/releases/download/macos-latest/bae-macos.dmg" class="sl-button primary">Download bae for macOS</a>
-<a href="https://github.com/bae-fm/bae/releases/download/baeium-macos-latest/baeium-macos.dmg" class="sl-button">Download baeium for macOS</a>
+<DownloadButton platform="macos" edition="full" class="sl-button primary">Download bae for macOS</DownloadButton>
+<DownloadButton platform="macos" edition="baeium" class="sl-button">Download baeium for macOS</DownloadButton>
 
 1. Open the downloaded `.dmg`
 2. Drag the app to your Applications folder
@@ -27,13 +29,13 @@ Both editions auto-update through their own Sparkle feed.
 
 iOS builds are **unsigned `.ipa` files for sideloading** — install with [AltStore](https://altstore.io) or [Sideloadly](https://sideloadly.io), or re-sign in Xcode with your own Apple ID (a free Apple ID works for baeium). App Store distribution isn't set up yet.
 
-<a href="https://github.com/bae-fm/bae/releases/download/ios-latest/bae-ios.ipa" class="sl-button primary">Download bae for iOS</a>
-<a href="https://github.com/bae-fm/bae/releases/download/baeium-ios-latest/baeium-ios.ipa" class="sl-button">Download baeium for iOS</a>
+<DownloadButton platform="ios" edition="full" class="sl-button primary">Download bae for iOS</DownloadButton>
+<DownloadButton platform="ios" edition="baeium" class="sl-button">Download baeium for iOS</DownloadButton>
 
 ## Android
 
-<a href="https://github.com/bae-fm/bae/releases/download/android-latest/bae-android.apk" class="sl-button primary">Download bae for Android</a>
-<a href="https://github.com/bae-fm/bae/releases/download/baeium-android-latest/baeium-android.apk" class="sl-button">Download baeium for Android</a>
+<DownloadButton platform="android" edition="full" class="sl-button primary">Download bae for Android</DownloadButton>
+<DownloadButton platform="android" edition="baeium" class="sl-button">Download baeium for Android</DownloadButton>
 
 Enable installing from your browser/files when prompted, then open the `.apk`.
 
@@ -41,8 +43,8 @@ Enable installing from your browser/files when prompted, then open the `.apk`.
 
 Windows builds are **unsigned** zips of the unpackaged app — extract and run `bae.exe` / `baeium.exe`. SmartScreen may warn on first launch.
 
-<a href="https://github.com/bae-fm/bae/releases/download/windows-latest/bae-windows-x64.zip" class="sl-button primary">Download bae for Windows</a>
-<a href="https://github.com/bae-fm/bae/releases/download/baeium-windows-latest/baeium-windows-x64.zip" class="sl-button">Download baeium for Windows</a>
+<DownloadButton platform="windows" edition="full" class="sl-button primary">Download bae for Windows</DownloadButton>
+<DownloadButton platform="windows" edition="baeium" class="sl-button">Download baeium for Windows</DownloadButton>
 
 ## Linux
 

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -1,0 +1,124 @@
+/**
+ * Latest published download per platform/edition, resolved from the GitHub
+ * Releases API at build time. The site links to permanent, versioned asset URLs
+ * (e.g. .../releases/download/android-v0.3/bae-android.apk) rather than a
+ * rolling `-latest` release: the repo's releases are immutable, so a tag can't
+ * be reused and an asset can't be replaced in place — the old "clobber the
+ * `-latest` asset each release" pattern can't work. Each app release triggers a
+ * website redeploy, which reruns this and re-bakes the download buttons and
+ * `/latest.json` against the newest versioned release.
+ */
+
+const REPO = 'bae-fm/bae';
+
+export type Platform = 'macos' | 'ios' | 'android' | 'windows';
+export type Edition = 'full' | 'baeium';
+
+/** The release asset filename per platform/edition, fixed by each build. */
+const ASSETS: Record<Platform, Record<Edition, string>> = {
+  macos: { full: 'bae-macos.dmg', baeium: 'baeium-macos.dmg' },
+  ios: { full: 'bae-ios.ipa', baeium: 'baeium-ios.ipa' },
+  android: { full: 'bae-android.apk', baeium: 'baeium-android.apk' },
+  windows: { full: 'bae-windows-x64.zip', baeium: 'baeium-windows-x64.zip' },
+};
+
+export interface EditionDownload {
+  version: string;
+  url: string;
+}
+/** A platform's available editions; an edition with no asset yet is absent. */
+export type PlatformDownloads = Partial<Record<Edition, EditionDownload>>;
+/** Latest per platform; a platform with no release yet is absent. */
+export type LatestManifest = Partial<Record<Platform, PlatformDownloads>>;
+
+interface GhAsset {
+  name: string;
+  browser_download_url: string;
+}
+interface GhRelease {
+  tag_name: string;
+  draft: boolean;
+  assets: GhAsset[];
+}
+
+/**
+ * Compare dotted numeric versions so "0.10" sorts above "0.2". A shorter version
+ * is normalized by padding absent trailing segments with zero — "0.3" equals
+ * "0.3.0" — which is the standard semver convention, made explicit here rather
+ * than defaulted inline.
+ */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+  while (pa.length < len) pa.push(0);
+  while (pb.length < len) pb.push(0);
+  for (let i = 0; i < len; i++) {
+    if (pa[i] !== pb[i]) return pa[i] > pb[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+async function fetchReleases(): Promise<GhRelease[]> {
+  const headers: Record<string, string> = {
+    // GitHub rejects API requests with no User-Agent.
+    'User-Agent': 'bae-website-build',
+    Accept: 'application/vnd.github+json',
+  };
+  // Authenticated when a token is in the build env (GitHub Actions runner):
+  // lifts the 60/hr unauthenticated cap. Anonymous (e.g. a Vercel build) still
+  // works — this is one request per build.
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, { headers });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub releases API returned ${res.status} ${res.statusText}; cannot resolve download links`,
+    );
+  }
+  return (await res.json()) as GhRelease[];
+}
+
+function buildManifest(releases: GhRelease[]): LatestManifest {
+  const manifest: LatestManifest = {};
+  for (const platform of Object.keys(ASSETS) as Platform[]) {
+    const prefix = `${platform}-v`;
+    const latest = releases
+      .filter((r) => !r.draft && r.tag_name.startsWith(prefix))
+      .map((r) => ({ release: r, version: r.tag_name.slice(prefix.length) }))
+      .sort((a, b) => compareVersions(b.version, a.version))[0];
+    if (!latest) {
+      // Expected for a platform that hasn't shipped (iOS, Windows): it's simply
+      // omitted, and its button renders "coming soon". Logged so the build shows
+      // which platforms resolved and which didn't.
+      console.info(`releases: no published ${platform}-v* release yet; omitting from manifest`);
+      continue;
+    }
+    const downloads: PlatformDownloads = {};
+    for (const edition of ['full', 'baeium'] as Edition[]) {
+      const asset = latest.release.assets.find((a) => a.name === ASSETS[platform][edition]);
+      if (asset) {
+        downloads[edition] = { version: latest.version, url: asset.browser_download_url };
+      } else {
+        // The release exists but is missing this edition's asset. Anomalous for a
+        // full build; a known gap for baeium on macOS/iOS, whose serialized
+        // per-edition release matrix can't append the second edition to an
+        // immutable release. Either way, name what's missing rather than drop it
+        // silently.
+        console.warn(
+          `releases: ${platform}-v${latest.version} has no ${ASSETS[platform][edition]} asset; omitting ${platform}/${edition}`,
+        );
+      }
+    }
+    if (Object.keys(downloads).length > 0) manifest[platform] = downloads;
+  }
+  return manifest;
+}
+
+let cache: Promise<LatestManifest> | undefined;
+
+/** Build-time-memoized: one releases fetch per build, shared by every caller. */
+export function getLatest(): Promise<LatestManifest> {
+  if (!cache) cache = fetchReleases().then(buildManifest);
+  return cache;
+}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,4 +1,16 @@
 ---
+import { getLatest } from '../lib/releases';
+
+// Landing CTAs point at the latest macOS build (the desktop flagship), resolved
+// at build time from the newest versioned release. If there's no published
+// macOS build, the CTAs fall back to the install page (which lists every
+// platform's state) — logged here so an unexpectedly-missing flagship build is
+// visible in the build, not silently swapped.
+const macFullUrl = (await getLatest()).macos?.full?.url;
+if (!macFullUrl) {
+  console.warn('index: no macOS full build resolved; landing CTAs fall back to the install page');
+}
+const macUrl = macFullUrl ?? '/getting-started/installation';
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -279,7 +291,7 @@
       <h1 class="jumbo r d1">Your music<br/><span class="pink">everywhere</span></h1>
       <p class="dek r d2">All your music, on your desktop and your phone. Listen everywhere, synced effortlessly. No server to keep running. <b style="white-space:nowrap;">Private, yours.</b></p>
       <div class="cta r d3">
-        <a class="btn pink" href="https://github.com/bae-fm/bae/releases/download/macos-latest/bae-macos.dmg">Download for macOS</a>
+        <a class="btn pink" href={macUrl}>Download for macOS</a>
         <a class="btn" href="#features">Explore features</a>
         <span class="meta">macOS · iOS · Windows · Android</span>
       </div>
@@ -432,7 +444,7 @@
   <h2 class="r d1" aria-label="Bring your collection home">Bring your collection <span class="cyc" aria-hidden="true"><span class="cyc-word cyc-pink">home</span><span class="cyc-dot">.</span></span><span class="cyc-fallback">home.</span></h2>
   <p class="r d2">Private, open source, and in active development. Everything you add is yours from day one.</p>
   <div class="cta r d3" style="justify-content:center;">
-    <a class="btn pink" href="https://github.com/bae-fm/bae/releases/download/macos-latest/bae-macos.dmg">Download for macOS</a>
+    <a class="btn pink" href={macUrl}>Download for macOS</a>
     <a class="btn" href="/architecture/overview">See how it works</a>
   </div>
 </div></section>

--- a/website/src/pages/latest.json.ts
+++ b/website/src/pages/latest.json.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro';
+import { getLatest } from '../lib/releases';
+
+// Published at /latest.json: the newest version + permanent download URL per
+// platform/edition. Regenerated on each website build (every app release
+// triggers a redeploy), so it always names the current releases. A machine
+// can read this to find the latest build without scraping the releases page.
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify(await getLatest(), null, 2), {
+    headers: { 'content-type': 'application/json' },
+  });
+};


### PR DESCRIPTION
The repo has immutable releases enabled, which breaks the rolling `-latest` release pattern every platform's download links and release workflows depended on. A tag once used by an immutable release can't be reused, and an immutable release's assets can't be replaced — so the release workflows' "clobber the `<platform>-latest` asset" step fails on every run (this is what reddened the latest Android release), and the website's `…/releases/download/<platform>-latest/…` links go stale or 404.

This drops the rolling `-latest` releases entirely and resolves downloads from the permanent, versioned release assets instead. At website build time a single GitHub API call finds the newest `<platform>-v*` release per platform, and that data both publishes as `/latest.json` and bakes the versioned asset URLs into the download buttons. A platform with no release yet (iOS, Windows) renders a disabled "coming soon" affordance instead of a dead link. Each release workflow drops its dead `-latest` step and instead dispatches a website redeploy, so the buttons and `/latest.json` refresh against the new release (~1 min).

Verified the static build locally: `/latest.json` and the install page resolve macOS-full and Android (both editions) to their `…-v0.3` assets and mark the rest "coming soon" — matching the actual release state, so no link regresses (the prior `baeium-macos-latest`/iOS/Windows links were already 404).

Known gap (called out in the commit): macOS and iOS attach only the full edition to the versioned release — their serialized per-edition matrix appends the second edition, which immutable releases reject — so baeium macOS/iOS read as "coming soon" until those workflows are restructured to create the release once with both editions, the way Android and Windows already do.

## Test plan
- [x] `npm run build` (website) — `/latest.json` + buttons resolve to versioned URLs; absent platforms render "coming soon"
- [x] All four release workflows parse; new `refresh-website` job wired to the right `needs`
- [ ] On merge: `deploy-website` runs (website/** push) and the live download links serve the versioned assets