### PR TITLE
Import previews: permutation gallery + shared preview infra

### DIFF
--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -963,6 +963,68 @@ enum PreviewData {
         bridge: releaseDetailBridge
     )
 
+    /// Editor seed for the confirming previews — the raw release edit produced
+    /// from the exact-pressing choice over `releaseDetailBridge`.
+    static let confirmEditValues: BridgeRawReleaseEdit =
+        rawReleaseEditFromUserEdit(
+            edit: shapeUserEditFromReleaseDetail(
+                detail: releaseDetailBridge,
+                choice: .exact(
+                    releaseId: releaseDetailBridge.releaseId,
+                    source: releaseDetailBridge.source,
+                )
+            ),
+            trackIdPrefix: "import-track"
+        )
+
+    /// Per-track audio candidate (nine FLAC files) plus one cover image and two
+    /// documents — the track-files counterpart to `candidateFiles` (CUE+FLAC).
+    static let candidateFilesTracks = CandidateFiles(
+        bridge: BridgeCandidateFiles(
+            audio: .trackFiles(
+                files: (1...9)
+                    .map { i in
+                        BridgeFileInfo(
+                            name: "Track \(i).flac",
+                            size: UInt64(35_000_000 + i * 2_000_000),
+                            sizeLabel: "\(33 + i * 2) MB",
+                            dirPrefix: nil,
+                            fileName: "Track \(i).flac",
+                            localPath: "/tmp/fake/Track \(i).flac",
+                        )
+                    }
+            ),
+            artwork: [
+                BridgeFileInfo(
+                    name: "Front.png",
+                    size: 2_500_000,
+                    sizeLabel: "2 MB",
+                    dirPrefix: nil,
+                    fileName: "Front.png",
+                    localPath: "/tmp/fake/Front.png"
+                )
+            ],
+            documents: [
+                BridgeFileInfo(
+                    name: "info.log",
+                    size: 6000,
+                    sizeLabel: "6 KB",
+                    dirPrefix: nil,
+                    fileName: "info.log",
+                    localPath: "/tmp/fake/info.log"
+                ),
+                BridgeFileInfo(
+                    name: "notes.txt",
+                    size: 1200,
+                    sizeLabel: "1 KB",
+                    dirPrefix: nil,
+                    fileName: "notes.txt",
+                    localPath: "/tmp/fake/notes.txt"
+                ),
+            ],
+        )
+    )
+
     // MARK: - Import search
 
     /// Two pressings of one release group — the exact-match results state.

