### PR TITLE
Import: New/Added/Skipped tabs + manual skip + content-hash Added

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -926,6 +926,16 @@ impl AppHandle {
             .map_err(|e| BridgeError::Import { msg: e })
     }
 
+    /// Mark the candidate at `path` skipped or unskipped. Persists the change and
+    /// broadcasts a `CandidateSkipChanged` event so the import view re-tabs the
+    /// row.
+    pub fn set_candidate_skipped(&self, path: String, skipped: bool) -> Result<(), BridgeError> {
+        self.app_services
+            .import()
+            .set_candidate_skipped(path, skipped)
+            .map_err(|e| BridgeError::Import { msg: e })
+    }
+
     /// Scan every watched folder, streaming results back as
     /// `FolderCandidateAdded` events. The UI calls this when the import view
     /// appears to populate the candidate list.
@@ -1571,11 +1581,16 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
                     watched_folder_path: candidate.watched_folder_path,
                     files: categorized_files_to_bridge(candidate.files),
                     track_count,
+                    skipped: candidate.skipped,
+                    is_added: candidate.is_added,
                 },
             })
         }
         UiBusEvent::ScanCandidateRemoved { key } => {
             Some(BridgeUiEvent::ScanCandidateRemoved { key })
+        }
+        UiBusEvent::CandidateSkipChanged { key, skipped } => {
+            Some(BridgeUiEvent::CandidateSkipChanged { key, skipped })
         }
         UiBusEvent::ScanFinished => Some(BridgeUiEvent::ScanFinished),
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -419,6 +419,12 @@ pub struct BridgeFolderCandidate {
     /// Folder candidates always have files on disk and CUEs parsed during the
     /// scan, so track count is always known.
     pub track_count: u32,
+    /// Whether the user manually marked this candidate as skipped — the import
+    /// view tabs it under "Skipped".
+    pub skipped: bool,
+    /// Whether this candidate's file structure was already imported (matched by
+    /// content hash). When true, the import view tabs it under "Added".
+    pub is_added: bool,
 }
 
 /// A folder the user watches for imports — one candidate-list group.
