### PR TITLE
Consolidate Cover Art Archive lookup paths

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -478,9 +478,9 @@ impl AppHandle {
             BridgeCoverSelection::ReleaseImage { file_id } => {
                 CoverSelection::ReleaseImage { file_id }
             }
-            BridgeCoverSelection::RemoteCover { url, source } => CoverSelection::RemoteCover {
-                url,
-                source: source.to_core(),
+            BridgeCoverSelection::RemoteCover { selection } => CoverSelection::RemoteCover {
+                url: selection.url,
+                source: selection.source.to_core(),
             },
         };
 
@@ -1187,12 +1187,7 @@ impl AppHandle {
             .map_err(|e| BridgeError::Import { msg: e })?;
         Ok(covers
             .into_iter()
-            .map(|c| BridgeRemoteCover {
-                url: c.url,
-                thumbnail_url: c.thumbnail_url,
-                label: c.label,
-                source: BridgeMetadataSource::from_core(c.source),
-            })
+            .map(crate::types::remote_cover_data_to_bridge)
             .collect())
     }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -403,10 +403,20 @@ pub enum BridgePreviewState {
 
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeRemoteCover {
-    pub url: String,
-    pub thumbnail_url: String,
+    pub cover_choice: BridgeCoverChoice,
     pub label: String,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeRemoteCoverSelection {
+    pub url: String,
     pub source: BridgeMetadataSource,
+}
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum BridgeCoverImageSource {
+    Remote { url: String },
+    Local { path: String },
 }
 
 #[derive(Debug, Clone, uniffi::Enum)]
@@ -415,9 +425,15 @@ pub enum BridgeCoverSelection {
         file_id: String,
     },
     RemoteCover {
-        url: String,
-        source: BridgeMetadataSource,
+        selection: BridgeRemoteCoverSelection,
     },
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeCoverChoice {
+    pub selection: BridgeCoverSelection,
+    pub preview_source: BridgeCoverImageSource,
+    pub thumbnail_source: BridgeCoverImageSource,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -494,6 +510,12 @@ pub struct BridgeFileInfo {
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeArtworkFile {
+    pub file: BridgeFileInfo,
+    pub cover_choice: BridgeCoverChoice,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeCueFlacPair {
     pub cue_name: String,
     pub cue_size: u64,
@@ -520,7 +542,7 @@ pub enum BridgeAudioContent {
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeCandidateFiles {
     pub audio: BridgeAudioContent,
-    pub artwork: Vec<BridgeFileInfo>,
+    pub artwork: Vec<BridgeArtworkFile>,
     pub documents: Vec<BridgeFileInfo>,
 }
 
@@ -803,7 +825,7 @@ pub struct BridgeReleaseGroup {
     pub title: String,
     pub artist: Option<String>,
     /// Representative cover for the card.
-    pub cover_url: Option<String>,
+    pub cover_art: Option<BridgeRemoteCover>,
     /// Human-readable source name ("MusicBrainz" / "Discogs").
     pub source_label: String,
     /// Editorial URL for the group on its source (release-group on
@@ -1351,15 +1373,6 @@ pub struct BridgeCandidateSearchResults {
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
-pub struct BridgeCoverArt {
-    pub url: String,
-    pub source: BridgeMetadataSource,
-    /// Pre-built name of the service this cover came from ("Cover Art
-    /// Archive" / "Discogs") — the UI renders it without switching on `source`.
-    pub source_label: String,
-}
-
-#[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeReleaseDetail {
     pub release_id: String,
     pub source: BridgeMetadataSource,
@@ -1380,11 +1393,8 @@ pub struct BridgeReleaseDetail {
     pub track_count: u32,
     pub track_count_mismatch: bool,
     pub tracks: Vec<BridgeReleaseTrack>,
-    pub cover_art: Vec<BridgeCoverArt>,
-    /// The source's primary cover URL (first entry). What the confirm
-    /// pane shows selected before a manual pick. `None` when the source
-    /// surfaced no cover art.
-    pub default_cover_url: Option<String>,
+    pub cover_art: Vec<BridgeRemoteCover>,
+    pub default_cover: Option<BridgeCoverChoice>,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -1859,8 +1869,8 @@ pub(crate) fn bridge_cover_to_import(c: BridgeCoverSelection) -> bae_core::impor
         BridgeCoverSelection::ReleaseImage { file_id } => {
             bae_core::import::CoverSelection::Local(file_id)
         }
-        BridgeCoverSelection::RemoteCover { url, source } => {
-            bae_core::import::CoverSelection::Remote(url, source.to_core())
+        BridgeCoverSelection::RemoteCover { selection } => {
+            bae_core::import::CoverSelection::Remote(selection.url, selection.source.to_core())
         }
     }
 }
@@ -1968,15 +1978,68 @@ pub(crate) fn metadata_result_to_bridge(
     }
 }
 
+#[cfg(any(
+    feature = "desktop",
+    not(any(target_os = "ios", target_os = "android"))
+))]
+pub(crate) fn remote_cover_data_to_bridge(
+    c: bae_core::import::cover_art::RemoteCover,
+) -> BridgeRemoteCover {
+    let selection = bridge_remote_cover_selection(c.url, c.source);
+    let cover_choice = remote_cover_choice_to_bridge(&selection, &c.thumbnail_url);
+    BridgeRemoteCover {
+        cover_choice,
+        label: c.label,
+    }
+}
+
+fn bridge_remote_cover_selection(
+    url: String,
+    source: bae_core::import::MetadataSource,
+) -> BridgeRemoteCoverSelection {
+    BridgeRemoteCoverSelection {
+        url,
+        source: BridgeMetadataSource::from_core(source),
+    }
+}
+
+#[cfg(any(
+    feature = "desktop",
+    not(any(target_os = "ios", target_os = "android"))
+))]
+fn remote_cover_choice_to_bridge(
+    selection: &BridgeRemoteCoverSelection,
+    thumbnail_url: &str,
+) -> BridgeCoverChoice {
+    BridgeCoverChoice {
+        selection: BridgeCoverSelection::RemoteCover {
+            selection: selection.clone(),
+        },
+        preview_source: BridgeCoverImageSource::Remote {
+            url: selection.url.clone(),
+        },
+        thumbnail_source: BridgeCoverImageSource::Remote {
+            url: thumbnail_url.to_string(),
+        },
+    }
+}
+
 #[cfg(feature = "desktop")]
 pub(crate) fn release_detail_to_bridge(
     d: bae_core::import::search::ImportSearchReleaseDetail,
     local_track_count: Option<u32>,
 ) -> BridgeReleaseDetail {
-    // Mismatch + default-cover derivations live on `ImportSearchReleaseDetail`
-    // in bae-core; the bridge just copies the results.
     let track_count_mismatch = d.track_count_mismatch(local_track_count);
-    let default_cover_url = d.default_cover_url();
+    let default_cover = d
+        .default_cover()
+        .cloned()
+        .map(remote_cover_data_to_bridge)
+        .map(|c| c.cover_choice);
+    let cover_art: Vec<BridgeRemoteCover> = d
+        .cover_art
+        .into_iter()
+        .map(remote_cover_data_to_bridge)
+        .collect();
     BridgeReleaseDetail {
         release_id: d.release_id,
         source: BridgeMetadataSource::from_core(d.source),
@@ -2005,16 +2068,29 @@ pub(crate) fn release_detail_to_bridge(
                 position_label: t.position_label,
             })
             .collect(),
-        cover_art: d
-            .cover_art
-            .into_iter()
-            .map(|c| BridgeCoverArt {
-                url: c.url,
-                source: BridgeMetadataSource::from_core(c.source),
-                source_label: c.source.cover_source_label().to_string(),
-            })
-            .collect(),
-        default_cover_url,
+        cover_art,
+        default_cover,
+    }
+}
+
+#[cfg(feature = "desktop")]
+fn bridge_remote_cover_to_core(c: BridgeRemoteCover) -> bae_core::import::cover_art::RemoteCover {
+    let BridgeCoverChoice {
+        selection,
+        thumbnail_source,
+        ..
+    } = c.cover_choice;
+    let BridgeCoverSelection::RemoteCover { selection } = selection else {
+        unreachable!("BridgeRemoteCover must carry a remote cover selection");
+    };
+    let BridgeCoverImageSource::Remote { url: thumbnail_url } = thumbnail_source else {
+        unreachable!("BridgeRemoteCover must carry a remote cover thumbnail");
+    };
+    bae_core::import::cover_art::RemoteCover {
+        url: selection.url,
+        thumbnail_url,
+        label: c.label,
+        source: selection.source.to_core(),
     }
 }
 
@@ -2056,10 +2132,7 @@ pub(crate) fn release_detail_from_bridge(
         cover_art: d
             .cover_art
             .into_iter()
-            .map(|c| bae_core::import::search::CoverArt {
-                url: c.url,
-                source: c.source.to_core(),
-            })
+            .map(bridge_remote_cover_to_core)
             .collect(),
     }
 }
@@ -2119,7 +2192,7 @@ pub(crate) fn release_group_to_bridge(
         id: g.id,
         title: g.title,
         artist: g.artist,
-        cover_url: g.cover_url,
+        cover_art: g.cover_art.map(remote_cover_data_to_bridge),
         source_label: g.source_label,
         group_url: g.group_url,
         meta_label: g.meta_label,
@@ -2301,6 +2374,21 @@ fn scanned_file_to_bridge(f: bae_core::import::folder_scanner::ScannedFile) -> B
     }
 }
 