--- a/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
@@ -378,51 +378,7 @@ extension View {
 
 #Preview("File Pane - Track Files") {
     ImportFilePane(
-        files: CandidateFiles(
-            bridge: BridgeCandidateFiles(
-                audio: .trackFiles(
-                    files: (1...9)
-                        .map { i in
-                            BridgeFileInfo(
-                                name: "Track \(i).flac",
-                                size: UInt64(35_000_000 + i * 2_000_000),
-                                sizeLabel: "\(33 + i * 2) MB",
-                                dirPrefix: nil,
-                                fileName: "Track \(i).flac",
-                                localPath: "/tmp/fake/Track \(i).flac",
-                            )
-                        }
-                ),
-                artwork: [
-                    BridgeFileInfo(
-                        name: "Front.png",
-                        size: 2_500_000,
-                        sizeLabel: "2 MB",
-                        dirPrefix: nil,
-                        fileName: "Front.png",
-                        localPath: "/tmp/fake/Front.png"
-                    )
-                ],
-                documents: [
-                    BridgeFileInfo(
-                        name: "info.log",
-                        size: 6000,
-                        sizeLabel: "6 KB",
-                        dirPrefix: nil,
-                        fileName: "info.log",
-                        localPath: "/tmp/fake/info.log"
-                    ),
-                    BridgeFileInfo(
-                        name: "notes.txt",
-                        size: 1200,
-                        sizeLabel: "1 KB",
-                        dirPrefix: nil,
-                        fileName: "notes.txt",
-                        localPath: "/tmp/fake/notes.txt"
-                    ),
-                ],
-            )
-        ),
+        files: PreviewData.candidateFilesTracks,
         onOpenGallery: { _ in },
         onOpenDocument: { _, _ in },
         onPreviewAudio: { _ in },

--- a/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
@@ -50,8 +50,7 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
+    .importPreviewEnvironment()
 }
 
 #Preview("Manual search — no results") {
@@ -70,6 +69,56 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
+    .importPreviewEnvironment()
+}
+
+#Preview("Main pane — tracks, manual search") {
+    ImportMainPane(
+        files: PreviewData.candidateFilesTracks,
+        onOpenGallery: { _ in },
+        onOpenDocument: { _, _ in },
+        onPreviewAudio: { _ in },
+        onError: { _ in },
+        previewState: .idle,
+    ) {
+        ImportResultPane(open: false, onClose: {}) {
+            ImportSearchPane.preview(state: PreviewData.searchStateNotFound)
+        } pane: {
+            EmptyView()
+        }
+    }
+    .frame(width: 900, height: 600)
+    .importPreviewEnvironment()
+}
+
+#Preview("Main pane — confirming (tracks)") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportMainPane(
+        files: PreviewData.candidateFilesTracks,
+        onOpenGallery: { _ in },
+        onOpenDocument: { _, _ in },
+        onPreviewAudio: { _ in },
+        onError: { _ in },
+        previewState: .idle,
+    ) {
+        ImportResultPane(open: true, onClose: {}) {
+            ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+        } pane: {
+            ImportConfirmationPreview.make(
+                values: $values,
+                storageManaged: $storageManaged,
+                storagePinned: $storagePinned
+            )
+        }
+    }
+    .frame(width: 900, height: 600)
+    .importPreviewEnvironment()
 }

