### PR TITLE
Import: surface invalid scanned folders in Skipped with a reason

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1586,6 +1586,15 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
                 },
             })
         }
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+        UiBusEvent::InvalidCandidate { candidate } => Some(BridgeUiEvent::InvalidCandidate {
+            candidate: BridgeInvalidCandidate {
+                folder_path: candidate.path.to_string_lossy().to_string(),
+                source_folder_name: candidate.name,
+                watched_folder_path: candidate.watched_folder_path,
+                reason: candidate.reason,
+            },
+        }),
         UiBusEvent::ScanCandidateRemoved { key } => {
             Some(BridgeUiEvent::ScanCandidateRemoved { key })
         }

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -427,6 +427,23 @@ pub struct BridgeFolderCandidate {
     pub is_added: bool,
 }
 
+/// A leaf folder that looks like a release but failed validation — the import
+/// view surfaces it under the Skipped tab with a warning and the reason. Mirror
+/// of `bae_core::import::InvalidCandidate`; carries no files or identify state
+/// because an invalid folder can't be imported.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeInvalidCandidate {
+    pub folder_path: String,
+    pub source_folder_name: String,
+    /// Absolute path of the watched folder this was scanned from — the grouping
+    /// key for the candidate-list section. Match it against
+    /// `BridgeWatchedFolder.path` for the section's display name.
+    pub watched_folder_path: String,
+    /// Why the folder failed validation, ready to render next to the warning
+    /// icon (e.g. "corrupt or zero-byte audio file: 01.flac").
+    pub reason: String,
+}
+
 /// A folder the user watches for imports — one candidate-list group.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeWatchedFolder {
@@ -1062,6 +1079,12 @@ pub enum BridgeUiEvent {
     },
     FolderCandidateAdded {
         candidate: BridgeFolderCandidate,
+    },
+    /// A leaf folder looked like a release but failed validation — the reducer
+    /// surfaces it under the Skipped tab with its reason and drops the folder
+    /// from the valid-candidate list if it was there before.
+    InvalidCandidate {
+        candidate: BridgeInvalidCandidate,
     },
     /// A candidate's folder was re-scanned and the release is gone — the reducer
     /// removes it by key.

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -206,6 +206,32 @@ pub struct PreparedRelease {
     pub metadata_pairs: Vec<(String, String)>,
 }
 
+/// A leaf folder that looks like a release (it has audio) but failed
+/// validation: corrupt or zero-byte audio, a corrupt image, or a CUE that
+/// references missing audio. Carries no files or identify state — it can't be
+/// imported — only enough to surface it under the Skipped tab with its reason.
+#[derive(Debug, Clone)]
+pub struct InvalidCandidate {
+    /// Root path of the folder that failed validation.
+    pub path: PathBuf,
+    /// Display name (derived from folder name).
+    pub name: String,
+    /// Absolute path of the watched folder this was scanned from — the
+    /// candidate-list group it belongs to. Equal to the scan root.
+    pub watched_folder_path: String,
+    /// Why the folder failed validation, ready to render as the failure
+    /// reason next to the warning icon.
+    pub reason: String,
+}
+
+/// One item the scan callback yields per leaf folder: a valid release
+/// candidate, or an invalid one (looked like a release but failed validation).
+#[derive(Debug, Clone)]
+pub enum ScanItem {
+    Valid(FolderCandidate),
+    Invalid(InvalidCandidate),
+}
+
 /// A folder candidate (leaf directory) detected during filesystem scanning.
 /// Called "candidate" because it hasn't been identified yet. One candidate
 /// per release; per-disc breakdown lives on `ScannedFile.dir_prefix`.
