### PR TITLE
Import: filesystem watching — propagate on-disk changes live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,8 @@ dependencies = [
  "natord",
  "ndk 0.9.0",
  "nom",
+ "notify",
+ "notify-debouncer-full",
  "rand 0.9.2",
  "rayon",
  "regex",
@@ -1858,6 +1860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1925,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -2567,6 +2587,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +2758,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8286c3ab222af2fa9e57874fe419893d967f739c7bf1743f98a88678edbf08"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -2984,6 +3044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3065,6 +3126,46 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5505,6 +5606,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5551,11 +5661,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5577,6 +5704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5593,6 +5726,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5613,10 +5752,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5637,6 +5788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5653,6 +5810,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5673,6 +5836,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5689,6 +5858,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1574,6 +1574,9 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
                 },
             })
         }
+        UiBusEvent::ScanCandidateRemoved { key } => {
+            Some(BridgeUiEvent::ScanCandidateRemoved { key })
+        }
         UiBusEvent::ScanFinished => Some(BridgeUiEvent::ScanFinished),
 
         // ── Library ────────────────────────────────────────────────

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1057,6 +1057,11 @@ pub enum BridgeUiEvent {
     FolderCandidateAdded {
         candidate: BridgeFolderCandidate,
     },
+    /// A candidate's folder was re-scanned and the release is gone — the reducer
+    /// removes it by key.
+    ScanCandidateRemoved {
+        key: String,
+    },
     ScanFinished,
 
     // ── Library ────────────────────────────────────────────────────

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -48,6 +48,8 @@ tokio-util = { version = "0.7", features = ["io", "rt"] }
 rand = "0.9"
 lru = "0.17"
 tracing = { workspace = true }
+notify = "8.2.0"
+notify-debouncer-full = "0.7.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -130,7 +130,7 @@ pub struct ImportServiceHandle {
     pub progress_handle: ImportProgressHandle,
     pub library_manager: LibraryManager,
     pub runtime_handle: tokio::runtime::Handle,
-    pub scan_tx: mpsc::UnboundedSender<ScanRequest>,
+    pub watcher_tx: mpsc::UnboundedSender<WatcherCommand>,
     /// Unified event channel — all import service events go here.
     pub event_tx: broadcast::Sender<ImportEvent>,
     /// The persistent watched-folder list. Mutated by `add_watched_folder` /
@@ -141,18 +141,25 @@ pub struct ImportServiceHandle {
 #[derive(Debug, Clone)]
 pub enum ScanEvent {
     /// The watched-folder list changed (queried at load, or after add/remove).
-    /// Carries the full ordered list; the reducer replaces its copy and drops
-    /// any candidate whose source folder is no longer watched.
+    /// Carries the full ordered list; the reducer replaces its copy.
     WatchedFoldersChanged {
         folders: Vec<WatchedFolder>,
     },
     FolderCandidate(FolderCandidate),
-    Error(String),
+    /// A previously-emitted candidate no longer resolves on disk — the watcher
+    /// re-scanned its folder and the release is gone. The reducer removes it by
+    /// key (the key is the candidate's folder path).
+    CandidateRemoved {
+        candidate_key: String,
+    },
     Finished,
 }
 
-pub struct ScanRequest {
-    pub path: std::path::PathBuf,
+/// Commands to the folder watcher. `Watch` starts watching a folder (idempotent)
+/// and scans it; `Unwatch` stops watching it.
+pub enum WatcherCommand {
+    Watch(std::path::PathBuf),
+    Unwatch(std::path::PathBuf),
 }
 
 impl ImportServiceHandle {
@@ -161,7 +168,7 @@ impl ImportServiceHandle {
         requests_tx: mpsc::UnboundedSender<ImportCommand>,
         library_manager: LibraryManager,
         runtime_handle: tokio::runtime::Handle,
-        scan_tx: mpsc::UnboundedSender<ScanRequest>,
+        watcher_tx: mpsc::UnboundedSender<WatcherCommand>,
         event_tx: broadcast::Sender<ImportEvent>,
         folder_registry: Arc<Mutex<ImportFolderRegistry>>,
     ) -> Self {
@@ -172,7 +179,7 @@ impl ImportServiceHandle {
             progress_handle,
             library_manager,
             runtime_handle,
-            scan_tx,
+            watcher_tx,
             event_tx,
             folder_registry,
         }
@@ -622,8 +629,8 @@ impl ImportServiceHandle {
     }
 
     /// Add a folder to watch for imports: persist it, broadcast the new list,
-    /// and scan it so its releases appear as candidates. A folder already
-    /// watched is left as-is.
+    /// and start watching + scanning it so its releases appear as candidates and
+    /// later on-disk changes propagate. A folder already watched is left as-is.
     pub fn add_watched_folder(&self, path: String) -> Result<(), String> {
         let library_dir = self.library_manager.library_dir();
         let mut registry = self.folder_registry.lock().unwrap();
@@ -637,16 +644,15 @@ impl ImportServiceHandle {
             &self.event_tx,
             ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
         );
-        self.scan_tx
-            .send(ScanRequest {
-                path: std::path::PathBuf::from(path),
-            })
-            .map_err(|_| "Failed to enqueue folder scan".to_string())
+        self.watcher_tx
+            .send(WatcherCommand::Watch(std::path::PathBuf::from(path)))
+            .map_err(|_| "Failed to start watching folder".to_string())
     }
 
-    /// Stop watching `path`: persist the removal and broadcast the new list.
-    /// The reducer drops the folder's candidates by reconciling against the
-    /// list, so no per-candidate removal events are needed.
+    /// Stop watching `path`: persist the removal, broadcast the new list, and
+    /// stop the filesystem watcher for it. The reducer drops the folder's
+    /// candidates by reconciling against the list, so no per-candidate removal
+    /// events are needed here.
     pub fn remove_watched_folder(&self, path: String) -> Result<(), String> {
         let library_dir = self.library_manager.library_dir();
         let mut registry = self.folder_registry.lock().unwrap();
@@ -658,21 +664,22 @@ impl ImportServiceHandle {
                 &self.event_tx,
                 ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
             );
+            self.watcher_tx
+                .send(WatcherCommand::Unwatch(std::path::PathBuf::from(path)))
+                .map_err(|_| "Failed to stop watching folder".to_string())?;
         }
         Ok(())
     }
 
-    /// Scan every watched folder, emitting one `FolderCandidate` per release
-    /// found. The UI calls this when the import view appears to populate the
-    /// candidate list (the scan results stream in as events).
+    /// Start watching + scanning every watched folder, emitting one
+    /// `FolderCandidate` per release found and `CandidateRemoved` for any that
+    /// have since vanished. The UI calls this when the import view appears.
     pub fn scan_watched_folders(&self) -> Result<(), String> {
         let folders = self.folder_registry.lock().unwrap().watched_folders();
         for folder in folders {
-            self.scan_tx
-                .send(ScanRequest {
-                    path: std::path::PathBuf::from(folder.path),
-                })
-                .map_err(|_| "Failed to enqueue folder scan".to_string())?;
+            self.watcher_tx
+                .send(WatcherCommand::Watch(std::path::PathBuf::from(folder.path)))
+                .map_err(|_| "Failed to start watching folder".to_string())?;
         }
         Ok(())
     }

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -1,6 +1,6 @@
 use crate::import::handle::ImportServiceHandle;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
-use crate::import::handle::{ScanEvent, ScanRequest};
+use crate::import::handle::{ScanEvent, WatcherCommand};
 use crate::import::types::{
     ImportCommand, ImportProgress, MetadataRef, MetadataSource, StorageMode,
 };
@@ -23,9 +23,12 @@ use {
     crate::storage::local::ReleaseStorageImpl,
     crate::util::content_type::ContentType,
     crate::util::content_type_hint::ContentTypeHint,
-    std::collections::HashMap,
+    notify::RecursiveMode,
+    notify_debouncer_full::{new_debouncer, DebounceEventResult},
+    std::collections::{HashMap, HashSet},
     std::path::{Path, PathBuf},
     std::sync::{Arc, Mutex},
+    std::time::Duration,
 };
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
@@ -307,55 +310,165 @@ impl ImportService {
     }
 }
 
+/// The watched roots that contain at least one of the `changed` paths, in
+/// `roots` order and without duplicates.
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+fn affected_roots(changed: &[&Path], roots: &[PathBuf]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .filter(|root| changed.iter().any(|path| path.starts_with(root)))
+        .cloned()
+        .collect()
+}
+
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl ImportService {
-    fn start_scan_worker(
+    /// The folder watcher. Owns a debouncing filesystem watcher and, per watched
+    /// folder, the set of candidate keys it last emitted. A `Watch` command
+    /// starts watching and scanning a folder, a debounced filesystem change
+    /// under a watched folder re-scans it, and `Unwatch` stops. Every re-scan
+    /// reconciles against the last known keys, emitting `FolderCandidate` for
+    /// what's on disk and `CandidateRemoved` for what's gone, so changes
+    /// propagate beyond the first scan.
+    fn start_watcher(
         runtime_handle: &tokio::runtime::Handle,
-        mut scan_rx: mpsc::UnboundedReceiver<ScanRequest>,
+        mut cmd_rx: mpsc::UnboundedReceiver<WatcherCommand>,
         event_tx: broadcast::Sender<crate::import::handle::ImportEvent>,
     ) {
         runtime_handle.spawn(async move {
-            while let Some(ScanRequest { path }) = scan_rx.recv().await {
-                let result = Self::scan_folder(path, &event_tx).await;
-
-                match result {
-                    Ok(()) => {
-                        send_event(
-                            &event_tx,
-                            crate::import::handle::ImportEvent::Scan(ScanEvent::Finished),
-                        );
+            let (fs_tx, mut fs_rx) = mpsc::unbounded_channel::<DebounceEventResult>();
+            let mut debouncer = match new_debouncer(
+                Duration::from_secs(1),
+                None,
+                move |result: DebounceEventResult| {
+                    // Runs on the debouncer's own thread; hand the batch to the
+                    // task. A send error means the task's receiver is gone (the
+                    // service is shutting down); the debouncer is dropped right
+                    // after, so this is benign but worth a line.
+                    if fs_tx.send(result).is_err() {
+                        warn!("folder watcher event dropped: task receiver gone");
                     }
-                    Err(error) => {
-                        send_event(
-                            &event_tx,
-                            crate::import::handle::ImportEvent::Scan(ScanEvent::Error(error)),
-                        );
-                        send_event(
-                            &event_tx,
-                            crate::import::handle::ImportEvent::Scan(ScanEvent::Finished),
-                        );
+                },
+            ) {
+                Ok(debouncer) => debouncer,
+                Err(e) => {
+                    error!("failed to start folder watcher: {e}");
+                    return;
+                }
+            };
+
+            let mut roots: Vec<PathBuf> = Vec::new();
+            let mut last_keys: HashMap<PathBuf, HashSet<String>> = HashMap::new();
+
+            loop {
+                tokio::select! {
+                    cmd = cmd_rx.recv() => {
+                        let Some(cmd) = cmd else { break };
+                        match cmd {
+                            WatcherCommand::Watch(path) => {
+                                if !roots.contains(&path) {
+                                    if let Err(e) =
+                                        debouncer.watch(&path, RecursiveMode::Recursive)
+                                    {
+                                        warn!("failed to watch {}: {e}", path.display());
+                                    }
+                                    roots.push(path.clone());
+                                }
+                                Self::rescan_and_reconcile(&path, &mut last_keys, &event_tx)
+                                    .await;
+                            }
+                            WatcherCommand::Unwatch(path) => {
+                                if let Err(e) = debouncer.unwatch(&path) {
+                                    warn!("failed to unwatch {}: {e}", path.display());
+                                }
+                                roots.retain(|p| p != &path);
+                                last_keys.remove(&path);
+                            }
+                        }
+                    }
+                    Some(result) = fs_rx.recv() => {
+                        let events = match result {
+                            Ok(events) => events,
+                            Err(errors) => {
+                                for e in errors {
+                                    warn!("folder watcher error: {e}");
+                                }
+                                continue;
+                            }
+                        };
+                        let changed: Vec<&Path> = events
+                            .iter()
+                            .flat_map(|e| e.paths.iter().map(PathBuf::as_path))
+                            .collect();
+                        for root in affected_roots(&changed, &roots) {
+                            Self::rescan_and_reconcile(&root, &mut last_keys, &event_tx).await;
+                        }
                     }
                 }
             }
         });
     }
 
-    async fn scan_folder(
-        path: PathBuf,
+    /// Re-scan `root` and reconcile against the candidate keys last emitted for
+    /// it: emit every current candidate (the reducer keeps in-progress state for
+    /// ones it already holds) and `CandidateRemoved` for any that vanished. A
+    /// scan error (folder unreadable/deleted) reconciles to empty, removing all
+    /// of the folder's candidates.
+    async fn rescan_and_reconcile(
+        root: &Path,
+        last_keys: &mut HashMap<PathBuf, HashSet<String>>,
         event_tx: &broadcast::Sender<crate::import::handle::ImportEvent>,
-    ) -> Result<(), String> {
-        let tx = event_tx.clone();
-        tokio::task::spawn_blocking(move || {
-            scan_for_candidates_with_callback(path, |candidate| {
-                send_event(
-                    &tx,
-                    crate::import::handle::ImportEvent::Scan(ScanEvent::FolderCandidate(candidate)),
-                );
-            })
+    ) {
+        let root_buf = root.to_path_buf();
+        let scanned = tokio::task::spawn_blocking(move || {
+            let mut candidates = Vec::new();
+            scan_for_candidates_with_callback(root_buf, |c| candidates.push(c)).map(|()| candidates)
         })
-        .await
-        .map_err(|e| format!("Scan task failed: {}", e))
-        .and_then(|r| r)
+        .await;
+
+        let candidates = match scanned {
+            Ok(Ok(candidates)) => candidates,
+            Ok(Err(e)) => {
+                warn!(
+                    "re-scan of {} failed ({e}); removing its candidates",
+                    root.display()
+                );
+                Vec::new()
+            }
+            Err(e) => {
+                error!("folder scan task panicked for {}: {e}", root.display());
+                return;
+            }
+        };
+
+        let new_keys: HashSet<String> = candidates
+            .iter()
+            .map(|c| c.path.to_string_lossy().into_owned())
+            .collect();
+
+        for candidate in candidates {
+            send_event(
+                event_tx,
+                crate::import::handle::ImportEvent::Scan(ScanEvent::FolderCandidate(candidate)),
+            );
+        }
+
+        if let Some(previous) = last_keys.get(root) {
+            for gone in previous.difference(&new_keys) {
+                send_event(
+                    event_tx,
+                    crate::import::handle::ImportEvent::Scan(ScanEvent::CandidateRemoved {
+                        candidate_key: gone.clone(),
+                    }),
+                );
+            }
+        }
+        last_keys.insert(root.to_path_buf(), new_keys);
+
+        send_event(
+            event_tx,
+            crate::import::handle::ImportEvent::Scan(ScanEvent::Finished),
+        );
     }
 
     /// Start the import service worker.
@@ -368,12 +481,12 @@ impl ImportService {
         library_manager: LibraryManager,
     ) -> ImportServiceHandle {
         let (commands_tx, commands_rx) = mpsc::unbounded_channel();
-        let (scan_tx, scan_rx) = mpsc::unbounded_channel();
+        let (watcher_tx, watcher_rx) = mpsc::unbounded_channel();
         let (event_tx, _) = broadcast::channel(1024);
         let event_tx_for_worker = event_tx.clone();
         let library_manager_for_handle = library_manager.clone();
 
-        ImportService::start_scan_worker(&runtime_handle, scan_rx, event_tx.clone());
+        ImportService::start_watcher(&runtime_handle, watcher_rx, event_tx.clone());
 
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -412,7 +525,7 @@ impl ImportService {
             commands_tx,
             library_manager_for_handle,
             runtime_handle,
-            scan_tx,
+            watcher_tx,
             event_tx,
             folder_registry,
         )
@@ -2011,6 +2124,29 @@ mod tests {
     use super::*;
     use crate::clock::FixedClock;
     use crate::id_provider::SequentialIdProvider;
+
+    #[test]
+    fn affected_roots_maps_changed_paths_to_their_watched_roots() {
+        let root_a = PathBuf::from("/music/new rips");
+        let root_b = PathBuf::from("/downloads/bandcamp");
+        let roots = vec![root_a.clone(), root_b.clone()];
+
+        // A change inside one root flags only that root.
+        let changed = [Path::new("/music/new rips/Album/01.flac")];
+        assert_eq!(affected_roots(&changed, &roots), vec![root_a.clone()]);
+
+        // Changes under both roots flag both, in roots order, deduped.
+        let changed = [
+            Path::new("/downloads/bandcamp/X/cover.jpg"),
+            Path::new("/music/new rips/Y"),
+            Path::new("/music/new rips/Z"),
+        ];
+        assert_eq!(affected_roots(&changed, &roots), vec![root_a, root_b]);
+
+        // A change outside every watched root flags nothing.
+        let changed = [Path::new("/elsewhere/file")];
+        assert!(affected_roots(&changed, &roots).is_empty());
+    }
 
     /// `common_ancestor` derives the unmanaged-path root by folding over the
     /// files' parent dirs. It must compare path components, not string

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -265,11 +265,11 @@ impl UiEventBus {
                         ScanEvent::FolderCandidate(c) => {
                             bus.emit(UiBusEvent::FolderCandidateAdded { candidate: c });
                         }
+                        ScanEvent::CandidateRemoved { candidate_key } => {
+                            bus.emit(UiBusEvent::ScanCandidateRemoved { key: candidate_key });
+                        }
                         ScanEvent::Finished => {
                             bus.emit(UiBusEvent::ScanFinished);
-                        }
-                        ScanEvent::Error(msg) => {
-                            bus.emit(UiBusEvent::Error { message: msg });
                         }
                     },
                     Ok(ImportEvent::ImportProgress {

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -146,6 +146,11 @@ pub enum UiBusEvent {
     FolderCandidateAdded {
         candidate: crate::import::FolderCandidate,
     },
+    /// A candidate's folder was re-scanned by the watcher and the release is
+    /// gone. The reducer removes it by key.
+    ScanCandidateRemoved {
+        key: String,
+    },
     ScanFinished,
 
     // ── Library ────────────────────────────────────────────────────

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -280,6 +280,91 @@ async fn folder_scan_produces_candidates() {
     println!("Folder scan produced 2 independent candidates");
 }
 
+/// The watcher reconciles a folder against the candidates it last emitted: a new
+/// release folder appears as a candidate, and a deleted one emits
+/// `CandidateRemoved`. Driven by `scan_watched_folders` re-triggers (plus the
+/// watcher's own debounced FS reconciles) over a fixed window, so it doesn't
+/// hinge on filesystem-event timing — both paths reconcile to the same on-disk
+/// truth, so `contains` assertions hold regardless of how many fire.
+#[tokio::test]
+#[serial]
+async fn watcher_reconciles_added_and_removed_candidates() {
+    support::tracing_init();
+    let f = ImportFixture::new().await;
+
+    let collection = f.temp_path().join("Collection");
+    let album1 = collection.join("Artist - First Album");
+    fs::create_dir_all(&album1).unwrap();
+    generate_album_files(&album1, &["01 Track.flac"]);
+    let album1_key = album1.to_string_lossy().into_owned();
+
+    let mut scan_rx = f.handle.subscribe_folder_scan_events();
+    f.handle
+        .add_watched_folder(collection.to_string_lossy().into_owned())
+        .unwrap();
+
+    let first = collect_scan_events(&mut scan_rx).await;
+    assert!(
+        first.added.contains(&album1_key),
+        "initial scan should surface the first album"
+    );
+    assert!(first.removed.is_empty());
+
+    // A new release folder appears on disk; re-scan surfaces it.
+    let album2 = collection.join("Artist - Second Album");
+    fs::create_dir_all(&album2).unwrap();
+    generate_album_files(&album2, &["01 Track.flac"]);
+    let album2_key = album2.to_string_lossy().into_owned();
+    f.handle.scan_watched_folders().unwrap();
+
+    let second = collect_scan_events(&mut scan_rx).await;
+    assert!(
+        second.added.contains(&album2_key),
+        "the newly-added folder should surface as a candidate"
+    );
+
+    // The first release folder is deleted; re-scan removes its candidate.
+    fs::remove_dir_all(&album1).unwrap();
+    f.handle.scan_watched_folders().unwrap();
+
+    let third = collect_scan_events(&mut scan_rx).await;
+    assert!(
+        third.removed.contains(&album1_key),
+        "the deleted folder's candidate should be removed"
+    );
+}
+
+struct ScanBatch {
+    added: Vec<String>,
+    removed: Vec<String>,
+}
+
+/// Drain scan events over a fixed window, collecting candidate paths added and
+/// candidate keys removed. A fixed window (rather than stopping at the first
+/// `Finished`) absorbs the watcher's debounced FS reconcile landing alongside an
+/// explicit re-scan.
+async fn collect_scan_events(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ScanEvent>,
+) -> ScanBatch {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
+            Ok(Some(ScanEvent::FolderCandidate(c))) => {
+                added.push(c.path.to_string_lossy().into_owned());
+            }
+            Ok(Some(ScanEvent::CandidateRemoved { candidate_key })) => {
+                removed.push(candidate_key);
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => break,
+            Err(_) => {}
+        }
+    }
+    ScanBatch { added, removed }
+}
+
 /// 3. Unmanaged folder import: album, release, tracks all in DB, files stay in place.
 #[tokio::test]
 #[serial]

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -276,6 +276,11 @@ enum UiEventReducer {
                 importStore.folderCandidates[native.key] = native
             }
 
+        case .scanCandidateRemoved(let key):
+            // The watcher re-scanned the candidate's folder and the release is
+            // gone from disk; drop it.
+            importStore.folderCandidates.removeValue(forKey: key)
+
         case .scanFinished:
             // No state change needed — views react to candidate additions
             break


### PR DESCRIPTION
After #19, a watched folder was scanned once when the import view appeared. If you then dropped a new rip into a watched folder, or deleted one, the candidate list didn't reflect it until the app restarted.

This replaces the one-shot scan worker with a debouncing filesystem watcher (the \`notify\` crate). Each watched folder is watched recursively; a debounced batch of changes maps to the affected watched roots, which are re-scanned. Each re-scan reconciles against the candidate keys the watcher last emitted for that folder — emitting \`FolderCandidate\` for everything currently on disk (the reducer keeps in-progress identify/import state for candidates it already holds) and a reintroduced \`CandidateRemoved\` for any that have vanished. A scan error (folder deleted/unreadable) reconciles to empty, removing its candidates.

The explicit re-scan the view triggers on appear goes through the same reconcile path, so the FS-event path and the explicit path converge on the same on-disk truth. Adding a watched folder starts its watch + initial scan; removing one stops the watch. The now-unused \`ScanEvent::Error\` (the old scan worker's only emitter is gone) is removed.

## Test plan
- [x] \`affected_roots\` unit test: changed paths map to their watched roots, in order, deduped
- [x] \`watcher_reconciles_added_and_removed_candidates\` integration test: add a release folder → it surfaces; delete one → \`CandidateRemoved\` (driven by re-scan triggers over a fixed window, robust to FS-event timing)
- [x] Existing \`folder_scan_produces_candidates\` still passes through the watcher
- [x] core clippy (lib + tests), bridge clippy, macOS build, periphery — all green via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)