### PR TITLE
Import previews: whole-view preview + inline preview env for the audit

### DIFF
--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -790,6 +790,43 @@ enum PreviewData {
 
     // MARK: - Import
 
+    static let importWatchedFolder = BridgeWatchedFolder(
+        path: "/Music/Downloads",
+        name: "Downloads"
+    )
+
+    /// Shared preview ConfigStore. ConfigStore is a non-Sendable `@Observable`,
+    /// so it needs `@MainActor` isolation to hold as a static.
+    @MainActor
+    static let configStore = ConfigStore(
+        config: Config(
+            bridge: BridgeConfig(
+                libraryId: "lib-preview",
+                libraryName: "Preview Library",
+                libraryPath: "/preview",
+                encryptionKeyStored: false,
+                encryptionKeyFingerprint: nil,
+                discogsTokenStatus: .notConfigured,
+                discogsUsable: false,
+                sync: nil
+            )
+        ),
+        syncReady: false
+    )
+
+    /// Seeded ImportStore for the FolderImportTab whole-view preview — the
+    /// watched folder plus every folder candidate. ImportStore is a non-Sendable
+    /// `@Observable`, so it needs `@MainActor` isolation to hold as a static.
+    @MainActor
+    static let folderImportStore: ImportStore = {
+        let s = ImportStore()
+        s.watchedFolders = [importWatchedFolder]
+        for candidate in folderCandidates {
+            s.folderCandidates[candidate.key] = candidate
+        }
+        return s
+    }()
+
     static let folderCandidates: [Candidate] = [
         BridgeFolderCandidate(
             folderPath: "/Music/Downloads/Album Title One",

--- a/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
+++ b/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
@@ -33,6 +33,14 @@ struct FolderImportTab: View {
     @Environment(UiStore.self)
     private var uiStore
 
+    /// Seeds the initially-selected candidate so a preview can render the
+    /// populated view. Production constructs `FolderImportTab()`, leaving the
+    /// list unselected.
+    init(initialSelection: String? = nil) {
+        _selectedKey = State(initialValue: initialSelection)
+        _documentContent = State(initialValue: nil)
+    }
+
     private var selectedCandidate: Candidate? {
         guard let key = selectedKey else {
             return nil
@@ -501,3 +509,25 @@ struct FolderImportTab: View {
         }
     }
 }
+
+#if DEBUG
+    #Preview("Folder import — whole view") {
+        FolderImportTab(
+            initialSelection: PreviewData.folderCandidates.first?.key
+        )
+        .frame(width: 1100, height: 700)
+        .environment(MediaPaths.stub)
+        .environment(UiStore())
+        .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+        .environment(PreviewData.configStore)
+        .environment(Library.stub)
+        .environment(PreviewAudio.stub)
+        .environment(PreviewData.folderImportStore)
+        .environment(
+            // FolderImportTab's .task re-hydrates watchedFolders from the
+            // Importer, so it must return the seeded folder or the view falls
+            // back to its empty state.
+            Importer(watchedFolders: { [PreviewData.importWatchedFolder] })
+        )
+    }
+#endif

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationPreview.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationPreview.swift
@@ -1,35 +1,6 @@
 #if DEBUG
     import SwiftUI
 
-    /// Stores the import previews read, injected as one modifier so a preview
-    /// only states its data. Covers both the search pane (MediaPaths, UiStore)
-    /// and the confirmation pane (OutboxStore, ConfigStore).
-    extension View {
-        func importPreviewEnvironment() -> some View {
-            self
-                .environment(MediaPaths.stub)
-                .environment(UiStore())
-                .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-                .environment(
-                    ConfigStore(
-                        config: Config(
-                            bridge: BridgeConfig(
-                                libraryId: "lib-preview",
-                                libraryName: "Preview Library",
-                                libraryPath: "/preview",
-                                encryptionKeyStored: false,
-                                encryptionKeyFingerprint: nil,
-                                discogsTokenStatus: .notConfigured,
-                                discogsUsable: false,
-                                sync: nil
-                            )
-                        ),
-                        syncReady: false
-                    )
-                )
-        }
-    }
-
     /// Preview builder for ImportConfirmationView — fixes the cover placeholder,
     /// the EmptyView action extra, and the action callbacks, exposing only the
     /// display knobs a permutation varies. (ImportConfirmationView is generic

--- a/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
@@ -50,7 +50,10 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Manual search — no results") {
@@ -69,7 +72,10 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Main pane — tracks, manual search") {
@@ -88,7 +94,10 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Main pane — confirming (tracks)") {
@@ -120,5 +129,8 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }

--- a/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
@@ -69,7 +69,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Confirming — track-count warning") {
@@ -96,7 +99,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Confirming — metadata only") {
@@ -122,7 +128,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Confirming — importing") {
@@ -153,7 +162,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Confirming — commit error") {
@@ -179,7 +191,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Loading detail") {
@@ -192,7 +207,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Conflict — dock closed") {
@@ -204,7 +222,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Confirming — already in library") {
@@ -238,7 +259,10 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Confirming — cover options") {
@@ -264,5 +288,8 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }

--- a/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
@@ -887,7 +887,10 @@ struct DiscogsKeyPopover: View {
         .frame(width: 700, height: 600)
         .background(Theme.background)
         .preferredColorScheme(.dark)
-        .importPreviewEnvironment()
+        .environment(MediaPaths.stub)
+        .environment(UiStore())
+        .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+        .environment(PreviewData.configStore)
 }
 
 #Preview("Main Pane - Manual Search") {
@@ -899,7 +902,10 @@ struct DiscogsKeyPopover: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .importPreviewEnvironment()
+    .environment(MediaPaths.stub)
+    .environment(UiStore())
+    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+    .environment(PreviewData.configStore)
 }
 
 #Preview("Main Pane - Conflict") {