--- a/bae-macos/bae/bae/Views/Import/ImportPreviewSupport.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportPreviewSupport.swift
@@ -1,0 +1,82 @@
+#if DEBUG
+    import SwiftUI
+
+    /// Stores the import previews read, injected as one modifier so a preview
+    /// only states its data. Covers both the search pane (MediaPaths, UiStore)
+    /// and the confirmation pane (OutboxStore, ConfigStore).
+    extension View {
+        func importPreviewEnvironment() -> some View {
+            self
+                .environment(MediaPaths.stub)
+                .environment(UiStore())
+                .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+                .environment(
+                    ConfigStore(
+                        config: Config(
+                            bridge: BridgeConfig(
+                                libraryId: "lib-preview",
+                                libraryName: "Preview Library",
+                                libraryPath: "/preview",
+                                encryptionKeyStored: false,
+                                encryptionKeyFingerprint: nil,
+                                discogsTokenStatus: .notConfigured,
+                                discogsUsable: false,
+                                sync: nil
+                            )
+                        ),
+                        syncReady: false
+                    )
+                )
+        }
+    }
+
+    /// Preview builder for ImportConfirmationView — fixes the cover placeholder,
+    /// the EmptyView action extra, and the action callbacks, exposing only the
+    /// display knobs a permutation varies. (ImportConfirmationView is generic
+    /// over its cover/action content, so this returns `some View`.)
+    enum ImportConfirmationPreview {
+        static func make(
+            values: Binding<BridgeRawReleaseEdit>,
+            storageManaged: Binding<Bool>,
+            storagePinned: Binding<Bool>,
+            trackCountMismatch: Bool = false,
+            expectedTrackCount: UInt32 = 9,
+            libraryStatus: LibraryStatus? = nil,
+            importStatus: ImportStatus? = nil,
+            error: String? = nil,
+            hasCoverOptions: Bool = false,
+            importing: Bool = false,
+            metadataOnly: Bool = false,
+        ) -> some View {
+            ImportConfirmationView(
+                values: values,
+                storageManaged: storageManaged,
+                storagePinned: storagePinned,
+                importDisabled: false,
+                trackCountMismatch: trackCountMismatch,
+                expectedTrackCount: expectedTrackCount,
+                libraryStatus: libraryStatus,
+                importStatus: importStatus,
+                error: error,
+                hasCoverOptions: hasCoverOptions,
+                importing: importing,
+                exactness: ImportExactnessChoice(
+                    isMetadataOnly: metadataOnly,
+                    onSelect: { _ in }
+                ),
+                onConfirmImport: {},
+                onViewInLibrary: { _ in },
+                onEditCover: {},
+                coverContent: {
+                    ZStack {
+                        Theme.placeholder
+                        Image(systemName: "photo").foregroundStyle(.tertiary)
+                    }
+                    .frame(width: 80, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                },
+                actionExtra: EmptyView.init
+            )
+        }
+    }
+#endif

--- a/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
@@ -50,16 +50,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
 #Preview("Confirming — results + docked detail") {
     @Previewable
     @State
-    var values = rawReleaseEditFromUserEdit(
-        edit: shapeUserEditFromReleaseDetail(
-            detail: PreviewData.releaseDetailBridge,
-            choice: .exact(
-                releaseId: PreviewData.releaseDetailBridge.releaseId,
-                source: PreviewData.releaseDetailBridge.source,
-            )
-        ),
-        trackIdPrefix: "import-track"
-    )
+    var values = PreviewData.confirmEditValues
     @Previewable
     @State
     var storageManaged = true
@@ -69,58 +60,209 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     ImportResultPane(open: true, onClose: {}) {
         ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
     } pane: {
-        ImportConfirmationView(
+        ImportConfirmationPreview.make(
             values: $values,
             storageManaged: $storageManaged,
-            storagePinned: $storagePinned,
-            importDisabled: false,
-            trackCountMismatch: PreviewData.releaseDetail.trackCountMismatch,
-            expectedTrackCount: PreviewData.releaseDetail.trackCount,
-            libraryStatus: nil,
-            importStatus: nil,
-            error: nil,
-            hasCoverOptions: false,
-            importing: false,
-            exactness: ImportExactnessChoice(
-                isMetadataOnly: false,
-                onSelect: { _ in }
-            ),
-            onConfirmImport: {},
-            onViewInLibrary: { _ in },
-            onEditCover: {},
-            coverContent: {
-                ZStack {
-                    Theme.placeholder
-                    Image(systemName: "photo")
-                        .foregroundStyle(.tertiary)
-                }
-                .frame(width: 80, height: 80)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-            },
-            actionExtra: EmptyView.init,
+            storagePinned: $storagePinned
         )
     }
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(
-        ConfigStore(
-            config: Config(
-                bridge: BridgeConfig(
-                    libraryId: "lib-preview",
-                    libraryName: "Preview Library",
-                    libraryPath: "/preview",
-                    encryptionKeyStored: false,
-                    encryptionKeyFingerprint: nil,
-                    discogsTokenStatus: .notConfigured,
-                    discogsUsable: false,
-                    sync: nil
-                )
-            ),
-            syncReady: false
+    .importPreviewEnvironment()
+}
+
+#Preview("Confirming — track-count warning") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ImportConfirmationPreview.make(
+            values: $values,
+            storageManaged: $storageManaged,
+            storagePinned: $storagePinned,
+            trackCountMismatch: true,
+            expectedTrackCount: 11
         )
-    )
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Confirming — metadata only") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ImportConfirmationPreview.make(
+            values: $values,
+            storageManaged: $storageManaged,
+            storagePinned: $storagePinned,
+            metadataOnly: true
+        )
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Confirming — importing") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ImportConfirmationPreview.make(
+            values: $values,
+            storageManaged: $storageManaged,
+            storagePinned: $storagePinned,
+            importStatus: .importing(
+                progressPercent: 45,
+                phase: nil,
+                statusText: "Storing files..."
+            ),
+            importing: true
+        )
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Confirming — commit error") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ImportConfirmationPreview.make(
+            values: $values,
+            storageManaged: $storageManaged,
+            storagePinned: $storagePinned,
+            error: "Couldn't start import: invalid metadata."
+        )
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Loading detail") {
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ProgressView("Loading release details...")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Conflict — dock closed") {
+    ImportResultPane(open: false, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateConflict)
+    } pane: {
+        EmptyView()
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Confirming — already in library") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ImportConfirmationPreview.make(
+            values: $values,
+            storageManaged: $storageManaged,
+            storagePinned: $storagePinned,
+            libraryStatus: LibraryStatus(
+                bridge: BridgeLibraryStatus(
+                    releaseId: "rel-123",
+                    releaseInLibrary: true,
+                    albumInLibrary: true,
+                    albumTitle: "Album Title",
+                    albumId: "album-preview"
+                )
+            )
+        )
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
+}
+
+#Preview("Confirming — cover options") {
+    @Previewable
+    @State
+    var values = PreviewData.confirmEditValues
+    @Previewable
+    @State
+    var storageManaged = true
+    @Previewable
+    @State
+    var storagePinned = true
+    ImportResultPane(open: true, onClose: {}) {
+        ImportSearchPane.preview(state: PreviewData.searchStateFoundExact)
+    } pane: {
+        ImportConfirmationPreview.make(
+            values: $values,
+            storageManaged: $storageManaged,
+            storagePinned: $storagePinned,
+            hasCoverOptions: true
+        )
+    }
+    .frame(width: 700, height: 600)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+    .importPreviewEnvironment()
 }

