### PR TITLE
Import previews: collapse ImportSearchPane display props into ImportSearchState

### DIFF
--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -1110,4 +1110,192 @@ enum PreviewData {
             ]
         )
     )
+
+    /// Exact-match display state: disc-id found one group, catalog confirms it.
+    static let searchStateFoundExact = ImportSearchState(
+        identifyState: .found(
+            group: searchGroupExact,
+            libraryStatuses: [:],
+            trackCount: 0,
+            source: .discid,
+            provenance: searchProvenanceExact,
+        ),
+        showManualSearch: false,
+        error: nil,
+        searchGroups: [],
+        selectedReleaseId: nil,
+        isSearching: false,
+        hasSearched: false,
+        isImporting: false,
+        libraryStatuses: [:],
+        discogsEnabled: true,
+        signals: settledSignals,
+        signalsToolbar: SignalsToolbar(signals: [
+            ToolbarSignal(
+                kind: .discId,
+                role: .identity,
+                value: "disc-hash",
+                origin: .discToc,
+                state: .found(count: 3),
+                excluded: false
+            ),
+            ToolbarSignal(
+                kind: .catalog,
+                role: .filter,
+                value: "WPCR-80001",
+                origin: .folderName,
+                state: .confirms(count: 1),
+                excluded: false
+            ),
+        ]),
+    )
+
+    /// Manual-search display state: results listed, the form open.
+    static let searchStateManual = ImportSearchState(
+        identifyState: .found(
+            group: searchGroupsManual[0],
+            libraryStatuses: [:],
+            trackCount: 0,
+            source: .discid,
+            provenance: [:],
+        ),
+        showManualSearch: true,
+        error: nil,
+        searchGroups: searchGroupsManual,
+        selectedReleaseId: nil,
+        isSearching: false,
+        hasSearched: true,
+        isImporting: false,
+        libraryStatuses: [:],
+        discogsEnabled: true,
+        signals: settledSignals,
+        signalsToolbar: SignalsToolbar(signals: [
+            ToolbarSignal(
+                kind: .discId,
+                role: .identity,
+                value: "disc-hash",
+                origin: .discToc,
+                state: .found(count: 2),
+                excluded: false
+            ),
+            ToolbarSignal(
+                kind: .catalog,
+                role: .filter,
+                value: "WPCR-80001",
+                origin: .folderName,
+                state: .confirms(count: 0),
+                excluded: false
+            ),
+        ]),
+    )
+
+    /// Conflict display state: disc-id and barcode disagree on identity.
+    static let searchStateConflict = ImportSearchState(
+        identifyState: .conflict(
+            discidResults: conflictDiscidResults,
+            discidLibraryStatuses: [:],
+            barcodeResults: conflictBarcodeResults,
+            barcodeLibraryStatuses: [:],
+            discidSourceLabel: "MusicBrainz",
+            matchedBarcode: "5051961234567",
+            trackCount: 11,
+        ),
+        showManualSearch: false,
+        error: nil,
+        searchGroups: [],
+        selectedReleaseId: nil,
+        isSearching: false,
+        hasSearched: false,
+        isImporting: false,
+        libraryStatuses: [:],
+        discogsEnabled: true,
+        signals: nil,
+        signalsToolbar: SignalsToolbar(signals: [
+            ToolbarSignal(
+                kind: .discId,
+                role: .identity,
+                value: "disc-hash",
+                origin: .discToc,
+                state: .found(count: 2),
+                excluded: false
+            ),
+            ToolbarSignal(
+                kind: .barcode,
+                role: .identity,
+                value: "5051961234567",
+                origin: .artwork,
+                state: .found(count: 3),
+                excluded: false
+            ),
+        ]),
+    )
+
+    /// Auto-lookup in progress: disc-id looking up, barcode skipped.
+    static let searchStateTriangulating = ImportSearchState(
+        identifyState: .triangulating(
+            discid: .lookingUp,
+            barcode: .skipped,
+        ),
+        showManualSearch: false,
+        error: nil,
+        searchGroups: [],
+        selectedReleaseId: nil,
+        isSearching: false,
+        hasSearched: false,
+        isImporting: false,
+        libraryStatuses: [:],
+        discogsEnabled: false,
+        signals: nil,
+        signalsToolbar: SignalsToolbar(signals: [
+            ToolbarSignal(
+                kind: .discId,
+                role: .identity,
+                value: "disc-hash",
+                origin: .discToc,
+                state: .lookingUp,
+                excluded: false
+            ),
+            ToolbarSignal(
+                kind: .barcode,
+                role: .identity,
+                value: nil,
+                origin: .artwork,
+                state: .skipped,
+                excluded: false
+            ),
+        ]),
+    )
+
+    /// Manual search after both signals came up empty.
+    static let searchStateNotFound = ImportSearchState(
+        identifyState: .notFoundAnywhere,
+        showManualSearch: true,
+        error: nil,
+        searchGroups: [],
+        selectedReleaseId: nil,
+        isSearching: false,
+        hasSearched: false,
+        isImporting: false,
+        libraryStatuses: [:],
+        discogsEnabled: true,
+        signals: nil,
+        signalsToolbar: SignalsToolbar(signals: [
+            ToolbarSignal(
+                kind: .discId,
+                role: .identity,
+                value: "disc-hash",
+                origin: .discToc,
+                state: .noMatch,
+                excluded: false
+            ),
+            ToolbarSignal(
+                kind: .barcode,
+                role: .identity,
+                value: "5051961234567",
+                origin: .artwork,
+                state: .noMatch,
+                excluded: false
+            ),
+        ]),
+    )
 }

