### PR TITLE
Release lightbox: show every image a release has (cloud-only fetched on demand)

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/ui/AlbumDetailScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/AlbumDetailScreen.kt
@@ -148,9 +148,14 @@ fun AlbumDetailScreen(
                 AlbumDetailContent(
                     detail = loaded,
                     selectedRelease = release,
-                    // The cover is the selected release's first gallery item; its
-                    // localPath is an absolute path the bridge already resolved.
-                    coverPath = release?.galleryItems?.firstOrNull()?.localPath,
+                    // The release's pre-resolved cover identifier (an absolute
+                    // path the bridge already computed), or null when no cover is
+                    // cached — the header shows a placeholder then.
+                    coverPath = release?.coverPath,
+                    // Fetches a cloud-only gallery image's bytes for the lightbox.
+                    fetchGalleryImage = { releaseId, fileId ->
+                        session.appHandle.fetchGalleryImage(releaseId, fileId)
+                    },
                     onSelectRelease = { newId ->
                         selectedReleaseId = newId
                     },
@@ -219,6 +224,7 @@ private fun AlbumDetailContent(
     detail: BridgeAlbumDetail,
     selectedRelease: BridgeRelease?,
     coverPath: String?,
+    fetchGalleryImage: suspend (releaseId: String, fileId: String) -> ByteArray,
     currentTrackId: String?,
     isPlaying: Boolean,
     onSelectRelease: (String) -> Unit,
@@ -235,9 +241,14 @@ private fun AlbumDetailContent(
     val isCompilation = album.isCompilation
 
     var showGallery by remember { mutableStateOf(false) }
-    val galleryItems = selectedRelease?.galleryItems ?: emptyList()
-    if (showGallery && galleryItems.isNotEmpty()) {
-        GalleryDialog(items = galleryItems, onDismiss = { showGallery = false })
+    val galleryRelease = selectedRelease
+    val galleryItems = galleryRelease?.galleryItems ?: emptyList()
+    if (showGallery && galleryRelease != null && galleryItems.isNotEmpty()) {
+        GalleryDialog(
+            items = galleryItems,
+            loadImage = { fileId -> fetchGalleryImage(galleryRelease.id, fileId) },
+            onDismiss = { showGallery = false },
+        )
     }
 
     LazyColumn(

--- a/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
@@ -1,5 +1,6 @@
 package fm.bae.app.ui
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,11 +9,17 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,15 +28,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import uniffi.bae_bridge.BridgeGalleryItem
+
+private const val TAG = "bae.GalleryDialog"
 
 /**
  * Full-screen artwork viewer over a release's gallery items (cover first, then
- * any synced image files). Swipeable when there's more than one. Each item's
- * [BridgeGalleryItem.localPath] is an absolute path the bridge already resolved.
+ * every image file the release has). Swipeable when there's more than one. An
+ * item already on disk renders from its [BridgeGalleryItem.localPath]; a
+ * cloud-only item (no local path) is fetched on demand via [loadImage], keyed by
+ * the item's id.
  */
 @Composable
-fun GalleryDialog(items: List<BridgeGalleryItem>, onDismiss: () -> Unit) {
+fun GalleryDialog(
+    items: List<BridgeGalleryItem>,
+    loadImage: suspend (fileId: String) -> ByteArray,
+    onDismiss: () -> Unit,
+) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -39,12 +57,16 @@ fun GalleryDialog(items: List<BridgeGalleryItem>, onDismiss: () -> Unit) {
             Box(modifier = Modifier.fillMaxSize()) {
                 HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
                     val item = items[page]
-                    AsyncImage(
-                        model = coverModel(item.localPath),
-                        contentDescription = item.label,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize(),
-                    )
+                    val localPath = item.localPath
+                    if (localPath != null) {
+                        GalleryImage(model = coverModel(localPath), contentDescription = item.label)
+                    } else {
+                        RemoteGalleryImage(
+                            fileId = item.id,
+                            label = item.label,
+                            loadImage = loadImage,
+                        )
+                    }
                 }
                 IconButton(
                     onClick = onDismiss,
@@ -73,6 +95,59 @@ fun GalleryDialog(items: List<BridgeGalleryItem>, onDismiss: () -> Unit) {
                     }
                 }
             }
+        }
+    }
+}
+
+/** A gallery image filling the page: cover-from-path or fetched cloud bytes. */
+@Composable
+private fun GalleryImage(model: Any?, contentDescription: String?) {
+    AsyncImage(
+        model = model,
+        contentDescription = contentDescription,
+        contentScale = ContentScale.Fit,
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+/**
+ * A gallery image whose file isn't on disk here: fetch its bytes (downloaded
+ * from the release's cloud home and decrypted by core) and render them, showing
+ * a spinner while loading and the failure reason if the fetch fails. `result`
+ * is null while loading, then success(bytes) or failure(error).
+ */
+@Composable
+private fun RemoteGalleryImage(
+    fileId: String,
+    label: String,
+    loadImage: suspend (fileId: String) -> ByteArray,
+) {
+    var result: Result<ByteArray>? by remember(fileId) {
+        mutableStateOf<Result<ByteArray>?>(null)
+    }
+    LaunchedEffect(fileId) {
+        result = try {
+            Result.success(withContext(Dispatchers.IO) { loadImage(fileId) })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load gallery image $fileId", e)
+            Result.failure(e)
+        }
+    }
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        val r = result
+        when {
+            r == null -> CircularProgressIndicator(color = Color.White)
+            r.isSuccess -> GalleryImage(model = r.getOrThrow(), contentDescription = label)
+            // The underlying failure is already logged above; the viewer shows a
+            // fixed, user-facing message rather than a raw exception string.
+            else ->
+                Text(
+                    text = "Couldn't load image",
+                    color = Color.White,
+                    modifier = Modifier.padding(24.dp),
+                )
         }
     }
 }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -733,6 +733,29 @@ impl AppHandle {
 }
 
 // =========================================================================
+// Release gallery (all platforms)
+// =========================================================================
+
+#[uniffi::export(async_runtime = "tokio")]
+impl AppHandle {
+    /// Bytes of a release's gallery image, fetched from the release's cloud home
+    /// (and decrypted) when it isn't on disk here. The lightbox calls this for
+    /// gallery items whose `local_path` is `None` — the release's cloud-only
+    /// image files. `file_id` is the gallery item's `id`.
+    pub async fn fetch_gallery_image(
+        &self,
+        release_id: String,
+        file_id: String,
+    ) -> Result<Vec<u8>, BridgeError> {
+        self.app_services
+            .library_manager()
+            .load_gallery_image(&release_id, &file_id)
+            .await
+            .map_err(|e| BridgeError::Import { msg: e.to_string() })
+    }
+}
+
+// =========================================================================
 // Apple-only: CloudKit
 // =========================================================================
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -206,8 +206,9 @@ pub struct BridgeRelease {
     pub track_groups: Vec<BridgeTrackGroup>,
     pub files: Vec<BridgeFile>,
     pub image_files: Vec<BridgeFile>,
-    /// Cover first (if on disk), then each image file that resolves to a
-    /// local path. Consumers render this as-is.
+    /// Cover first (if on disk), then every image file the release has —
+    /// including cloud-only ones, which carry no local path and are fetched on
+    /// demand. Consumers render this as-is.
     pub gallery_items: Vec<BridgeGalleryItem>,
     pub total_duration_label: String,
     pub file_count: i64,
@@ -297,12 +298,14 @@ pub struct BridgeFile {
 
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeGalleryItem {
-    /// Stable identifier: "cover" for the release cover, or the file id.
+    /// Stable identifier: "cover" for the release cover, or the file id. For a
+    /// cloud-only image, the file id the lightbox passes to `fetch_gallery_image`.
     pub id: String,
     /// Display label: "Cover" or the file's original filename.
     pub label: String,
-    /// Absolute local path (required — items without a path aren't emitted).
-    pub local_path: String,
+    /// Absolute local path when the image is on disk; `None` for a cloud-only
+    /// image file not downloaded here — the lightbox fetches its bytes on demand.
+    pub local_path: Option<String>,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]

--- a/bae-core/src/album_detail.rs
+++ b/bae-core/src/album_detail.rs
@@ -240,20 +240,23 @@ pub struct ReleaseDetail {
     pub track_groups: Vec<TrackGroup>,
     pub files: Vec<FileDetail>,
     pub image_files: Vec<FileDetail>,
-    /// Cover (if on disk) followed by image files. Items without a
-    /// resolvable local path are omitted.
+    /// Cover (if on disk) followed by every image file the release has —
+    /// including cloud-only ones not yet downloaded (those carry no local path;
+    /// the lightbox fetches them on demand).
     pub gallery_items: Vec<GalleryItem>,
 }
 
 /// One slot in a release's lightbox gallery.
 #[derive(Debug, Clone)]
 pub struct GalleryItem {
-    /// Stable identifier: `"cover"` for the release cover, or the file id.
+    /// Stable identifier: `"cover"` for the release cover, or the file id. For a
+    /// cloud-only image this is the file id the lightbox passes back to fetch it.
     pub id: String,
     /// Display label: `"Cover"` or the file's original filename.
     pub label: String,
-    /// Absolute local path. Items without a resolvable path are never emitted.
-    pub local_path: String,
+    /// Absolute local path when the image is on disk; `None` for a cloud-only
+    /// image file that hasn't been downloaded yet.
+    pub local_path: Option<String>,
 }
 
 /// Full album detail: album + releases (with tracks, files, gallery).

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -3424,17 +3424,18 @@ pub(crate) fn resolve_release(
         gallery.push(GalleryItem {
             id: "cover".to_string(),
             label: "Cover".to_string(),
-            local_path: cover_identifier,
+            local_path: Some(cover_identifier),
         });
     }
+    // Every image file the release has, whether or not it's on disk here. A
+    // cloud-only file (no local copy on this device) gets a None path; the
+    // lightbox fetches its bytes on demand via `load_gallery_image`.
     for f in &image_files {
-        if let Some(path) = image_file_local_path(f) {
-            gallery.push(GalleryItem {
-                id: f.id.clone(),
-                label: f.original_filename.clone(),
-                local_path: path,
-            });
-        }
+        gallery.push(GalleryItem {
+            id: f.id.clone(),
+            label: f.original_filename.clone(),
+            local_path: image_file_local_path(f),
+        });
     }
 
     let display_name = build_release_display_name(
@@ -3586,6 +3587,31 @@ impl LibraryManager {
         release_id: &str,
     ) -> Result<Vec<DbFile>, LibraryError> {
         Ok(self.database.get_files_for_release(release_id).await?)
+    }
+
+    /// Bytes of one of a release's image files, read from the local copy when it
+    /// exists here and otherwise downloaded from the release's cloud home (and
+    /// decrypted). Backs the lightbox for cloud-only gallery items — the ones
+    /// whose `GalleryItem.local_path` is `None`.
+    pub async fn load_gallery_image(
+        &self,
+        release_id: &str,
+        file_id: &str,
+    ) -> Result<Vec<u8>, LibraryError> {
+        let file = self
+            .get_files_for_release(release_id)
+            .await?
+            .into_iter()
+            .find(|f| f.id == file_id)
+            .ok_or_else(|| {
+                LibraryError::Import(format!(
+                    "Image file {file_id} is not part of release {release_id}"
+                ))
+            })?;
+        let local_copy = self.get_release_local_copy(release_id).await?;
+        crate::storage::local::transfer::read_release_file_bytes(local_copy.as_ref(), &file, self)
+            .await
+            .map_err(|e| LibraryError::Import(e.to_string()))
     }
     /// Get a specific file by ID
     ///
@@ -5708,6 +5734,47 @@ mod tests {
         assert!(
             detail.tracks.iter().any(|t| t.title == "Closing"),
             "closing track surfaced"
+        );
+    }
+
+    #[tokio::test]
+    async fn gallery_includes_cloud_only_image_files_with_no_local_path() {
+        let (manager, _temp_dir) = setup_test_manager().await;
+        let album = create_test_album();
+        let release = create_test_release(&album.id);
+        manager.database.insert_album(&album).await.unwrap();
+        manager.database.insert_release(&release).await.unwrap();
+
+        // An image file for the release with no local copy on this device — the
+        // release's images live only in the cloud here.
+        let image = crate::db::DbFile::new(
+            &release.id,
+            "back.jpg",
+            1234,
+            crate::util::content_type::ContentType::Jpeg,
+            Uuid::new_v4().to_string(),
+            Utc::now(),
+        );
+        manager.add_file(&image).await.unwrap();
+
+        let detail = manager
+            .find_release_detail(&release.id)
+            .await
+            .unwrap()
+            .expect("detail present");
+
+        // The lightbox shows every image the release has: the cloud-only image
+        // is surfaced as a gallery item (so it can be fetched on demand), with
+        // no local path because it isn't downloaded here.
+        let item = detail
+            .gallery_items
+            .iter()
+            .find(|g| g.id == image.id)
+            .expect("cloud-only image surfaced in gallery");
+        assert_eq!(item.label, "back.jpg");
+        assert!(
+            item.local_path.is_none(),
+            "a cloud-only image has no local path until fetched"
         );
     }
 

--- a/bae-ios/bae/bae/AppService.swift
+++ b/bae-ios/bae/bae/AppService.swift
@@ -63,7 +63,10 @@ final class AppService: Observable {
         // on-disk covers, so build `MediaPaths` without it.
         mediaPaths = MediaPaths(
             imagePathIfExists: { appHandle.imagePathIfExists(imageId: $0) },
-            filePath: { try appHandle.filePath(fileId: $0) }
+            filePath: { try appHandle.filePath(fileId: $0) },
+            fetchGalleryImage: {
+                try await appHandle.fetchGalleryImage(releaseId: $0, fileId: $1)
+            }
         )
         sync = Sync(handle: appHandle)
     }

--- a/bae-ios/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-ios/bae/bae/Views/AlbumDetailView.swift
@@ -91,7 +91,12 @@ struct AlbumDetailView: View {
             .padding(16)
         }
         .fullScreenCover(isPresented: $showGallery) {
-            GalleryView(items: detail.galleryItems)
+            GalleryView(
+                items: detail.galleryItems,
+                loadImage: { fileId in
+                    try await mediaPaths.fetchGalleryImage(releaseId, fileId)
+                }
+            )
         }
     }
 

--- a/bae-ios/bae/bae/Views/GalleryView.swift
+++ b/bae-ios/bae/bae/Views/GalleryView.swift
@@ -1,10 +1,18 @@
 import SwiftUI
+import os.log
+
+private let logger = Logger.bae("GalleryView")
 
 /// Full-screen artwork viewer over a release's gallery items (cover first, then
-/// any synced image files). Swipeable when there's more than one; each item's
-/// `localPath` is an absolute path the bridge already resolved.
+/// every image file the release has). Swipeable when there's more than one. An
+/// item already on disk renders from its `localPath`; a cloud-only item (no
+/// local path) has its bytes fetched on demand via `loadImage`, keyed by the
+/// item's id.
 struct GalleryView: View {
     let items: [BridgeGalleryItem]
+    /// Fetches a cloud-only gallery item's bytes by its id, for items whose
+    /// `localPath` is nil (image files not downloaded on this device).
+    let loadImage: @Sendable (_ fileId: String) async throws -> Data
 
     @Environment(\.dismiss)
     private var dismiss
@@ -16,7 +24,7 @@ struct GalleryView: View {
             Color.black.ignoresSafeArea()
             TabView(selection: $selection) {
                 ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-                    ImageView(path: item.localPath, pointSize: 1024, contentMode: .fit)
+                    GalleryPage(item: item, loadImage: loadImage)
                         .tag(index)
                 }
             }
@@ -41,6 +49,90 @@ struct GalleryView: View {
                     .font(.title)
                     .foregroundStyle(.white)
                     .padding()
+            }
+        }
+    }
+}
+
+/// One page of the gallery: a single view per `ForEach` element (so the paging
+/// container's element type stays stable) that renders an on-disk item from its
+/// path and fetches a cloud-only one on demand.
+private struct GalleryPage: View {
+    let item: BridgeGalleryItem
+    let loadImage: @Sendable (_ fileId: String) async throws -> Data
+
+    var body: some View {
+        if let path = item.localPath {
+            ImageView(path: path, pointSize: 1024, contentMode: .fit)
+        }
+        else {
+            RemoteGalleryImage(fileId: item.id, loadImage: loadImage)
+        }
+    }
+}
+
+/// A gallery image whose file isn't on disk here: fetch its bytes (downloaded
+/// from the release's cloud home and decrypted by core), decode off the main
+/// thread, and render it — a spinner while loading, a warning glyph on failure.
+private struct RemoteGalleryImage: View {
+    let fileId: String
+    let loadImage: @Sendable (_ fileId: String) async throws -> Data
+
+    @State
+    private var image: UIImage?
+    @State
+    private var failed = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+            else if failed {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.largeTitle)
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            else {
+                ProgressView()
+                    .tint(.white)
+            }
+        }
+        .task(id: fileId) {
+            do {
+                let data = try await loadImage(fileId)
+                let decoded = await Task.detached(priority: .userInitiated) {
+                    UIImage(data: data)
+                }.value
+                if Task.isCancelled {
+                    logger.debug(
+                        "gallery image decode cancelled: \(fileId, privacy: .public)"
+                    )
+                    return
+                }
+                if let decoded {
+                    image = decoded
+                }
+                else {
+                    logger.warning(
+                        "Couldn't decode gallery image \(fileId, privacy: .public) (\(data.count) bytes)"
+                    )
+                    failed = true
+                }
+            }
+            catch is CancellationError {
+                // The viewer was dismissed mid-fetch; leave state as-is.
+                logger.debug(
+                    "gallery image fetch cancelled: \(fileId, privacy: .public)"
+                )
+            }
+            catch {
+                logger.warning(
+                    "Failed to load gallery image \(fileId, privacy: .public): \(error)"
+                )
+                failed = true
             }
         }
     }

--- a/bae-macos/bae/bae/Services/MediaPaths.swift
+++ b/bae-macos/bae/bae/Services/MediaPaths.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+#if os(iOS)
+    /// A `MediaPaths` capability that isn't wired in this iOS context — the
+    /// preview stub, or a desktop-only closure (`fetchCoverBytes`) that iOS
+    /// never calls. Throwing surfaces misuse instead of masking it with empty
+    /// bytes.
+    private struct MediaPathsUnavailable: Error {}
+#endif
+
 /// Image and file path resolution against the live library. Wraps the
 /// narrow subset of `AppHandle` that views need to render artwork and
 /// resolve local file paths — separated out so leaves can take this
@@ -8,6 +16,15 @@ final class MediaPaths: Sendable, Observable {
     let imagePathIfExists: @Sendable (_ imageId: String) -> String?
     let filePath: @Sendable (_ fileId: String) throws -> String?
     let fetchCoverBytes: @Sendable (_ url: String) async throws -> Data
+    #if os(iOS)
+        /// Bytes of a release's gallery image, downloaded from the cloud (and
+        /// decrypted) when it isn't on disk here. The lightbox calls this for
+        /// gallery items with no local path. iOS-only: the macOS lightbox shows
+        /// local images only (the desktop pins releases on view).
+        let fetchGalleryImage:
+            @Sendable (_ releaseId: String, _ fileId: String) async throws ->
+                Data
+    #endif
 
     init(
         imagePathIfExists: @escaping @Sendable (String) -> String? = { _ in nil
@@ -20,7 +37,29 @@ final class MediaPaths: Sendable, Observable {
         self.imagePathIfExists = imagePathIfExists
         self.filePath = filePath
         self.fetchCoverBytes = fetchCoverBytes
+        #if os(iOS)
+            // No-arg form is the preview stub; a real fetch is wired by the
+            // iOS designated init below. Throw rather than return empty bytes.
+            self.fetchGalleryImage = { _, _ in throw MediaPathsUnavailable() }
+        #endif
     }
+
+    #if os(iOS)
+        /// iOS designated initializer that wires the cloud-only gallery image
+        /// fetch the lightbox needs. `fetchCoverBytes` is desktop-only and never
+        /// called on iOS, so it throws rather than masking with empty bytes.
+        init(
+            imagePathIfExists: @escaping @Sendable (String) -> String?,
+            filePath: @escaping @Sendable (String) throws -> String?,
+            fetchGalleryImage:
+                @escaping @Sendable (String, String) async throws -> Data
+        ) {
+            self.imagePathIfExists = imagePathIfExists
+            self.filePath = filePath
+            self.fetchCoverBytes = { _ in throw MediaPathsUnavailable() }
+            self.fetchGalleryImage = fetchGalleryImage
+        }
+    #endif
 
     // `fetchCoverBytes` pulls remote cover art for the desktop import flow and
     // isn't exported on iOS. This `handle`-wiring convenience initializer

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -70,6 +70,9 @@ struct AlbumDetailView: View {
                         coverPath: mediaPaths.imagePathIfExists(
                             selectedReleaseId
                         ),
+                        // Every gallery item; a cloud-only one carries a nil path
+                        // and the lightbox renders it as "No image" (the desktop
+                        // pins releases on view, so it doesn't fetch on demand).
                         lightboxItems: selectedDetail.galleryItems.map {
                             LightboxItem(
                                 id: $0.id,

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1016,9 +1016,14 @@ pub unsafe extern "C" fn bae_gallery(
     let items: Vec<FfiGalleryItem> = detail
         .gallery_items
         .into_iter()
-        .map(|item| FfiGalleryItem {
-            label: item.label,
-            path: item.local_path,
+        // Local images only on Windows (the desktop pins releases on view); a
+        // cloud-only item has no local path here, so it's dropped rather than
+        // shown as a blank entry.
+        .filter_map(|item| {
+            item.local_path.map(|path| FfiGalleryItem {
+                label: item.label,
+                path,
+            })
         })
         .collect();
     json_cstring(&items)


### PR DESCRIPTION
Tapping a release's cover opens a lightbox, but it only showed images already on disk: `gallery_items` was built from the cover plus image files that resolved to a local path. For a cloud-only release (not downloaded on this device) that meant just the cover — the back and inserts, which live in the cloud, were dropped.

Core now builds `gallery_items` from *every* image file the release has; a file with no local copy here carries no path (`local_path: Option<String>`). A new `AppHandle.fetch_gallery_image(release_id, file_id)` reads a release image's bytes from the local copy, or downloads and decrypts it from the release's cloud home — reusing the existing `read_release_file_bytes` path. The Android and iOS lightboxes render on-disk items from their path and fetch the cloud-only ones on demand: a spinner while loading, the failure surfaced inline.

macOS keeps its existing local-only lightbox (the desktop pins releases on view), filtering out cloud-only items rather than showing blank pages; its `MediaPaths` gallery-fetch hook is `#if os(iOS)`-restricted so it isn't dead code there.

## Test plan
- [x] New core test: a cloud-only image surfaces in `gallery_items` with no local path
- [x] Pre-commit green: cargo fmt/clippy (incl. tests), swift-format, **macOS xcodebuild + periphery**
- [ ] CI: Rust tests + both Android builds (full + baeium) compile the Kotlin against the new bridge
- [ ] **iOS not built in PR CI** (release-only) — iOS lightbox changes mirror the existing `ImageView`/`fullScreenCover` patterns; needs a real iOS build to confirm end to end