### PR TITLE
Album previews: render the real AlbumDetailView instead of a fork

### DIFF
--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -1252,156 +1252,119 @@ private class ExportFormatDelegate: NSObject {
     }
 }
 
-// MARK: - Preview helpers
-
-@MainActor
-private func previewExpansion(
-    albumId: String,
-    currentTrackId: String? = nil,
-    loadingTrackId: String? = nil,
-    isPlaying: Bool = false,
-) -> some View {
-    let store = LibraryStore()
-    store.handleAlbumAdded(album: PreviewData.albumDetails[albumId]!)
-    let summary = store.albumSummaries[albumId]!
-    let primary = store.releaseDetails[summary.primaryReleaseId]!
-    guard
-        let cursor = Cursor(
-            items: summary.releaseIds.map { ReleaseRef(id: $0) },
-            preferring: summary.primaryReleaseId,
-        )
-    else {
-        fatalError("preview album has empty releaseIds")
-    }
-    return AlbumExpansionContent(
-        summary: summary,
-        selectedRelease: primary,
-        coverPath: nil,
-        lightboxItems: [],
-        releaseCursor: .constant(cursor),
-        currentTrackId: currentTrackId,
-        loadingTrackId: loadingTrackId,
-        isPlaying: isPlaying,
-        onClose: {},
-        onPlay: {},
-        onShuffle: {},
-        onPlayFromTrack: { _ in },
-        onTogglePlayPause: {},
-        onAddNext: { _ in },
-        onAddToQueue: { _ in },
-        onAddNextAlbum: {},
-        onAddAlbumToQueue: {},
-        onChangeCover: {},
-        onEditMetadata: {},
-        onReIdentify: {},
-        onManage: {},
-        onSetPrimaryRelease: {},
-        onDeleteRelease: {},
-        onExportTrack: { _ in },
-    )
-    .padding()
-    .frame(width: 1100)
-    .background(Theme.background)
-    .environment(UiStore())
-    .environment(store)
-}
-
-// MARK: - Previews
-
-#Preview("Single Disc") {
-    previewExpansion(albumId: "a-01", currentTrackId: "t-d1-2", isPlaying: true)
-}
-
-#Preview("Single Disc — Track Loading") {
-    previewExpansion(
-        albumId: "a-01",
-        currentTrackId: "t-d1-2",
-        loadingTrackId: "t-d1-3",
-        isPlaying: true
-    )
-}
-
-#Preview("Vinyl — Two Sides") {
-    previewExpansion(albumId: "a-21", currentTrackId: "t-d2-3", isPlaying: true)
-}
-
-#Preview("CD — Two Discs") {
-    previewExpansion(albumId: "a-22")
-}
-
-struct MultiReleasePreview: View {
-    @State
-    private var selectedReleaseId: String = "rel-a-04-0"
-    @State
-    private var store = LibraryStore()
-
-    var body: some View {
-        let _ = seedIfNeeded()
-        let summary = store.albumSummaries["a-04"]!
-        let selected = store.releaseDetails[selectedReleaseId]!
-        AlbumExpansionContent(
-            summary: summary,
-            selectedRelease: selected,
-            coverPath: nil,
-            lightboxItems: [],
-            releaseCursor: Binding(
-                get: {
-                    guard
-                        let cursor = Cursor(
-                            items: summary.releaseIds.map {
-                                ReleaseRef(id: $0)
-                            },
-                            preferring: selectedReleaseId,
-                        )
-                    else {
-                        fatalError("preview album has empty releaseIds")
-                    }
-                    return cursor
-                },
-                set: { selectedReleaseId = $0.current.id },
-            ),
-            currentTrackId: "t-d2-3",
-            loadingTrackId: nil,
-            isPlaying: true,
-            onClose: {},
-            onPlay: {},
-            onShuffle: {},
-            onPlayFromTrack: { _ in },
-            onTogglePlayPause: {},
-            onAddNext: { _ in },
-            onAddToQueue: { _ in },
-            onAddNextAlbum: {},
-            onAddAlbumToQueue: {},
-            onChangeCover: {},
-            onEditMetadata: {},
-            onReIdentify: {},
-            onManage: {},
-            onSetPrimaryRelease: {},
-            onDeleteRelease: {},
-            onExportTrack: { _ in },
-        )
-        .padding()
-        .frame(width: 1100, height: 700, alignment: .top)
-        .background(Theme.background)
-        .environment(UiStore())
-        .environment(store)
-        .environment(MediaPaths.stub)
-    }
+#if DEBUG
+    // MARK: - Previews
 
     @MainActor
-    private func seedIfNeeded() {
-        if store.albumSummaries["a-04"] == nil {
-            store.handleAlbumAdded(album: PreviewData.albumDetails["a-04"]!)
+    private func previewExpansion(
+        albumId: String,
+        currentTrackId: String? = nil,
+        loadingTrackId: String? = nil,
+        isPlaying: Bool = false,
+    ) -> some View {
+        let store = LibraryStore()
+        store.handleAlbumAdded(album: PreviewData.albumDetails[albumId]!)
+        let summary = store.albumSummaries[albumId]!
+        let primary = store.releaseDetails[summary.primaryReleaseId]!
+        let cursor = PreviewData.releaseCursor(
+            releaseIds: summary.releaseIds,
+            preferring: summary.primaryReleaseId
+        )
+        return
+            PreviewData.albumExpansionContent(
+                summary: summary,
+                selectedRelease: primary,
+                releaseCursor: .constant(cursor),
+                currentTrackId: currentTrackId,
+                loadingTrackId: loadingTrackId,
+                isPlaying: isPlaying,
+            )
+            .padding()
+            .frame(width: 1100)
+            .background(Theme.background)
+            .environment(UiStore())
+            .environment(store)
+    }
+
+    #Preview("Single Disc") {
+        previewExpansion(
+            albumId: "a-01",
+            currentTrackId: "t-d1-2",
+            isPlaying: true
+        )
+    }
+
+    #Preview("Single Disc — Track Loading") {
+        previewExpansion(
+            albumId: "a-01",
+            currentTrackId: "t-d1-2",
+            loadingTrackId: "t-d1-3",
+            isPlaying: true
+        )
+    }
+
+    #Preview("Vinyl — Two Sides") {
+        previewExpansion(
+            albumId: "a-21",
+            currentTrackId: "t-d2-3",
+            isPlaying: true
+        )
+    }
+
+    #Preview("CD — Two Discs") {
+        previewExpansion(albumId: "a-22")
+    }
+
+    struct MultiReleasePreview: View {
+        @State
+        private var selectedReleaseId: String = "rel-a-04-0"
+        @State
+        private var store = LibraryStore()
+
+        var body: some View {
+            let _ = seedIfNeeded()
+            let summary = store.albumSummaries["a-04"]!
+            let selected = store.releaseDetails[selectedReleaseId]!
+            PreviewData.albumExpansionContent(
+                summary: summary,
+                selectedRelease: selected,
+                // Live cursor so selecting a release in the picker cycles the
+                // preview to that release's detail.
+                releaseCursor: Binding(
+                    get: {
+                        PreviewData.releaseCursor(
+                            releaseIds: summary.releaseIds,
+                            preferring: selectedReleaseId
+                        )
+                    },
+                    set: { selectedReleaseId = $0.current.id },
+                ),
+                currentTrackId: "t-d2-3",
+                isPlaying: true,
+            )
+            .padding()
+            .frame(width: 1100, height: 700, alignment: .top)
+            .background(Theme.background)
+            .environment(UiStore())
+            .environment(store)
+            .environment(MediaPaths.stub)
+        }
+
+        @MainActor
+        private func seedIfNeeded() {
+            if store.albumSummaries["a-04"] == nil {
+                store.handleAlbumAdded(album: PreviewData.albumDetails["a-04"]!)
+            }
         }
     }
