### PR TITLE
CI: bump swiftui-environment-audit to v0.3.0 (preview coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Missing-environment check (swiftui-environment-audit)
       if: ${{ !cancelled() && steps.build_macos.conclusion == 'success' }}
       env:
-        AUDIT_VERSION: v0.2.0
+        AUDIT_VERSION: v0.3.0
       run: |
         set -euo pipefail
         archive="swiftui-environment-audit-${AUDIT_VERSION}-macos-arm64.tar.gz"

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
@@ -628,4 +628,21 @@ struct CoverPickerView: View {
     .background(Theme.background)
     .preferredColorScheme(.dark)
     .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(
+        ConfigStore(
+            config: Config(
+                bridge: BridgeConfig(
+                    libraryId: "lib-preview",
+                    libraryName: "Preview Library",
+                    libraryPath: "/preview",
+                    encryptionKeyStored: false,
+                    encryptionKeyFingerprint: nil,
+                    discogsTokenStatus: .notConfigured,
+                    discogsUsable: false,
+                    sync: nil
+                )
+            ),
+            syncReady: false
+        )
+    )
 }


### PR DESCRIPTION
The missing-environment audit in CI runs v0.2.0, which only walks the App's `Scene` roots. Previews are a separate root tree — every dependency a preview's view reads has to be injected by the preview body itself — so a `#Preview` that forgets an `@Environment` object isn't a build error and isn't caught by v0.2.0; it only crashes when someone opens the canvas. That's the exact gap the original tooling question was about.

v0.3.0 adds walking of every `#Preview` macro as a root. This bump points CI at it.

Running v0.3.0 against the current tree surfaces a real, pre-existing finding: the `Main Pane - Confirm` preview in `ImportConfirmationView` injects `OutboxStore` but the view also reads `@Environment(ConfigStore.self)`, so that canvas traps on open. **CI on this PR is therefore expected to fail on the missing-environment step** — that failure is the gate doing its job. Landing this for real is paired with the one-line `ConfigStore` injection in that preview.

## Test plan
- [ ] CI "Missing-environment check" step fails, naming the `ConfigStore` gap in `ImportConfirmationView`'s `Main Pane - Confirm` preview.
- [ ] All other previews and scenes pass (no new findings).