--- a/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
@@ -147,6 +147,8 @@ struct ImportSearchState {
     let showManualSearch: Bool
     let error: String?
     let searchGroups: [ReleaseGroup]
+    /// Release id of the pressing whose confirm pane is open, so its row renders
+    /// selected.
     let selectedReleaseId: String?
     let isSearching: Bool
     let hasSearched: Bool
@@ -154,6 +156,8 @@ struct ImportSearchState {
     let libraryStatuses: [String: LibraryStatus]
     let discogsEnabled: Bool
     let signals: Signals?
+    /// The interactive signals toolbar — the pre-shaped badge list. Empty until
+    /// the first identify transition; the toolbar is hidden until then.
     let signalsToolbar: SignalsToolbar
 }
 
@@ -883,8 +887,7 @@ struct DiscogsKeyPopover: View {
         .frame(width: 700, height: 600)
         .background(Theme.background)
         .preferredColorScheme(.dark)
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
+        .importPreviewEnvironment()
 }
 
 #Preview("Main Pane - Manual Search") {
@@ -896,17 +899,15 @@ struct DiscogsKeyPopover: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
+    .importPreviewEnvironment()
 }
 
 #Preview("Main Pane - Conflict") {
     ImportSearchPane.preview(state: PreviewData.searchStateConflict)
-        .environment(UiStore())
-        .environment(MediaPaths.stub)
         .frame(width: 700, height: 600)
         .background(Theme.background)
         .preferredColorScheme(.dark)
+        .importPreviewEnvironment()
 }
 
 #Preview("Source Picker - Discogs Disabled") {


### PR DESCRIPTION
The payoff of the preceding refactors: a curated gallery of import-screen previews so these screens can be iterated quickly. With the search state now a single value (`ImportSearchState`) and the docked layout a component (`ImportResultPane`), each permutation is a few lines that state only what differs.

It covers the axes that actually vary in the import flow: the confirming pane across track-count-warning, metadata-only, importing, and commit-error states; a loading-detail state; conflict and manual-search; and cue-vs-track-files variants of the whole main pane.

Two shared pieces land here. `importPreviewEnvironment()` injects, in one modifier, the four stores the import previews read (MediaPaths, UiStore, OutboxStore, ConfigStore) — which also removes the hand-built inline `ConfigStore` the earlier confirming preview carried. `ImportConfirmationPreview.make(...)` is a builder over the generic `ImportConfirmationView` that fixes the inert chrome (cover placeholder, empty action extra, no-op callbacks) and exposes only the display knobs. The track-files and confirm-edit-values fixtures move into `PreviewData`, and the `ImportSearchState` field docs dropped in the prior change are restored.

## Test plan
- [ ] macOS build passes (CI).
- [ ] No missing-environment findings (CI audit) — every preview routes through `importPreviewEnvironment()`.
- [ ] Each new preview renders its intended state in the Xcode canvas.