@@ -615,16 +641,32 @@ fn tree_is_leaf_directory(tree: &FileTree, dir: &Path) -> bool {
 
 // ── File categorization ─────────────────────────────────────────────────────
 
+/// The result of categorizing a leaf folder's files: a valid release, or an
+/// invalid one carrying the reason it failed validation (corrupt/zero-byte
+/// audio, corrupt image, CUE referencing missing audio). `Err` is reserved for
+/// genuine I/O faults, which are not the same as a failed-validation leaf.
+#[derive(Debug)]
+enum CategorizeOutcome {
+    Valid(CategorizedFiles),
+    Invalid(String),
+}
+
+/// Shorthand for a failed-validation leaf carrying `reason`.
+fn invalid(reason: impl Into<String>) -> Result<CategorizeOutcome, String> {
+    Ok(CategorizeOutcome::Invalid(reason.into()))
+}
+
 /// Categorize files from a FileTree for a given release root.
 ///
 /// `fs_root` is the folder being imported: file validation reads actual bytes
 /// from disk.
-/// Returns None if no valid audio files are found (candidate should be skipped).
+/// Returns `Invalid(reason)` when the folder has audio but fails validation, so
+/// the caller can surface why it can't be imported.
 fn categorize_files_from_tree(
     tree: &FileTree,
     release_root: &Path,
     fs_root: &Path,
-) -> Result<Option<CategorizedFiles>, String> {
+) -> Result<CategorizeOutcome, String> {
     let mut all_audio: Vec<ScannedFile> = Vec::new();
     let mut all_cue: Vec<ScannedFile> = Vec::new();
     let mut artwork: Vec<ScannedFile> = Vec::new();
@@ -654,8 +696,8 @@ fn categorize_files_from_tree(
             let valid = file_validation::is_valid_audio(&absolute_path)
                 .map_err(|e| format!("Failed to validate audio file {absolute_path:?}: {e}"))?;
             if entry.size == 0 || !valid {
-                info!("Skipping candidate: corrupt audio file {:?}", entry.path);
-                return Ok(None);
+                info!("Invalid candidate: corrupt or zero-byte audio file {relative_path}");
+                return invalid(format!("corrupt or zero-byte audio file: {relative_path}"));
             }
 
             all_audio.push(ScannedFile::new(
@@ -675,8 +717,8 @@ fn categorize_files_from_tree(
             let valid = file_validation::is_valid_image(&absolute_path)
                 .map_err(|e| format!("Failed to validate image file {absolute_path:?}: {e}"))?;
             if entry.size == 0 || !valid {
-                info!("Skipping candidate: corrupt image file {:?}", entry.path);
-                return Ok(None);
+                info!("Invalid candidate: corrupt or zero-byte image {relative_path}");
+                return invalid(format!("corrupt or zero-byte image: {relative_path}"));
             }
 
             artwork.push(ScannedFile::new(
@@ -768,12 +810,12 @@ fn categorize_files_from_tree(
 
         if cue_sheet.tracks.len() > on_disk_audio {
             info!(
-                "Skipping candidate: CUE {:?} declares {} tracks but only {} audio files on disk",
+                "Invalid candidate: CUE {:?} declares {} tracks but only {} audio files on disk",
                 cue.path,
                 cue_sheet.tracks.len(),
                 on_disk_audio
             );
-            return Ok(None);
+            return invalid("CUE references a missing audio file");
         }
     }
 
@@ -844,7 +886,10 @@ fn categorize_files_from_tree(
                 .and_then(|e| e.to_str())
                 .expect("Audio file must have an extension")
                 .to_uppercase(),
-            None => return Ok(None),
+            None => {
+                info!("Invalid candidate: no valid audio files after categorization");
+                return invalid("no valid audio files");
+            }
         };
         let audio = AudioContent::TrackFiles {
             tracks,
@@ -861,7 +906,7 @@ fn categorize_files_from_tree(
     artwork.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
     documents.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
-    Ok(Some(CategorizedFiles {
+    Ok(CategorizeOutcome::Valid(CategorizedFiles {
         audio,
         artwork,
         documents,
@@ -871,22 +916,29 @@ fn categorize_files_from_tree(
 
 // ── Tree walker ─────────────────────────────────────────────────────────────
 
-/// Internal leaf data emitted by the tree walker. The public API functions
-/// wrap this into the appropriate candidate type.
-pub(crate) struct RawCandidate {
-    pub(crate) path: PathBuf,
-    pub(crate) name: String,
-    pub(crate) files: CategorizedFiles,
+/// Internal leaf data emitted by the tree walker. The public API stamps
+/// `watched_folder_path` to turn this into a `ScanItem`.
+pub(crate) enum RawScanItem {
+    Valid {
+        path: PathBuf,
+        name: String,
+        files: CategorizedFiles,
+    },
+    Invalid {
+        path: PathBuf,
+        name: String,
+        reason: String,
+    },
 }
 
 fn scan_tree_recursive<F>(
     tree: &FileTree,
     dir: &Path,
     fs_root: &Path,
-    on_candidate: &mut F,
+    on_item: &mut F,
 ) -> Result<(), String>
 where
-    F: FnMut(RawCandidate),
+    F: FnMut(RawScanItem),
 {
     if tree_is_leaf_directory(tree, dir) {
         // Release-level marker check: a leaf is a release, and markers
@@ -916,30 +968,35 @@ where
 
         info!("Found candidate leaf: {:?}", dir);
 
-        if let Some(files) = categorize_files_from_tree(tree, dir, fs_root)? {
-            let candidate_path = fs_root.join(dir);
-
-            on_candidate(RawCandidate {
-                path: candidate_path,
-                name,
-                files,
-            });
-        } else {
-            // Structurally this looked like a leaf (a release), but
-            // categorization failed: zero-byte audio, corrupt file, CUE
-            // references a missing file, etc. Suppress the whole release.
-            // Symmetric with the partial-markers-deep check above.
-            info!(
-                "Skipping leaf {:?}: categorization failed (incomplete release)",
-                dir
-            );
+        let candidate_path = fs_root.join(dir);
+        match categorize_files_from_tree(tree, dir, fs_root)? {
+            CategorizeOutcome::Valid(files) => {
+                on_item(RawScanItem::Valid {
+                    path: candidate_path,
+                    name,
+                    files,
+                });
+            }
+            CategorizeOutcome::Invalid(reason) => {
+                // Structurally this looked like a leaf (a release), but
+                // categorization failed: zero-byte audio, corrupt file, CUE
+                // references a missing file, etc. Surface it with its reason so
+                // the user sees why the folder didn't import. Symmetric with
+                // the partial-markers-deep check above (which truly suppresses).
+                info!("Invalid leaf {:?}: {reason}", dir);
+                on_item(RawScanItem::Invalid {
+                    path: candidate_path,
+                    name,
+                    reason,
+                });
+            }
         }
 
         return Ok(());
     }
 
     for subdir in tree.immediate_subdirs(dir) {
-        scan_tree_recursive(tree, &subdir, fs_root, on_candidate)?;
+        scan_tree_recursive(tree, &subdir, fs_root, on_item)?;
     }
 
     Ok(())
@@ -947,30 +1004,39 @@ where
 
 // ── Public API: folder scanning (filesystem) ────────────────────────────────
 
-/// Scan a folder for candidates and invoke callback as each is found.
-pub fn scan_for_candidates_with_callback<F>(
-    root: PathBuf,
-    mut on_candidate: F,
-) -> Result<(), String>
+/// Scan a folder and invoke `on_item` for each leaf: a valid release candidate,
+/// or an invalid one (looked like a release but failed validation). Both carry
+/// `watched_folder_path` stamped from the scan root.
+pub fn scan_for_candidates_with_callback<F>(root: PathBuf, mut on_item: F) -> Result<(), String>
 where
-    F: FnMut(FolderCandidate),
+    F: FnMut(ScanItem),
 {
     info!("Scanning for candidates in: {:?}", root);
-    // Every candidate from this scan belongs to the same watched folder (the
-    // scan root) — the group it renders under in the candidate list.
+    // Every item from this scan belongs to the same watched folder (the scan
+    // root) — the group it renders under in the candidate list.
     let watched_folder_path = root.to_string_lossy().into_owned();
     let tree = FileTree::from_filesystem(&root)?;
-    scan_tree_recursive(&tree, &PathBuf::new(), &root, &mut |raw| {
-        on_candidate(FolderCandidate {
-            path: raw.path,
-            name: raw.name,
-            files: raw.files,
-            watched_folder_path: watched_folder_path.clone(),
-            // The blocking walk has neither the registry nor the DB; the watcher
-            // stamps the real per-candidate facts after this scan returns.
-            skipped: false,
-            is_added: false,
-        });
+    scan_tree_recursive(&tree, &PathBuf::new(), &root, &mut |raw| match raw {
+        RawScanItem::Valid { path, name, files } => {
+            on_item(ScanItem::Valid(FolderCandidate {
+                path,
+                name,
+                files,
+                watched_folder_path: watched_folder_path.clone(),
+                // The blocking walk has neither the registry nor the DB; the
+                // watcher stamps the real per-candidate facts after this scan.
+                skipped: false,
+                is_added: false,
+            }));
+        }
+        RawScanItem::Invalid { path, name, reason } => {
+            on_item(ScanItem::Invalid(InvalidCandidate {
+                path,
+                name,
+                watched_folder_path: watched_folder_path.clone(),
+                reason,
+            }));
+        }
     })
 }
 
@@ -981,8 +1047,12 @@ where
 /// Unrecognized file types are ignored.
 pub fn collect_release_candidate_files(release_root: &Path) -> Result<CategorizedFiles, String> {
     let tree = FileTree::from_filesystem(release_root)?;
-    categorize_files_from_tree(&tree, &PathBuf::new(), release_root)?
-        .ok_or_else(|| format!("No valid audio files found in {:?}", release_root))
+    // An invalid folder can't be imported: surface its reason as the error so
+    // the import-commit caller fails with why the folder is unusable.
+    match categorize_files_from_tree(&tree, &PathBuf::new(), release_root)? {
+        CategorizeOutcome::Valid(files) => Ok(files),
+        CategorizeOutcome::Invalid(reason) => Err(reason),
+    }
 }
 
 #[cfg(test)]
@@ -999,6 +1069,25 @@ mod tests {
         // STREAMINFO: 34 bytes, all zeros -> sample_rate=0 so size check is skipped
         buf.extend_from_slice(&[0u8; 34]);
         buf
+    }
+
+    /// Every scan item (valid + invalid) for `root`.
+    fn scan_items(root: impl Into<PathBuf>) -> Vec<ScanItem> {
+        let mut items = Vec::new();
+        scan_for_candidates_with_callback(root.into(), |item| items.push(item)).unwrap();
+        items
+    }
+
+    /// Only the valid `FolderCandidate`s for `root` — the shape most scanner
+    /// tests assert against (counts, paths, categorized files).
+    fn scan_valid(root: impl Into<PathBuf>) -> Vec<FolderCandidate> {
+        scan_items(root)
+            .into_iter()
+            .filter_map(|item| match item {
+                ScanItem::Valid(c) => Some(c),
+                ScanItem::Invalid(_) => None,
+            })
+            .collect()
     }
 
     #[test]
@@ -1270,8 +1359,7 @@ FILE "{flac_filename}" WAVE
             std::fs::write(album_dir.join("cover.jpg"), [0xFF, 0xD8, 0xFF, 0xE0]).unwrap();
         }
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         // An artist/discography container is NOT a candidate — each album
         // inside it is its own candidate.
@@ -1313,8 +1401,7 @@ FILE "{flac_filename}" WAVE
             .unwrap();
         }
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         // The multi-disc album is the sole candidate. Its CUE/FLAC pairs
         // cover both discs.
@@ -1348,8 +1435,7 @@ FILE "{flac_filename}" WAVE
             std::fs::write(disc_dir.join("track.flac"), fake_flac()).unwrap();
         }
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1391,8 +1477,7 @@ FILE "{flac_filename}" WAVE
             std::fs::write(album_dir.join("track.flac"), fake_flac()).unwrap();
         }
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1458,7 +1543,7 @@ FILE "{flac_filename}" WAVE
     }
 
     #[test]
-    fn test_cue_with_corrupt_ape_detected_as_bad() {
+    fn test_cue_with_corrupt_ape_surfaces_as_invalid_candidate() {
         let temp_dir = tempfile::tempdir().unwrap();
         let root = temp_dir.path().join("APE Album");
         std::fs::create_dir(&root).unwrap();
@@ -1475,14 +1560,20 @@ FILE "album.ape" WAVE
         std::fs::write(root.join("album.ape"), b"fake ape data").unwrap();
         std::fs::write(root.join("cover.jpg"), [0xFF, 0xD8, 0xFF, 0xE0]).unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
-
-        assert_eq!(
-            candidates.len(),
-            0,
-            "Folder with only corrupt audio should not be emitted as a candidate"
-        );
+        // A folder whose only audio is corrupt is not dropped and not a valid
+        // candidate — it surfaces as an invalid candidate carrying the reason.
+        let items = scan_items(root);
+        assert_eq!(items.len(), 1, "exactly one scan item for the leaf");
+        match &items[0] {
+            ScanItem::Invalid(invalid) => {
+                assert!(
+                    invalid.reason.contains("audio"),
+                    "reason names the audio fault, got: {}",
+                    invalid.reason,
+                );
+            }
+            ScanItem::Valid(_) => panic!("corrupt-audio folder must not be a valid candidate"),
+        }
     }
 
     #[test]
@@ -1491,8 +1582,7 @@ FILE "album.ape" WAVE
         let root = temp_dir.path().join("Empty Album");
         std::fs::create_dir(&root).unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(candidates.len(), 0, "Empty folder should not be detected");
     }
@@ -1510,8 +1600,7 @@ FILE "album.ape" WAVE
         )
         .unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1531,8 +1620,7 @@ FILE "album.ape" WAVE
         std::fs::write(video_ts.join("VIDEO_TS.VOB"), b"fake video").unwrap();
         std::fs::write(video_ts.join("VTS_01_1.VOB"), b"fake video").unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1555,8 +1643,7 @@ FILE "album.ape" WAVE
             std::fs::write(vol_dir.join("track.flac"), fake_flac()).unwrap();
         }
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         // `Vol. NN (...)` names carry descriptive text — they do NOT match
         // the disc-indicator pattern, so the parent is a navigation container
@@ -1582,8 +1669,7 @@ FILE "album.ape" WAVE
         std::fs::write(root.join("02 - Track Two.flac"), b"").unwrap();
         std::fs::write(root.join("cover.jpg"), [0xFF, 0xD8, 0xFF, 0xE0]).unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1602,8 +1688,7 @@ FILE "album.ape" WAVE
         std::fs::write(root.join("02 - Track Two.flac"), b"").unwrap();
         std::fs::write(root.join("03 - Track Three.flac"), b"").unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root.clone(), |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root.clone());
 
         assert_eq!(
             candidates.len(),
@@ -1623,8 +1708,7 @@ FILE "album.ape" WAVE
         std::fs::write(root.join("back.jpg"), b"not a jpeg").unwrap();
         std::fs::write(root.join("inlay.png"), b"").unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1651,8 +1735,7 @@ FILE "album.ape" WAVE
         // Marker one level below the multi-disc leaf.
         std::fs::write(disc2.join("02.flac.part"), b"in progress").unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert_eq!(
             candidates.len(),
@@ -1681,8 +1764,7 @@ FILE "album.ape" WAVE
         // Zero-byte file marks this disc as in-progress / abandoned.
         std::fs::write(disc2.join("02.flac"), b"").unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root, |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root);
 
         assert!(
             candidates.is_empty(),
@@ -1819,9 +1901,7 @@ FILE "album.ape" WAVE
         // folder.jpg at album root
         std::fs::write(album.join("folder.jpg"), [0xFF, 0xD8, 0xFF, 0xE0]).unwrap();
 
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(tmp.path().join("Collection"), |c| candidates.push(c))
-            .unwrap();
+        let candidates = scan_valid(tmp.path().join("Collection"));
 
         assert_eq!(
             candidates.len(),
@@ -3262,8 +3342,7 @@ FILE "02 - Track Two.flac" WAVE
         assert_fixture_invariants(root, &spec);
 
         // Run the real scanner.
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root.to_path_buf(), |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root.to_path_buf());
 
         // --- Assertion 1: exact top-level candidate set ---
 
@@ -3456,8 +3535,7 @@ FILE "02 - Track Two.flac" WAVE
         let root = tmp.path().to_path_buf();
         build_fixture(&root, &entries);
         assert_fixture_invariants(&root, &entries);
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(root.clone(), |c| candidates.push(c)).unwrap();
+        let candidates = scan_valid(root.clone());
         ScenarioResult {
             _tmp: tmp,
             candidates,
@@ -3989,9 +4067,7 @@ FILE "02 - Track Two.flac" WAVE
              FILE \"03.m4a\" WAVE\n  TRACK 03 AUDIO\n    INDEX 01 00:00:00\n",
         )
         .unwrap();
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(tmp.path().to_path_buf(), |c| candidates.push(c))
-            .unwrap();
+        let candidates = scan_valid(tmp.path().to_path_buf());
         assert_eq!(candidates.len(), 1);
         let c = &candidates[0];
         match &c.files.audio {
@@ -4026,9 +4102,7 @@ FILE "02 - Track Two.flac" WAVE
              TRACK 02 AUDIO\n    INDEX 01 03:00:00\n",
         )
         .unwrap();
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(tmp.path().to_path_buf(), |c| candidates.push(c))
-            .unwrap();
+        let candidates = scan_valid(tmp.path().to_path_buf());
         assert_eq!(candidates.len(), 1);
         match &candidates[0].files.audio {
             AudioContent::CueFlacPairs { pairs, .. } => {
@@ -4594,9 +4668,7 @@ FILE "02 - Track Two.flac" WAVE
             "PERFORMER \"X\"\nTITLE \"Y\"\nFILE \"Album.flac\" WAVE\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\nFILE \"Missing.flac\" WAVE\n  TRACK 02 AUDIO\n    INDEX 01 05:00:00\n",
         )
         .unwrap();
-        let mut candidates = Vec::new();
-        scan_for_candidates_with_callback(tmp.path().to_path_buf(), |c| candidates.push(c))
-            .unwrap();
+        let candidates = scan_valid(tmp.path().to_path_buf());
         assert_eq!(
             candidates.len(),
             0,

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1,6 +1,6 @@
 use crate::discogs::DiscogsClient;
 use crate::import::folder_registry::{ImportFolderRegistry, WatchedFolder};
-use crate::import::folder_scanner::FolderCandidate;
+use crate::import::folder_scanner::{FolderCandidate, InvalidCandidate};
 use crate::import::progress::ImportProgressHandle;
 use crate::import::types::{
     DiscoveredFile, ImportCommand, ImportProgress, MetadataSource, StorageMode,
@@ -146,6 +146,11 @@ pub enum ScanEvent {
         folders: Vec<WatchedFolder>,
     },
     FolderCandidate(FolderCandidate),
+    /// A leaf folder that looks like a release but failed validation
+    /// (corrupt/zero-byte audio, corrupt image, CUE referencing missing audio).
+    /// The reducer surfaces it under the Skipped tab with its reason. The key is
+    /// the folder path, shared with `CandidateRemoved` for reconciliation.
+    InvalidCandidate(InvalidCandidate),
     /// A previously-emitted candidate no longer resolves on disk — the watcher
     /// re-scanned its folder and the release is gone. The reducer removes it by
     /// key (the key is the candidate's folder path).

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -51,6 +51,7 @@ pub struct ParsedAlbum {
 pub use folder_registry::{ImportFolderRegistry, WatchedFolder};
 pub use folder_scanner::{
     scan_for_candidates_with_callback, CategorizedFiles, FileEntry, FolderCandidate,
+    InvalidCandidate, ScanItem,
 };
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub use handle::{

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -13,7 +13,9 @@ use {
         DbTrackArtist,
     },
     crate::import::folder_registry::ImportFolderRegistry,
-    crate::import::folder_scanner::scan_for_candidates_with_callback,
+    crate::import::folder_scanner::{
+        scan_for_candidates_with_callback, InvalidCandidate, ScanItem,
+    },
     crate::import::handle::{fetch_artist_images, remap_album_artists, remap_track_artists},
     crate::import::track_to_file_mapper::map_tracks_to_files,
     crate::import::types::{
@@ -438,19 +440,24 @@ impl ImportService {
     ) {
         let root_buf = root.to_path_buf();
         let scanned = tokio::task::spawn_blocking(move || {
-            let mut candidates = Vec::new();
-            scan_for_candidates_with_callback(root_buf, |c| candidates.push(c)).map(|()| candidates)
+            let mut valid = Vec::new();
+            let mut invalid = Vec::new();
+            scan_for_candidates_with_callback(root_buf, |item| match item {
+                ScanItem::Valid(c) => valid.push(c),
+                ScanItem::Invalid(c) => invalid.push(c),
+            })
+            .map(|()| (valid, invalid))
         })
         .await;
 
-        let mut candidates = match scanned {
-            Ok(Ok(candidates)) => candidates,
+        let (mut candidates, invalid_candidates): (_, Vec<InvalidCandidate>) = match scanned {
+            Ok(Ok(split)) => split,
             Ok(Err(e)) => {
                 warn!(
                     "re-scan of {} failed ({e}); removing its candidates",
                     root.display()
                 );
-                Vec::new()
+                (Vec::new(), Vec::new())
             }
             Err(e) => {
                 error!("folder scan task panicked for {}: {e}", root.display());
@@ -460,7 +467,8 @@ impl ImportService {
 
         // The blocking walk left `skipped`/`is_added` at their defaults (it has
         // neither the registry nor the DB). Stamp the real values now, before
-        // reconciling, so every emitted candidate carries its tab state.
+        // reconciling, so every emitted candidate carries its tab state. Invalid
+        // candidates carry no files or tab state, so they need no stamping.
         for candidate in &mut candidates {
             let path = candidate.path.to_string_lossy();
             candidate.skipped = folder_registry.lock().unwrap().is_skipped(&path);
@@ -482,15 +490,30 @@ impl ImportService {
             };
         }
 
+        // Reconciliation keys span both lists: a folder that flipped valid →
+        // invalid (or vice versa) keeps the same path key, so a removal is only
+        // emitted when the path drops out of the scan entirely.
         let new_keys: HashSet<String> = candidates
             .iter()
             .map(|c| c.path.to_string_lossy().into_owned())
+            .chain(
+                invalid_candidates
+                    .iter()
+                    .map(|c| c.path.to_string_lossy().into_owned()),
+            )
             .collect();
 
         for candidate in candidates {
             send_event(
                 event_tx,
                 crate::import::handle::ImportEvent::Scan(ScanEvent::FolderCandidate(candidate)),
+            );
+        }
+
+        for invalid in invalid_candidates {
+            send_event(
+                event_tx,
+                crate::import::handle::ImportEvent::Scan(ScanEvent::InvalidCandidate(invalid)),
             );
         }
 

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -265,6 +265,9 @@ impl UiEventBus {
                         ScanEvent::FolderCandidate(c) => {
                             bus.emit(UiBusEvent::FolderCandidateAdded { candidate: c });
                         }
+                        ScanEvent::InvalidCandidate(c) => {
+                            bus.emit(UiBusEvent::InvalidCandidate { candidate: c });
+                        }
                         ScanEvent::CandidateRemoved { candidate_key } => {
                             bus.emit(UiBusEvent::ScanCandidateRemoved { key: candidate_key });
                         }

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -146,6 +146,13 @@ pub enum UiBusEvent {
     FolderCandidateAdded {
         candidate: crate::import::FolderCandidate,
     },
+    /// A leaf folder looked like a release but failed validation. The reducer
+    /// surfaces it under the Skipped tab with its reason, dropping the folder
+    /// from the valid-candidate list if it was there before.
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    InvalidCandidate {
+        candidate: crate::import::InvalidCandidate,
+    },
     /// A candidate's folder was re-scanned by the watcher and the release is
     /// gone. The reducer removes it by key.
     ScanCandidateRemoved {

--- a/bae-core/tests/alac_fixtures.rs
+++ b/bae-core/tests/alac_fixtures.rs
@@ -16,7 +16,7 @@ use bae_core::db::Database;
 use bae_core::discogs::models::{DiscogsRelease, DiscogsTrack};
 use bae_core::import::discid::compute_discid_from_categorized;
 use bae_core::import::folder_scanner::{
-    collect_release_candidate_files, scan_for_candidates_with_callback, AudioContent,
+    collect_release_candidate_files, scan_for_candidates_with_callback, AudioContent, ScanItem,
 };
 use bae_core::import::{
     IdentityChoice, ImportCommand, ImportService, MetadataRef, MetadataSource, StorageMode,
@@ -265,8 +265,16 @@ fn scanner_recognizes_cue_alac_pair() {
     std::fs::copy(fix.join("cue-alac.cue"), album_dir.join("cue-alac.cue")).expect("copy cue");
 
     let mut candidates = Vec::new();
-    scan_for_candidates_with_callback(album_dir.clone(), |c| candidates.push(c))
-        .expect("scan folder");
+    scan_for_candidates_with_callback(album_dir.clone(), |item| match item {
+        ScanItem::Valid(c) => candidates.push(c),
+        ScanItem::Invalid(c) => {
+            panic!(
+                "ALAC fixture must scan as a valid release, got invalid: {}",
+                c.reason
+            )
+        }
+    })
+    .expect("scan folder");
 
     assert_eq!(candidates.len(), 1, "one release in the folder");
     let candidate = &candidates[0];

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -854,6 +854,17 @@ enum PreviewData {
         ),
     ]
 
+    /// Folders that look like a release but failed validation — surface under
+    /// the Skipped tab with a warning and reason.
+    static let invalidCandidates: [BridgeInvalidCandidate] = [
+        BridgeInvalidCandidate(
+            folderPath: "/Music/Downloads/Broken Rip",
+            sourceFolderName: "Broken Rip",
+            watchedFolderPath: "/Music/Downloads",
+            reason: "corrupt or zero-byte audio file: 03.flac"
+        )
+    ]
+
     static let bridgeCandidateFiles = BridgeCandidateFiles(
         audio: .cueFlacPairs(pairs: [
             BridgeCueFlacPair(

--- a/bae-macos/bae/bae/Services/ImportStore.swift
+++ b/bae-macos/bae/bae/Services/ImportStore.swift
@@ -10,6 +10,21 @@ enum CandidateTab: Hashable {
     case skipped
 }
 
+/// One row under the Skipped tab: a manually-skipped candidate, or an invalid
+/// folder (looked like a release but failed validation). The view renders each
+/// case with its own row; the data layer decides which folder a row belongs to.
+enum SkippedRow: Identifiable {
+    case candidate(Candidate)
+    case invalid(BridgeInvalidCandidate)
+
+    var id: String {
+        switch self {
+        case .candidate(let c): c.key
+        case .invalid(let c): c.folderPath
+        }
+    }
+}
+
 /// Session state for the import flow. Mixed-writer: the reducer drives
 /// event-driven fields (scan, identify, preview state), while views drive
 /// user-set fields (mode, selectedCoverUrl) via `mutateCandidate(forKey:_:)`.
@@ -22,6 +37,13 @@ enum CandidateTab: Hashable {
 @Observable
 class ImportStore {
     var folderCandidates: OrderedDictionary<String, Candidate> = [:]
+    /// Folders that look like a release but failed validation, keyed by folder
+    /// path. They carry no files or identify state — they can't be imported —
+    /// only a reason. Surfaced under the Skipped tab with a warning. A folder is
+    /// never in both `folderCandidates` and here: the reducer moves it across as
+    /// validity flips.
+    var invalidCandidates: OrderedDictionary<String, BridgeInvalidCandidate> =
+        [:]
     /// The folders being watched for imports, in add order. The candidate list
     /// renders one collapsible group per folder; each candidate's
     /// `watchedFolderPath` matches one of these `path`s. Fetched when the import
@@ -165,25 +187,58 @@ class ImportStore {
                     return nil
                 }
             }
-            let ordered: [Candidate] =
-                switch sortOrder {
-                case .nameAZ:
-                    Self.sortedByName(rows, ascending: true)
-                case .nameZA:
-                    Self.sortedByName(rows, ascending: false)
-                case .dateAddedNewest:
-                    Array(rows)
-                case .dateAddedOldest:
-                    Array(rows.reversed())
-                }
+            let ordered = Self.ordered(
+                rows,
+                by: sortOrder,
+                name: \.displayName
+            )
             return (folder, ordered)
+        }
+    }
+
+    /// Rows for the Skipped tab, grouped per watched folder: each folder's
+    /// manually-skipped candidates plus the invalid candidates scanned from it,
+    /// filtered by `filterText` (display name or path) and ordered by
+    /// `sortOrder`. Folders with no matching rows drop out. The view iterates and
+    /// renders this; the grouping/filtering/sorting lives here in the data layer.
+    func skippedGroups(filterText: String, sortOrder: CandidateSortOrder)
+        -> [(folder: BridgeWatchedFolder, rows: [SkippedRow])]
+    {
+        let query = filterText.lowercased()
+        let skippedByFolder = candidateGroups(
+            tab: .skipped,
+            filterText: filterText,
+            sortOrder: sortOrder
+        )
+        return watchedFolders.compactMap { folder in
+            let candidateRows: [SkippedRow] =
+                (skippedByFolder.first { $0.folder.path == folder.path }?
+                .candidates ?? [])
+                .map(SkippedRow.candidate)
+
+            var invalid = invalidCandidates.values.filter {
+                $0.watchedFolderPath == folder.path
+            }
+            if !query.isEmpty {
+                invalid = invalid.filter {
+                    $0.sourceFolderName.lowercased().contains(query)
+                        || $0.folderPath.lowercased().contains(query)
+                }
+            }
+            let invalidRows: [SkippedRow] =
+                Self.ordered(invalid, by: sortOrder, name: \.sourceFolderName)
+                .map(SkippedRow.invalid)
+
+            let rows = candidateRows + invalidRows
+            return rows.isEmpty ? nil : (folder, rows)
         }
     }
 
     /// Per-tab candidate counts across every folder candidate (independent of
     /// the active filter), for the tab bar's count badges. A candidate whose
     /// watched folder is no longer present still counts — the watcher drops such
-    /// candidates from the store, so the store only holds live ones.
+    /// candidates from the store, so the store only holds live ones. Invalid
+    /// candidates count under Skipped alongside manually-skipped ones.
     func candidateTabCounts() -> (new: Int, added: Int, skipped: Int) {
         var counts = (new: 0, added: 0, skipped: 0)
         for candidate in folderCandidates.values {
@@ -193,17 +248,33 @@ class ImportStore {
             case .skipped: counts.skipped += 1
             }
         }
+        counts.skipped += invalidCandidates.count
         return counts
     }
 
-    private static func sortedByName(_ rows: [Candidate], ascending: Bool)
-        -> [Candidate]
-    {
-        let wanted: ComparisonResult =
-            ascending ? .orderedAscending : .orderedDescending
-        return rows.sorted {
-            $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
-                == wanted
+    /// Order `rows` by `sortOrder`, keying the name cases off `name`. One
+    /// dispatch for both candidate rows (by display name) and invalid rows (by
+    /// folder name), so a new `CandidateSortOrder` case is handled in one place.
+    private static func ordered<T>(
+        _ rows: [T],
+        by sortOrder: CandidateSortOrder,
+        name: (T) -> String
+    ) -> [T] {
+        switch sortOrder {
+        case .nameAZ:
+            return rows.sorted {
+                name($0).localizedCaseInsensitiveCompare(name($1))
+                    == .orderedAscending
+            }
+        case .nameZA:
+            return rows.sorted {
+                name($0).localizedCaseInsensitiveCompare(name($1))
+                    == .orderedDescending
+            }
+        case .dateAddedNewest:
+            return rows
+        case .dateAddedOldest:
+            return rows.reversed()
         }
     }
 }

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -270,16 +270,30 @@ enum UiEventReducer {
         case .folderCandidateAdded(let candidate):
             // Insert only if absent: a re-scan (e.g. when the import view
             // reappears) re-emits every candidate, and overwriting would wipe a
-            // candidate's in-progress identify/search/import state.
+            // candidate's in-progress identify/search/import state. The folder
+            // may have been invalid before (a corrupt file got fixed), so drop
+            // it from the invalid list — a folder is never in both.
             let native = Candidate(bridge: candidate)
+            importStore.invalidCandidates.removeValue(forKey: native.key)
             if importStore.folderCandidates[native.key] == nil {
                 importStore.folderCandidates[native.key] = native
             }
 
+        case .invalidCandidate(let candidate):
+            // A folder that looks like a release but failed validation. Surface
+            // it under Skipped, and drop it from the valid-candidate list — it
+            // may have been valid before (a file got corrupted); a folder is
+            // never in both lists.
+            importStore.invalidCandidates[candidate.folderPath] = candidate
+            importStore.folderCandidates.removeValue(
+                forKey: candidate.folderPath
+            )
+
         case .scanCandidateRemoved(let key):
-            // The watcher re-scanned the candidate's folder and the release is
-            // gone from disk; drop it.
+            // The watcher re-scanned the candidate's folder and it's gone from
+            // disk; drop it from whichever list holds it.
             importStore.folderCandidates.removeValue(forKey: key)
+            importStore.invalidCandidates.removeValue(forKey: key)
 
         case .candidateSkipChanged(let key, let skipped):
             // The user skipped or unskipped the candidate; flip its flag so the

--- a/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
@@ -50,7 +50,8 @@ struct ImportCandidateListContent: View {
 
     /// One section per watched folder, candidates in the active tab, filtered and
     /// sorted — built by the store. `activeTab`, `filterText`, and `sortOrder`
-    /// are this view's own UI state.
+    /// are this view's own UI state. Used for the New and Added tabs; the
+    /// Skipped tab uses `displayedSkippedGroups` (it also holds invalid rows).
     private var displayedGroups:
         [(folder: BridgeWatchedFolder, candidates: [Candidate])]
     {
@@ -59,6 +60,23 @@ struct ImportCandidateListContent: View {
             filterText: filterText,
             sortOrder: sortOrder
         )
+    }
+
+    /// One section per watched folder for the Skipped tab: manually-skipped
+    /// candidates plus invalid folders, built by the store.
+    private var displayedSkippedGroups:
+        [(folder: BridgeWatchedFolder, rows: [SkippedRow])]
+    {
+        importStore.skippedGroups(
+            filterText: filterText,
+            sortOrder: sortOrder
+        )
+    }
+
+    /// True when the active tab has nothing to show — drives the empty state.
+    private var activeTabIsEmpty: Bool {
+        activeTab == .skipped
+            ? displayedSkippedGroups.isEmpty : displayedGroups.isEmpty
     }
 
     var body: some View {
@@ -95,8 +113,11 @@ struct ImportCandidateListContent: View {
             }
             .frame(maxWidth: .infinity)
         } content: {
-            if displayedGroups.isEmpty {
+            if activeTabIsEmpty {
                 emptyState
+            }
+            else if activeTab == .skipped {
+                skippedList
             }
             else {
                 candidateList
@@ -161,6 +182,59 @@ struct ImportCandidateListContent: View {
         }
         .scrollContentBackground(.hidden)
         .background(Theme.surface)
+    }
+
+    /// The Skipped tab: manually-skipped candidates and invalid folders, grouped
+    /// by watched folder. Invalid rows aren't selectable — selecting their key is
+    /// a no-op upstream (they aren't in `folderCandidates`, so no detail pane
+    /// opens).
+    private var skippedList: some View {
+        List(selection: $selectedKey) {
+            ForEach(displayedSkippedGroups, id: \.folder.path) { group in
+                Section {
+                    if !collapsedFolders.contains(group.folder.path) {
+                        ForEach(group.rows) { row in
+                            skippedRow(row)
+                        }
+                    }
+                } header: {
+                    FolderSectionHeader(
+                        folder: group.folder,
+                        count: group.rows.count,
+                        isCollapsed: collapsedFolders.contains(
+                            group.folder.path
+                        ),
+                        onToggle: { toggleCollapsed(group.folder.path) },
+                        onRemove: { onRemoveFolder(group.folder.path) },
+                    )
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Theme.surface)
+    }
+
+    @ViewBuilder
+    private func skippedRow(_ row: SkippedRow) -> some View {
+        switch row {
+        case .candidate(let candidate):
+            CandidateRow(
+                displayName: candidate.displayName,
+                revealPath: candidate.folderPathIfReal,
+                status: candidate.importStatus,
+                isAdded: candidate.isAdded,
+                skipped: candidate.skipped,
+                isLikelyDupe: isLikelyDupe(candidate.displayName),
+                onSkip: { skipped in onSkip(candidate.key, skipped) },
+            )
+            .tag(candidate.key)
+        case .invalid(let invalid):
+            InvalidCandidateRow(
+                displayName: invalid.sourceFolderName,
+                reason: invalid.reason,
+                revealPath: invalid.folderPath,
+            )
+        }
     }
 
     private func toggleCollapsed(_ path: String) {
@@ -401,6 +475,46 @@ struct CandidateRow: View {
     }
 }
 
+// MARK: - InvalidCandidateRow
+
+/// A folder that looked like a release but failed validation. Shows a warning
+/// icon and the reason; it has no Skip action and no detail pane (selecting it
+/// is a no-op — its key isn't a real candidate).
+private struct InvalidCandidateRow: View {
+    let displayName: String
+    let reason: String
+    /// Real filesystem path for Reveal in Finder.
+    let revealPath: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(displayName)
+                    .font(.callout)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .help(reason)
+        .contextMenu {
+            Button("Reveal in Finder") {
+                SystemActions.revealInFinder(path: revealPath)
+            }
+        }
+    }
+}
+
 // MARK: - Previews
 
 #Preview("Candidate List") {
@@ -413,6 +527,9 @@ struct CandidateRow: View {
         var copy = candidate
         copy.importStatus = PreviewData.importStatuses[candidate.key]
         store.folderCandidates[copy.key] = copy
+    }
+    for invalid in PreviewData.invalidCandidates {
+        store.invalidCandidates[invalid.folderPath] = invalid
     }
     return ImportCandidateListContent(
         importStore: store,


### PR DESCRIPTION
A subfolder that looks like a release — it has audio — but fails validation (corrupt or zero-byte audio, a corrupt image, or a CUE referencing a missing audio file) used to be silently dropped during the scan. The user had no idea a folder didn't import or why.

Now the scanner reports *why* a folder is invalid instead of discarding it. `categorize_files_from_tree` returns a `Valid(files)` / `Invalid(reason)` outcome, and `scan_for_candidates_with_callback` emits a `ScanItem::Valid(FolderCandidate)` or `ScanItem::Invalid(InvalidCandidate)`. The watcher tracks invalid candidates alongside valid ones — reconciling removals across both lists so a folder that flips between valid and invalid (a file gets fixed or corrupted) keeps its key and moves cleanly between the two without a spurious removal. The import view renders invalid candidates under the **Skipped** tab with an orange warning icon, the folder name, and the failure reason (also a tooltip); they have no Skip action and aren't selectable.

Invalid folders still can't be imported — the import-commit path (`collect_release_candidate_files`) turns the reason into an error.

This completes the import candidate-list work (#17 overwrite, #19 watched folders + grouping, #22 filesystem watching, #23 New/Added/Skipped tabs + skip + Added).

## Test plan
- [x] New core test: a folder with a corrupt audio file scans as an invalid candidate carrying a reason (not dropped, not a valid candidate); full folder_scanner / service / event_bus / alac suites pass
- [x] core clippy (lib + tests), bridge clippy, macOS build, periphery — green via pre-commit
- [ ] Manual: put a folder with a zero-byte FLAC under a watched folder → it appears under Skipped with a warning + reason; fix the file → it moves to New

🤖 Generated with [Claude Code](https://claude.com/claude-code)