@@ -1061,6 +1067,12 @@ pub enum BridgeUiEvent {
     /// removes it by key.
     ScanCandidateRemoved {
         key: String,
+    },
+    /// The user manually skipped or unskipped a candidate — the reducer flips
+    /// its `skipped` flag, re-tabbing it New ↔ Skipped.
+    CandidateSkipChanged {
+        key: String,
+        skipped: bool,
     },
     ScanFinished,
 

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -2807,6 +2807,28 @@ impl Database {
             .await
     }
 
+    /// The album id of a release stored from the file structure that hashes to
+    /// `hash`, or `None` when no release carries that content hash. The import
+    /// Whether some release in the library was imported from this exact file
+    /// structure (its `content_hash` matches `hash`). The import view uses this
+    /// to mark a scanned folder as already added.
+    pub async fn is_content_hash_imported(&self, hash: &str) -> Result<bool, DbError> {
+        let hash = hash.to_string();
+        self.inner
+            .coven_db
+            .call(move |conn| {
+                conn.query_row(
+                    "SELECT 1 FROM releases WHERE content_hash = ? LIMIT 1",
+                    params![hash],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map(|o| o.is_some())
+                .map_err(DbError::from)
+            })
+            .await
+    }
+
     /// Check, for each candidate in `checks`, whether the library already
     /// holds the same pressing or the same album (group). Drives the
     /// "in library" badges shown in the identify-pipeline result lists.

--- a/bae-core/src/import/folder_registry.rs
+++ b/bae-core/src/import/folder_registry.rs
@@ -47,6 +47,13 @@ impl WatchedFolder {
 pub struct ImportFolderRegistry {
     /// Watched folder paths, in the order the user added them.
     folders: Vec<String>,
+    /// Candidate folder paths the user manually marked as skipped. A skipped
+    /// candidate still scans but renders under the import view's "Skipped" tab
+    /// instead of "New". `#[serde(default)]` so an `import_folders.yaml` that
+    /// omits this field (only `folders`) still loads as an empty skip set
+    /// instead of failing to deserialize.
+    #[serde(default)]
+    skipped: Vec<String>,
 }
 
 impl ImportFolderRegistry {
@@ -128,6 +135,38 @@ impl ImportFolderRegistry {
         self.save(library_dir)?;
         Ok(true)
     }
+
+    /// Whether the candidate folder at `path` is manually marked as skipped.
+    pub fn is_skipped(&self, path: &str) -> bool {
+        self.skipped.iter().any(|p| p == path)
+    }
+
+    /// Mark `path` skipped (insert) or unskip it (remove), persisting on change.
+    /// Returns `true` when the skip set changed, `false` when the request was a
+    /// no-op (already in the requested state).
+    pub fn set_skipped(
+        &mut self,
+        library_dir: &LibraryDir,
+        path: String,
+        skipped: bool,
+    ) -> Result<bool, String> {
+        let changed = if skipped {
+            if self.skipped.contains(&path) {
+                false
+            } else {
+                self.skipped.push(path);
+                true
+            }
+        } else {
+            let before = self.skipped.len();
+            self.skipped.retain(|p| p != &path);
+            self.skipped.len() != before
+        };
+        if changed {
+            self.save(library_dir)?;
+        }
+        Ok(changed)
+    }
 }
 
 #[cfg(test)]
@@ -195,5 +234,87 @@ mod tests {
                 name: "b".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn skip_persists_and_survives_reload() {
+        let (_tmp, library_dir) = temp_library_dir();
+        let mut registry = ImportFolderRegistry::load(&library_dir);
+        assert!(!registry.is_skipped("/a"));
+
+        assert!(registry
+            .set_skipped(&library_dir, "/a".to_string(), true)
+            .unwrap());
+        // Skipping an already-skipped path is a no-op.
+        assert!(!registry
+            .set_skipped(&library_dir, "/a".to_string(), true)
+            .unwrap());
+        assert!(registry.is_skipped("/a"));
+
+        // A fresh load sees the persisted skip.
+        let reloaded = ImportFolderRegistry::load(&library_dir);
+        assert!(reloaded.is_skipped("/a"));
+        assert!(!reloaded.is_skipped("/b"));
+    }
+
+    #[test]
+    fn unskip_persists_and_reports_change() {
+        let (_tmp, library_dir) = temp_library_dir();
+        let mut registry = ImportFolderRegistry::load(&library_dir);
+        registry
+            .set_skipped(&library_dir, "/a".to_string(), true)
+            .unwrap();
+
+        assert!(registry
+            .set_skipped(&library_dir, "/a".to_string(), false)
+            .unwrap());
+        // Unskipping an already-unskipped path is a no-op.
+        assert!(!registry
+            .set_skipped(&library_dir, "/a".to_string(), false)
+            .unwrap());
+
+        let reloaded = ImportFolderRegistry::load(&library_dir);
+        assert!(!reloaded.is_skipped("/a"));
+    }
+
+    #[test]
+    fn skip_set_is_independent_of_watched_folders() {
+        // The skip set tracks candidate folders, which are distinct from the
+        // watched roots; the two lists don't interfere.
+        let (_tmp, library_dir) = temp_library_dir();
+        let mut registry = ImportFolderRegistry::load(&library_dir);
+        registry.add(&library_dir, "/root".to_string()).unwrap();
+        registry
+            .set_skipped(&library_dir, "/root/Album".to_string(), true)
+            .unwrap();
+
+        let reloaded = ImportFolderRegistry::load(&library_dir);
+        assert_eq!(
+            reloaded.watched_folders(),
+            vec![WatchedFolder {
+                path: "/root".to_string(),
+                name: "root".to_string(),
+            }]
+        );
+        assert!(reloaded.is_skipped("/root/Album"));
+    }
+
+    #[test]
+    fn loads_file_omitting_skipped_field() {
+        // An `import_folders.yaml` that omits the `skipped` field (only
+        // `folders`) must still load, defaulting to an empty skip set.
+        let (_tmp, library_dir) = temp_library_dir();
+        let path = ImportFolderRegistry::file_path(&library_dir);
+        std::fs::write(&path, "folders:\n  - /a\n").unwrap();
+
+        let registry = ImportFolderRegistry::load(&library_dir);
+        assert_eq!(
+            registry.watched_folders(),
+            vec![WatchedFolder {
+                path: "/a".to_string(),
+                name: "a".to_string(),
+            }]
+        );
+        assert!(!registry.is_skipped("/a"));
     }
 }

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -221,6 +221,17 @@ pub struct FolderCandidate {
     /// the candidate-list group it belongs to. Equal to the scan root. The
     /// group's display name comes from the watched-folder list, not here.
     pub watched_folder_path: String,
+    /// Whether the user manually marked this candidate as skipped. The scanner's
+    /// blocking walk has no registry access, so it leaves this `false`; the
+    /// watcher stamps the real value from the folder registry after the scan.
+    pub skipped: bool,
+    /// Whether this folder's file structure was already imported (its
+    /// `CategorizedFiles::content_hash` matches a release in the library). Like
+    /// `skipped`, the scanner can't query the DB, so it leaves this `false`; the
+    /// watcher stamps it after the scan. Drives the import view's "Added" tab so
+    /// a re-scanned, already-imported folder still surfaces as added across
+    /// restarts.
+    pub is_added: bool,
 }
 
 // ── FileTree: abstract file source ──────────────────────────────────────────
@@ -955,6 +966,10 @@ where
             name: raw.name,
             files: raw.files,
             watched_folder_path: watched_folder_path.clone(),
+            // The blocking walk has neither the registry nor the DB; the watcher
+            // stamps the real per-candidate facts after this scan returns.
+            skipped: false,
+            is_added: false,
         });
     })
 }

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -152,6 +152,13 @@ pub enum ScanEvent {
     CandidateRemoved {
         candidate_key: String,
     },
+    /// The user manually skipped or unskipped a candidate. The reducer flips the
+    /// candidate's `skipped` flag in place; the import view re-tabs it from New
+    /// to Skipped (or back). The key is the candidate's folder path.
+    CandidateSkipChanged {
+        candidate_key: String,
+        skipped: bool,
+    },
     Finished,
 }
 