+fn scanned_artwork_to_bridge(
+    f: bae_core::import::folder_scanner::ScannedFile,
+) -> BridgeArtworkFile {
+    let file_id = f.relative_path.clone();
+    let path = f.path.to_string_lossy().to_string();
+    BridgeArtworkFile {
+        file: scanned_file_to_bridge(f),
+        cover_choice: BridgeCoverChoice {
+            selection: BridgeCoverSelection::ReleaseImage { file_id },
+            preview_source: BridgeCoverImageSource::Local { path: path.clone() },
+            thumbnail_source: BridgeCoverImageSource::Local { path },
+        },
+    }
+}
+
 pub(crate) fn categorized_files_to_bridge(
     files: bae_core::import::folder_scanner::CategorizedFiles,
 ) -> BridgeCandidateFiles {
@@ -2333,7 +2421,7 @@ pub(crate) fn categorized_files_to_bridge(
         artwork: files
             .artwork
             .into_iter()
-            .map(scanned_file_to_bridge)
+            .map(scanned_artwork_to_bridge)
             .collect(),
         documents: files
             .documents

--- a/bae-core/src/app.rs
+++ b/bae-core/src/app.rs
@@ -225,13 +225,18 @@ fn bootstrap_inner(
     // library manager and the in-core player.
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     let app_services = {
-        let import_handle =
-            crate::import::ImportService::start(runtime.handle().clone(), library_manager.clone());
+        let cover_art_archive = crate::import::cover_art::CoverArtArchiveClient::new();
+        let import_handle = crate::import::ImportService::start(
+            runtime.handle().clone(),
+            library_manager.clone(),
+            cover_art_archive.clone(),
+        );
 
         let identify_handle = crate::identify::IdentifyService::start(
             library_manager.clone(),
             runtime.handle().clone(),
             import_handle.event_tx.clone(),
+            cover_art_archive,
         );
 
         let extraction_handle = crate::signals::ExtractionService::start(

--- a/bae-core/src/discogs/client.rs
+++ b/bae-core/src/discogs/client.rs
@@ -1,4 +1,6 @@
 use crate::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
+use crate::discogs::remote_cover_from_urls;
+use crate::import::cover_art::RemoteCover;
 use lru::LruCache;
 use reqwest::{Client, Error as ReqwestError};
 use serde::Deserialize;
@@ -123,6 +125,19 @@ pub struct DiscogsSearchResult {
     #[serde(rename = "type")]
     pub result_type: String,
 }
+
+impl DiscogsSearchResult {
+    /// Best available cover image from Discogs search result fields.
+    pub fn remote_cover(&self) -> Option<RemoteCover> {
+        remote_cover_from_urls(
+            self.cover_image.as_deref(),
+            self.thumb.as_deref(),
+            "search result",
+            self.id,
+        )
+    }
+}
+
 /// Artist credit in Discogs API responses
 #[derive(Debug, Deserialize, Clone)]
 struct ArtistCredit {
@@ -639,7 +654,63 @@ pub async fn fetch_discogs_xref(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::import::MetadataSource;
     use std::sync::{Arc, Mutex};
+
+    fn search_result_with_cover_fields(
+        cover_image: Option<&str>,
+        thumb: Option<&str>,
+    ) -> DiscogsSearchResult {
+        DiscogsSearchResult {
+            id: 1,
+            title: "Artist Name - Album Title".to_string(),
+            year: None,
+            genre: None,
+            style: None,
+            format: None,
+            country: None,
+            label: None,
+            catno: None,
+            barcode: None,
+            cover_image: cover_image.map(str::to_string),
+            thumb: thumb.map(str::to_string),
+            master_id: None,
+            result_type: "release".to_string(),
+        }
+    }
+
+    #[test]
+    fn search_result_remote_cover_uses_thumb_as_cover_when_cover_image_is_absent() {
+        let result =
+            search_result_with_cover_fields(None, Some("https://discogs.example/thumb.jpg"));
+
+        let cover = result.remote_cover().unwrap();
+
+        assert_eq!(cover.url, "https://discogs.example/thumb.jpg");
+        assert_eq!(cover.thumbnail_url, "https://discogs.example/thumb.jpg");
+        assert_eq!(cover.label, MetadataSource::Discogs.cover_source_label());
+        assert_eq!(cover.source, MetadataSource::Discogs);
+    }
+
+    #[test]
+    fn search_result_remote_cover_uses_cover_as_thumbnail_when_thumb_is_absent() {
+        let result =
+            search_result_with_cover_fields(Some("https://discogs.example/full.jpg"), None);
+
+        let cover = result.remote_cover().unwrap();
+
+        assert_eq!(cover.url, "https://discogs.example/full.jpg");
+        assert_eq!(cover.thumbnail_url, "https://discogs.example/full.jpg");
+        assert_eq!(cover.label, MetadataSource::Discogs.cover_source_label());
+        assert_eq!(cover.source, MetadataSource::Discogs);
+    }
+
+    #[test]
+    fn search_result_remote_cover_is_absent_without_cover_fields() {
+        let result = search_result_with_cover_fields(None, None);
+
+        assert!(result.remote_cover().is_none());
+    }
 
     #[test]
     fn observe_signals_only_on_rejection_or_success() {

--- a/bae-core/src/discogs/mod.rs
+++ b/bae-core/src/discogs/mod.rs
@@ -1,7 +1,11 @@
 pub mod client;
 pub mod models;
+use crate::import::cover_art::RemoteCover;
+use crate::import::MetadataSource;
 pub use client::DiscogsClient;
 pub use models::*;
+use std::fmt::Display;
+use tracing::debug;
 
 /// Split a Discogs "Artist - Album" title into its trimmed `(artist, album)`
 /// halves. Discogs packs both into one title field separated by " - ". Returns
@@ -24,4 +28,52 @@ where
 {
     use serde::Deserialize;
     Ok(Option::<String>::deserialize(deserializer)?.filter(|s| !s.is_empty()))
+}
+
+pub(crate) fn remote_cover_from_urls<I>(
+    cover_image: Option<&str>,
+    thumb: Option<&str>,
+    entity: &str,
+    id: I,
+) -> Option<RemoteCover>
+where
+    I: Display + Copy,
+{
+    let url = match (cover_image, thumb) {
+        (Some(url), _) => url.to_string(),
+        (None, Some(thumb)) => {
+            debug!(
+                discogs_entity = entity,
+                discogs_id = %id,
+                "Discogs cover has no cover image URL; using thumbnail URL"
+            );
+            thumb.to_string()
+        }
+        (None, None) => {
+            debug!(
+                discogs_entity = entity,
+                discogs_id = %id,
+                "Discogs cover has no cover image or thumbnail URL; skipping remote cover"
+            );
+            return None;
+        }
+    };
+    let thumbnail_url = match thumb {
+        Some(thumb) => thumb.to_string(),
+        None => {
+            debug!(
+                discogs_entity = entity,
+                discogs_id = %id,
+                "Discogs cover has no thumbnail URL; using image URL"
+            );
+            url.clone()
+        }
+    };
+
+    Some(RemoteCover {
+        url,
+        thumbnail_url,
+        label: MetadataSource::Discogs.cover_source_label().to_string(),
+        source: MetadataSource::Discogs,
+    })
 }

--- a/bae-core/src/discogs/models.rs
+++ b/bae-core/src/discogs/models.rs
@@ -1,4 +1,7 @@
+use crate::discogs::remote_cover_from_urls;
+use crate::import::cover_art::RemoteCover;
 use serde::{Deserialize, Serialize};
+
 /// Artist credit from Discogs
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiscogsArtist {
@@ -25,6 +28,18 @@ pub struct DiscogsRelease {
     pub tracklist: Vec<DiscogsTrack>,
     pub master_id: Option<String>,
 }
+
+impl DiscogsRelease {
+    pub fn remote_cover(&self) -> Option<RemoteCover> {
+        remote_cover_from_urls(
+            self.cover_image.as_deref(),
+            self.thumb.as_deref(),
+            "release",
+            self.id.as_str(),
+        )
+    }
+}
+
 /// Represents a track from Discogs
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiscogsTrack {
@@ -36,4 +51,51 @@ pub struct DiscogsTrack {
     /// Track type: "track", "heading", or "index"
     #[serde(default)]
     pub type_: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import::MetadataSource;
+
+    fn release_with_cover_fields(cover_image: Option<&str>, thumb: Option<&str>) -> DiscogsRelease {
+        DiscogsRelease {
+            id: "discogs-release-1".to_string(),
+            title: "Album Title".to_string(),
+            year: None,
+            genre: vec![],
+            style: vec![],
+            format: vec![],
+            country: None,
+            label: vec![],
+            cover_image: cover_image.map(str::to_string),
+            thumb: thumb.map(str::to_string),
+            catno: None,
+            artists: vec![DiscogsArtist {
+                id: "discogs-artist-1".to_string(),
+                name: "Artist Name".to_string(),
+            }],
+            tracklist: vec![],
+            master_id: None,
+        }
+    }
+
+    #[test]
+    fn remote_cover_uses_thumb_as_cover_when_cover_image_is_absent() {
+        let release = release_with_cover_fields(None, Some("https://discogs.example/thumb.jpg"));
+
+        let cover = release.remote_cover().unwrap();
+
+        assert_eq!(cover.url, "https://discogs.example/thumb.jpg");
+        assert_eq!(cover.thumbnail_url, "https://discogs.example/thumb.jpg");
+        assert_eq!(cover.label, MetadataSource::Discogs.cover_source_label());
+        assert_eq!(cover.source, MetadataSource::Discogs);
+    }
+
+    #[test]
+    fn remote_cover_is_absent_without_cover_fields() {
+        let release = release_with_cover_fields(None, None);
+
+        assert!(release.remote_cover().is_none());
+    }
 }

--- a/bae-core/src/identify/barcode.rs
+++ b/bae-core/src/identify/barcode.rs
@@ -5,6 +5,7 @@
 
 use crate::db::LibraryStatus;
 use crate::discogs::DiscogsClient;
+use crate::import::cover_art::CoverArtArchiveClient;
 use crate::import::search::{search_discogs_by_barcode, search_mb_by_barcode, MetadataResult};
 
 /// Union search: MB first, then Discogs. Returns the merged results (MB
@@ -12,10 +13,12 @@ use crate::import::search::{search_discogs_by_barcode, search_mb_by_barcode, Met
 /// as `Err`; Discogs failures are logged and skipped so a provider outage
 /// doesn't break the phase.
 pub async fn lookup_barcode(
+    cover_art_archive: &CoverArtArchiveClient,
     barcode: &str,
     discogs_client: Option<&DiscogsClient>,
 ) -> Result<Vec<MetadataResult>, String> {
-    let mut combined: Vec<MetadataResult> = search_mb_by_barcode(barcode.to_string()).await?;
+    let mut combined: Vec<MetadataResult> =
+        search_mb_by_barcode(cover_art_archive, barcode.to_string()).await?;
 
     if let Some(client) = discogs_client {
         match search_discogs_by_barcode(client, barcode.to_string()).await {

--- a/bae-core/src/identify/combine.rs
+++ b/bae-core/src/identify/combine.rs
@@ -285,7 +285,7 @@ mod tests {
             label: None,
             catalog_number: catalog.map(str::to_string),
             country: None,
-            cover_url: None,
+            cover_art: None,
             source_group_id: group_id.map(str::to_string),
         }
     }

--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -3,6 +3,7 @@
 //! module just orchestrates when to call it.
 
 use crate::db::LibraryStatus;
+use crate::import::cover_art::CoverArtArchiveClient;
 use crate::import::search::{lookup_by_discid, DiscIdResult, MetadataResult};
 use std::path::PathBuf;
 
@@ -136,12 +137,13 @@ pub async fn resolve_release_artwork_paths(
 /// the same way as a barcode signal that produced no matches: settled
 /// with zero, ready for combine.
 pub async fn lookup_and_resolve(
+    cover_art_archive: &CoverArtArchiveClient,
     disc_id: &str,
     library_manager: &crate::library::LibraryManager,
 ) -> Result<(Vec<MetadataResult>, Vec<LibraryStatus>), String> {
     use crate::db::LibraryCheck;
 
-    let result = lookup_by_discid(disc_id)
+    let result = lookup_by_discid(cover_art_archive, disc_id)
         .await
         .map_err(|e| format!("MusicBrainz lookup failed: {e}"))?;
 

--- a/bae-core/src/identify/service.rs
+++ b/bae-core/src/identify/service.rs
@@ -6,6 +6,7 @@ use super::analyzer::{ArtworkAnalyzer, NoopAnalyzer};
 use super::barcode::{annotate_with_library_status, lookup_barcode};
 use super::discid::lookup_and_resolve;
 use super::state::{step, Effect, ExcludedSignal, IdentifyEvent, IdentifyState};
+use crate::import::cover_art::CoverArtArchiveClient;
 use crate::import::ImportEvent;
 use crate::library::LibraryManager;
 use std::collections::HashMap;
@@ -45,6 +46,7 @@ struct IdentifyServiceInner {
     library_manager: LibraryManager,
     runtime_handle: tokio::runtime::Handle,
     event_tx: broadcast::Sender<ImportEvent>,
+    cover_art_archive: CoverArtArchiveClient,
     analyzer: Mutex<Arc<dyn ArtworkAnalyzer>>,
     cancel_tokens: Mutex<HashMap<String, CancellationToken>>,
     /// Per-candidate sender into the running driver's internal event channel.
@@ -62,12 +64,14 @@ impl IdentifyService {
         library_manager: LibraryManager,
         runtime_handle: tokio::runtime::Handle,
         event_tx: broadcast::Sender<ImportEvent>,
+        cover_art_archive: CoverArtArchiveClient,
     ) -> IdentifyServiceHandle {
         IdentifyServiceHandle {
             inner: Arc::new(IdentifyServiceInner {
                 library_manager,
                 runtime_handle,
                 event_tx,
+                cover_art_archive,
                 analyzer: Mutex::new(Arc::new(NoopAnalyzer) as Arc<dyn ArtworkAnalyzer>),
                 cancel_tokens: Mutex::new(HashMap::new()),
                 inboxes: Mutex::new(HashMap::new()),
@@ -285,8 +289,10 @@ fn dispatch_effect(
             track_count,
         } => {
             let library_manager = inner.library_manager.clone();
+            let cover_art_archive = inner.cover_art_archive.clone();
             runtime.spawn(async move {
-                let outcome = lookup_and_resolve(&disc_id, &library_manager).await;
+                let outcome =
+                    lookup_and_resolve(&cover_art_archive, &disc_id, &library_manager).await;
                 if token.is_cancelled() {
                     return;
                 }
@@ -310,6 +316,7 @@ fn dispatch_effect(
 
         Effect::LookupBarcode { barcode } => {
             let library_manager = inner.library_manager.clone();
+            let cover_art_archive = inner.cover_art_archive.clone();
             runtime.spawn(async move {
                 let discogs = match library_manager.discogs_client() {
                     Ok(c) => c,
@@ -321,7 +328,7 @@ fn dispatch_effect(
                         return;
                     }
                 };
-                let lookup = lookup_barcode(&barcode, discogs.as_ref()).await;
+                let lookup = lookup_barcode(&cover_art_archive, &barcode, discogs.as_ref()).await;
                 if token.is_cancelled() {
                     return;
                 }

--- a/bae-core/src/identify/state.rs
+++ b/bae-core/src/identify/state.rs
@@ -1051,7 +1051,7 @@ mod tests {
             label: None,
             catalog_number: None,
             country: None,
-            cover_url: None,
+            cover_art: None,
             source_group_id: group_id.map(str::to_string),
         }
     }

--- a/bae-core/src/import/cover_art.rs
+++ b/bae-core/src/import/cover_art.rs
@@ -2,13 +2,15 @@ use crate::import::MetadataSource;
 use crate::network::upgrade_to_https;
 use crate::util::content_type::ContentType;
 use lru::LruCache;
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+use tokio::sync::{OnceCell, Semaphore};
 use tracing::{debug, info, warn};
 
 /// A remote cover art option from an external source.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RemoteCover {
     pub url: String,
     pub thumbnail_url: String,
@@ -22,6 +24,9 @@ const MAX_RETRIES: u32 = 3;
 /// Base delay between retries (doubles each attempt: 1s, 2s, 4s).
 const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
+const CAA_LOOKUP_CACHE_CAPACITY: usize = 128;
+const CAA_MAX_CONCURRENT_LOOKUPS: usize = 4;
+
 /// Capacity for the cover-bytes LRU cache. Sized for a typical session;
 /// a miss costs one HTTP fetch.
 const COVER_CACHE_CAPACITY: usize = 25;
@@ -33,6 +38,10 @@ const COVER_CACHE_CAPACITY: usize = 25;
 /// commit worker calls it again at import time. Both go through this
 /// cache, so the bytes hit the wire at most once per URL per session.
 type CoverCacheValue = (Vec<u8>, ContentType);
+/// Outer `None` means the lookup failed and must not be cached; inner `None`
+/// means CAA returned a cacheable no-cover result.
+type CaaLookup = Option<Option<RemoteCover>>;
+type CaaLookupCell = Arc<OnceCell<CaaLookup>>;
 
 fn cover_bytes_cache() -> &'static Mutex<LruCache<String, CoverCacheValue>> {
     static CACHE: OnceLock<Mutex<LruCache<String, CoverCacheValue>>> = OnceLock::new();
@@ -43,43 +52,188 @@ fn cover_bytes_cache() -> &'static Mutex<LruCache<String, CoverCacheValue>> {
     })
 }
 
+/// Cover Art Archive lookup client for release/release-group cover selection.
+#[derive(Clone)]
+pub struct CoverArtArchiveClient {
+    http: reqwest::Client,
+    lookup_cache: Arc<Mutex<LruCache<String, Option<RemoteCover>>>>,
+    in_flight: Arc<Mutex<HashMap<String, CaaLookupCell>>>,
+    lookup_limiter: Arc<Semaphore>,
+}
+
+impl CoverArtArchiveClient {
+    pub fn new() -> Self {
+        let http = crate::util::http::client_builder()
+            .build()
+            .expect("Failed to create HTTP client for Cover Art Archive");
+        Self {
+            http,
+            lookup_cache: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(CAA_LOOKUP_CACHE_CAPACITY)
+                    .expect("CAA_LOOKUP_CACHE_CAPACITY > 0"),
+            ))),
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
+            lookup_limiter: Arc::new(Semaphore::new(CAA_MAX_CONCURRENT_LOOKUPS)),
+        }
+    }
+
+    /// Fetch cover art candidates from Cover Art Archive for a MusicBrainz
+    /// release and release group.
+    pub async fn fetch_candidates(
+        &self,
+        release_id: Option<&str>,
+        release_group_id: Option<&str>,
+    ) -> Vec<RemoteCover> {
+        let mut covers = Vec::new();
+        if let Some(rid) = release_id {
+            if let Some(cover) = self.fetch_release(rid).await {
+                push_unique_cover(&mut covers, cover);
+            }
+        }
+        if let Some(rg_id) = release_group_id {
+            if let Some(cover) = self.fetch_release_group(rg_id).await {
+                push_unique_cover(&mut covers, cover);
+            }
+        }
+        covers
+    }
+
+    /// Fetch cover art from Cover Art Archive for a MusicBrainz release.
+    ///
+    /// Retries up to 3 times on transient failures (network errors, 5xx).
+    /// Does not retry on 404 (no cover art exists) or other client errors.
+    pub async fn fetch_release(&self, release_id: &str) -> Option<RemoteCover> {
+        self.fetch_entity(
+            "release",
+            "release",
+            release_id,
+            MetadataSource::MusicBrainz.cover_source_label().to_string(),
+        )
+        .await
+    }
+
+    /// Fetch cover art from Cover Art Archive for a MusicBrainz release group.
+    ///
+    /// The release-group endpoint returns the community-selected best cover for the
+    /// album concept, which may differ from any specific release's cover.
+    pub async fn fetch_release_group(&self, release_group_id: &str) -> Option<RemoteCover> {
+        self.fetch_entity(
+            "release-group",
+            "release group",
+            release_group_id,
+            format!(
+                "{} (Album)",
+                MetadataSource::MusicBrainz.cover_source_label()
+            ),
+        )
+        .await
+    }
+}
+
+impl Default for CoverArtArchiveClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Whether an HTTP error is transient and worth retrying.
 fn is_transient_status(status: reqwest::StatusCode) -> bool {
     status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
 }
 
-/// Fetch cover art URL from Cover Art Archive for a MusicBrainz release.
-///
-/// Retries up to 3 times on transient failures (network errors, 5xx).
-/// Does not retry on 404 (no cover art exists) or other client errors.
-pub async fn fetch_cover_art_from_archive(release_id: &str) -> Option<String> {
-    let url = format!("https://coverartarchive.org/release/{}", release_id);
-    fetch_cover_art_from_url(&url, "release", release_id).await
+pub(crate) fn push_unique_cover(covers: &mut Vec<RemoteCover>, cover: RemoteCover) {
+    if !covers.iter().any(|existing| existing.url == cover.url) {
+        covers.push(cover);
+    }
 }
 
-/// Fetch cover art URL from Cover Art Archive for a MusicBrainz release group.
-///
-/// The release-group endpoint returns the community-selected best cover for the
-/// album concept, which may differ from any specific release's cover.
-pub async fn fetch_cover_art_from_release_group(release_group_id: &str) -> Option<String> {
-    let url = format!(
-        "https://coverartarchive.org/release-group/{}",
-        release_group_id
-    );
-    fetch_cover_art_from_url(&url, "release group", release_group_id).await
+impl CoverArtArchiveClient {
+    async fn fetch_entity(
+        &self,
+        caa_entity: &str,
+        log_entity: &str,
+        id: &str,
+        label: String,
+    ) -> Option<RemoteCover> {
+        self.fetch_url(
+            format!("{caa_entity}:{id}"),
+            format!("https://coverartarchive.org/{caa_entity}/{id}"),
+            log_entity,
+            id,
+            label,
+        )
+        .await
+    }
+
+    async fn fetch_url(
+        &self,
+        cache_key: String,
+        json_url: String,
+        entity: &str,
+        id: &str,
+        label: String,
+    ) -> Option<RemoteCover> {
+        if let Some(cached) = self
+            .lookup_cache
+            .lock()
+            .expect("Cover Art Archive lookup cache mutex poisoned")
+            .get(&cache_key)
+            .cloned()
+        {
+            return cached;
+        }
+
+        let cell = {
+            let mut inflight = self
+                .in_flight
+                .lock()
+                .expect("Cover Art Archive in-flight map mutex poisoned");
+            inflight
+                .entry(cache_key.clone())
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
+
+        let owned_id = id.to_string();
+        let entity = entity.to_string();
+        cell.get_or_init(|| async move {
+            let lookup = match self.lookup_limiter.acquire().await {
+                Ok(permit) => {
+                    let _permit = permit;
+                    fetch_cover_art_from_url(&self.http, json_url, &entity, &owned_id, label).await
+                }
+                Err(e) => {
+                    warn!("Cover Art Archive lookup limiter closed: {}", e);
+                    None
+                }
+            };
+            if let Some(cache_value) = &lookup {
+                self.lookup_cache
+                    .lock()
+                    .expect("Cover Art Archive lookup cache mutex poisoned")
+                    .put(cache_key.clone(), cache_value.clone());
+            }
+            self.in_flight
+                .lock()
+                .expect("Cover Art Archive in-flight map mutex poisoned")
+                .remove(&cache_key);
+            lookup
+        })
+        .await
+        .clone()
+        .flatten()
+    }
 }
 
 /// Shared implementation for fetching cover art from a Cover Art Archive URL.
-async fn fetch_cover_art_from_url(json_url: &str, entity: &str, id: &str) -> Option<String> {
+async fn fetch_cover_art_from_url(
+    client: &reqwest::Client,
+    json_url: String,
+    entity: &str,
+    id: &str,
+    label: String,
+) -> CaaLookup {
     debug!("Fetching cover art from Cover Art Archive: {}", json_url);
-
-    let client = match crate::util::http::client_builder().build() {
-        Ok(client) => client,
-        Err(e) => {
-            warn!("Failed to create HTTP client for Cover Art Archive: {}", e);
-            return None;
-        }
-    };
 
     let mut last_error = String::new();
     for attempt in 0..=MAX_RETRIES {
@@ -97,16 +251,16 @@ async fn fetch_cover_art_from_url(json_url: &str, entity: &str, id: &str) -> Opt
             tokio::time::sleep(delay).await;
         }
 
-        match client.get(json_url).send().await {
+        match client.get(&json_url).send().await {
             Ok(response) => {
                 if response.status().is_success() {
-                    return parse_cover_art_response(response, json_url).await;
+                    return parse_cover_art_response(response, &json_url, &label).await;
                 } else if response.status() == reqwest::StatusCode::NOT_FOUND {
                     debug!(
                         "No cover art found in Cover Art Archive for {} {}",
                         entity, id
                     );
-                    return None;
+                    return Some(None);
                 } else if is_transient_status(response.status()) {
                     last_error = format!("status {}", response.status());
                     continue;
@@ -138,7 +292,11 @@ async fn fetch_cover_art_from_url(json_url: &str, entity: &str, id: &str) -> Opt
 }
 
 /// Parse the Cover Art Archive JSON response, extracting the best image URL.
-async fn parse_cover_art_response(response: reqwest::Response, url: &str) -> Option<String> {
+async fn parse_cover_art_response(
+    response: reqwest::Response,
+    url: &str,
+    label: &str,
+) -> CaaLookup {
     let json = match response.json::<serde_json::Value>().await {
         Ok(json) => json,
         Err(e) => {
@@ -149,34 +307,76 @@ async fn parse_cover_art_response(response: reqwest::Response, url: &str) -> Opt
             return None;
         }
     };
-    select_cover_url(&json)
+    match select_cover_candidate(&json, label) {
+        Some(cover) => Some(Some(cover)),
+        None => {
+            debug!(
+                "Cover Art Archive JSON from {} had no usable cover image",
+                url
+            );
+            Some(None)
+        }
+    }
 }
 
 /// Pick the best image URL from a Cover Art Archive JSON body: prefer the
 /// front cover, else the first image. Pure (no I/O) so the selection rules are
 /// testable without a live response.
-fn select_cover_url(json: &serde_json::Value) -> Option<String> {
+fn select_cover_candidate(json: &serde_json::Value, label: &str) -> Option<RemoteCover> {
     let images = json.get("images").and_then(|i| i.as_array())?;
 
     // Prefer the front cover
     for image in images {
         if image.get("front").and_then(|f| f.as_bool()) == Some(true) {
-            if let Some(url) = extract_image_url(image) {
-                return Some(url);
+            if let Some(cover) = extract_cover_candidate(image, label) {
+                return Some(cover);
             }
         }
     }
 
-    // Fall back to first available image
-    images.first().and_then(extract_image_url)
+    // Fall back to the first image with a usable URL.
+    images
+        .iter()
+        .find_map(|image| extract_cover_candidate(image, label))
 }
 
-/// Extract the best available image URL from a Cover Art Archive image entry.
+/// Extract the selected image URL and thumbnail from a Cover Art Archive image entry.
+fn extract_cover_candidate(image: &serde_json::Value, label: &str) -> Option<RemoteCover> {
+    let url = extract_image_url(image)?;
+    let thumbnail_url = extract_thumbnail_url(image, &url);
+    Some(RemoteCover {
+        url,
+        thumbnail_url,
+        label: label.to_string(),
+        source: MetadataSource::MusicBrainz,
+    })
+}
+
+/// Extract the image URL from a Cover Art Archive image entry.
 fn extract_image_url(image: &serde_json::Value) -> Option<String> {
-    for key in ["image", "thumb", "small"] {
-        if let Some(url) = image.get(key).and_then(|v| v.as_str()) {
-            debug!("Using cover art ({}): {}", key, url);
-            return Some(upgrade_to_https(url));
+    let (key, url) = find_url_in(image, &["image", "thumb", "small"])?;
+    debug!("Using cover art ({}): {}", key, url);
+    Some(url)
+}
+
+/// Extract the thumbnail URL from a Cover Art Archive image entry.
+fn extract_thumbnail_url(image: &serde_json::Value, image_url: &str) -> String {
+    if let Some(thumbnails) = image.get("thumbnails") {
+        if let Some((_key, url)) = find_url_in(thumbnails, &["250", "small", "500", "large"]) {
+            return url;
+        }
+    }
+    if let Some((_key, url)) = find_url_in(image, &["thumb", "small"]) {
+        return url;
+    }
+    debug!("CAA image {image_url} has no thumbnail URL; using image URL");
+    image_url.to_string()
+}
+
+fn find_url_in<'a>(value: &serde_json::Value, keys: &'a [&'a str]) -> Option<(&'a str, String)> {
+    for key in keys {
+        if let Some(url) = value.get(*key).and_then(|v| v.as_str()) {
+            return Some((*key, upgrade_to_https(url)));
         }
     }
     None
@@ -297,18 +497,26 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn select_cover_url_prefers_front_then_first() {
+    fn select_cover_candidate_prefers_front_then_first() {
         // A front cover wins even when it isn't first in the list.
         let body = json!({
             "images": [
                 { "front": false, "image": "https://caa.example/back.jpg" },
-                { "front": true, "image": "https://caa.example/front.jpg" },
+                {
+                    "front": true,
+                    "image": "https://caa.example/front.jpg",
+                    "thumbnails": {
+                        "250": "https://caa.example/front-250.jpg",
+                        "500": "https://caa.example/front-500.jpg"
+                    }
+                },
             ]
         });
-        assert_eq!(
-            select_cover_url(&body),
-            Some("https://caa.example/front.jpg".to_string())
-        );
+        let cover = select_cover_candidate(&body, "Cover Art Archive").unwrap();
+        assert_eq!(cover.url, "https://caa.example/front.jpg");
+        assert_eq!(cover.thumbnail_url, "https://caa.example/front-250.jpg");
+        assert_eq!(cover.label, "Cover Art Archive");
+        assert_eq!(cover.source, MetadataSource::MusicBrainz);
 
         // With no front cover, the first image is the fallback.
         let body = json!({
@@ -317,27 +525,27 @@ mod tests {
                 { "front": false, "image": "https://caa.example/b.jpg" },
             ]
         });
-        assert_eq!(
-            select_cover_url(&body),
-            Some("https://caa.example/a.jpg".to_string())
-        );
+        let cover = select_cover_candidate(&body, "Cover Art Archive").unwrap();
+        assert_eq!(cover.url, "https://caa.example/a.jpg");
+        assert_eq!(cover.thumbnail_url, "https://caa.example/a.jpg");
 
-        // No images array / empty list → nothing to select.
-        assert_eq!(select_cover_url(&json!({})), None);
-        assert_eq!(select_cover_url(&json!({ "images": [] })), None);
+        // No images array / empty list means nothing to select.
+        assert!(select_cover_candidate(&json!({}), "Cover Art Archive").is_none());
+        assert!(select_cover_candidate(&json!({ "images": [] }), "Cover Art Archive").is_none());
     }
 
     #[test]
-    fn extract_image_url_walks_keys_and_upgrades_to_https() {
+    fn extract_cover_candidate_walks_keys_and_upgrades_to_https() {
         // 'image' is preferred over 'thumb'/'small' and http is upgraded.
         let image = json!({
             "image": "http://caa.example/full.jpg",
-            "thumb": "http://caa.example/thumb.jpg",
+            "thumbnails": {
+                "small": "http://caa.example/thumb.jpg",
+            },
         });
-        assert_eq!(
-            extract_image_url(&image),
-            Some("https://caa.example/full.jpg".to_string())
-        );
+        let cover = extract_cover_candidate(&image, "Cover Art Archive").unwrap();
+        assert_eq!(cover.url, "https://caa.example/full.jpg");
+        assert_eq!(cover.thumbnail_url, "https://caa.example/thumb.jpg");
 
         // Falls through to 'thumb' then 'small' when 'image' is absent.
         assert_eq!(
@@ -347,6 +555,29 @@ mod tests {
 
         // An entry with none of the keys yields nothing.
         assert_eq!(extract_image_url(&json!({ "front": true })), None);
+    }
+
+    #[test]
+    fn push_unique_cover_dedupes_by_url() {
+        let mut covers = vec![RemoteCover {
+            url: "https://caa.example/cover.jpg".to_string(),
+            thumbnail_url: "https://caa.example/thumb-a.jpg".to_string(),
+            label: "Cover Art Archive".to_string(),
+            source: MetadataSource::MusicBrainz,
+        }];
+
+        push_unique_cover(
+            &mut covers,
+            RemoteCover {
+                url: "https://caa.example/cover.jpg".to_string(),
+                thumbnail_url: "https://caa.example/thumb-b.jpg".to_string(),
+                label: "Cover Art Archive (Album)".to_string(),
+                source: MetadataSource::MusicBrainz,
+            },
+        );
+
+        assert_eq!(covers.len(), 1);
+        assert_eq!(covers[0].thumbnail_url, "https://caa.example/thumb-a.jpg");
     }
 
     #[test]
@@ -399,6 +630,137 @@ mod tests {
             let _ = axum::serve(listener, app).await;
         });
         format!("http://{addr}/cover.jpg")
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn caa_lookup_does_not_cache_transient_failure() {
+        let success = br#"{
+            "images": [
+                {
+                    "front": true,
+                    "image": "https://caa.example/cover.jpg",
+                    "thumbnails": {
+                        "250": "https://caa.example/thumb.jpg"
+                    }
+                }
+            ]
+        }"#
+        .to_vec();
+        let url = start_mock(vec![
+            (503, vec![]),
+            (503, vec![]),
+            (503, vec![]),
+            (503, vec![]),
+            (200, success),
+        ])
+        .await;
+        let cache_key = "release:transient-cache-test".to_string();
+        let label = MetadataSource::MusicBrainz.cover_source_label().to_string();
+        let client = CoverArtArchiveClient::new();
+
+        assert!(client
+            .fetch_url(
+                cache_key.clone(),
+                url.clone(),
+                "release",
+                "transient-cache-test",
+                label.clone(),
+            )
+            .await
+            .is_none());
+
+        let cover = client
+            .fetch_url(cache_key, url, "release", "transient-cache-test", label)
+            .await
+            .expect("transient failure should not be cached");
+
+        assert_eq!(cover.url, "https://caa.example/cover.jpg");
+        assert_eq!(cover.thumbnail_url, "https://caa.example/thumb.jpg");
+    }
+
+    #[tokio::test]
+    async fn caa_lookup_caches_selected_cover() {
+        let first = br#"{
+            "images": [
+                {
+                    "front": true,
+                    "image": "https://caa.example/cover-a.jpg",
+                    "thumbnails": {
+                        "250": "https://caa.example/thumb-a.jpg"
+                    }
+                }
+            ]
+        }"#
+        .to_vec();
+        let second = br#"{
+            "images": [
+                {
+                    "front": true,
+                    "image": "https://caa.example/cover-b.jpg",
+                    "thumbnails": {
+                        "250": "https://caa.example/thumb-b.jpg"
+                    }
+                }
+            ]
+        }"#
+        .to_vec();
+        let url = start_mock(vec![(200, first), (200, second)]).await;
+        let cache_key = "release:cover-cache-test".to_string();
+        let label = MetadataSource::MusicBrainz.cover_source_label().to_string();
+        let client = CoverArtArchiveClient::new();
+
+        let first = client
+            .fetch_url(
+                cache_key.clone(),
+                url.clone(),
+                "release",
+                "cover-cache-test",
+                label.clone(),
+            )
+            .await
+            .unwrap();
+        let second = client
+            .fetch_url(cache_key, url, "release", "cover-cache-test", label)
+            .await
+            .unwrap();
+
+        assert_eq!(first.url, "https://caa.example/cover-a.jpg");
+        assert_eq!(second.url, "https://caa.example/cover-a.jpg");
+    }
+
+    #[tokio::test]
+    async fn caa_lookup_caches_not_found() {
+        let success = br#"{
+            "images": [
+                {
+                    "front": true,
+                    "image": "https://caa.example/cover.jpg",
+                    "thumbnails": {
+                        "250": "https://caa.example/thumb.jpg"
+                    }
+                }
+            ]
+        }"#
+        .to_vec();
+        let url = start_mock(vec![(404, vec![]), (200, success)]).await;
+        let cache_key = "release:not-found-cache-test".to_string();
+        let label = MetadataSource::MusicBrainz.cover_source_label().to_string();
+        let client = CoverArtArchiveClient::new();
+
+        assert!(client
+            .fetch_url(
+                cache_key.clone(),
+                url.clone(),
+                "release",
+                "not-found-cache-test",
+                label.clone(),
+            )
+            .await
+            .is_none());
+        assert!(client
+            .fetch_url(cache_key, url, "release", "not-found-cache-test", label,)
+            .await
+            .is_none());
     }
 
     #[tokio::test]

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1,4 +1,5 @@
 use crate::discogs::DiscogsClient;
+use crate::import::cover_art::CoverArtArchiveClient;
 use crate::import::folder_registry::{ImportFolderRegistry, WatchedFolder};
 use crate::import::folder_scanner::{FolderCandidate, InvalidCandidate};
 use crate::import::progress::ImportProgressHandle;
@@ -120,8 +121,8 @@ fn validation_from_validate_result(
 ///
 /// Holds no caches; the network-layer caches in
 /// `crate::musicbrainz`, `crate::discogs::client`, and
-/// `crate::import::cover_art` carry session-wide hits transparently for
-/// every caller. The handle is a thin orchestration layer: it dispatches
+/// the Cover Art Archive client carry session hits transparently for every
+/// caller. The handle is a thin orchestration layer: it dispatches
 /// fire-and-forget prefetches, builds `ImportCommand`s carrying just
 /// `MetadataRef`s, and forwards them to the worker.
 #[derive(Clone)]
@@ -136,6 +137,7 @@ pub struct ImportServiceHandle {
     /// The persistent watched-folder list. Mutated by `add_watched_folder` /
     /// `remove_watched_folder`, which persist it and broadcast the new list.
     pub folder_registry: Arc<Mutex<ImportFolderRegistry>>,
+    cover_art_archive: CoverArtArchiveClient,
 }
 
 #[derive(Debug, Clone)]
@@ -183,6 +185,7 @@ impl ImportServiceHandle {
         watcher_tx: mpsc::UnboundedSender<WatcherCommand>,
         event_tx: broadcast::Sender<ImportEvent>,
         folder_registry: Arc<Mutex<ImportFolderRegistry>>,
+        cover_art_archive: CoverArtArchiveClient,
     ) -> Self {
         let progress_handle =
             ImportProgressHandle::new(event_tx.subscribe(), runtime_handle.clone());
@@ -194,6 +197,7 @@ impl ImportServiceHandle {
             watcher_tx,
             event_tx,
             folder_registry,
+            cover_art_archive,
         }
     }
 
@@ -246,7 +250,7 @@ impl ImportServiceHandle {
                 source,
             } => match source {
                 MetadataSource::MusicBrainz => {
-                    super::search::search_musicbrainz(artist, album, None, None).await?
+                    self.search_musicbrainz(artist, album, None, None).await?
                 }
                 MetadataSource::Discogs => {
                     let client = self.discogs_client()?;
@@ -261,7 +265,11 @@ impl ImportServiceHandle {
                 source,
             } => match source {
                 MetadataSource::MusicBrainz => {
-                    super::search::search_mb_by_catalog_number(catalog_number).await?
+                    super::search::search_mb_by_catalog_number(
+                        &self.cover_art_archive,
+                        catalog_number,
+                    )
+                    .await?
                 }
                 MetadataSource::Discogs => {
                     let client = self.discogs_client()?;
@@ -273,7 +281,9 @@ impl ImportServiceHandle {
                 }
             },
             SearchQuery::Barcode { barcode, source } => match source {
-                MetadataSource::MusicBrainz => super::search::search_mb_by_barcode(barcode).await?,
+                MetadataSource::MusicBrainz => {
+                    super::search::search_mb_by_barcode(&self.cover_art_archive, barcode).await?
+                }
                 MetadataSource::Discogs => {
                     let client = self.discogs_client()?;
                     self.run_discogs_search(super::search::search_discogs_by_barcode(
@@ -331,6 +341,16 @@ impl ImportServiceHandle {
         .await
     }
 
+    pub async fn search_musicbrainz(
+        &self,
+        artist: String,
+        album: String,
+        year: Option<String>,
+        label: Option<String>,
+    ) -> Result<Vec<super::search::MetadataResult>, String> {
+        super::search::search_musicbrainz(&self.cover_art_archive, artist, album, year, label).await
+    }
+
     /// Fetch available remote cover art options for a release.
     /// Reads `release_identities` for the release and queries each
     /// source's cover endpoint:
@@ -348,8 +368,6 @@ impl ImportServiceHandle {
         &self,
         release_id: &str,
     ) -> Result<Vec<super::cover_art::RemoteCover>, String> {
-        use super::cover_art::RemoteCover;
-
         let identities = self
             .library_manager
             .get_release_identities(release_id)
@@ -361,33 +379,15 @@ impl ImportServiceHandle {
         for identity in &identities {
             match identity.source {
                 MetadataSource::MusicBrainz => {
-                    // Per-pressing CAA, when the identity is Exact.
-                    if let Some(rid) = &identity.source_release_id {
-                        if let Some(url) = super::cover_art::fetch_cover_art_from_archive(rid).await
-                        {
-                            covers.push(RemoteCover {
-                                url: url.clone(),
-                                thumbnail_url: url,
-                                label: "MusicBrainz".to_string(),
-                                source: MetadataSource::MusicBrainz,
-                            });
-                        }
-                    }
-                    // Album-level (release-group) CAA. Skip if duplicate
-                    // of the per-pressing URL.
-                    if let Some(rg_url) = super::cover_art::fetch_cover_art_from_release_group(
-                        &identity.source_group_id,
-                    )
-                    .await
+                    for cover in self
+                        .cover_art_archive
+                        .fetch_candidates(
+                            identity.source_release_id.as_deref(),
+                            Some(identity.source_group_id.as_str()),
+                        )
+                        .await
                     {
-                        if !covers.iter().any(|c| c.url == rg_url) {
-                            covers.push(RemoteCover {
-                                url: rg_url.clone(),
-                                thumbnail_url: rg_url,
-                                label: "MusicBrainz (Album)".to_string(),
-                                source: MetadataSource::MusicBrainz,
-                            });
-                        }
+                        super::cover_art::push_unique_cover(&mut covers, cover);
                     }
                 }
                 MetadataSource::Discogs => {
@@ -422,18 +422,8 @@ impl ImportServiceHandle {
                     };
                     match client.get_release(rid).await {
                         Ok((discogs_release, _raw_json)) => {
-                            if let Some(cover_url) = discogs_release
-                                .cover_image
-                                .or(discogs_release.thumb.clone())
-                            {
-                                let thumb =
-                                    discogs_release.thumb.unwrap_or_else(|| cover_url.clone());
-                                covers.push(RemoteCover {
-                                    url: cover_url,
-                                    thumbnail_url: thumb,
-                                    label: "Discogs".to_string(),
-                                    source: MetadataSource::Discogs,
-                                });
+                            if let Some(cover) = discogs_release.remote_cover() {
+                                covers.push(cover);
                             }
                         }
                         Err(ref e) => {
@@ -462,7 +452,9 @@ impl ImportServiceHandle {
         source: MetadataSource,
     ) -> Result<super::search::ImportSearchReleaseDetail, String> {
         match source {
-            MetadataSource::MusicBrainz => super::search::prefetch_mb_release(release_id).await,
+            MetadataSource::MusicBrainz => {
+                super::search::prefetch_mb_release(&self.cover_art_archive, release_id).await
+            }
             MetadataSource::Discogs => {
                 let client = self.discogs_client()?;
                 super::search::prefetch_discogs_release(&client, release_id).await

--- a/bae-core/src/import/release_group.rs
+++ b/bae-core/src/import/release_group.rs
@@ -8,6 +8,7 @@
 //! just iterates and renders.
 
 use crate::identify::GroupKey;
+use crate::import::cover_art::RemoteCover;
 use crate::import::search::MetadataResult;
 use crate::import::types::MetadataSource;
 
@@ -22,7 +23,7 @@ pub struct ReleaseGroup {
     pub title: String,
     pub artist: Option<String>,
     /// Representative cover for the card — the first pressing that surfaced one.
-    pub cover_url: Option<String>,
+    pub cover_art: Option<RemoteCover>,
     /// Human-readable source name ("MusicBrainz" / "Discogs").
     pub source_label: String,
     /// Editorial URL for the group on its source (release-group on
@@ -57,13 +58,13 @@ impl ReleaseGroup {
             .expect("release group built from at least one pressing");
         let title = first.title.clone();
         let artist = pressings.iter().find_map(|p| p.artist.clone());
-        let cover_url = pressings.iter().find_map(|p| p.cover_url.clone());
+        let cover_art = pressings.iter().find_map(|p| p.cover_art.clone());
         let meta_label = group_meta_label(&pressings);
         Self {
             id,
             title,
             artist,
-            cover_url,
+            cover_art,
             source_label: source.display_name().to_string(),
             group_url,
             meta_label,
@@ -142,7 +143,6 @@ fn group_meta_label(pressings: &[MetadataResult]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     fn result(release_id: &str, group_id: Option<&str>, year: Option<i32>) -> MetadataResult {
         MetadataResult {
             source: MetadataSource::MusicBrainz,
@@ -154,8 +154,17 @@ mod tests {
             label: None,
             catalog_number: None,
             country: None,
-            cover_url: None,
+            cover_art: None,
             source_group_id: group_id.map(str::to_string),
+        }
+    }
+
+    fn cover() -> RemoteCover {
+        RemoteCover {
+            url: "https://caa.example/front.jpg".to_string(),
+            thumbnail_url: "https://caa.example/thumb.jpg".to_string(),
+            label: MetadataSource::MusicBrainz.cover_source_label().to_string(),
+            source: MetadataSource::MusicBrainz,
         }
     }
 
@@ -251,5 +260,16 @@ mod tests {
         );
         assert_eq!(rg.title, "Album Title");
         assert_eq!(rg.artist.as_deref(), Some("Artist Name"));
+    }
+
+    #[test]
+    fn representative_cover_preserves_remote_cover_pair() {
+        let cover = cover();
+        let mut first = result("rel-1", Some("g"), Some(1992));
+        first.cover_art = Some(cover.clone());
+
+        let groups = group_results(vec![first, result("rel-2", Some("g"), Some(1994))]);
+
+        assert_eq!(groups[0].cover_art, Some(cover));
     }
 }

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -8,11 +8,12 @@
 //! in bae-core.
 
 use crate::discogs::client::{DiscogsClient, DiscogsError, DiscogsSearchParams};
+use crate::import::cover_art::{CoverArtArchiveClient, RemoteCover};
 use crate::import::types::MetadataSource;
 use crate::musicbrainz::{self, DiscIdRelease, ReleaseSearchParams, SearchRelease};
 use crate::retry::retry_with_backoff;
 use crate::util::format::compute_track_labels;
-use tracing::{debug, warn};
+use tracing::warn;
 
 /// A unified metadata search result from either MusicBrainz or Discogs.
 ///
@@ -33,7 +34,7 @@ pub struct MetadataResult {
     pub label: Option<String>,
     pub catalog_number: Option<String>,
     pub country: Option<String>,
-    pub cover_url: Option<String>,
+    pub cover_art: Option<RemoteCover>,
     pub source_group_id: Option<String>,
 }
 
@@ -70,23 +71,19 @@ pub struct ImportSearchReleaseDetail {
     pub barcode: Option<String>,
     pub track_count: u32,
     pub tracks: Vec<ReleaseTrack>,
-    pub cover_art: Vec<CoverArt>,
+    pub cover_art: Vec<RemoteCover>,
 }
 
 impl ImportSearchReleaseDetail {
-    /// The source's primary cover URL — the first entry, which MB and
-    /// Discogs both order front-image-first. This is what the confirm
-    /// pane shows selected before the user makes a manual pick. `None`
-    /// when the source surfaced no cover art.
-    pub fn default_cover_url(&self) -> Option<String> {
-        self.cover_art.first().map(|c| c.url.clone())
-    }
-
     /// Does the source's `track_count` disagree with the user's local
     /// track count? `None` (count not known yet) returns `false`: can't
     /// mismatch against an unknown.
     pub fn track_count_mismatch(&self, local_track_count: Option<u32>) -> bool {
         local_track_count.is_some_and(|local| self.track_count != local)
+    }
+
+    pub fn default_cover(&self) -> Option<&RemoteCover> {
+        self.cover_art.first()
     }
 }
 
@@ -106,13 +103,6 @@ pub struct ReleaseTrack {
     pub position_label: String,
 }
 
-/// A cover art option for a release.
-#[derive(Debug, Clone)]
-pub struct CoverArt {
-    pub url: String,
-    pub source: MetadataSource,
-}
-
 /// Disc ID lookup result.
 #[derive(Debug)]
 pub enum DiscIdResult {
@@ -121,40 +111,16 @@ pub enum DiscIdResult {
     MultipleMatches(Vec<MetadataResult>),
 }
 
-/// Check Cover Art Archive for cover art thumbnails.
-/// Does HEAD requests to CAA; returns redirect Location URLs (250px thumbnails).
-pub async fn check_cover_art(release_ids: &[String]) -> Vec<Option<String>> {
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .unwrap();
-
-    let futures: Vec<_> = release_ids
-        .iter()
-        .map(|id| {
-            let client = &client;
-            let url = format!("https://coverartarchive.org/release/{id}/front-250");
-            async move {
-                match client.head(&url).send().await {
-                    Ok(resp) if resp.status() == reqwest::StatusCode::TEMPORARY_REDIRECT => resp
-                        .headers()
-                        .get("location")
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.to_string()),
-                    Ok(resp) => {
-                        debug!("check_cover_art HEAD {url}: status {}", resp.status());
-                        None
-                    }
-                    Err(e) => {
-                        debug!("check_cover_art HEAD {url}: {e}");
-                        None
-                    }
-                }
-            }
-        })
-        .collect();
-
-    futures::future::join_all(futures).await
+async fn search_covers(
+    cover_art_archive: &CoverArtArchiveClient,
+    release_ids: &[String],
+) -> Vec<Option<RemoteCover>> {
+    futures::future::join_all(
+        release_ids
+            .iter()
+            .map(|release_id| cover_art_archive.fetch_release(release_id)),
+    )
+    .await
 }
 
 /// Convert a Discogs search result to a MetadataResult.
@@ -177,7 +143,7 @@ pub fn discogs_search_result_to_metadata(
     let year = r.year.as_ref().and_then(|y| y.parse::<i32>().ok());
     let format = r.format.as_ref().map(|f| f.join(", "));
     let label = r.label.as_ref().and_then(|l| l.first().cloned());
-    let cover_url = r.thumb.clone();
+    let cover_art = r.remote_cover();
     let source_group_id = r.master_id.map(|id| id.to_string());
     MetadataResult {
         source: MetadataSource::Discogs,
@@ -189,7 +155,7 @@ pub fn discogs_search_result_to_metadata(
         label,
         catalog_number: r.catno,
         country: r.country,
-        cover_url,
+        cover_art,
         source_group_id,
     }
 }
@@ -198,7 +164,7 @@ fn parse_year(date: Option<&str>) -> Option<i32> {
     date?.split('-').next()?.parse().ok()
 }
 
-fn disc_id_release_to_metadata(r: DiscIdRelease, cover_url: Option<String>) -> MetadataResult {
+fn disc_id_release_to_metadata(r: DiscIdRelease, cover_art: Option<RemoteCover>) -> MetadataResult {
     let (label, catalog_number) = r
         .label_info
         .first()
@@ -219,12 +185,12 @@ fn disc_id_release_to_metadata(r: DiscIdRelease, cover_url: Option<String>) -> M
         label,
         catalog_number,
         country: r.country,
-        cover_url,
+        cover_art,
         source_group_id: r.release_group.as_ref().map(|rg| rg.id.clone()),
     }
 }
 
-fn search_release_to_metadata(r: SearchRelease, cover_url: Option<String>) -> MetadataResult {
+fn search_release_to_metadata(r: SearchRelease, cover_art: Option<RemoteCover>) -> MetadataResult {
     let (label, catalog_number) = r
         .label_info
         .first()
@@ -245,14 +211,29 @@ fn search_release_to_metadata(r: SearchRelease, cover_url: Option<String>) -> Me
         label,
         catalog_number,
         country: r.country,
-        cover_url,
+        cover_art,
         source_group_id: r.release_group.as_ref().map(|rg| rg.id.clone()),
     }
+}
+
+async fn musicbrainz_releases_to_metadata(
+    cover_art_archive: &CoverArtArchiveClient,
+    releases: Vec<SearchRelease>,
+) -> Vec<MetadataResult> {
+    let release_ids: Vec<String> = releases.iter().map(|r| r.id.clone()).collect();
+    let covers = search_covers(cover_art_archive, &release_ids).await;
+
+    releases
+        .into_iter()
+        .zip(covers)
+        .map(|(r, cover_art)| search_release_to_metadata(r, cover_art))
+        .collect()
 }
 
 /// Search MusicBrainz for metadata matching given criteria.
 /// Includes cover art checks from the Cover Art Archive.
 pub async fn search_musicbrainz(
+    cover_art_archive: &CoverArtArchiveClient,
     artist: String,
     album: String,
     year: Option<String>,
@@ -271,14 +252,7 @@ pub async fn search_musicbrainz(
     .await
     .map_err(|e| format!("MusicBrainz search failed: {e}"))?;
 
-    let release_ids: Vec<String> = releases.iter().map(|r| r.id.clone()).collect();
-    let cover_urls = check_cover_art(&release_ids).await;
-
-    Ok(releases
-        .into_iter()
-        .zip(cover_urls)
-        .map(|(r, cover_url)| search_release_to_metadata(r, cover_url))
-        .collect())
+    Ok(musicbrainz_releases_to_metadata(cover_art_archive, releases).await)
 }
 
 /// Search Discogs for metadata matching given criteria.
@@ -305,6 +279,7 @@ pub async fn search_discogs(
 
 /// Search by catalog number on MusicBrainz.
 pub async fn search_mb_by_catalog_number(
+    cover_art_archive: &CoverArtArchiveClient,
     catalog_number: String,
 ) -> Result<Vec<MetadataResult>, String> {
     let params = ReleaseSearchParams {
@@ -317,14 +292,7 @@ pub async fn search_mb_by_catalog_number(
     .await
     .map_err(|e| format!("MusicBrainz search failed: {e}"))?;
 
-    let release_ids: Vec<String> = releases.iter().map(|r| r.id.clone()).collect();
-    let cover_urls = check_cover_art(&release_ids).await;
-
-    Ok(releases
-        .into_iter()
-        .zip(cover_urls)
-        .map(|(r, cover_url)| search_release_to_metadata(r, cover_url))
-        .collect())
+    Ok(musicbrainz_releases_to_metadata(cover_art_archive, releases).await)
 }
 
 /// Search by catalog number on Discogs.
@@ -344,7 +312,10 @@ pub async fn search_discogs_by_catalog_number(
 }
 
 /// Search by barcode on MusicBrainz.
-pub async fn search_mb_by_barcode(barcode: String) -> Result<Vec<MetadataResult>, String> {
+pub async fn search_mb_by_barcode(
+    cover_art_archive: &CoverArtArchiveClient,
+    barcode: String,
+) -> Result<Vec<MetadataResult>, String> {
     let params = ReleaseSearchParams {
         barcode: Some(barcode),
         ..Default::default()
@@ -355,14 +326,7 @@ pub async fn search_mb_by_barcode(barcode: String) -> Result<Vec<MetadataResult>
     .await
     .map_err(|e| format!("MusicBrainz search failed: {e}"))?;
 
-    let release_ids: Vec<String> = releases.iter().map(|r| r.id.clone()).collect();
-    let cover_urls = check_cover_art(&release_ids).await;
-
-    Ok(releases
-        .into_iter()
-        .zip(cover_urls)
-        .map(|(r, cover_url)| search_release_to_metadata(r, cover_url))
-        .collect())
+    Ok(musicbrainz_releases_to_metadata(cover_art_archive, releases).await)
 }
 
 /// Search by barcode on Discogs.
@@ -382,7 +346,10 @@ pub async fn search_discogs_by_barcode(
 }
 
 /// Lookup releases by MusicBrainz disc ID.
-pub async fn lookup_by_discid(discid: &str) -> Result<DiscIdResult, String> {
+pub async fn lookup_by_discid(
+    cover_art_archive: &CoverArtArchiveClient,
+    discid: &str,
+) -> Result<DiscIdResult, String> {
     let result = retry_with_backoff(3, "MusicBrainz DiscID lookup", || {
         musicbrainz::lookup_by_discid(discid)
     })
@@ -395,12 +362,12 @@ pub async fn lookup_by_discid(discid: &str) -> Result<DiscIdResult, String> {
             }
 
             let release_ids: Vec<String> = releases.iter().map(|r| r.id.clone()).collect();
-            let cover_urls = check_cover_art(&release_ids).await;
+            let covers = search_covers(cover_art_archive, &release_ids).await;
 
             let results: Vec<MetadataResult> = releases
                 .into_iter()
-                .zip(cover_urls)
-                .map(|(r, cover_url)| disc_id_release_to_metadata(r, cover_url))
+                .zip(covers)
+                .map(|(r, cover_art)| disc_id_release_to_metadata(r, cover_art))
                 .collect();
 
             if results.len() == 1 {
@@ -442,6 +409,7 @@ pub fn parse_duration_to_ms(duration: &str) -> Option<u64> {
 fn build_mb_detail(
     release_id: &str,
     mb_response: &crate::musicbrainz::MbReleaseResponse,
+    cover_art: Vec<RemoteCover>,
 ) -> ImportSearchReleaseDetail {
     let year = parse_year(mb_response.date.as_deref());
 
@@ -542,26 +510,6 @@ fn build_mb_detail(
         };
     }
 
-    let cover_url = format!(
-        "https://coverartarchive.org/release/{}/front-500",
-        release_id
-    );
-    let mut cover_art = vec![CoverArt {
-        url: cover_url,
-        source: MetadataSource::MusicBrainz,
-    }];
-
-    let release_group_id = mb_response.release_group.as_ref().map(|rg| rg.id.as_str());
-    if let Some(rg_id) = release_group_id {
-        cover_art.push(CoverArt {
-            url: format!(
-                "https://coverartarchive.org/release-group/{}/front-500",
-                rg_id
-            ),
-            source: MetadataSource::MusicBrainz,
-        });
-    }
-
     let artist = mb_response.artist_credit.first().map(|ac| ac.name.clone());
     let (label, catalog_number) = mb_response
         .label_info
@@ -596,9 +544,16 @@ fn build_mb_detail(
 /// Discogs cross-ref (the picker doesn't render any cross-source data) and
 /// no DB-shape mapping. Pairs with `commit_mb_release`, which composes the
 /// same `fetch_mb_response` with cross-ref enrichment and DB mapping.
-pub async fn prefetch_mb_release(release_id: &str) -> Result<ImportSearchReleaseDetail, String> {
+pub async fn prefetch_mb_release(
+    cover_art_archive: &CoverArtArchiveClient,
+    release_id: &str,
+) -> Result<ImportSearchReleaseDetail, String> {
     let (response, _, _) = crate::import::musicbrainz_mapper::fetch_mb_response(release_id).await?;
-    Ok(build_mb_detail(release_id, &response))
+    let release_group_id = response.release_group.as_ref().map(|rg| rg.id.as_str());
+    let cover_art = cover_art_archive
+        .fetch_candidates(Some(response.id.as_str()), release_group_id)
+        .await;
+    Ok(build_mb_detail(release_id, &response, cover_art))
 }
 
 /// Commit path for MusicBrainz: fetch + Discogs cross-ref + map to DB shape.
@@ -687,11 +642,8 @@ fn build_discogs_detail(release: &crate::discogs::DiscogsRelease) -> ImportSearc
         .collect();
 
     let mut cover_art = Vec::new();
-    if let Some(ref url) = release.cover_image {
-        cover_art.push(CoverArt {
-            url: url.clone(),
-            source: MetadataSource::Discogs,
-        });
+    if let Some(cover) = release.remote_cover() {
+        cover_art.push(cover);
     }
 
     let year = release.year.map(|y| y as i32);
@@ -768,6 +720,7 @@ pub async fn commit_discogs_release(
 mod tests {
     use super::*;
     use crate::discogs::client::DiscogsSearchResult;
+    use crate::musicbrainz::{MbArtistCredit, MbMedium, MbReleaseGroupRef, MbReleaseResponse};
 
     fn result_with_title(title: &str) -> DiscogsSearchResult {
         DiscogsSearchResult {
@@ -807,5 +760,60 @@ mod tests {
         let m = discogs_search_result_to_metadata(result_with_title(" - Album Title"));
         assert_eq!(m.artist, None);
         assert_eq!(m.title, "Album Title");
+    }
+
+    #[test]
+    fn discogs_search_result_carries_remote_cover_pair() {
+        let mut result = result_with_title("Artist Name - Album Title");
+        result.cover_image = Some("https://discogs.example/full.jpg".to_string());
+        result.thumb = Some("https://discogs.example/thumb.jpg".to_string());
+
+        let metadata = discogs_search_result_to_metadata(result);
+
+        assert_eq!(
+            metadata.cover_art,
+            Some(RemoteCover {
+                url: "https://discogs.example/full.jpg".to_string(),
+                thumbnail_url: "https://discogs.example/thumb.jpg".to_string(),
+                label: MetadataSource::Discogs.cover_source_label().to_string(),
+                source: MetadataSource::Discogs,
+            })
+        );
+    }
+
+    #[test]
+    fn mb_detail_uses_supplied_cover_art_archive_candidates() {
+        let response = MbReleaseResponse {
+            id: "mb-release-1".to_string(),
+            title: "Album Title".to_string(),
+            date: None,
+            country: None,
+            barcode: None,
+            artist_credit: vec![MbArtistCredit {
+                name: "Artist Name".to_string(),
+                artist: None,
+            }],
+            release_group: Some(MbReleaseGroupRef {
+                id: "mb-group-1".to_string(),
+                first_release_date: None,
+                relations: None,
+            }),
+            label_info: vec![],
+            media: vec![MbMedium {
+                format: Some("CD".to_string()),
+                tracks: vec![],
+            }],
+            relations: vec![],
+        };
+        let cover_art = vec![RemoteCover {
+            url: "https://caa.example/cover.jpg".to_string(),
+            thumbnail_url: "https://caa.example/thumb.jpg".to_string(),
+            label: MetadataSource::MusicBrainz.cover_source_label().to_string(),
+            source: MetadataSource::MusicBrainz,
+        }];
+
+        let detail = build_mb_detail("mb-release-1", &response, cover_art.clone());
+
+        assert_eq!(detail.cover_art, cover_art);
     }
 }

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -543,6 +543,7 @@ impl ImportService {
     pub fn start(
         runtime_handle: tokio::runtime::Handle,
         library_manager: LibraryManager,
+        cover_art_archive: crate::import::cover_art::CoverArtArchiveClient,
     ) -> ImportServiceHandle {
         let (commands_tx, commands_rx) = mpsc::unbounded_channel();
         let (watcher_tx, watcher_rx) = mpsc::unbounded_channel();
@@ -600,6 +601,7 @@ impl ImportService {
             watcher_tx,
             event_tx,
             folder_registry,
+            cover_art_archive,
         )
     }
 

--- a/bae-core/tests/alac_fixtures.rs
+++ b/bae-core/tests/alac_fixtures.rs
@@ -38,7 +38,11 @@ fn start_test_import(
     runtime_handle: tokio::runtime::Handle,
     library_manager: LibraryManager,
 ) -> bae_core::import::ImportServiceHandle {
-    ImportService::start(runtime_handle.clone(), library_manager)
+    ImportService::start(
+        runtime_handle.clone(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    )
 }
 
 fn make_discogs_release(id: &str, title: &str, tracks: &[&str]) -> DiscogsRelease {

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -29,7 +29,11 @@ fn start_test_import(
     runtime_handle: tokio::runtime::Handle,
     library_manager: LibraryManager,
 ) -> bae_core::import::ImportServiceHandle {
-    ImportService::start(runtime_handle.clone(), library_manager)
+    ImportService::start(
+        runtime_handle.clone(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    )
 }
 
 fn copy_cue_ape_fixture(dir: &Path) {

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -31,7 +31,11 @@ fn start_test_import(
     runtime_handle: tokio::runtime::Handle,
     library_manager: LibraryManager,
 ) -> bae_core::import::ImportServiceHandle {
-    ImportService::start(runtime_handle.clone(), library_manager)
+    ImportService::start(
+        runtime_handle.clone(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    )
 }
 /// CUE/FLAC imports record each track's sample window correctly.
 ///

--- a/bae-core/tests/test_export.rs
+++ b/bae-core/tests/test_export.rs
@@ -53,8 +53,11 @@ impl ExportFixture {
         let cloud = Arc::new(MockCloudHome::new());
         mgr.set_cloud_override(cloud.clone(), EncryptionService::new_with_key(&[7u8; 32]));
 
-        let handle =
-            bae_core::import::ImportService::start(tokio::runtime::Handle::current(), mgr.clone());
+        let handle = bae_core::import::ImportService::start(
+            tokio::runtime::Handle::current(),
+            mgr.clone(),
+            bae_core::import::cover_art::CoverArtArchiveClient::new(),
+        );
 
         Self {
             db,

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -58,7 +58,11 @@ impl ImportFixture {
             None,
         );
 
-        let handle = ImportService::start(tokio::runtime::Handle::current(), library_manager);
+        let handle = ImportService::start(
+            tokio::runtime::Handle::current(),
+            library_manager,
+            bae_core::import::cover_art::CoverArtArchiveClient::new(),
+        );
 
         Self {
             db,

--- a/bae-core/tests/test_pending_upload_source.rs
+++ b/bae-core/tests/test_pending_upload_source.rs
@@ -57,8 +57,11 @@ impl Fixture {
             EncryptionService::new_with_key(&[7u8; 32]),
         );
 
-        let handle =
-            bae_core::import::ImportService::start(tokio::runtime::Handle::current(), mgr.clone());
+        let handle = bae_core::import::ImportService::start(
+            tokio::runtime::Handle::current(),
+            mgr.clone(),
+            bae_core::import::cover_art::CoverArtArchiveClient::new(),
+        );
 
         Self {
             mgr,

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -76,7 +76,11 @@ fn start_test_import(
     runtime_handle: tokio::runtime::Handle,
     library_manager: LibraryManager,
 ) -> bae_core::import::ImportServiceHandle {
-    bae_core::import::ImportService::start(runtime_handle.clone(), library_manager)
+    bae_core::import::ImportService::start(
+        runtime_handle.clone(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    )
 }
 /// Test helper to set up playback service with imported test tracks
 struct PlaybackTestFixture {

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -23,7 +23,11 @@ fn start_test_import(
     runtime_handle: tokio::runtime::Handle,
     library_manager: LibraryManager,
 ) -> bae_core::import::ImportServiceHandle {
-    bae_core::import::ImportService::start(runtime_handle.clone(), library_manager)
+    bae_core::import::ImportService::start(
+        runtime_handle.clone(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    )
 }
 
 /// Check if audio tests should be skipped (e.g., in CI without audio device)

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -25,7 +25,11 @@ fn start_test_import(
     runtime_handle: tokio::runtime::Handle,
     library_manager: LibraryManager,
 ) -> bae_core::import::ImportServiceHandle {
-    ImportService::start(runtime_handle.clone(), library_manager)
+    ImportService::start(
+        runtime_handle.clone(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    )
 }
 
 /// Initialize tracing for tests
@@ -665,7 +669,11 @@ async fn run_real_album_test(album_dir: PathBuf, discogs_release_id: String) {
     );
     let runtime_handle = tokio::runtime::Handle::current();
     // Use the real API resolver since this test exercises real Discogs data
-    let import_handle = ImportService::start(runtime_handle, library_manager.clone());
+    let import_handle = ImportService::start(
+        runtime_handle,
+        library_manager.clone(),
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    );
     let import_id = import_handle
         .start_import(
             "test",

--- a/bae-macos/bae/bae/ImageLoader.swift
+++ b/bae-macos/bae/bae/ImageLoader.swift
@@ -10,6 +10,15 @@ enum ImageLoader {
         case local(path: String)
         case remote(url: String)
 
+        init(bridge: BridgeCoverImageSource) {
+            switch bridge {
+            case .local(let path):
+                self = .local(path: path)
+            case .remote(let url):
+                self = .remote(url: url)
+            }
+        }
+
         /// Human-readable description for failure logs.
         var description: String {
             switch self {

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -902,6 +902,29 @@ enum PreviewData {
         )
     ]
 
+    private static func previewArtworkFile(
+        name: String,
+        size: UInt64,
+        sizeLabel: String,
+        localPath: String
+    ) -> BridgeArtworkFile {
+        BridgeArtworkFile(
+            file: BridgeFileInfo(
+                name: name,
+                size: size,
+                sizeLabel: sizeLabel,
+                dirPrefix: nil,
+                fileName: name,
+                localPath: localPath
+            ),
+            coverChoice: BridgeCoverChoice(
+                selection: .releaseImage(fileId: name),
+                previewSource: .local(path: localPath),
+                thumbnailSource: .local(path: localPath)
+            )
+        )
+    }
+
     static let bridgeCandidateFiles = BridgeCandidateFiles(
         audio: .cueFlacPairs(pairs: [
             BridgeCueFlacPair(
@@ -917,28 +940,22 @@ enum PreviewData {
             )
         ]),
         artwork: [
-            BridgeFileInfo(
+            previewArtworkFile(
                 name: "Front.png",
                 size: 2_500_000,
                 sizeLabel: "2 MB",
-                dirPrefix: nil,
-                fileName: "Front.png",
                 localPath: "/tmp/fake/Front.png"
             ),
-            BridgeFileInfo(
+            previewArtworkFile(
                 name: "Back.png",
                 size: 1_800_000,
                 sizeLabel: "2 MB",
-                dirPrefix: nil,
-                fileName: "Back.png",
                 localPath: "/tmp/fake/Back.png"
             ),
-            BridgeFileInfo(
+            previewArtworkFile(
                 name: "Matrix.png",
                 size: 900_000,
                 sizeLabel: "879 KB",
-                dirPrefix: nil,
-                fileName: "Matrix.png",
                 localPath: "/tmp/fake/Matrix.png"
             ),
         ],
@@ -992,7 +1009,7 @@ enum PreviewData {
             trackCountMismatch: false,
             tracks: tracks,
             coverArt: [],
-            defaultCoverUrl: nil,
+            defaultCover: nil,
         )
     }()
 
@@ -1032,12 +1049,10 @@ enum PreviewData {
                     }
             ),
             artwork: [
-                BridgeFileInfo(
+                previewArtworkFile(
                     name: "Front.png",
                     size: 2_500_000,
                     sizeLabel: "2 MB",
-                    dirPrefix: nil,
-                    fileName: "Front.png",
                     localPath: "/tmp/fake/Front.png"
                 )
             ],
@@ -1091,7 +1106,7 @@ enum PreviewData {
             id: "group-preview",
             title: "Album Title",
             artist: "Artist Name",
-            coverUrl: nil,
+            coverArt: nil,
             sourceLabel: "MusicBrainz",
             groupUrl: "https://musicbrainz.org/release-group/group-preview",
             metaLabel: "1988 \u{2013} 1996 \u{00b7} 2 pressings",
@@ -1119,7 +1134,7 @@ enum PreviewData {
                 id: "grp-1",
                 title: "Album Title One",
                 artist: "Artist Name",
-                coverUrl: nil,
+                coverArt: nil,
                 sourceLabel: "MusicBrainz",
                 groupUrl: "https://musicbrainz.org/release-group/grp-1",
                 metaLabel: "1996 \u{00b7} 2 pressings",
@@ -1150,7 +1165,7 @@ enum PreviewData {
                 id: "grp-2",
                 title: "Album Title One (Remaster)",
                 artist: "Artist Name",
-                coverUrl: nil,
+                coverArt: nil,
                 sourceLabel: "MusicBrainz",
                 groupUrl: "https://musicbrainz.org/release-group/grp-2",
                 metaLabel: "2005 \u{00b7} 1 pressing",

--- a/bae-macos/bae/bae/Services/AppService.swift
+++ b/bae-macos/bae/bae/Services/AppService.swift
@@ -29,7 +29,7 @@ final class AppService: @unchecked Sendable, Observable {
 
     /// Import-flow session state — folder candidates and the preview audio
     /// state. Mixed-writer: reducer drives event-driven fields (scan, identify,
-    /// preview state); views drive user-set fields (mode, selectedCoverUrl).
+    /// preview state); views drive user-set fields (mode, selectedCover).
     let importStore: ImportStore
 
     /// Entity slices — the library cache. Keyed-by-id maps of the albums

--- a/bae-macos/bae/bae/Services/ImportStore.swift
+++ b/bae-macos/bae/bae/Services/ImportStore.swift
@@ -27,7 +27,7 @@ enum SkippedRow: Identifiable {
 
 /// Session state for the import flow. Mixed-writer: the reducer drives
 /// event-driven fields (scan, identify, preview state), while views drive
-/// user-set fields (mode, selectedCoverUrl) via `mutateCandidate(forKey:_:)`.
+/// user-set fields (mode, selectedCover) via `mutateCandidate(forKey:_:)`.
 /// The single-writer rule applies per field, not per store.
 ///
 /// One ordered dictionary per source: folder-scan candidates and re-identify

--- a/bae-macos/bae/bae/Services/Store/Candidate.swift
+++ b/bae-macos/bae/bae/Services/Store/Candidate.swift
@@ -125,7 +125,7 @@ struct Candidate: Equatable, Identifiable {
     var libraryStatuses: [String: LibraryStatus] = [:]
     var mode: CandidateMode = .identifying
     var error: String?
-    var selectedCoverUrl: String?
+    var selectedCover: BridgeCoverChoice?
     var search: CandidateSearchState = .init()
     /// Extracted signals (disc ID, barcodes, classified text), `nil` until the
     /// first extraction snapshot. The search UI surfaces these and feeds the

--- a/bae-macos/bae/bae/Services/Store/CandidateFiles.swift
+++ b/bae-macos/bae/bae/Services/Store/CandidateFiles.swift
@@ -23,6 +23,21 @@ struct FileInfo: Equatable {
     }
 }
 
+// MARK: - ArtworkFile
+
+struct ArtworkFile: Equatable {
+    let file: FileInfo
+    let coverChoice: BridgeCoverChoice
+
+    var name: String { file.name }
+    var localPath: String { file.localPath }
+
+    init(bridge: BridgeArtworkFile) {
+        file = FileInfo(bridge: bridge.file)
+        coverChoice = bridge.coverChoice
+    }
+}
+
 // MARK: - CueFlacPair
 
 struct CueFlacPair: Equatable {
@@ -68,16 +83,16 @@ enum AudioContent: Equatable {
 
 struct CandidateFiles: Equatable {
     var audio: AudioContent
-    var artwork: [FileInfo]
+    var artwork: [ArtworkFile]
     var documents: [FileInfo]
 
     init(bridge: BridgeCandidateFiles) {
         audio = AudioContent(bridge: bridge.audio)
-        artwork = bridge.artwork.map(FileInfo.init(bridge:))
+        artwork = bridge.artwork.map(ArtworkFile.init(bridge:))
         documents = bridge.documents.map(FileInfo.init(bridge:))
     }
 
-    init(audio: AudioContent, artwork: [FileInfo], documents: [FileInfo]) {
+    init(audio: AudioContent, artwork: [ArtworkFile], documents: [FileInfo]) {
         self.audio = audio
         self.artwork = artwork
         self.documents = documents

--- a/bae-macos/bae/bae/Services/Store/ImportReleaseDetail.swift
+++ b/bae-macos/bae/bae/Services/Store/ImportReleaseDetail.swift
@@ -9,12 +9,12 @@ struct ImportReleaseDetail: Equatable {
     let releaseId: String
     let trackCount: UInt32
     let trackCountMismatch: Bool
-    let coverArt: [CoverArt]
+    let coverArt: [BridgeRemoteCover]
 
     init(bridge: BridgeReleaseDetail) {
         releaseId = bridge.releaseId
         trackCount = bridge.trackCount
         trackCountMismatch = bridge.trackCountMismatch
-        coverArt = bridge.coverArt.map(CoverArt.init(bridge:))
+        coverArt = bridge.coverArt
     }
 }

--- a/bae-macos/bae/bae/Services/Store/MetadataResult.swift
+++ b/bae-macos/bae/bae/Services/Store/MetadataResult.swift
@@ -46,18 +46,3 @@ struct MetadataResult: Equatable, Identifiable {
         country = bridge.country
     }
 }
-
-struct CoverArt: Equatable {
-    let url: String
-    /// Carried back to core when the user picks this cover (the commit path).
-    let source: MetadataSource
-    /// Pre-built source name from bae-core ("Cover Art Archive" / "Discogs"),
-    /// rendered as-is — the UI never switches on `source` for display.
-    let sourceLabel: String
-
-    init(bridge: BridgeCoverArt) {
-        url = bridge.url
-        source = MetadataSource(bridge: bridge.source)
-        sourceLabel = bridge.sourceLabel
-    }
-}

--- a/bae-macos/bae/bae/Services/Store/ReleaseGroup.swift
+++ b/bae-macos/bae/bae/Services/Store/ReleaseGroup.swift
@@ -8,7 +8,7 @@ struct ReleaseGroup: Equatable, Identifiable {
     let id: String
     let title: String
     let artist: String?
-    let coverImageSource: ImageLoader.Source?
+    let coverArt: BridgeRemoteCover?
     /// Human-readable source name ("MusicBrainz" / "Discogs"), pre-built by core.
     let sourceLabel: String
     /// Editorial URL for the group on its source. `nil` for an ungrouped result.
@@ -17,11 +17,17 @@ struct ReleaseGroup: Equatable, Identifiable {
     let metaLabel: String
     let pressings: [MetadataResult]
 
+    var coverImageSource: ImageLoader.Source? {
+        coverArt.map {
+            ImageLoader.Source(bridge: $0.coverChoice.thumbnailSource)
+        }
+    }
+
     init(bridge: BridgeReleaseGroup) {
         id = bridge.id
         title = bridge.title
         artist = bridge.artist
-        coverImageSource = bridge.coverUrl.map { .remote(url: $0) }
+        coverArt = bridge.coverArt
         sourceLabel = bridge.sourceLabel
         groupUrl = bridge.groupUrl.flatMap(URL.init(string:))
         metaLabel = bridge.metaLabel

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -282,10 +282,7 @@ struct AlbumDetailView: View {
                     changeCover(
                         albumId: albumId,
                         releaseId: selectedReleaseId,
-                        selection: .remoteCover(
-                            url: cover.url,
-                            source: cover.source
-                        ),
+                        selection: cover.coverChoice.selection,
                     )
                 },
                 onSelectReleaseImage: { fileId in

--- a/bae-macos/bae/bae/Views/CoverSheetView.swift
+++ b/bae-macos/bae/bae/Views/CoverSheetView.swift
@@ -57,7 +57,10 @@ struct CoverSheetView: View {
                             columns: [GridItem(.adaptive(minimum: 120))],
                             spacing: 12
                         ) {
-                            ForEach(remoteCovers, id: \.url) { cover in
+                            ForEach(
+                                remoteCovers,
+                                id: \.coverChoice.selection
+                            ) { cover in
                                 remoteCoverOption(cover)
                             }
                         }
@@ -143,7 +146,9 @@ struct CoverSheetView: View {
         Button(action: { onSelectRemote(cover) }) {
             VStack(spacing: 4) {
                 ImageView(
-                    source: .remote(url: cover.thumbnailUrl),
+                    source: ImageLoader.Source(
+                        bridge: cover.coverChoice.thumbnailSource
+                    ),
                     pointSize: 120
                 )
                 .frame(width: 120, height: 120)
@@ -157,6 +162,25 @@ struct CoverSheetView: View {
     }
 }
 
+private func previewRemoteCover(
+    url: String,
+    thumbnailUrl: String,
+    label: String
+) -> BridgeRemoteCover {
+    let selection = BridgeRemoteCoverSelection(
+        url: url,
+        source: .musicBrainz
+    )
+    return BridgeRemoteCover(
+        coverChoice: BridgeCoverChoice(
+            selection: .remoteCover(selection: selection),
+            previewSource: .remote(url: url),
+            thumbnailSource: .remote(url: thumbnailUrl)
+        ),
+        label: label
+    )
+}
+
 #Preview("Cover Sheet") {
     CoverSheetView(
         releaseImages: [
@@ -165,17 +189,15 @@ struct CoverSheetView: View {
         ],
         fetchRemoteCovers: {
             [
-                BridgeRemoteCover(
+                previewRemoteCover(
                     url: "https://example.com/cover1.jpg",
                     thumbnailUrl: "https://example.com/thumb1.jpg",
-                    label: "Front",
-                    source: .musicBrainz
+                    label: "Front"
                 ),
-                BridgeRemoteCover(
+                previewRemoteCover(
                     url: "https://example.com/cover2.jpg",
                     thumbnailUrl: "https://example.com/thumb2.jpg",
-                    label: "Back",
-                    source: .musicBrainz
+                    label: "Back"
                 ),
             ]
         },

--- a/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
+++ b/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
@@ -394,8 +394,9 @@ struct FolderImportTab: View {
             },
             coverContent: {
                 folderCoverThumb(
-                    selectedUrl: candidate.selectedCoverUrl,
-                    artwork: candidate.files.artwork,
+                    source: candidate.selectedCover.map {
+                        ImageLoader.Source(bridge: $0.thumbnailSource)
+                    },
                 )
             },
             actionExtra: EmptyView.init,
@@ -404,29 +405,15 @@ struct FolderImportTab: View {
 
     // MARK: - Folder-specific cover thumbnail (supports local artwork)
 
-    private func folderCoverThumb(selectedUrl: String?, artwork: [FileInfo])
+    private func folderCoverThumb(source: ImageLoader.Source?)
         -> some View
     {
         Group {
-            if let url = selectedUrl {
-                if url.hasPrefix("local:") {
-                    let filename = String(url.dropFirst("local:".count))
-                    let localPath =
-                        artwork.first(where: { $0.name == filename })?
-                        .localPath
-                    if let localPath {
-                        ImageView(
-                            source: .local(path: localPath),
-                            pointSize: 80
-                        )
-                    }
-                    else {
-                        Theme.placeholder
-                    }
-                }
-                else {
-                    ImageView(source: .remote(url: url), pointSize: 80)
-                }
+            if let source {
+                ImageView(
+                    source: source,
+                    pointSize: 80
+                )
             }
             else {
                 Theme.placeholder
@@ -443,36 +430,7 @@ struct FolderImportTab: View {
         // Start each attempt from a clean error state so a prior failed
         // commit's banner doesn't linger over a now-succeeding retry.
         importStore.mutateCandidate(forKey: candidate.key) { $0.error = nil }
-        let selectedUrl = candidate.selectedCoverUrl
-
-        let coverSelection: BridgeCoverSelection?
-        if let url = selectedUrl {
-            if url.hasPrefix("local:") {
-                let filename = String(url.dropFirst("local:".count))
-                coverSelection = .releaseImage(fileId: filename)
-            }
-            else {
-                // Remote cover URLs only originate from the source
-                // detail's `coverArt`, so source is always populated
-                // when the user picked a remote URL.
-                guard
-                    let coverSource = candidate.releaseDetail?.coverArt
-                        .first?
-                        .source
-                else {
-                    fatalError(
-                        "remote cover selected with no source cover art"
-                    )
-                }
-                coverSelection = .remoteCover(
-                    url: url,
-                    source: coverSource.bridge
-                )
-            }
-        }
-        else {
-            coverSelection = nil
-        }
+        let coverSelection = candidate.selectedCover?.selection
 
         let storageMode = configStore.config.importStorageMode(
             managed: storageManaged,

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
@@ -358,14 +358,30 @@ struct ImportConfirmationView<
 // MARK: - CoverItem
 
 struct CoverItem: Identifiable, Equatable {
-    var id: String {
-        url
+    static func == (lhs: CoverItem, rhs: CoverItem) -> Bool {
+        lhs.id == rhs.id
     }
 
-    let url: String  // remote URL or "local:filename"
+    var id: BridgeCoverSelection { selection }
+    var selection: BridgeCoverSelection { coverChoice.selection }
+    var previewSource: ImageLoader.Source {
+        ImageLoader.Source(bridge: coverChoice.previewSource)
+    }
+
+    var thumbnailSource: ImageLoader.Source {
+        ImageLoader.Source(bridge: coverChoice.thumbnailSource)
+    }
+
+    let coverChoice: BridgeCoverChoice
     let label: String
-    let isLocal: Bool
-    let localPath: String?
+
+    init(
+        coverChoice: BridgeCoverChoice,
+        label: String
+    ) {
+        self.coverChoice = coverChoice
+        self.label = label
+    }
 }
 
 // MARK: - CoverPickerView
@@ -373,10 +389,10 @@ struct CoverItem: Identifiable, Equatable {
 /// A gallery-style picker for selecting cover art from remote and local sources.
 /// Presented as a sheet from the import confirmation view.
 struct CoverPickerView: View {
-    let remoteCoverArts: [CoverArt]
-    let localArtwork: [FileInfo]
-    let selectedUrl: String?
-    let onSelect: (String) -> Void
+    let remoteCoverArts: [BridgeRemoteCover]
+    let localArtwork: [ArtworkFile]
+    let selectedCover: BridgeCoverChoice?
+    let onSelect: (BridgeCoverChoice) -> Void
     let onDone: () -> Void
 
     @State
@@ -387,10 +403,8 @@ struct CoverPickerView: View {
         for cover in remoteCoverArts {
             result.append(
                 CoverItem(
-                    url: cover.url,
-                    label: cover.sourceLabel,
-                    isLocal: false,
-                    localPath: nil,
+                    coverChoice: cover.coverChoice,
+                    label: cover.label
                 )
             )
         }
@@ -399,20 +413,22 @@ struct CoverPickerView: View {
             // so it's always present on disk.
             result.append(
                 CoverItem(
-                    url: "local:\(file.name)",
-                    label: file.name,
-                    isLocal: true,
-                    localPath: file.localPath,
+                    coverChoice: file.coverChoice,
+                    label: file.name
                 )
             )
         }
         return result
     }
 
+    private var selectedItemId: BridgeCoverSelection? {
+        selectedCover?.selection
+    }
+
     private func rebuild() {
         cursor = Cursor(
             items: items,
-            preferring: cursor?.current.id ?? selectedUrl
+            preferring: cursor?.current.id ?? selectedItemId
         )
     }
 
@@ -480,10 +496,10 @@ struct CoverPickerView: View {
                     HStack {
                         Spacer()
                         Button("Use This Cover") {
-                            onSelect(cursor.current.url)
+                            onSelect(cursor.current.coverChoice)
                         }
                         .buttonStyle(.borderedProminent)
-                        .disabled(cursor.current.url == selectedUrl)
+                        .disabled(cursor.current.id == selectedItemId)
                     }
                     .padding(.horizontal, 16)
                 }
@@ -517,45 +533,23 @@ struct CoverPickerView: View {
 
     @ViewBuilder
     private func coverPreview(for item: CoverItem) -> some View {
-        let source: ImageLoader.Source? =
-            item.isLocal
-            ? item.localPath.map { .local(path: $0) }
-            : .remote(url: item.url)
-        Group {
-            if let source {
-                ImageView(source: source, contentMode: .fit, pointSize: 600)
-            }
-            else {
-                Theme.placeholder
-            }
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .shadow(radius: 10)
+        ImageView(source: item.previewSource, contentMode: .fit, pointSize: 600)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .shadow(radius: 10)
     }
 
     @ViewBuilder
     private func pickerThumbnail(for item: CoverItem, isActive: Bool)
         -> some View
     {
-        let isSelected = item.url == selectedUrl
+        let isSelected = item.id == selectedItemId
 
         Button(action: { cursor?.select(id: item.id) }) {
             Group {
-                if item.isLocal, let localPath = item.localPath {
-                    ImageView(
-                        source: .local(path: localPath),
-                        pointSize: 56
-                    )
-                }
-                else if !item.isLocal {
-                    ImageView(
-                        source: .remote(url: item.url),
-                        pointSize: 56
-                    )
-                }
-                else {
-                    Theme.placeholder
-                }
+                ImageView(
+                    source: item.thumbnailSource,
+                    pointSize: 56
+                )
             }
             .frame(width: 56, height: 56)
             .clipShape(RoundedRectangle(cornerRadius: 6))

--- a/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
@@ -120,7 +120,7 @@ struct ImportFilePane: View {
     // MARK: - Artwork cell
 
     /// 1:1 thumbnail. Tap opens the gallery at this index.
-    private func artworkCell(_ file: FileInfo, index: Int)
+    private func artworkCell(_ file: ArtworkFile, index: Int)
         -> some View
     {
         Color.clear

--- a/bae-macos/bae/bae/Views/Import/ImportSearchFlow.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchFlow.swift
@@ -197,9 +197,9 @@ enum ImportSearchFlow {
             // library-status banner, no track-count mismatch, no
             // Exact/Metadata choice).
             candidate.releaseDetailBridge = nil
-            // No source cover URL exists for Unknown; leave the local
+            // No source cover exists for Unknown; leave the local
             // artwork picker as the only cover affordance.
-            candidate.selectedCoverUrl = nil
+            candidate.selectedCover = nil
         }
 
         let task = Task { @MainActor in
@@ -280,7 +280,7 @@ enum ImportSearchFlow {
                     // Manual prefetch: the user just picked a different
                     // release, so any prior pick was for a now-stale cover
                     // set — replace it with the new release's default.
-                    candidate.selectedCoverUrl = bridgeDetail.defaultCoverUrl
+                    candidate.selectedCover = bridgeDetail.defaultCover
                     // Editor seed comes pre-shaped from bae-core (the
                     // Exact-vs-Approximate/Unknown pressing-field
                     // masking and per-track artist-override logic live
@@ -530,12 +530,12 @@ enum ImportSearchFlow {
         trackCountMismatch: Bool,
         expectedTrackCount: UInt32,
         libraryStatus: LibraryStatus?,
-        remoteCoverArts: [CoverArt],
+        remoteCoverArts: [BridgeRemoteCover],
         hasCoverOptions: Bool,
         storageManaged: Binding<Bool>,
         storagePinned: Binding<Bool>,
         importDisabled: Bool,
-        localArtwork: [FileInfo],
+        localArtwork: [ArtworkFile],
         uiStore: UiStore,
         onConfirmImport: @escaping () -> Void,
         onViewInLibrary: @escaping (String) -> Void,
@@ -543,7 +543,7 @@ enum ImportSearchFlow {
         @ViewBuilder actionExtra: @escaping () -> some View,
     ) -> some View {
         let candidate = importStore.candidate(forKey: key)
-        let selectedUrl = candidate?.selectedCoverUrl
+        let selectedCover = candidate?.selectedCover
         let importing = candidate.map(isImporting) ?? false
 
         if let candidate {
@@ -595,10 +595,10 @@ enum ImportSearchFlow {
                         CoverPickerView(
                             remoteCoverArts: remoteCoverArts,
                             localArtwork: localArtwork,
-                            selectedUrl: selectedUrl,
-                            onSelect: { url in
+                            selectedCover: selectedCover,
+                            onSelect: { selection in
                                 importStore.mutateCandidate(forKey: key) {
-                                    $0.selectedCoverUrl = url
+                                    $0.selectedCover = selection
                                 }
                                 uiStore.dismissModal()
                             },

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -369,6 +369,15 @@ struct FfiRemoteCover {
     source: String,
 }
 
+fn remote_cover_to_ffi(cover: &bae_core::import::cover_art::RemoteCover) -> FfiRemoteCover {
+    FfiRemoteCover {
+        url: cover.url.clone(),
+        thumbnail_url: cover.thumbnail_url.clone(),
+        label: cover.label.clone(),
+        source: cover.source.as_str().to_string(),
+    }
+}
+
 /// A local image file in an import candidate's folder, offered as a cover
 /// choice in the import confirmation picker. `file_id` is the folder-relative
 /// path the import worker matches when this cover is selected (passed back as a
@@ -426,12 +435,7 @@ pub unsafe extern "C" fn bae_fetch_remote_covers(
     };
     let covers: Vec<FfiRemoteCover> = covers
         .into_iter()
-        .map(|cover| FfiRemoteCover {
-            url: cover.url,
-            thumbnail_url: cover.thumbnail_url,
-            label: cover.label,
-            source: cover.source.as_str().to_string(),
-        })
+        .map(|cover| remote_cover_to_ffi(&cover))
         .collect();
     json_cstring(&covers)
 }
@@ -2989,12 +2993,11 @@ pub unsafe extern "C" fn bae_search_releases(
                 .import()
                 .search_discogs(artist, album, None, None),
         ),
-        bae_core::import::MetadataSource::MusicBrainz => {
-            app.runtime
-                .block_on(bae_core::import::search::search_musicbrainz(
-                    artist, album, None, None,
-                ))
-        }
+        bae_core::import::MetadataSource::MusicBrainz => app.runtime.block_on(
+            app.services
+                .import()
+                .search_musicbrainz(artist, album, None, None),
+        ),
     };
     let results = match results {
         Ok(results) => results,
@@ -3236,18 +3239,8 @@ pub unsafe extern "C" fn bae_prefetch_candidate_edit(
         }
     };
 
-    let remote_covers: Vec<FfiRemoteCover> = detail
-        .cover_art
-        .iter()
-        .map(|cover| FfiRemoteCover {
-            url: cover.url.clone(),
-            // The prefetched detail carries one URL per cover; the picker scales
-            // it for the grid, so the full image doubles as its own thumbnail.
-            thumbnail_url: cover.url.clone(),
-            label: cover.source.display_name().to_string(),
-            source: cover.source.as_str().to_string(),
-        })
-        .collect();
+    let remote_covers: Vec<FfiRemoteCover> =
+        detail.cover_art.iter().map(remote_cover_to_ffi).collect();
 
     // Image files in the candidate's folder. The commit worker re-walks the
     // folder, so this scan is purely to populate the picker; a failure here just
@@ -3552,5 +3545,22 @@ mod tests {
             assert_eq!(json["track_id"], "trk-1");
             assert_eq!(json["album_id"], "alb-1");
         }
+    }
+
+    #[test]
+    fn remote_cover_ffi_preserves_thumbnail_url() {
+        let cover = bae_core::import::cover_art::RemoteCover {
+            url: "https://cover.example/full.jpg".to_string(),
+            thumbnail_url: "https://cover.example/thumb.jpg".to_string(),
+            label: "Cover Source".to_string(),
+            source: bae_core::import::MetadataSource::MusicBrainz,
+        };
+
+        let ffi = remote_cover_to_ffi(&cover);
+
+        assert_eq!(ffi.url, "https://cover.example/full.jpg");
+        assert_eq!(ffi.thumbnail_url, "https://cover.example/thumb.jpg");
+        assert_eq!(ffi.label, "Cover Source");
+        assert_eq!(ffi.source, "musicbrainz");
     }
 }

--- a/notes/02-data-model.md
+++ b/notes/02-data-model.md
@@ -175,7 +175,7 @@ library_images
 File location is deterministic from the id: `images/{prefix}/{subprefix}/{id}` (same hash-based layout as `storage/`). No extension on disk -- content type is in the DB. No `source_path` needed -- the path is derived.
 
 `source_url` values:
-- MusicBrainz: Cover Art Archive URL (e.g., `"https://coverartarchive.org/release/{mbid}/front-1200"`)
+- MusicBrainz: selected Cover Art Archive image URL
 - Discogs: image URL (e.g., `"https://i.discogs.com/..."`)
 - Local (selected from release files): `"release://{relative_path}"` (e.g., `"release://Artwork/front.jpg"`)
 


### PR DESCRIPTION
Cover Art Archive lookup had three paths: search HEAD thumbnail checks, prefetch fixed `/front-500` URLs, and edit JSON lookup. This PR makes the JSON lookup return the selected full image plus thumbnail and source label, then uses that shape for search thumbnails, prefetch cover choices, and edit candidates. `source_url` docs now describe the selected CAA image URL instead of a fixed endpoint.

Search thumbnails now use CAA JSON GETs instead of HEAD redirects. That is intentional: the search grid shows the same CAA-selected image/thumbnail pair that prefetch and edit use, so it no longer has a separate answer for cover existence. To reduce repeated CAA work, lookups now share one HTTP client, reuse in-flight release/release-group requests, cap CAA JSON concurrency at 4, and keep a session LRU cache for selected covers plus confirmed misses. Transient CAA failures are not cached.

The remaining optimization is a separate search UI/API change: return MusicBrainz rows before cover lookup finishes, then fill thumbnails for visible/top rows as CAA results arrive.

Closes #25.

Test plan:
- `cargo fmt --check`
- `git diff --check FETCH_HEAD...HEAD`
- `env CARGO_BUILD_RUSTC_WRAPPER= cargo check -p bae-core -p bae-bridge -p bae-windows-ffi`
- `env CARGO_BUILD_RUSTC_WRAPPER= cargo test -p bae-core --features test-utils --lib import::search::tests`
- `env CARGO_BUILD_RUSTC_WRAPPER= cargo test -p bae-core --features test-utils --lib import::cover_art::tests`
- `env CARGO_BUILD_RUSTC_WRAPPER= cargo test -p bae-core --features test-utils --lib discogs::models::tests`
- `xcodebuild -project bae.xcodeproj -scheme bae -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -derivedDataPath .build/derivedData build`
- Commit hook: cargo fmt, clippy for `bae-core`, clippy for `bae-bridge`