--- a/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
@@ -43,29 +43,7 @@ struct ImportMainPane<RightPane: View>: View {
     ) {
         ImportResultPane(open: false, onClose: {}) {
             ImportSearchPane.preview(
-                identifyState: .triangulating(
-                    discid: .lookingUp,
-                    barcode: .skipped,
-                ),
-                discogsEnabled: false,
-                signalsToolbar: SignalsToolbar(signals: [
-                    ToolbarSignal(
-                        kind: .discId,
-                        role: .identity,
-                        value: "disc-hash",
-                        origin: .discToc,
-                        state: .lookingUp,
-                        excluded: false
-                    ),
-                    ToolbarSignal(
-                        kind: .barcode,
-                        role: .identity,
-                        value: nil,
-                        origin: .artwork,
-                        state: .skipped,
-                        excluded: false
-                    ),
-                ])
+                state: PreviewData.searchStateTriangulating
             )
         } pane: {
             EmptyView()
@@ -86,28 +64,7 @@ struct ImportMainPane<RightPane: View>: View {
         previewState: .idle,
     ) {
         ImportResultPane(open: false, onClose: {}) {
-            ImportSearchPane.preview(
-                identifyState: .notFoundAnywhere,
-                showManualSearch: true,
-                signalsToolbar: SignalsToolbar(signals: [
-                    ToolbarSignal(
-                        kind: .discId,
-                        role: .identity,
-                        value: "disc-hash",
-                        origin: .discToc,
-                        state: .noMatch,
-                        excluded: false
-                    ),
-                    ToolbarSignal(
-                        kind: .barcode,
-                        role: .identity,
-                        value: "5051961234567",
-                        origin: .artwork,
-                        state: .noMatch,
-                        excluded: false
-                    ),
-                ])
-            )
+            ImportSearchPane.preview(state: PreviewData.searchStateNotFound)
         } pane: {
             EmptyView()
         }

--- a/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
@@ -67,16 +67,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     @State
     var storagePinned = true
     ImportResultPane(open: true, onClose: {}) {
-        ImportSearchPane.preview(
-            identifyState: .found(
-                group: PreviewData.searchGroupExact,
-                libraryStatuses: [:],
-                trackCount: 0,
-                source: .discid,
-                provenance: PreviewData.searchProvenanceExact,
-            ),
-            signals: PreviewData.settledSignals
-        )
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
     } pane: {
         ImportConfirmationView(
             values: $values,

--- a/bae-macos/bae/bae/Views/Import/ImportSearchFlow.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchFlow.swift
@@ -375,15 +375,20 @@ enum ImportSearchFlow {
             }
 
         ImportSearchPane(
-            identifyState: candidate.identifyState,
-            showManualSearch: candidate.search.showManualSearch,
-            error: candidate.error,
-            searchGroups: tabResults.groups,
-            selectedReleaseId: selectedReleaseId,
-            isSearching: tabResults.isSearching,
-            hasSearched: tabResults.hasSearched,
-            isImporting: isImporting(candidate),
-            libraryStatuses: candidate.libraryStatuses,
+            state: ImportSearchState(
+                identifyState: candidate.identifyState,
+                showManualSearch: candidate.search.showManualSearch,
+                error: candidate.error,
+                searchGroups: tabResults.groups,
+                selectedReleaseId: selectedReleaseId,
+                isSearching: tabResults.isSearching,
+                hasSearched: tabResults.hasSearched,
+                isImporting: isImporting(candidate),
+                libraryStatuses: candidate.libraryStatuses,
+                discogsEnabled: configStore.config.discogsUsable,
+                signals: candidate.signals,
+                signalsToolbar: candidate.signalsToolbar,
+            ),
             activeTab: makeActiveTabBinding(
                 importStore: importStore,
                 key: key,
@@ -418,9 +423,6 @@ enum ImportSearchFlow {
                 candidate: candidate,
                 field: \.searchBarcode
             ),
-            discogsEnabled: configStore.config.discogsUsable,
-            signals: candidate.signals,
-            signalsToolbar: candidate.signalsToolbar,
             onSearch: {
                 dispatchSearch(
                     importer: importer,

--- a/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
@@ -137,20 +137,30 @@ struct ImportSearchFormView: View {
     }
 }
 
-// MARK: - ImportSearchPane
+// MARK: - ImportSearchState
 
-struct ImportSearchPane: View {
-    /// Current identify-pipeline state from core.
+/// Everything `ImportSearchPane` renders from — the identify/results state and
+/// the surrounding flags. The editable form fields (search bindings) and the
+/// actions stay separate; this is the read-only display state.
+struct ImportSearchState {
     let identifyState: IdentifyState
     let showManualSearch: Bool
     let error: String?
     let searchGroups: [ReleaseGroup]
-    /// Release id of the pressing whose confirm pane is open, for row selection.
     let selectedReleaseId: String?
     let isSearching: Bool
     let hasSearched: Bool
     let isImporting: Bool
     let libraryStatuses: [String: LibraryStatus]
+    let discogsEnabled: Bool
+    let signals: Signals?
+    let signalsToolbar: SignalsToolbar
+}
+
+// MARK: - ImportSearchPane
+
+struct ImportSearchPane: View {
+    let state: ImportSearchState
     @Binding
     var activeTab: SearchTab
     @Binding
@@ -163,11 +173,6 @@ struct ImportSearchPane: View {
     var searchCatalog: String
     @Binding
     var searchBarcode: String
-    let discogsEnabled: Bool
-    let signals: Signals?
-    /// The interactive signals toolbar — the pre-shaped badge list. Empty
-    /// until the first identify transition; the toolbar is hidden until then.
-    let signalsToolbar: SignalsToolbar
     let onSearch: () -> Void
     let onOpenSettings: () -> Void
     let onSearchManually: () -> Void
@@ -197,7 +202,7 @@ struct ImportSearchPane: View {
     {
         guard
             case .found(let group, let statuses, _, _, let provenance) =
-                identifyState
+                state.identifyState
         else {
             return nil
         }
@@ -208,7 +213,7 @@ struct ImportSearchPane: View {
     /// "Identifying…" placeholder (the per-signal progress lives in the
     /// toolbar's spinning badges now).
     private var isTriangulating: Bool {
-        if case .triangulating = identifyState {
+        if case .triangulating = state.identifyState {
             return true
         }
         return false
@@ -218,13 +223,13 @@ struct ImportSearchPane: View {
     /// transition. Hidden until then (empty badge list) and in idle.
     @ViewBuilder
     private var toolbar: some View {
-        if !signalsToolbar.signals.isEmpty {
+        if !state.signalsToolbar.signals.isEmpty {
             SignalsToolbarView(
-                toolbar: signalsToolbar,
+                toolbar: state.signalsToolbar,
                 onToggle: onToggleSignal,
                 onRerun: onRerun,
                 onSearchManually: onSearchManually,
-                onAddAsUnknown: showManualSearch ? nil : onAddAsUnknown,
+                onAddAsUnknown: state.showManualSearch ? nil : onAddAsUnknown,
             )
         }
     }
@@ -243,7 +248,7 @@ struct ImportSearchPane: View {
             let discidSourceLabel,
             let matchedBarcode,
             _
-        ) = identifyState, !showManualSearch {
+        ) = state.identifyState, !state.showManualSearch {
             conflictView(
                 discidResults: discidResults,
                 discidLibraryStatuses: discidLibraryStatuses,
@@ -261,14 +266,14 @@ struct ImportSearchPane: View {
     @ViewBuilder
     private var normalBody: some View {
         let found = foundResult
-        let showingAutoMatches = found != nil && !showManualSearch
+        let showingAutoMatches = found != nil && !state.showManualSearch
 
         VStack(spacing: 0) {
             toolbar
 
             identifyBanner
 
-            if let error {
+            if let error = state.error {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle.fill")
                     Text(error)
@@ -282,14 +287,14 @@ struct ImportSearchPane: View {
             if showingAutoMatches, let found {
                 ReleaseGroupListView(
                     groups: [found.group],
-                    isImporting: isImporting,
+                    isImporting: state.isImporting,
                     libraryStatuses: found.statuses,
                     provenance: found.provenance,
-                    selectedReleaseId: selectedReleaseId,
+                    selectedReleaseId: state.selectedReleaseId,
                     onSelect: onSelect,
                 )
             }
-            else if isTriangulating, !showManualSearch {
+            else if isTriangulating, !state.showManualSearch {
                 // The toolbar's spinning badges carry the per-signal progress;
                 // the body just notes the pipeline is still working.
                 ContentUnavailableView(
@@ -307,18 +312,18 @@ struct ImportSearchPane: View {
                     searchAlbum: $searchAlbum,
                     searchCatalog: $searchCatalog,
                     searchBarcode: $searchBarcode,
-                    discogsEnabled: discogsEnabled,
-                    signals: signals,
+                    discogsEnabled: state.discogsEnabled,
+                    signals: state.signals,
                     onSearch: onSearch,
                     onOpenSettings: onOpenSettings,
                 )
                 Divider()
 
-                if isSearching {
+                if state.isSearching {
                     ProgressView("Searching...")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                else if !hasSearched {
+                else if !state.hasSearched {
                     ContentUnavailableView(
                         "No results",
                         systemImage: "magnifyingglass",
@@ -328,7 +333,7 @@ struct ImportSearchPane: View {
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                else if searchGroups.isEmpty {
+                else if state.searchGroups.isEmpty {
                     ContentUnavailableView(
                         "No matches found",
                         systemImage: "magnifyingglass",
@@ -340,10 +345,10 @@ struct ImportSearchPane: View {
                 }
                 else {
                     ReleaseGroupListView(
-                        groups: searchGroups,
-                        isImporting: isImporting,
-                        libraryStatuses: libraryStatuses,
-                        selectedReleaseId: selectedReleaseId,
+                        groups: state.searchGroups,
+                        isImporting: state.isImporting,
+                        libraryStatuses: state.libraryStatuses,
+                        selectedReleaseId: state.selectedReleaseId,
                         onSelect: onSelect,
                     )
                 }
@@ -354,13 +359,13 @@ struct ImportSearchPane: View {
 
     @ViewBuilder
     private var identifyBanner: some View {
-        let showingAutoMatches = foundResult != nil && !showManualSearch
+        let showingAutoMatches = foundResult != nil && !state.showManualSearch
 
         // The toolbar above owns the global escapes (Search manually / Skip
         // identifying / Re-run), so the banner carries only the status copy
         // and banner-specific navigation (the source link, "View automatic
         // matches"). Error has no toolbar, so it keeps its own escape.
-        switch identifyState {
+        switch state.identifyState {
         case .triangulating:
             // The toolbar's spinning badges and the body placeholder cover
             // triangulation; the banner stays out of the way.
@@ -471,7 +476,7 @@ struct ImportSearchPane: View {
 
             conflictBannerLarge
 
-            if let error {
+            if let error = state.error {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle.fill")
                     Text(error)
@@ -576,7 +581,7 @@ struct ImportSearchPane: View {
                 }
                 .buttonStyle(.link)
                 .font(.caption)
-                .disabled(isImporting)
+                .disabled(state.isImporting)
             }
             .padding(.top, 8)
             .padding(.bottom, 6)
@@ -587,9 +592,9 @@ struct ImportSearchPane: View {
                 ForEach(results, id: \.releaseId) { result in
                     ImportSearchResultRow(
                         result: result,
-                        isImporting: isImporting,
+                        isImporting: state.isImporting,
                         libraryStatus: libraryStatuses[result.releaseId],
-                        isSelected: result.releaseId == selectedReleaseId,
+                        isSelected: result.releaseId == state.selectedReleaseId,
                         onSelect: { onSelect(result) },
                     )
                     Rectangle().fill(.white.opacity(0.05)).frame(height: 1)
@@ -848,35 +853,18 @@ struct DiscogsKeyPopover: View {
         /// Preview builder — fixes the form bindings and action callbacks to inert
         /// defaults so a preview states only the result situation it exercises.
         static func preview(
-            identifyState: IdentifyState,
-            showManualSearch: Bool = false,
-            searchGroups: [ReleaseGroup] = [],
-            hasSearched: Bool = false,
-            discogsEnabled: Bool = true,
-            signals: Signals? = nil,
-            signalsToolbar: SignalsToolbar = SignalsToolbar(signals: []),
+            state: ImportSearchState,
             searchArtist: String = "",
             searchAlbum: String = "",
         ) -> ImportSearchPane {
             ImportSearchPane(
-                identifyState: identifyState,
-                showManualSearch: showManualSearch,
-                error: nil,
-                searchGroups: searchGroups,
-                selectedReleaseId: nil,
-                isSearching: false,
-                hasSearched: hasSearched,
-                isImporting: false,
-                libraryStatuses: [:],
+                state: state,
                 activeTab: .constant(.general),
                 activeSource: .constant(.musicBrainz),
                 searchArtist: .constant(searchArtist),
                 searchAlbum: .constant(searchAlbum),
                 searchCatalog: .constant(""),
                 searchBarcode: .constant(""),
-                discogsEnabled: discogsEnabled,
-                signals: signals,
-                signalsToolbar: signalsToolbar,
                 onSearch: {},
                 onOpenSettings: {},
                 onSearchManually: {},
@@ -891,72 +879,17 @@ struct DiscogsKeyPopover: View {
 #endif
 
 #Preview("Main Pane - Exact Matches") {
-    ImportSearchPane.preview(
-        identifyState: .found(
-            group: PreviewData.searchGroupExact,
-            libraryStatuses: [:],
-            trackCount: 0,
-            source: .discid,
-            provenance: PreviewData.searchProvenanceExact,
-        ),
-        signals: PreviewData.settledSignals,
-        signalsToolbar: SignalsToolbar(signals: [
-            ToolbarSignal(
-                kind: .discId,
-                role: .identity,
-                value: "disc-hash",
-                origin: .discToc,
-                state: .found(count: 3),
-                excluded: false
-            ),
-            ToolbarSignal(
-                kind: .catalog,
-                role: .filter,
-                value: "WPCR-80001",
-                origin: .folderName,
-                state: .confirms(count: 1),
-                excluded: false
-            ),
-        ]),
-    )
-    .frame(width: 700, height: 600)
-    .background(Theme.background)
-    .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
+    ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+        .frame(width: 700, height: 600)
+        .background(Theme.background)
+        .preferredColorScheme(.dark)
+        .environment(MediaPaths.stub)
+        .environment(UiStore())
 }
 
 #Preview("Main Pane - Manual Search") {
     ImportSearchPane.preview(
-        identifyState: .found(
-            group: PreviewData.searchGroupsManual[0],
-            libraryStatuses: [:],
-            trackCount: 0,
-            source: .discid,
-            provenance: [:],
-        ),
-        showManualSearch: true,
-        searchGroups: PreviewData.searchGroupsManual,
-        hasSearched: true,
-        signals: PreviewData.settledSignals,
-        signalsToolbar: SignalsToolbar(signals: [
-            ToolbarSignal(
-                kind: .discId,
-                role: .identity,
-                value: "disc-hash",
-                origin: .discToc,
-                state: .found(count: 2),
-                excluded: false
-            ),
-            ToolbarSignal(
-                kind: .catalog,
-                role: .filter,
-                value: "WPCR-80001",
-                origin: .folderName,
-                state: .confirms(count: 0),
-                excluded: false
-            ),
-        ]),
+        state: PreviewData.searchStateManual,
         searchArtist: "Artist Name",
         searchAlbum: "Album Title One",
     )
@@ -968,40 +901,12 @@ struct DiscogsKeyPopover: View {
 }
 
 #Preview("Main Pane - Conflict") {
-    ImportSearchPane.preview(
-        identifyState: .conflict(
-            discidResults: PreviewData.conflictDiscidResults,
-            discidLibraryStatuses: [:],
-            barcodeResults: PreviewData.conflictBarcodeResults,
-            barcodeLibraryStatuses: [:],
-            discidSourceLabel: "MusicBrainz",
-            matchedBarcode: "5051961234567",
-            trackCount: 11,
-        ),
-        signalsToolbar: SignalsToolbar(signals: [
-            ToolbarSignal(
-                kind: .discId,
-                role: .identity,
-                value: "disc-hash",
-                origin: .discToc,
-                state: .found(count: 2),
-                excluded: false
-            ),
-            ToolbarSignal(
-                kind: .barcode,
-                role: .identity,
-                value: "5051961234567",
-                origin: .artwork,
-                state: .found(count: 3),
-                excluded: false
-            ),
-        ]),
-    )
-    .environment(UiStore())
-    .environment(MediaPaths.stub)
-    .frame(width: 700, height: 600)
-    .background(Theme.background)
-    .preferredColorScheme(.dark)
+    ImportSearchPane.preview(state: PreviewData.searchStateConflict)
+        .environment(UiStore())
+        .environment(MediaPaths.stub)
+        .frame(width: 700, height: 600)
+        .background(Theme.background)
+        .preferredColorScheme(.dark)
 }
 
 #Preview("Source Picker - Discogs Disabled") {


### PR DESCRIPTION
`ImportSearchPane` took 12 read-only display props — `identifyState`, `searchGroups`, `isSearching`, `hasSearched`, `libraryStatuses`, `signals`, `signalsToolbar`, and so on — passed as loose arguments alongside the editable form bindings and the action callbacks. Those 12 are one cohesive concept: what the search pane renders from.

This bundles them into an `ImportSearchState` value. The form bindings (search fields, tabs) and the callbacks stay separate — they're interaction, not display state. The sole production caller, `ImportSearchFlow.buildSearchPane`, builds the state from the same `candidate`/`configStore` expressions and passes it; the `#if DEBUG` preview builder takes a state; and the preview scenarios become named `ImportSearchState` fixtures in `PreviewData` (`searchStateFoundExact`, `searchStateManual`, `searchStateConflict`, `searchStateTriangulating`, `searchStateNotFound`). A preview now varies one value instead of a dozen — the groundwork for the permutation gallery to come.

## Test plan
- [ ] macOS build passes (CI).
- [ ] Folder-import search behaves identically (the only production caller, buildSearchPane, was the only non-preview construction site).
- [ ] All search previews render the same scenarios as before.