-}
 
-#Preview("Multiple Releases") {
-    MultiReleasePreview()
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(LibraryStore())
-}
+    #Preview("Multiple Releases") {
+        MultiReleasePreview()
+            .environment(MediaPaths.stub)
+            .environment(UiStore())
+            .environment(LibraryStore())
+    }
+#endif
 
 extension View {
     /// Presents an OK-dismissible alert bound to an optional error message,

--- a/bae-macos/bae/bae/Views/AlbumGridView.swift
+++ b/bae-macos/bae/bae/Views/AlbumGridView.swift
@@ -450,171 +450,92 @@ private class MenuItem: NSMenuItem {
     }
 }
 
-// MARK: - Previews
+#if DEBUG
+    // MARK: - Previews
 
-private struct GridPreview: View {
-    let width: CGFloat
-    let height: CGFloat
-    @State
-    private var selectedAlbumId: String? = "a-04"
-    @State
-    private var sortCriteria: [BridgeSortCriterion] = [
-        BridgeSortCriterion(field: .dateAdded, direction: .descending)
-    ]
-    @State
-    private var selectedReleaseId: String = "r-04"
-    @State
-    private var libraryStore = LibraryStore()
+    private struct GridPreview: View {
+        let width: CGFloat
+        let height: CGFloat
+        /// The seeded store the grid interns its list into. Shared with the
+        /// `#Preview` root, which injects the same instance via
+        /// `albumDetailPreviewEnvironment` so the audit resolves the
+        /// `AlbumDetailView` chain's environment from one place.
+        let store: LibraryStore
+        @State
+        private var selectedAlbumId: String? = "a-04"
+        @State
+        private var sortCriteria: [BridgeSortCriterion] = [
+            BridgeSortCriterion(field: .dateAdded, direction: .descending)
+        ]
 
-    var body: some View {
-        let list = AlbumList.preview(
-            albums: PreviewData.albums,
-            sort: sortCriteria,
-            store: libraryStore
-        )
-        AlbumGridView(
-            list: list,
-            selectedAlbumId: $selectedAlbumId,
-            sortCriteria: $sortCriteria,
-            availableFields: BridgeSortField.allCases,
-            onPlay: { _ in },
-            onAddToQueue: { _ in },
-            onAddNext: { _ in },
-            headerTitle: "Library",
-        ) { albumId in
-            if let bridge = PreviewData.albumDetails[albumId] {
-                PreviewAlbumExpansion(
-                    bridge: bridge,
-                    store: libraryStore,
-                    selectedReleaseId: $selectedReleaseId,
-                    onClose: { selectedAlbumId = nil },
-                )
-            }
-        }
-        .frame(width: width, height: height)
-        .environment(UiStore())
-        .environment(libraryStore)
-    }
-}
-
-/// Preview wrapper: seeds the passed-in `LibraryStore` with the preview
-/// bridge payload, then renders `AlbumExpansionContent` against the
-/// store. Previews that instantiate this see the real component with
-/// real slice reads.
-private struct PreviewAlbumExpansion: View {
-    let bridge: BridgeAlbumDetail
-    let store: LibraryStore
-    @Binding
-    var selectedReleaseId: String
-    let onClose: () -> Void
-
-    var body: some View {
-        let _ = seedIfNeeded()
-        if let summary = store.albumSummaries[bridge.album.id],
-            let selected = store.releaseDetails[selectedReleaseId]
-                ?? summary.releaseIds.first.flatMap({ store.releaseDetails[$0] }
-                )
-        {
-            AlbumExpansionContent(
-                summary: summary,
-                selectedRelease: selected,
-                coverPath: nil,
-                lightboxItems: [],
-                releaseCursor: Binding(
-                    get: {
-                        guard
-                            let cursor = Cursor(
-                                items: summary.releaseIds.map {
-                                    ReleaseRef(id: $0)
-                                },
-                                preferring: selectedReleaseId,
-                            )
-                        else {
-                            fatalError("preview album has empty releaseIds")
-                        }
-                        return cursor
-                    },
-                    set: { selectedReleaseId = $0.current.id },
-                ),
-                currentTrackId: nil,
-                loadingTrackId: nil,
-                isPlaying: false,
-                onClose: onClose,
-                onPlay: {},
-                onShuffle: {},
-                onPlayFromTrack: { _ in },
-                onTogglePlayPause: {},
-                onAddNext: { _ in },
+        var body: some View {
+            let list = AlbumList.preview(
+                albums: PreviewData.albumDetailAlbums,
+                sort: sortCriteria,
+                store: store
+            )
+            AlbumGridView(
+                list: list,
+                selectedAlbumId: $selectedAlbumId,
+                sortCriteria: $sortCriteria,
+                availableFields: BridgeSortField.allCases,
+                onPlay: { _ in },
                 onAddToQueue: { _ in },
-                onAddNextAlbum: {},
-                onAddAlbumToQueue: {},
-                onChangeCover: {},
-                onEditMetadata: {},
-                onReIdentify: {},
-                onManage: {},
-                onSetPrimaryRelease: {},
-                onDeleteRelease: {},
-                onExportTrack: { _ in },
+                onAddNext: { _ in },
+                headerTitle: "Library",
+            ) { albumId in
+                AlbumDetailView(albumId: albumId)
+            }
+            .frame(width: width, height: height)
+        }
+    }
+
+    #Preview("Grid \u{2014} Wide") {
+        let store = PreviewData.seededLibraryStore()
+        GridPreview(width: 1100, height: 700, store: store)
+            .albumDetailPreviewEnvironment(store: store)
+    }
+
+    #Preview("Grid \u{2014} Medium") {
+        let store = PreviewData.seededLibraryStore()
+        GridPreview(width: 700, height: 600, store: store)
+            .albumDetailPreviewEnvironment(store: store)
+    }
+
+    #Preview("Grid \u{2014} Narrow") {
+        let store = PreviewData.seededLibraryStore()
+        GridPreview(width: 400, height: 600, store: store)
+            .albumDetailPreviewEnvironment(store: store)
+    }
+
+    #Preview("Album Card") {
+        let album = PreviewData.albums[0]
+        let selected = PreviewData.albums[3]
+        HStack(spacing: 20) {
+            AlbumCardView(
+                title: album.title,
+                artistNames: album.artistNames,
+                year: album.year,
+                coverPath: nil,
+                isSelected: false,
+                size: albumCardSize,
+                onPlay: {},
+                onAddToQueue: {},
+                onAddNext: {},
+            )
+            AlbumCardView(
+                title: selected.title,
+                artistNames: selected.artistNames,
+                year: selected.year,
+                coverPath: nil,
+                isSelected: true,
+                size: albumCardSize,
+                onPlay: {},
+                onAddToQueue: {},
+                onAddNext: {},
             )
         }
-    }
-
-    @MainActor
-    private func seedIfNeeded() {
-        if store.albumSummaries[bridge.album.id] == nil {
-            store.handleAlbumAdded(album: bridge)
-        }
-    }
-}
-
-#Preview("Grid \u{2014} Wide") {
-    GridPreview(width: 1100, height: 700)
+        .padding()
         .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(LibraryStore())