@@ -907,7 +913,10 @@ struct DiscogsKeyPopover: View {
         .frame(width: 700, height: 600)
         .background(Theme.background)
         .preferredColorScheme(.dark)
-        .importPreviewEnvironment()
+        .environment(MediaPaths.stub)
+        .environment(UiStore())
+        .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+        .environment(PreviewData.configStore)
 }
 
 #Preview("Source Picker - Discogs Disabled") {


### PR DESCRIPTION
Two things, both about making the import previews complete and verifiable.

**Whole-view preview.** Adds a preview of the entire folder-import view — the release-candidate list, the file pane, and the results pane together. `FolderImportTab` is store-wired and its `.task` re-hydrates the watched-folder list from the `Importer`, so the preview seeds an `ImportStore` (sample candidates) and supplies an `Importer` whose `watchedFolders()` returns the seed; without that the `.task` would wipe it and the view would fall to its empty state. A new `FolderImportTab(initialSelection:)` initializer lets the preview start with a candidate selected so the populated main pane renders beside the list — production constructs `FolderImportTab()` with the default `nil`.

**Inline preview env for the audit.** The `importPreviewEnvironment()` modifier introduced in the previous change bundled four `.environment(...)` calls, but the environment audit run in CI only resolves literal `.environment(arg)` calls written directly in a preview — it can't see inside a custom view modifier, so every preview using it read as missing-env (nine findings; the modifier also hid any genuine gap). This replaces the modifier with inline `.environment()` calls in audit-resolvable form (a `.stub` static, plain constructors, and a shared `PreviewData.configStore`), and seeds the whole-view preview's `ImportStore` through a `PreviewData` `static let` rather than an unresolvable closure. The audit is back to zero. The support file, now holding only `ImportConfirmationPreview`, is renamed to match.

## Test plan
- [ ] macOS build passes (CI).
- [ ] CI environment audit reports zero findings (this restores green after the prior change reddened it).
- [ ] The whole-view preview renders the candidate list + file pane + search/results pane in the Xcode canvas.