### PR TITLE
Read managed cloud audio through the home's at-rest cipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=64870ed54444a03ed99fa8288b690e683756afab#64870ed54444a03ed99fa8288b690e683756afab"
+source = "git+https://github.com/bae-fm/coven?rev=bac449365d9dc1489482475edd2319791ac43436#bac449365d9dc1489482475edd2319791ac43436"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -11,7 +11,7 @@ name = "bae_core"
 path = "src/lib.rs"
 
 [dependencies]
-coven = { git = "https://github.com/bae-fm/coven", rev = "64870ed54444a03ed99fa8288b690e683756afab" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "bac449365d9dc1489482475edd2319791ac43436" }
 reqwest = { workspace = true, features = ["form", "json", "query", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -104,7 +104,7 @@ tempfile = "3.8"
 tokio = { version = "1.0", features = ["test-util"] }
 serial_test = "3.4.0"
 # coven's deterministic clock/id fakes for bae's tests (off in production builds).
-coven = { git = "https://github.com/bae-fm/coven", rev = "64870ed54444a03ed99fa8288b690e683756afab", features = ["test-utils"] }
+coven = { git = "https://github.com/bae-fm/coven", rev = "bac449365d9dc1489482475edd2319791ac43436", features = ["test-utils"] }
 
 [[test]]
 name = "test_playback_behavior"

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -1121,6 +1121,17 @@ impl LibraryManager {
         self.test_overrides.cleanup_delay = Some(delay);
     }
 
+    /// Set the cloud home's storage mode in config, so a test can exercise the
+    /// browsable read/write paths against an injected cloud override (production
+    /// sets this through the cloud-setup wizard). `cloud_blob_cipher` reads it to
+    /// pick plaintext vs. encrypted.
+    #[cfg(feature = "test-utils")]
+    pub fn set_home_storage(&self, storage: crate::config::HomeStorage) {
+        self.config_handle
+            .update(|c| c.cloud_home.storage = storage)
+            .expect("set test home storage mode");
+    }
+
     /// Spawn the deferred drain of the pending-deletions manifest. Every
     /// deletion entry point (delete_release/delete_album/unpin/unmanage) routes
     /// through here so the queued local `storage/` copies are actually removed.
@@ -1694,6 +1705,21 @@ impl LibraryManager {
             return Some(cloud_home.clone());
         }
         self.sync_manager_inner().and_then(|sm| sm.cloud_home())
+    }
+
+    /// The at-rest cipher protecting this library's managed cloud blobs, from
+    /// the home's storage mode (see [`coven::sync::cloud_storage::CloudCipher::for_storage`]):
+    /// `Encrypted` under the master key for an opaque home, `Plaintext` for a
+    /// browsable one. `None` for an opaque home with no encryption service (a
+    /// locked library). Every managed cloud read — playback, pin, unmanage —
+    /// builds a [`crate::storage::BlobRangeReader`] with this so the read applies
+    /// the same protection the upload sealed under: an opaque home decrypts, a
+    /// browsable home reads the verbatim bytes.
+    pub fn cloud_blob_cipher(&self) -> Option<coven::sync::cloud_storage::CloudCipher> {
+        coven::sync::cloud_storage::CloudCipher::for_storage(
+            self.config_handle.config().cloud_home.storage,
+            self.get_encryption_service(),
+        )
     }
 
     pub fn generate_restore_code(&self) -> Result<String, String> {

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -4,7 +4,6 @@
 //! - Local files (non-storage releases, or storage releases with local backend)
 //! - Cloud storage (storage releases with cloud backend)
 
-use crate::encryption::EncryptionService;
 use crate::playback::progress::{emit_progress, PlaybackProgress};
 use crate::playback::sparse_buffer::{ReaderDemand, SharedSparseBuffer, SparseStreamingBuffer};
 use std::sync::{Arc, Weak};
@@ -14,8 +13,9 @@ use tracing::{debug, error, info};
 
 /// Reads audio data into a sparse buffer for streaming playback.
 ///
-/// Local reads serve plaintext bytes from disk; cloud reads decrypt every blob
-/// with the library master key (every cloud object is master-key-encrypted).
+/// Local reads serve plaintext bytes from disk; cloud reads apply the home's
+/// at-rest cipher to each blob — decrypting under the library key on an opaque
+/// home, or reading the verbatim bytes on a browsable one.
 pub trait AudioDataReader: Send + 'static {
     /// Start reading data into the buffer.
     ///
@@ -23,7 +23,8 @@ pub trait AudioDataReader: Send + 'static {
     /// reader needs next (read-ahead), evicts what they have passed, and idles
     /// when every read-ahead window is full -- so playback starts after one
     /// window and memory stays bounded to a window around the playhead instead
-    /// of the whole file. The cloud reader decrypts each window as it lands.
+    /// of the whole file. On an opaque home the cloud reader decrypts each
+    /// window as it lands; on a browsable one it reads the bytes verbatim.
     fn start_reading(
         self: Box<Self>,
         buffer: SharedSparseBuffer,
@@ -154,10 +155,11 @@ impl AudioDataReader for LocalReader {
 /// Reads a local file when `source` resolves one (this device's copy, or a
 /// still-pending upload's original). A pending upload whose source is gone
 /// errors before any cloud read — the object may not exist yet. A `CloudOnly`
-/// source is a managed track's cloud-only, master-key-encrypted object: read
-/// and decrypt it, or report sync disconnected if no cloud home is configured.
-/// An `Unreachable` source is an unmanaged track whose local file is gone —
-/// there is nowhere to read it.
+/// source is a managed track's cloud-only object: read it through the home's
+/// at-rest cipher (decrypt on an opaque home, verbatim on a browsable one), or
+/// report sync disconnected if no cloud home is configured. An `Unreachable`
+/// source is an unmanaged track whose local file is gone — there is nowhere to
+/// read it.
 pub fn create_audio_reader(
     source: crate::library::manager::ReadableFileSource,
     file_id: &str,
@@ -174,22 +176,20 @@ pub fn create_audio_reader(
         }
         ReadableFileSource::UploadPendingSourceMissing => Err(PlaybackError::UploadPending),
         ReadableFileSource::CloudOnly => {
-            // A managed track's audio is a cloud-only, master-key-encrypted
-            // object: read and decrypt it where the read needs the home and
-            // key, or report sync disconnected if no cloud home is configured.
-            // A managed release always has an unlocked library, so a missing
-            // encryption service is a broken invariant, surfaced as an error
-            // rather than masked.
+            // A managed track's audio is a cloud-only object sealed under the
+            // home's at-rest cipher: read it through that cipher where the read
+            // needs the home and cipher, or report sync disconnected if no cloud
+            // home is configured. An opaque home's cipher needs the library key;
+            // a managed release always has an unlocked library, so a missing
+            // cipher there is a broken invariant, surfaced as an error rather
+            // than masked. A browsable home's cipher is plaintext and always
+            // present.
             if let Some(cloud_home) = library_manager.get_cloud_home() {
-                let encryption = library_manager.get_encryption_service().ok_or_else(|| {
-                    PlaybackError::not_found("encryption service for managed cloud file", file_id)
+                let cipher = library_manager.cloud_blob_cipher().ok_or_else(|| {
+                    PlaybackError::not_found("blob cipher for managed cloud file", file_id)
                 })?;
                 let read_config = make_read_config(crate::storage::local::storage_path(file_id));
-                Ok(Box::new(CloudReader::new(
-                    read_config,
-                    cloud_home,
-                    Arc::new(encryption),
-                )))
+                Ok(Box::new(CloudReader::new(read_config, cloud_home, cipher)))
             } else {
                 Err(PlaybackError::SyncDisconnected)
             }
@@ -202,24 +202,25 @@ pub fn create_audio_reader(
     }
 }
 
-/// Reads from cloud storage, decrypting with the library master key. Every
-/// cloud object is a managed, master-key-encrypted blob, so the key is required.
+/// Reads from cloud storage through the home's at-rest cipher: an opaque home's
+/// `Encrypted` cipher decrypts each managed blob under the library key, a
+/// browsable home's `Plaintext` cipher reads the verbatim bytes.
 pub struct CloudReader {
     config: AudioReadConfig,
     cloud_home: Arc<dyn crate::storage::cloud::CloudHome>,
-    encryption_service: Arc<EncryptionService>,
+    cipher: coven::sync::cloud_storage::CloudCipher,
 }
 
 impl CloudReader {
     pub fn new(
         config: AudioReadConfig,
         cloud_home: Arc<dyn crate::storage::cloud::CloudHome>,
-        encryption_service: Arc<EncryptionService>,
+        cipher: coven::sync::cloud_storage::CloudCipher,
     ) -> Self {
         Self {
             config,
             cloud_home,
-            encryption_service,
+            cipher,
         }
     }
 }
@@ -232,19 +233,20 @@ impl AudioDataReader for CloudReader {
     ) {
         let config = self.config;
         let cloud_home = self.cloud_home;
-        let encryption_service = self.encryption_service;
+        let cipher = self.cipher;
         let (wake, buffer) = prepare_fill(buffer);
 
         tokio::spawn(async move {
             let source_size = config.source_size;
             info!("CloudReader: source_size={source_size}");
 
-            // One reader per track: the nonce header is fetched once and reused
-            // across every range read (a full-file stream issues many). Every
-            // managed blob is master-key-scoped (see `BaeBlobPlan`).
+            // One reader per track: on an encrypted home the nonce header is
+            // fetched once and reused across every range read (a full-file stream
+            // issues many); a plaintext home reads each window verbatim. Every
+            // managed blob is master-scoped (see `BaeBlobPlan`).
             let reader = crate::storage::BlobRangeReader::new(
                 cloud_home,
-                &coven::sync::cloud_storage::CloudCipher::Encrypted((*encryption_service).clone()),
+                &cipher,
                 coven::blob::ResolvedScope::Master,
                 config.path.clone(),
                 source_size,
@@ -414,6 +416,7 @@ mod tests {
     use crate::encryption::{EncryptionService, CHUNK_SIZE};
     use crate::playback::sparse_buffer::create_sparse_buffer;
     use crate::storage::cloud::{CloudHome, CloudHomeError, CloudHomeJoinInfo};
+    use coven::sync::cloud_storage::CloudCipher;
     use std::io::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
@@ -629,18 +632,18 @@ mod tests {
         }
     }
 
-    /// Build a `CloudReader` over `cloud` for `file_id`, decrypting with `key` —
-    /// the same reader `create_audio_reader`'s cloud arm constructs, built
-    /// directly here so the decrypt tests don't stand up a `LibraryManager`. The
-    /// storage path matches production's `storage_path(file_id)`.
+    /// Build a `CloudReader` over `cloud` for `file_id` reading through `cipher`
+    /// — the same reader `create_audio_reader`'s cloud arm constructs, built
+    /// directly here so the read-path tests don't stand up a `LibraryManager`.
+    /// The storage path matches production's `storage_path(file_id)`.
     fn cloud_reader_for(
         cloud: Arc<dyn CloudHome>,
         file_id: &str,
-        key: EncryptionService,
+        cipher: CloudCipher,
         source_size: u64,
     ) -> Box<CloudReader> {
         let config = full_file_config(crate::storage::local::storage_path(file_id), source_size);
-        Box::new(CloudReader::new(config, cloud, Arc::new(key)))
+        Box::new(CloudReader::new(config, cloud, cipher))
     }
 
     /// The playback decrypt path: a managed track whose audio lives only in the
@@ -664,7 +667,7 @@ mod tests {
         let reader = cloud_reader_for(
             cloud,
             file_id,
-            EncryptionService::from_key(master_key),
+            CloudCipher::Encrypted(EncryptionService::from_key(master_key)),
             plaintext.len() as u64,
         );
 
@@ -680,6 +683,47 @@ mod tests {
         assert_eq!(
             actual, plaintext,
             "CloudReader must recover the audio after decrypting with the master key"
+        );
+    }
+
+    /// The browsable-home playback path: a managed track whose audio lives only
+    /// in the cloud, stored verbatim (a browsable home seals nothing), is read
+    /// back through a `Plaintext` `CloudReader` and recovered byte-for-byte. The
+    /// upload writes the bytes as-is, so the read must not look for a nonce or
+    /// try to decrypt. Mirror of the opaque decrypt test with the home's cipher
+    /// flipped to `Plaintext` and the stored blob left unencrypted.
+    #[tokio::test]
+    async fn cloud_reader_reads_browsable_managed_audio_verbatim() {
+        // A browsable home stores the audio in the clear: the stored blob IS the
+        // plaintext, with no nonce header.
+        let plaintext = b"managed cloud audio on a browsable home".to_vec();
+
+        let file_id = "file-browsable-1";
+        let storage_key = crate::storage::local::storage_path(file_id);
+        let cloud: Arc<dyn CloudHome> = Arc::new(OneBlobCloud {
+            key: storage_key,
+            blob: plaintext.clone(),
+        });
+
+        let reader = cloud_reader_for(
+            cloud,
+            file_id,
+            CloudCipher::Plaintext,
+            plaintext.len() as u64,
+        );
+
+        let buffer = create_sparse_buffer(plaintext.len() as u64);
+        let (progress_tx, _progress_rx) = tokio_mpsc::unbounded_channel();
+        reader.start_reading(buffer.clone(), progress_tx);
+        let actual = drain_async(buffer.clone()).await;
+
+        assert!(
+            !buffer.is_cancelled(),
+            "a verbatim read on a browsable home must succeed"
+        );
+        assert_eq!(
+            actual, plaintext,
+            "CloudReader must recover the verbatim audio from a browsable home"
         );
     }
 
@@ -713,7 +757,7 @@ mod tests {
         let reader = cloud_reader_for(
             cloud,
             file_id,
-            EncryptionService::from_key(master_key),
+            CloudCipher::Encrypted(EncryptionService::from_key(master_key)),
             plaintext.len() as u64,
         );
 
@@ -766,7 +810,12 @@ mod tests {
         });
         let (progress_tx, mut progress_rx) = tokio_mpsc::unbounded_channel();
 
-        let reader = cloud_reader_for(cloud, file_id, EncryptionService::from_key([3u8; 32]), 4096);
+        let reader = cloud_reader_for(
+            cloud,
+            file_id,
+            CloudCipher::Encrypted(EncryptionService::from_key([3u8; 32])),
+            4096,
+        );
 
         let buffer = create_sparse_buffer(4096);
         reader.start_reading(buffer.clone(), progress_tx);
@@ -821,7 +870,12 @@ mod tests {
         });
         let (progress_tx, mut progress_rx) = tokio_mpsc::unbounded_channel();
 
-        let reader = cloud_reader_for(cloud, file_id, EncryptionService::from_key([3u8; 32]), 4096);
+        let reader = cloud_reader_for(
+            cloud,
+            file_id,
+            CloudCipher::Encrypted(EncryptionService::from_key([3u8; 32])),
+            4096,
+        );
 
         reader.start_reading(buffer.clone(), progress_tx);
         let actual = drain_async(buffer.clone()).await;
@@ -862,7 +916,7 @@ mod tests {
         let reader = cloud_reader_for(
             cloud,
             file_id,
-            EncryptionService::from_key(wrong_key),
+            CloudCipher::Encrypted(EncryptionService::from_key(wrong_key)),
             plaintext.len() as u64,
         );
 

--- a/bae-core/src/storage/local/transfer.rs
+++ b/bae-core/src/storage/local/transfer.rs
@@ -27,15 +27,16 @@ use super::cleanup::PendingDeletion;
 
 /// Read one release file's bytes from wherever it currently lives: this
 /// device's local copy (managed `storage/` copy or an unmanaged original),
-/// the original source of a still-pending cloud upload, or otherwise a
-/// cloud download + decrypt. Verifies `bytes.len() == file.file_size` so a
-/// short or zero read aborts the caller before any delete is queued (SAFETY
+/// the original source of a still-pending cloud upload, or otherwise a cloud
+/// read through the home's at-rest cipher. Verifies `bytes.len() == file.file_size`
+/// so a short or zero read aborts the caller before any delete is queued (SAFETY
 /// INVARIANT).
 ///
-/// Decryption happens only on the cloud path — a local read never decrypts.
-/// Managed cloud audio is encrypted with the library master key; a missing
-/// encryption service there is a broken invariant (a managed release always
-/// has an unlocked library), surfaced as an error rather than masked.
+/// The cipher applies only on the cloud path — a local read is always verbatim.
+/// An opaque home decrypts the blob under the library master key; a browsable
+/// home reads the verbatim bytes. The cipher is absent only for an opaque,
+/// locked library — a broken invariant for a managed release (which always has
+/// an unlocked library), surfaced as an error rather than masked.
 pub async fn read_release_file_bytes(
     local_copy: Option<&DbReleaseLocalCopy>,
     file: &DbFile,
@@ -64,13 +65,22 @@ pub async fn read_release_file_bytes(
                     file.id
                 )
             })?;
-            let encryption = mgr.get_encryption_service().ok_or_else(|| {
-                format!("no encryption service for managed release file {}", file.id)
-            })?;
-            let key = storage_path(&file.id);
-            let raw = cloud_home.read(&key).await?;
-            // Managed cloud audio is encrypted with the library master key.
-            encryption.decrypt(&raw)?
+            let cipher = mgr
+                .cloud_blob_cipher()
+                .ok_or_else(|| format!("no blob cipher for managed release file {}", file.id))?;
+            // Read the whole object through the home's cipher: one ranged read
+            // that decrypts under the master key on an opaque home, or returns
+            // the verbatim bytes on a browsable one. Every managed blob is
+            // master-scoped (see `BaeBlobPlan`).
+            let source_size = file.file_size as u64;
+            let reader = crate::storage::BlobRangeReader::new(
+                cloud_home,
+                &cipher,
+                coven::blob::ResolvedScope::Master,
+                storage_path(&file.id),
+                source_size,
+            );
+            reader.read(0, source_size).await?
         }
         ReadableFileSource::Unreachable => {
             return Err(format!("File {} has no readable location", file.id).into());
@@ -372,14 +382,15 @@ async fn do_pin(
                 let cloud_home = mgr
                     .get_cloud_home()
                     .ok_or("Cannot pin a cloud-only release without a cloud home")?;
-                // Only the cloud download decrypts; a managed release always has
-                // an unlocked library, so a missing key here is a broken
-                // invariant, surfaced as an error rather than masked.
-                let encryption = mgr
-                    .get_encryption_service()
-                    .ok_or_else(|| "no encryption service for managed release".to_string())?;
+                // The cloud download reads through the home's cipher: it decrypts
+                // on an opaque home, reads verbatim on a browsable one. The cipher
+                // is absent only for an opaque, locked library — a broken
+                // invariant for a managed release, surfaced as an error.
+                let cipher = mgr
+                    .cloud_blob_cipher()
+                    .ok_or_else(|| "no blob cipher for managed release".to_string())?;
                 let dest = mgr.local_storage_path_for_file(file);
-                download_cloud_file_chunked(cloud_home, encryption, file, &dest, &report_progress)
+                download_cloud_file_chunked(cloud_home, cipher, file, &dest, &report_progress)
                     .await?;
             }
             ReadableFileSource::Unreachable => {
@@ -405,29 +416,31 @@ async fn do_pin(
     Ok(())
 }
 
-/// Plaintext window size for a chunked cloud pin download: one window is read,
-/// decrypted, and appended to the temp file before the next is fetched, so peak
-/// memory is one window regardless of file size.
+/// Plaintext window size for a chunked cloud pin download: one window is read
+/// (decrypted on an opaque home, verbatim on a browsable one) and appended to
+/// the temp file before the next is fetched, so peak memory is one window
+/// regardless of file size.
 const PIN_DOWNLOAD_WINDOW: u64 = 1_048_576;
 
-/// Download a single managed cloud file to `dest`, decrypting on the fly, one
-/// `PIN_DOWNLOAD_WINDOW`-sized plaintext window at a time. Each window is
-/// retried so a transient provider stall doesn't kill the whole pin. The bytes
-/// land in a `<dest>.part` temp file that is length-verified, fsync'd, and
-/// renamed into place; any failure removes the temp file so a partial download
-/// never masquerades as a pinned copy.
+/// Download a single managed cloud file to `dest` through the home's `cipher`,
+/// one `PIN_DOWNLOAD_WINDOW`-sized plaintext window at a time — decrypting on an
+/// opaque home, reading verbatim on a browsable one. Each window is retried so a
+/// transient provider stall doesn't kill the whole pin. The bytes land in a
+/// `<dest>.part` temp file that is length-verified, fsync'd, and renamed into
+/// place; any failure removes the temp file so a partial download never
+/// masquerades as a pinned copy.
 async fn download_cloud_file_chunked(
     cloud_home: std::sync::Arc<dyn crate::storage::cloud::CloudHome>,
-    encryption: crate::encryption::EncryptionService,
+    cipher: coven::sync::cloud_storage::CloudCipher,
     file: &DbFile,
     dest: &std::path::Path,
     on_progress: &(dyn Fn(u8) + Send + Sync),
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let source_size = file.file_size as u64;
-    // Every managed blob is master-key-scoped (see `BaeBlobPlan`).
+    // Every managed blob is master-scoped (see `BaeBlobPlan`).
     let reader = crate::storage::BlobRangeReader::new(
         cloud_home,
-        &coven::sync::cloud_storage::CloudCipher::Encrypted(encryption),
+        &cipher,
         coven::blob::ResolvedScope::Master,
         storage_path(&file.id),
         source_size,

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -88,6 +88,20 @@ async fn setup_db_with_cloud(
     (db, mgr, cloud)
 }
 
+/// Like [`setup_db_with_cloud`], but the home is browsable: its blobs are stored
+/// in the clear at readable paths, so `cloud_blob_cipher` resolves to plaintext
+/// and managed reads must return the verbatim bytes (no decryption). The cloud
+/// override still carries an `EncryptionService`, but a browsable home never
+/// consults it.
+async fn setup_db_with_browsable_cloud(
+    temp: &TempDir,
+    library_path: &Path,
+) -> (Database, LibraryManager, Arc<MockCloudHome>) {
+    let (db, mgr, cloud) = setup_db_with_cloud(temp, library_path).await;
+    mgr.set_home_storage(bae_core::config::HomeStorage::Browsable);
+    (db, mgr, cloud)
+}
+
 /// Write unmanaged original files to disk under `dir` and insert DbFile rows.
 /// Returns (filename, bytes) pairs.
 async fn create_unmanaged_files(
@@ -881,17 +895,17 @@ async fn upsert_local_copy_preserves_delete_unmanaged_source_intent() {
 }
 
 /// Insert DbFile rows for a cloud-only managed release (no local copy on disk)
-/// and seed each file's encrypted blob at its content-addressed cloud key,
-/// encrypted with the library master key. Returns (file_id, bytes).
+/// and seed each file's blob at its content-addressed cloud key, sealed through
+/// the home's at-rest cipher exactly as the upload outbox would — encrypted
+/// under the library master key on an opaque home, stored verbatim on a
+/// browsable one. Returns (file_id, bytes).
 async fn seed_cloud_only_files(
     mgr: &LibraryManager,
     cloud: &MockCloudHome,
     release_id: &str,
     files: &[(&str, &[u8])],
 ) -> Vec<(String, Vec<u8>)> {
-    let content_enc = mgr
-        .get_encryption_service()
-        .expect("the library is unlocked");
+    let cipher = mgr.cloud_blob_cipher().expect("the home has a blob cipher");
 
     let mut result = Vec::new();
     for (name, data) in files {
@@ -904,7 +918,8 @@ async fn seed_cloud_only_files(
             chrono::Utc::now(),
         );
         let key = bae_core::storage::local::storage_path(&db_file.id);
-        cloud.put(&key, content_enc.encrypt(data));
+        // Managed audio is master-scoped; `seal` matches the outbox's seal.
+        cloud.put(&key, cipher.seal(data));
         mgr.add_file(&db_file).await.unwrap();
         result.push((db_file.id.clone(), data.to_vec()));
     }
@@ -961,6 +976,70 @@ async fn test_pin_cloud_only_downloads_chunked() {
     }
 
     // The download used range reads only — never a full-object read.
+    assert_eq!(
+        cloud.full_read_count(),
+        0,
+        "chunked pin must not issue a full-object read"
+    );
+
+    use bae_core::album_detail::ReleaseStorageState;
+    assert_eq!(
+        storage_state(&mgr, &release_id).await,
+        ReleaseStorageState::Pinned
+    );
+}
+
+/// Pinning a cloud-only release on a browsable home: the blobs are stored
+/// verbatim (no encryption), so the chunked download must read them through the
+/// plaintext cipher and land them byte-identical in `storage/` — never trying
+/// to decrypt plaintext through a fabricated nonce. Same path as the opaque pin
+/// with the home's cipher flipped.
+#[tokio::test]
+async fn test_pin_cloud_only_browsable_downloads_verbatim() {
+    tracing_init();
+
+    let temp = TempDir::new().unwrap();
+    let library_path = temp.path().join("library");
+    tokio::fs::create_dir_all(&library_path).await.unwrap();
+    let library_dir = LibraryDir::new(library_path.clone());
+
+    let (db, mgr, cloud) = setup_db_with_browsable_cloud(&temp, &library_path).await;
+    let (_album_id, release_id) = create_album_and_release(&db, None, false).await;
+
+    // A blob spanning multiple 1 MiB download windows, plus a tiny one.
+    let big: Vec<u8> = (0..(3 * 1_048_576 + 4242))
+        .map(|i| (i % 251) as u8)
+        .collect();
+    let small = b"a short final track".to_vec();
+    let files = seed_cloud_only_files(
+        &mgr,
+        &cloud,
+        &release_id,
+        &[("track1.flac", &big), ("track2.flac", &small)],
+    )
+    .await;
+
+    let service = TransferService::new(mgr.clone());
+    let rx = service.pin_release_task(release_id.clone()).0;
+    let events = collect_progress(rx).await;
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, TransferProgress::Complete { .. })),
+        "pin of a cloud-only browsable release should complete"
+    );
+    assert!(!events
+        .iter()
+        .any(|e| matches!(e, TransferProgress::Failed { .. })));
+
+    // The verbatim bytes landed in storage/, byte-identical to the originals.
+    for (file_id, data) in &files {
+        let stored = library_dir.join(bae_core::storage::local::storage_path(file_id));
+        let on_disk = tokio::fs::read(&stored).await.unwrap();
+        assert_eq!(&on_disk, data, "pinned browsable bytes for {file_id}");
+    }
+
     assert_eq!(
         cloud.full_read_count(),
         0,


### PR DESCRIPTION
Managed cloud audio uploads already respect a browsable home — bae's outbox seals each blob with the home's shared cipher, which is plaintext on a browsable home, so the bytes land verbatim. The read side did not. Playback, pin, and unmanage of a managed cloud-only track each constructed their `BlobRangeReader` with a hardcoded `Encrypted(master)` cipher and required the library key up front. A browsable home has no library key and stores the audio in the clear, so every managed read failed before fetching a byte; even with a key present, an `Encrypted` reader would read a fabricated 24-byte nonce out of the plaintext and fail to decrypt.

This makes the read side ask the home which cipher protects its blobs, the same way the upload seals them. `LibraryManager::cloud_blob_cipher()` resolves the home's storage mode through coven's new `CloudCipher::for_storage` — `Encrypted` under the master key for an opaque home, `Plaintext` for a browsable one. `CloudReader` now holds the resolved `CloudCipher` instead of an `EncryptionService`, and the three managed-read paths (`create_audio_reader`, `download_cloud_file_chunked`, `read_release_file_bytes`) all stream through it: decrypting on an opaque home, reading verbatim on a browsable one.

Pulls in coven `bac4493` (CloudCipher::for_storage / SyncManager::blob_cipher).

Images on a browsable home are a separate break (coven `put_blob` with the `Plain` path scheme needs a `cloud_path`) and are left for a follow-up.

## Test plan
- [x] `cargo test -p bae-core --lib --features test-utils` (768 pass) — includes new `cloud_reader_reads_browsable_managed_audio_verbatim`
- [x] `cargo test -p bae-core --features test-utils --test test_transfer --test test_storage_state_machine` — includes new `test_pin_cloud_only_browsable_downloads_verbatim`
- [x] `cargo test -p bae-core --features test-utils --test test_playback_behavior`
- [x] `cargo clippy -p bae-core --all-targets --features test-utils`, `cargo check -p bae-bridge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)