-}
-
-#Preview("Grid \u{2014} Medium") {
-    GridPreview(width: 700, height: 600)
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(LibraryStore())
-}
-
-#Preview("Grid \u{2014} Narrow") {
-    GridPreview(width: 400, height: 600)
-        .environment(MediaPaths.stub)
-        .environment(UiStore())
-        .environment(LibraryStore())
-}
-
-#Preview("Album Card") {
-    let album = PreviewData.albums[0]
-    let selected = PreviewData.albums[3]
-    HStack(spacing: 20) {
-        AlbumCardView(
-            title: album.title,
-            artistNames: album.artistNames,
-            year: album.year,
-            coverPath: nil,
-            isSelected: false,
-            size: albumCardSize,
-            onPlay: {},
-            onAddToQueue: {},
-            onAddNext: {},
-        )
-        AlbumCardView(
-            title: selected.title,
-            artistNames: selected.artistNames,
-            year: selected.year,
-            coverPath: nil,
-            isSelected: true,
-            size: albumCardSize,
-            onPlay: {},
-            onAddToQueue: {},
-            onAddNext: {},
-        )
     }
-    .padding()
-    .environment(MediaPaths.stub)
-}
+#endif

--- a/bae-macos/bae/bae/Views/PreviewData+AlbumDetail.swift
+++ b/bae-macos/bae/bae/Views/PreviewData+AlbumDetail.swift
@@ -1,0 +1,123 @@
+#if DEBUG
+    import SwiftUI
+
+    // Preview support for `AlbumDetailView` and `AlbumExpansionContent`.
+    // Seeds a `LibraryStore` with the album summaries and release details the
+    // detail view reads, injects the services the view tree pulls from the
+    // environment, and factors the `AlbumExpansionContent` no-op-callback
+    // boilerplate shared by its previews into one builder.
+
+    extension PreviewData {
+        /// Albums for the grid list, taken from the detail payloads so the
+        /// grid summaries and the seeded `releaseDetails` agree on release ids.
+        /// (`PreviewData.albums` carries different release ids than
+        /// `albumDetails`, so a grid built from it would look up release
+        /// details that the detail seed never populated.)
+        static let albumDetailAlbums: [BridgeAlbum] =
+            albumDetails.values.map(\.album)
+
+        /// A `LibraryStore` seeded with every preview album's summary and its
+        /// releases' fat details, via the same `handleAlbumAdded` reducer the
+        /// app runs on an `AlbumAdded` event. `AlbumDetailView.body` finds
+        /// `albumSummaries[albumId]` and `releaseDetails[…]` without a live
+        /// load, and its `.task` is a no-op because `loadReleaseDetail`
+        /// short-circuits when the detail is already present.
+        @MainActor
+        static func seededLibraryStore() -> LibraryStore {
+            let store = LibraryStore()
+            for detail in albumDetails.values {
+                store.handleAlbumAdded(album: detail)
+            }
+            return store
+        }
+
+        /// The release cursor over an album's releases, preferring one id.
+        /// Holds the single empty-`releaseIds` guard for the preview builders.
+        @MainActor
+        static func releaseCursor(
+            releaseIds: [String],
+            preferring: String
+        ) -> Cursor<ReleaseRef> {
+            guard
+                let cursor = Cursor(
+                    items: releaseIds.map { ReleaseRef(id: $0) },
+                    preferring: preferring,
+                )
+            else {
+                fatalError("preview album has empty releaseIds")
+            }
+            return cursor
+        }
+
+        /// Builds an `AlbumExpansionContent` against seeded store data with
+        /// no-op callbacks — the shared body of `AlbumExpansionContent`'s
+        /// previews. The cursor is a `Binding` so callers can pass a constant
+        /// cursor or a live `@State`-backed one (for the release picker to
+        /// cycle).
+        @MainActor
+        static func albumExpansionContent(
+            summary: AlbumSummary,
+            selectedRelease: ReleaseDetail,
+            releaseCursor: Binding<Cursor<ReleaseRef>>,
+            currentTrackId: String? = nil,
+            loadingTrackId: String? = nil,
+            isPlaying: Bool = false,
+        ) -> some View {
+            AlbumExpansionContent(
+                summary: summary,
+                selectedRelease: selectedRelease,
+                coverPath: nil,
+                lightboxItems: [],
+                releaseCursor: releaseCursor,
+                currentTrackId: currentTrackId,
+                loadingTrackId: loadingTrackId,
+                isPlaying: isPlaying,
+                onClose: {},
+                onPlay: {},
+                onShuffle: {},
+                onPlayFromTrack: { _ in },
+                onTogglePlayPause: {},
+                onAddNext: { _ in },
+                onAddToQueue: { _ in },
+                onAddNextAlbum: {},
+                onAddAlbumToQueue: {},
+                onChangeCover: {},
+                onEditMetadata: {},
+                onReIdentify: {},
+                onManage: {},
+                onSetPrimaryRelease: {},
+                onDeleteRelease: {},
+                onExportTrack: { _ in },
+            )
+        }
+    }
+
+    extension View {
+        /// Injects every service the `AlbumDetailView` tree reads from the
+        /// environment so its real body — and the modal sheets it can present
+        /// (cover, edit-metadata, re-identify, storage) — render without a
+        /// missing-environment trap. Eight `.stub` domain services plus the
+        /// four the modals reach (`Importer`, `ImportStore`, `OutboxStore`,
+        /// `ConfigStore`), fresh `PlaybackStore`/`UiStore`, and the passed-in
+        /// seeded `LibraryStore`. Nothing about the view is reconstructed.
+        @MainActor
+        func albumDetailPreviewEnvironment(store: LibraryStore) -> some View {
+            self
+                .environment(MediaPaths.stub)
+                .environment(Playback.stub)
+                .environment(Queue.stub)
+                .environment(Library.stub)
+                .environment(ReleaseEditor.stub)
+                .environment(Sync.stub)
+                .environment(Downloads.stub)
+                .environment(Export.stub)
+                .environment(Importer.stub)
+                .environment(store)
+                .environment(PlaybackStore())
+                .environment(UiStore())
+                .environment(ImportStore())
+                .environment(OutboxStore(snapshot: OutboxStore.emptySnapshot))
+                .environment(PreviewData.configStore)
+        }
+    }
+#endif