@@ -667,6 +674,27 @@ impl ImportServiceHandle {
             self.watcher_tx
                 .send(WatcherCommand::Unwatch(std::path::PathBuf::from(path)))
                 .map_err(|_| "Failed to stop watching folder".to_string())?;
+        }
+        Ok(())
+    }
+
+    /// Mark the candidate at `path` skipped or unskipped, persisting the change
+    /// and broadcasting it so the import view re-tabs the row (New ↔ Skipped).
+    /// A no-op request (already in the requested state) persists nothing and
+    /// emits no event.
+    pub fn set_candidate_skipped(&self, path: String, skipped: bool) -> Result<(), String> {
+        let library_dir = self.library_manager.library_dir();
+        let mut registry = self.folder_registry.lock().unwrap();
+        let changed = registry.set_skipped(library_dir, path.clone(), skipped)?;
+        drop(registry);
+        if changed {
+            send_event(
+                &self.event_tx,
+                ImportEvent::Scan(ScanEvent::CandidateSkipChanged {
+                    candidate_key: path,
+                    skipped,
+                }),
+            );
         }
         Ok(())
     }

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -334,6 +334,8 @@ impl ImportService {
         runtime_handle: &tokio::runtime::Handle,
         mut cmd_rx: mpsc::UnboundedReceiver<WatcherCommand>,
         event_tx: broadcast::Sender<crate::import::handle::ImportEvent>,
+        library_manager: LibraryManager,
+        folder_registry: Arc<Mutex<ImportFolderRegistry>>,
     ) {
         runtime_handle.spawn(async move {
             let (fs_tx, mut fs_rx) = mpsc::unbounded_channel::<DebounceEventResult>();
@@ -374,8 +376,14 @@ impl ImportService {
                                     }
                                     roots.push(path.clone());
                                 }
-                                Self::rescan_and_reconcile(&path, &mut last_keys, &event_tx)
-                                    .await;
+                                Self::rescan_and_reconcile(
+                                    &path,
+                                    &mut last_keys,
+                                    &event_tx,
+                                    &library_manager,
+                                    &folder_registry,
+                                )
+                                .await;
                             }
                             WatcherCommand::Unwatch(path) => {
                                 if let Err(e) = debouncer.unwatch(&path) {
@@ -401,7 +409,14 @@ impl ImportService {
                             .flat_map(|e| e.paths.iter().map(PathBuf::as_path))
                             .collect();
                         for root in affected_roots(&changed, &roots) {
-                            Self::rescan_and_reconcile(&root, &mut last_keys, &event_tx).await;
+                            Self::rescan_and_reconcile(
+                                &root,
+                                &mut last_keys,
+                                &event_tx,
+                                &library_manager,
+                                &folder_registry,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -418,6 +433,8 @@ impl ImportService {
         root: &Path,
         last_keys: &mut HashMap<PathBuf, HashSet<String>>,
         event_tx: &broadcast::Sender<crate::import::handle::ImportEvent>,
+        library_manager: &LibraryManager,
+        folder_registry: &Arc<Mutex<ImportFolderRegistry>>,
     ) {
         let root_buf = root.to_path_buf();
         let scanned = tokio::task::spawn_blocking(move || {
@@ -426,7 +443,7 @@ impl ImportService {
         })
         .await;
 
-        let candidates = match scanned {
+        let mut candidates = match scanned {
             Ok(Ok(candidates)) => candidates,
             Ok(Err(e)) => {
                 warn!(
@@ -440,6 +457,30 @@ impl ImportService {
                 return;
             }
         };
+
+        // The blocking walk left `skipped`/`is_added` at their defaults (it has
+        // neither the registry nor the DB). Stamp the real values now, before
+        // reconciling, so every emitted candidate carries its tab state.
+        for candidate in &mut candidates {
+            let path = candidate.path.to_string_lossy();
+            candidate.skipped = folder_registry.lock().unwrap().is_skipped(&path);
+            candidate.is_added = match library_manager
+                .is_content_hash_imported(&candidate.files.content_hash())
+                .await
+            {
+                Ok(is_added) => is_added,
+                Err(e) => {
+                    // A DB read fault leaves the candidate as "not added" rather
+                    // than dropping it — the user still sees it under "New" and
+                    // can act on it; the next re-scan retries the lookup.
+                    warn!(
+                        "added-state lookup failed for {}; treating as not added: {e}",
+                        candidate.path.display()
+                    );
+                    false
+                }
+            };
+        }
 
         let new_keys: HashSet<String> = candidates
             .iter()
@@ -486,7 +527,21 @@ impl ImportService {
         let event_tx_for_worker = event_tx.clone();
         let library_manager_for_handle = library_manager.clone();
 
-        ImportService::start_watcher(&runtime_handle, watcher_rx, event_tx.clone());
+        // The watched-folder list is durable per-library appdata; `load` warns
+        // and starts empty if the file is corrupt, so app start never fails on it.
+        // The same `Arc` is shared by the watcher (which reads the skip set while
+        // stamping candidates) and the handle (which mutates it on add/remove/skip).
+        let folder_registry = Arc::new(Mutex::new(ImportFolderRegistry::load(
+            library_manager_for_handle.library_dir(),
+        )));
+
+        ImportService::start_watcher(
+            &runtime_handle,
+            watcher_rx,
+            event_tx.clone(),
+            library_manager_for_handle.clone(),
+            folder_registry.clone(),
+        );
 
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -514,12 +569,6 @@ impl ImportService {
                 }
             });
         });
-
-        // The watched-folder list is durable per-library appdata; `load` warns
-        // and starts empty if the file is corrupt, so app start never fails on it.
-        let folder_registry = Arc::new(Mutex::new(ImportFolderRegistry::load(
-            library_manager_for_handle.library_dir(),
-        )));
 
         ImportServiceHandle::new(
             commands_tx,

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -1916,6 +1916,14 @@ impl LibraryManager {
         Ok(self.database.find_release_by_id(release_id).await?)
     }
 
+    /// Whether a release whose stored content hash equals `hash` is in the
+    /// library. The import watcher stamps each scanned candidate with this so an
+    /// already-imported folder surfaces under the "Added" tab even after a
+    /// restart (it matches by file structure, not by name).
+    pub async fn is_content_hash_imported(&self, hash: &str) -> Result<bool, LibraryError> {
+        Ok(self.database.is_content_hash_imported(hash).await?)
+    }
+
     /// This device's `release_local_copy` row for a release, if any.
     pub async fn get_release_local_copy(
         &self,

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -268,6 +268,15 @@ impl UiEventBus {
                         ScanEvent::CandidateRemoved { candidate_key } => {
                             bus.emit(UiBusEvent::ScanCandidateRemoved { key: candidate_key });
                         }
+                        ScanEvent::CandidateSkipChanged {
+                            candidate_key,
+                            skipped,
+                        } => {
+                            bus.emit(UiBusEvent::CandidateSkipChanged {
+                                key: candidate_key,
+                                skipped,
+                            });
+                        }
                         ScanEvent::Finished => {
                             bus.emit(UiBusEvent::ScanFinished);
                         }

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -151,6 +151,12 @@ pub enum UiBusEvent {
     ScanCandidateRemoved {
         key: String,
     },
+    /// The user manually skipped or unskipped a candidate. The reducer flips the
+    /// candidate's `skipped` flag in place, re-tabbing it New ↔ Skipped.
+    CandidateSkipChanged {
+        key: String,
+        skipped: bool,
+    },
     ScanFinished,
 
     // ── Library ────────────────────────────────────────────────────

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -797,6 +797,8 @@ enum PreviewData {
             watchedFolderPath: "/Music/Downloads",
             files: bridgeCandidateFiles,
             trackCount: 9,
+            skipped: false,
+            isAdded: false,
         ),
         BridgeFolderCandidate(
             folderPath: "/Music/Downloads/Album Title Two [Label CAT-002]",
@@ -804,6 +806,9 @@ enum PreviewData {
             watchedFolderPath: "/Music/Downloads",
             files: bridgeCandidateFiles,
             trackCount: 12,
+            // Skipped example — renders under the Skipped tab.
+            skipped: true,
+            isAdded: false,
         ),
         BridgeFolderCandidate(
             folderPath: "/Music/Downloads/Compilation Vol. 3",
@@ -811,6 +816,8 @@ enum PreviewData {
             watchedFolderPath: "/Music/Downloads",
             files: bridgeCandidateFiles,
             trackCount: 15,
+            skipped: false,
+            isAdded: false,
         ),
         BridgeFolderCandidate(
             folderPath: "/Music/Downloads/EP Release",
@@ -818,6 +825,8 @@ enum PreviewData {
             watchedFolderPath: "/Music/Downloads",
             files: bridgeCandidateFiles,
             trackCount: 5,
+            skipped: false,
+            isAdded: false,
         ),
         BridgeFolderCandidate(
             folderPath: "/Music/Downloads/Live Recording 2023",
@@ -825,6 +834,9 @@ enum PreviewData {
             watchedFolderPath: "/Music/Downloads",
             files: bridgeCandidateFiles,
             trackCount: 18,
+            // Added example (content-hash match) — renders under the Added tab.
+            skipped: false,
+            isAdded: true,
         ),
     ]
     .map(Candidate.init(bridge:))
@@ -835,11 +847,7 @@ enum PreviewData {
             phase: nil,
             statusText: "Storing files..."
         ),
-        "/Music/Downloads/Live Recording 2023": .importing(
-            progressPercent: 30,
-            phase: "acquire",
-            statusText: "Downloading..."
-        ),
+        // A completed import — tabs under Added via its import status.
         "/Music/Downloads/EP Release": .complete(
             albumId: "preview-album",
             releaseId: "preview-release"

--- a/bae-macos/bae/bae/Services/ImportStore.swift
+++ b/bae-macos/bae/bae/Services/ImportStore.swift
@@ -2,6 +2,14 @@ import Combine
 import OrderedCollections
 import SwiftUI
 
+/// The three state tabs the import candidate list groups candidates under.
+/// `tab(for:)` assigns each candidate to exactly one.
+enum CandidateTab: Hashable {
+    case new
+    case added
+    case skipped
+}
+
 /// Session state for the import flow. Mixed-writer: the reducer drives
 /// event-driven fields (scan, identify, preview state), while views drive
 /// user-set fields (mode, selectedCoverUrl) via `mutateCandidate(forKey:_:)`.
@@ -112,19 +120,41 @@ class ImportStore {
         }
     }
 
+    /// The state tab a candidate belongs to. Skipped wins (a skipped candidate
+    /// stays under Skipped even if it was also imported); otherwise a candidate
+    /// that completed an import this session or matches an already-imported
+    /// folder is Added; everything else is New.
+    func tab(for candidate: Candidate) -> CandidateTab {
+        if candidate.skipped {
+            return .skipped
+        }
+        if case .complete = candidate.importStatus {
+            return .added
+        }
+        if candidate.isAdded {
+            return .added
+        }
+        return .new
+    }
+
     /// Folder candidates grouped for the candidate list: one entry per watched
-    /// folder (in add order), each holding that folder's candidates filtered by
-    /// `filterText` and ordered by `sortOrder`. Candidates whose watched folder
-    /// is no longer watched are excluded, and — while filtering — folders with
-    /// no matches drop out. The view iterates and renders this; the filtering,
-    /// sorting, and grouping live here in the state layer.
-    func candidateGroups(filterText: String, sortOrder: CandidateSortOrder)
+    /// folder (in add order), each holding that folder's candidates that belong
+    /// to `tab`, filtered by `filterText` and ordered by `sortOrder`. Candidates
+    /// whose watched folder is no longer watched are excluded, and — while
+    /// filtering — folders with no matches drop out. The view iterates and
+    /// renders this; the tab-assignment, filtering, sorting, and grouping live
+    /// here in the state layer.
+    func candidateGroups(
+        tab: CandidateTab,
+        filterText: String,
+        sortOrder: CandidateSortOrder
+    )
         -> [(folder: BridgeWatchedFolder, candidates: [Candidate])]
     {
         let query = filterText.lowercased()
         return watchedFolders.compactMap { folder in
             var rows = folderCandidates.values.filter {
-                $0.watchedFolderPath == folder.path
+                $0.watchedFolderPath == folder.path && self.tab(for: $0) == tab
             }
             if !query.isEmpty {
                 rows = rows.filter {
@@ -148,6 +178,22 @@ class ImportStore {
                 }
             return (folder, ordered)
         }
+    }
+
+    /// Per-tab candidate counts across every folder candidate (independent of
+    /// the active filter), for the tab bar's count badges. A candidate whose
+    /// watched folder is no longer present still counts — the watcher drops such
+    /// candidates from the store, so the store only holds live ones.
+    func candidateTabCounts() -> (new: Int, added: Int, skipped: Int) {
+        var counts = (new: 0, added: 0, skipped: 0)
+        for candidate in folderCandidates.values {
+            switch tab(for: candidate) {
+            case .new: counts.new += 1
+            case .added: counts.added += 1
+            case .skipped: counts.skipped += 1
+            }
+        }
+        return counts
     }
 
     private static func sortedByName(_ rows: [Candidate], ascending: Bool)

--- a/bae-macos/bae/bae/Services/Importer.swift
+++ b/bae-macos/bae/bae/Services/Importer.swift
@@ -12,6 +12,9 @@ final class Importer: Sendable, Observable {
     let addWatchedFolder: @Sendable (_ path: String) throws -> Void
     /// Stop watching a folder; its candidates drop out of the list.
     let removeWatchedFolder: @Sendable (_ path: String) throws -> Void
+    /// Mark a candidate skipped (or unskipped); the import view re-tabs the row.
+    let setCandidateSkipped:
+        @Sendable (_ path: String, _ skipped: Bool) throws -> Void
     /// Scan every watched folder, streaming candidates back as events. Called
     /// when the import view appears to populate the list.
     let scanWatchedFolders: @Sendable () throws -> Void
@@ -47,6 +50,8 @@ final class Importer: Sendable, Observable {
         removeWatchedFolder: @escaping @Sendable (String) throws -> Void = {
             _ in
         },
+        setCandidateSkipped:
+            @escaping @Sendable (String, Bool) throws -> Void = { _, _ in },
         scanWatchedFolders: @escaping @Sendable () throws -> Void = {},
         autoIdentifyFolder: @escaping @Sendable (String, String) -> Void = {
             _,
@@ -81,6 +86,7 @@ final class Importer: Sendable, Observable {
         self.watchedFolders = watchedFolders
         self.addWatchedFolder = addWatchedFolder
         self.removeWatchedFolder = removeWatchedFolder
+        self.setCandidateSkipped = setCandidateSkipped
         self.scanWatchedFolders = scanWatchedFolders
         self.autoIdentifyFolder = autoIdentifyFolder
         self.autoIdentifyRelease = autoIdentifyRelease
@@ -97,6 +103,9 @@ final class Importer: Sendable, Observable {
             watchedFolders: { handle.watchedFolders() },
             addWatchedFolder: { try handle.addWatchedFolder(path: $0) },
             removeWatchedFolder: { try handle.removeWatchedFolder(path: $0) },
+            setCandidateSkipped: {
+                try handle.setCandidateSkipped(path: $0, skipped: $1)
+            },
             scanWatchedFolders: { try handle.scanWatchedFolders() },
             autoIdentifyFolder: {
                 handle.autoIdentifyFolder(candidateKey: $0, folderPath: $1)

--- a/bae-macos/bae/bae/Services/Store/Candidate.swift
+++ b/bae-macos/bae/bae/Services/Store/Candidate.swift
@@ -103,6 +103,14 @@ struct Candidate: Equatable, Identifiable {
     var files: CandidateFiles
     var identifyState: IdentifyState = .idle
     var importStatus: ImportStatus?
+    /// Whether the user manually skipped this candidate. Drives the import view's
+    /// Skipped tab; flipped by the reducer on a `candidateSkipChanged` event.
+    var skipped: Bool = false
+    /// Whether this candidate's file structure was already imported (matched by
+    /// content hash). Set from the scan; drives the Added tab so an
+    /// already-imported folder surfaces as added even without a fresh import in
+    /// the session.
+    var isAdded: Bool = false
     /// Full release detail fetched after the user picks a pressing. Stored as
     /// the bridge type (not just the `ImportReleaseDetail` projection) so the
     /// bottom pane can re-seed the editor when the user flips the Exact /
@@ -162,6 +170,8 @@ struct Candidate: Equatable, Identifiable {
         displayName = bridge.sourceFolderName
         trackCount = bridge.trackCount
         files = CandidateFiles(bridge: bridge.files)
+        skipped = bridge.skipped
+        isAdded = bridge.isAdded
     }
 
     /// Construct a re-identify candidate. The release already lives in

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -281,6 +281,12 @@ enum UiEventReducer {
             // gone from disk; drop it.
             importStore.folderCandidates.removeValue(forKey: key)
 
+        case .candidateSkipChanged(let key, let skipped):
+            // The user skipped or unskipped the candidate; flip its flag so the
+            // import view re-tabs it New ↔ Skipped. In-place mutation keeps the
+            // candidate's identify/search/import state.
+            importStore.mutateCandidate(forKey: key) { $0.skipped = skipped }
+
         case .scanFinished:
             // No state change needed — views react to candidate additions
             break

--- a/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
+++ b/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
@@ -200,7 +200,21 @@ struct FolderImportTab: View {
             },
             onAddFolder: { pickFolderAndAdd() },
             onRemoveFolder: { path in removeWatchedFolder(path) },
+            onSkip: { key, skipped in setCandidateSkipped(key, skipped) },
         )
+    }
+
+    /// Mark the candidate at `key` skipped or unskipped. The reducer re-tabs the
+    /// row when the `candidateSkipChanged` event arrives.
+    private func setCandidateSkipped(_ key: String, _ skipped: Bool) {
+        do {
+            try importer.setCandidateSkipped(key, skipped)
+        }
+        catch {
+            uiStore.showError(
+                "Couldn't update skip state: \(error.localizedDescription)"
+            )
+        }
     }
 
     /// Stop watching `path`. If the selected candidate lived in that folder,

--- a/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
@@ -36,7 +36,11 @@ struct ImportCandidateListContent: View {
     let isLikelyDupe: (String) -> Bool
     let onAddFolder: () -> Void
     let onRemoveFolder: (_ path: String) -> Void
+    /// Skip (or unskip) the candidate at `key`. Wired to the row context menu.
+    let onSkip: (_ key: String, _ skipped: Bool) -> Void
 
+    @State
+    private var activeTab: CandidateTab = .new
     @State
     private var filterText = ""
     @State
@@ -44,12 +48,14 @@ struct ImportCandidateListContent: View {
     @AppStorage("importCandidateSort")
     private var sortOrder: CandidateSortOrder = .dateAddedNewest
 
-    /// One section per watched folder, candidates filtered and sorted — built by
-    /// the store. `filterText` and `sortOrder` are this view's own UI state.
+    /// One section per watched folder, candidates in the active tab, filtered and
+    /// sorted — built by the store. `activeTab`, `filterText`, and `sortOrder`
+    /// are this view's own UI state.
     private var displayedGroups:
         [(folder: BridgeWatchedFolder, candidates: [Candidate])]
     {
         importStore.candidateGroups(
+            tab: activeTab,
             filterText: filterText,
             sortOrder: sortOrder
         )
@@ -57,64 +63,104 @@ struct ImportCandidateListContent: View {
 
     var body: some View {
         ImportSidebarList {
-            HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.tertiary)
-                    .font(.callout)
-                TextField("Filter...", text: $filterText)
-                    .textFieldStyle(.plain)
-                    .font(.callout)
-                if !filterText.isEmpty {
-                    Button {
-                        filterText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.tertiary)
+            VStack(spacing: 8) {
+                CandidateTabBar(
+                    activeTab: $activeTab,
+                    importStore: importStore
+                )
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.tertiary)
+                        .font(.callout)
+                    TextField("Filter...", text: $filterText)
+                        .textFieldStyle(.plain)
+                        .font(.callout)
+                    if !filterText.isEmpty {
+                        Button {
+                            filterText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.tertiary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    sortMenu
+                    Button(action: onAddFolder) {
+                        Image(systemName: "plus")
                     }
                     .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .help("Add a folder to watch for imports")
                 }
             }
             .frame(maxWidth: .infinity)
-            sortMenu
-            Button(action: onAddFolder) {
-                Image(systemName: "plus")
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .help("Add a folder to watch for imports")
         } content: {
-            List(selection: $selectedKey) {
-                ForEach(displayedGroups, id: \.folder.path) { group in
-                    Section {
-                        if !collapsedFolders.contains(group.folder.path) {
-                            ForEach(group.candidates, id: \.key) { candidate in
-                                CandidateRow(
-                                    displayName: candidate.displayName,
-                                    revealPath: candidate.folderPathIfReal,
-                                    status: candidate.importStatus,
-                                    isLikelyDupe: isLikelyDupe(
-                                        candidate.displayName
-                                    ),
-                                )
-                                .tag(candidate.key)
-                            }
+            if displayedGroups.isEmpty {
+                emptyState
+            }
+            else {
+                candidateList
+            }
+        }
+    }
+
+    /// Per-tab empty state: distinguishes "no matches" while filtering from
+    /// "nothing in this tab yet".
+    private var emptyState: some View {
+        ContentUnavailableView(
+            filterText.isEmpty ? "Nothing here yet" : "No matches",
+            systemImage: filterText.isEmpty
+                ? emptyTabSymbol : "magnifyingglass"
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.surface)
+    }
+
+    private var emptyTabSymbol: String {
+        switch activeTab {
+        case .new: "folder"
+        case .added: "checkmark.circle"
+        case .skipped: "minus.circle"
+        }
+    }
+
+    private var candidateList: some View {
+        List(selection: $selectedKey) {
+            ForEach(displayedGroups, id: \.folder.path) { group in
+                Section {
+                    if !collapsedFolders.contains(group.folder.path) {
+                        ForEach(group.candidates, id: \.key) { candidate in
+                            CandidateRow(
+                                displayName: candidate.displayName,
+                                revealPath: candidate.folderPathIfReal,
+                                status: candidate.importStatus,
+                                isAdded: candidate.isAdded,
+                                skipped: candidate.skipped,
+                                isLikelyDupe: isLikelyDupe(
+                                    candidate.displayName
+                                ),
+                                onSkip: { skipped in
+                                    onSkip(candidate.key, skipped)
+                                },
+                            )
+                            .tag(candidate.key)
                         }
-                    } header: {
-                        FolderSectionHeader(
-                            folder: group.folder,
-                            count: group.candidates.count,
-                            isCollapsed: collapsedFolders.contains(
-                                group.folder.path
-                            ),
-                            onToggle: { toggleCollapsed(group.folder.path) },
-                            onRemove: { onRemoveFolder(group.folder.path) },
-                        )
                     }
+                } header: {
+                    FolderSectionHeader(
+                        folder: group.folder,
+                        count: group.candidates.count,
+                        isCollapsed: collapsedFolders.contains(
+                            group.folder.path
+                        ),
+                        onToggle: { toggleCollapsed(group.folder.path) },
+                        onRemove: { onRemoveFolder(group.folder.path) },
+                    )
                 }
             }
-            .scrollContentBackground(.hidden)
-            .background(Theme.surface)
         }
+        .scrollContentBackground(.hidden)
+        .background(Theme.surface)
     }
 
     private func toggleCollapsed(_ path: String) {
@@ -155,6 +201,66 @@ struct ImportCandidateListContent: View {
                 Text(label)
             }
         }
+    }
+}
+
+// MARK: - CandidateTabBar
+
+/// The New / Added / Skipped tab bar above the candidate list. Three equal
+/// segments, each a label plus a count badge; the active one is highlighted.
+private struct CandidateTabBar: View {
+    @Binding
+    var activeTab: CandidateTab
+    /// Read the counts at the leaf so the parent isn't subscribed to every
+    /// candidate change just to pass them down.
+    let importStore: ImportStore
+
+    var body: some View {
+        let counts = importStore.candidateTabCounts()
+        HStack(spacing: 4) {
+            segment(.new, "New", counts.new)
+            segment(.added, "Added", counts.added)
+            segment(.skipped, "Skipped", counts.skipped)
+        }
+    }
+
+    private func segment(_ tab: CandidateTab, _ label: String, _ count: Int)
+        -> some View
+    {
+        let isActive = activeTab == tab
+        return Button {
+            activeTab = tab
+        } label: {
+            HStack(spacing: 4) {
+                Text(label)
+                    .font(.caption)
+                    .fontWeight(isActive ? .semibold : .regular)
+                Text("\(count)")
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(
+                        Capsule()
+                            .fill(
+                                isActive
+                                    ? Color.accentColor.opacity(0.25)
+                                    : Color.secondary.opacity(0.15)
+                            )
+                    )
+            }
+            .foregroundStyle(isActive ? Color.accentColor : Color.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(
+                        isActive
+                            ? Color.accentColor.opacity(0.12) : Color.clear
+                    )
+            )
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -209,7 +315,14 @@ struct CandidateRow: View {
     /// candidates.
     let revealPath: String?
     let status: ImportStatus?
+    /// The candidate was already imported from this folder (content-hash match),
+    /// shown the same as an in-session completed import.
+    let isAdded: Bool
+    /// The user manually skipped this candidate.
+    let skipped: Bool
     let isLikelyDupe: Bool
+    /// Skip (true) or unskip (false) this candidate.
+    let onSkip: (_ skipped: Bool) -> Void
 
     @Environment(OutboxStore.self)
     private var outboxStore
@@ -223,7 +336,7 @@ struct CandidateRow: View {
                     .font(.callout)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                if isLikelyDupe, status == nil {
+                if isLikelyDupe, status == nil, !isAdded, !skipped {
                     Text("Likely imported")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -236,7 +349,9 @@ struct CandidateRow: View {
         .padding(.vertical, 4)
         .contentShape(Rectangle())
         .contextMenu {
+            Button(skipped ? "Move to New" : "Skip") { onSkip(!skipped) }
             if let revealPath {
+                Divider()
                 Button("Reveal in Finder") {
                     SystemActions.revealInFinder(path: revealPath)
                 }
@@ -246,7 +361,10 @@ struct CandidateRow: View {
 
     @ViewBuilder
     private var statusIcon: some View {
-        if let status {
+        if skipped {
+            icon("minus.circle", .secondary)
+        }
+        else if let status {
             switch status {
             case .importing:
                 ProgressView()
@@ -257,22 +375,29 @@ struct CandidateRow: View {
                 if let progress = outboxStore.progress(forRelease: releaseId),
                     !progress.isIdle
                 {
-                    Image(systemName: "icloud.and.arrow.up")
-                        .foregroundStyle(.secondary)
+                    icon("icloud.and.arrow.up", .secondary)
                 }
                 else {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+                    icon("checkmark.circle.fill", .green)
                 }
             case .error:
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.red)
+                icon("exclamationmark.triangle.fill", .red)
             }
         }
-        else {
-            Image(systemName: "folder")
-                .foregroundStyle(.secondary)
+        else if isAdded {
+            // An already-imported folder (content-hash match) shows the same
+            // green check as an in-session completed import.
+            icon("checkmark.circle.fill", .green)
         }
+        else {
+            icon("folder", .secondary)
+        }
+    }
+
+    private func icon<S: ShapeStyle>(_ systemName: String, _ style: S)
+        -> some View
+    {
+        Image(systemName: systemName).foregroundStyle(style)
     }
 }
 
@@ -295,6 +420,7 @@ struct CandidateRow: View {
         isLikelyDupe: { $0 == "Album Title One" },
         onAddFolder: {},
         onRemoveFolder: { _ in },
+        onSkip: { _, _ in },
     )
     .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
     .frame(width: 280, height: 500)


### PR DESCRIPTION
The candidate list groups by watched folder (#19) and updates live (#22), but every candidate looked alike — there was no New/Added/Skipped view of where each one is in its lifecycle.

This adds three state tabs above the list, each with a live count:
- **New** — not yet imported (and not skipped).
- **Added** — already imported. A candidate is Added when its content hash (#17) matches a release in the library, so a folder you imported in a past session shows as Added on relaunch — not only right after an in-session import. In-session completion also lands here.
- **Skipped** — you manually marked it as one you don't intend to import.

The manual-skip set persists per library in `import_folders.yaml` (appdata, beside the watched-folder list). The filesystem watcher stamps each candidate's skipped/added state on every (re)scan — `skipped` from the registry, `added` from a content-hash lookup against the DB — and a new `CandidateSkipChanged` event flips skip live without a re-scan. Skip/Move-to-New are row context-menu actions.

Tab assignment, per-tab filtering, grouping, and the tab counts all live in `ImportStore` (the data layer); the view just renders the active tab. Invalid scanned folders surfacing in Skipped with a warning is a separate follow-up.

## Test plan
- [x] `folder_registry` skip-set tests (incl. a legacy `import_folders.yaml` without `skipped` still loading)
- [x] core clippy (lib + tests), bridge clippy, macOS build, periphery — all green via pre-commit
- [ ] Manual: import a folder → it moves to Added; relaunch → still Added (content-hash match); skip a New candidate → moves to Skipped, survives restart; tab counts update live

🤖 Generated with [Claude Code](https://claude.com/claude-code)