### PR TITLE
Import previews: restore importPreviewEnvironment(); audit v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Missing-environment check (swiftui-environment-audit)
       if: ${{ !cancelled() && steps.build_macos.conclusion == 'success' }}
       env:
-        AUDIT_VERSION: v0.3.0
+        AUDIT_VERSION: v0.4.0
       run: |
         set -euo pipefail
         archive="swiftui-environment-audit-${AUDIT_VERSION}-macos-arm64.tar.gz"

--- a/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
+++ b/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
@@ -516,10 +516,7 @@ struct FolderImportTab: View {
             initialSelection: PreviewData.folderCandidates.first?.key
         )
         .frame(width: 1100, height: 700)
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-        .environment(PreviewData.configStore)
+        .importPreviewEnvironment()
         .environment(Library.stub)
         .environment(PreviewAudio.stub)
         .environment(PreviewData.folderImportStore)

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationPreview.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationPreview.swift
@@ -50,4 +50,17 @@
             )
         }
     }
+
+    /// The stores every import preview reads, injected as one modifier:
+    /// MediaPaths + UiStore for the search/file panes, OutboxStore + ConfigStore
+    /// for the confirmation.
+    extension View {
+        func importPreviewEnvironment() -> some View {
+            self
+                .environment(MediaPaths.stub)
+                .environment(UiStore())
+                .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+                .environment(PreviewData.configStore)
+        }
+    }
 #endif

--- a/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportMainPane.swift
@@ -50,10 +50,7 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Manual search — no results") {
@@ -72,10 +69,7 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Main pane — tracks, manual search") {
@@ -94,10 +88,7 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Main pane — confirming (tracks)") {
@@ -129,8 +120,5 @@ struct ImportMainPane<RightPane: View>: View {
         }
     }
     .frame(width: 900, height: 600)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }

--- a/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
@@ -69,10 +69,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Confirming — track-count warning") {
@@ -99,10 +96,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Confirming — metadata only") {
@@ -128,10 +122,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Confirming — importing") {
@@ -162,10 +153,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Confirming — commit error") {
@@ -191,10 +179,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Loading detail") {
@@ -207,10 +192,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Conflict — dock closed") {
@@ -222,10 +204,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Confirming — already in library") {
@@ -259,10 +238,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Confirming — cover options") {
@@ -288,8 +264,5 @@ struct ImportResultPane<Top: View, Pane: View>: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }

--- a/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
@@ -887,10 +887,7 @@ struct DiscogsKeyPopover: View {
         .frame(width: 700, height: 600)
         .background(Theme.background)
         .preferredColorScheme(.dark)
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-        .environment(PreviewData.configStore)
+        .importPreviewEnvironment()
 }
 
 #Preview("Main Pane - Manual Search") {
@@ -902,10 +899,7 @@ struct DiscogsKeyPopover: View {
     .frame(width: 700, height: 600)
     .background(Theme.background)
     .preferredColorScheme(.dark)
-    .environment(MediaPaths.stub)
-    .environment(UiStore())
-    .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-    .environment(PreviewData.configStore)
+    .importPreviewEnvironment()
 }
 
 #Preview("Main Pane - Conflict") {
@@ -913,10 +907,7 @@ struct DiscogsKeyPopover: View {
         .frame(width: 700, height: 600)
         .background(Theme.background)
         .preferredColorScheme(.dark)
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
-        .environment(PreviewData.configStore)
+        .importPreviewEnvironment()
 }
 
 #Preview("Source Picker - Discogs Disabled") {


### PR DESCRIPTION
A few changes back, the import previews each carried four inline `.environment(...)` calls because the environment audit (v0.3.0) couldn't resolve env provided through a custom view modifier — so the DRY `importPreviewEnvironment()` modifier was removed to keep the audit able to verify them.

`swiftui-environment-audit` v0.4.0 fixes that at the source: its resolver now follows custom env-bundle `View` modifiers into their bodies, and along the way also resolves function/factory return types, type-annotated locals, `.environmentObject(...)` provisions, and generic-wrapped view instantiations (all with fixture coverage in the tool). So the modifier comes back: import previews call `.importPreviewEnvironment()` again, the four inline calls collapse to one, and the CI audit still verifies every preview's environment.

Verified locally with the v0.4.0 binary against this branch: zero findings, with the resolver reporting the modifier's provisions (`PreviewData.configStore → ConfigStore`, etc.) — i.e. it genuinely sees through the modifier rather than skipping the previews.

The whole-view `FolderImportTab` preview keeps its folder-specific stores (`Library`, `PreviewAudio`, `Importer`, `ImportStore`) inline alongside the modifier. `AUDIT_VERSION` in CI bumped to v0.4.0.

## Test plan
- [ ] CI environment audit (now v0.4.0) reports zero findings with the modifier in place.
- [ ] macOS build passes.