### PR DESCRIPTION
`AlbumGridView`'s three Grid previews rebuilt `AlbumDetailView.body` by hand (a private `PreviewAlbumExpansion` struct) — they previewed a fork, not what ships. Production (`LibraryView`) fills that slot with the real `AlbumDetailView(albumId:)`; the fork existed only because `AlbumDetailView` reads eleven `@Environment` services and needs a seeded `LibraryStore`.

This renders the real component. A new `#if DEBUG` `AlbumDetailPreview.swift` seeds a `LibraryStore` (album summaries + release details, from `PreviewData.albumDetails`), injects the eleven services through an `albumDetailPreviewEnvironment(store:)` modifier (which the v0.4.0 audit resolves), and provides shared builders for the release cursor and the `AlbumExpansionContent` callbacks — boilerplate that was previously triplicated across `AlbumGridView` and `AlbumDetailView`'s two expansion previews. The grid list is built from the same `albumDetails` so its release ids agree with the seed. The seeded details survive the view's `.task` because `loadReleaseDetail` returns early when a detail is already present. `PreviewAlbumExpansion` is deleted.

## Test plan
- [ ] macOS build passes (CI).
- [ ] CI environment audit reports zero findings.
- [ ] Grid previews render the populated expanded detail (real `AlbumDetailView`), not a spinner.