### PR TITLE
Gallery lightbox: pinch-to-zoom with snap-back + progressive decode on iOS/Android

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
@@ -1,6 +1,11 @@
 package fm.bae.app.ui
 
 import android.util.Log
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateCentroid
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,19 +22,29 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.size.Size
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.bae_bridge.BridgeGalleryItem
 
@@ -40,7 +55,7 @@ private const val TAG = "bae.GalleryDialog"
  * every image file the release has). Swipeable when there's more than one. An
  * item already on disk renders from its [BridgeGalleryItem.localPath]; a
  * cloud-only item (no local path) is fetched on demand via [loadImage], keyed by
- * the item's id.
+ * the item's id. Each page pinch-zooms and snaps back when you release.
  */
 @Composable
 fun GalleryDialog(
@@ -59,7 +74,13 @@ fun GalleryDialog(
                     val item = items[page]
                     val localPath = item.localPath
                     if (localPath != null) {
-                        GalleryImage(model = coverModel(localPath), contentDescription = item.label)
+                        // The full identifier (with any `#v=<mtime>` suffix) is the
+                        // cache key; [coverFile] strips it to the on-disk path.
+                        ZoomableGalleryImage(
+                            data = coverFile(localPath),
+                            cacheKey = localPath,
+                            contentDescription = item.label,
+                        )
                     } else {
                         RemoteGalleryImage(
                             fileId = item.id,
@@ -99,22 +120,112 @@ fun GalleryDialog(
     }
 }
 
-/** A gallery image filling the page: cover-from-path or fetched cloud bytes. */
+/**
+ * A pinch-zoomable gallery image. Coil downsamples to the page size for the
+ * initial draw (so a huge — e.g. 35 MB — JPEG never decodes at full resolution
+ * just to fill the screen); once the user pinches in, it requests the original
+ * resolution so the zoomed-in detail is sharp, crossfading up from the
+ * downsampled image. The pinch scales the image around the gesture centroid and
+ * releases back to fit, mirroring the macOS lightbox.
+ *
+ * [data] is the Coil model — a [java.io.File] for an on-disk image or a
+ * [ByteArray] for fetched cloud bytes. [cacheKey] keys the downsampled image in
+ * the memory/disk cache (the bridge identifier for a local file, the file id for
+ * fetched bytes); the full-resolution request reuses it as its placeholder so
+ * the upgrade doesn't flash.
+ */
 @Composable
-private fun GalleryImage(model: Any?, contentDescription: String?) {
+private fun ZoomableGalleryImage(
+    data: Any,
+    cacheKey: String,
+    contentDescription: String?,
+) {
+    val context = LocalPlatformContext.current
+    var scale by remember(cacheKey) { mutableFloatStateOf(1f) }
+    var origin by remember(cacheKey) { mutableStateOf(TransformOrigin.Center) }
+    var fullRes by remember(cacheKey) { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    val model =
+        remember(data, cacheKey, fullRes) {
+            ImageRequest.Builder(context)
+                .data(data)
+                .crossfade(true)
+                .apply {
+                    if (fullRes) {
+                        // Decode at the source's full resolution and reuse the
+                        // already-cached downsampled image as the placeholder, so
+                        // the zoomed view sharpens in place instead of blanking.
+                        size(Size.ORIGINAL)
+                        memoryCacheKey("$cacheKey#orig")
+                        diskCacheKey(cacheKey)
+                        placeholderMemoryCacheKey(cacheKey)
+                    } else {
+                        // Default size resolves to the page bounds: Coil
+                        // downsamples the source to fit, the cheap initial decode.
+                        memoryCacheKey(cacheKey)
+                        diskCacheKey(cacheKey)
+                    }
+                }
+                .build()
+        }
+
     AsyncImage(
         model = model,
         contentDescription = contentDescription,
         contentScale = ContentScale.Fit,
-        modifier = Modifier.fillMaxSize(),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(cacheKey) {
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false)
+                        var originSet = false
+                        do {
+                            val event = awaitPointerEvent()
+                            val zoom = event.calculateZoom()
+                            if (zoom != 1f) {
+                                if (!originSet && size.width > 0 && size.height > 0) {
+                                    val centroid = event.calculateCentroid()
+                                    origin =
+                                        TransformOrigin(
+                                            centroid.x / size.width,
+                                            centroid.y / size.height,
+                                        )
+                                    originSet = true
+                                }
+                                scale = (scale * zoom).coerceAtLeast(1f)
+                                if (scale > 1.01f && !fullRes) {
+                                    fullRes = true
+                                }
+                                // Consume so the pager doesn't treat a pinch as a
+                                // page swipe; single-finger drags (zoom == 1) fall
+                                // through to the pager.
+                                event.changes.forEach { it.consume() }
+                            }
+                        } while (event.changes.any { it.pressed })
+                        // All pointers up: snap back to fit.
+                        if (scale != 1f) {
+                            scope.launch {
+                                animate(scale, 1f) { value, _ -> scale = value }
+                            }
+                        }
+                    }
+                }
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    transformOrigin = origin
+                },
     )
 }
 
 /**
  * A gallery image whose file isn't on disk here: fetch its bytes (downloaded
- * from the release's cloud home and decrypted by core) and render them, showing
- * a spinner while loading and the failure reason if the fetch fails. `result`
- * is null while loading, then success(bytes) or failure(error).
+ * from the release's cloud home and decrypted by core), then hand them to
+ * [ZoomableGalleryImage] to decode and display. Shows a spinner while fetching
+ * and the failure reason if the fetch fails. `result` is null while loading,
+ * then success(bytes) or failure(error).
  */
 @Composable
 private fun RemoteGalleryImage(
@@ -139,7 +250,12 @@ private fun RemoteGalleryImage(
         val r = result
         when {
             r == null -> CircularProgressIndicator(color = Color.White)
-            r.isSuccess -> GalleryImage(model = r.getOrThrow(), contentDescription = label)
+            r.isSuccess ->
+                ZoomableGalleryImage(
+                    data = r.getOrThrow(),
+                    cacheKey = fileId,
+                    contentDescription = label,
+                )
             // The underlying failure is already logged above; the viewer shows a
             // fixed, user-facing message rather than a raw exception string.
             else ->

--- a/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
@@ -42,6 +42,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Size
+import java.io.File
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -152,19 +153,23 @@ private fun ZoomableGalleryImage(
                 .data(data)
                 .crossfade(true)
                 .apply {
+                    // A local on-disk file can be disk-cached by its identifier;
+                    // in-memory bytes (a fetched cloud image) aren't disk-cacheable,
+                    // so the disk key only applies to the File source.
+                    if (data is File) {
+                        diskCacheKey(cacheKey)
+                    }
                     if (fullRes) {
                         // Decode at the source's full resolution and reuse the
                         // already-cached downsampled image as the placeholder, so
                         // the zoomed view sharpens in place instead of blanking.
                         size(Size.ORIGINAL)
                         memoryCacheKey("$cacheKey#orig")
-                        diskCacheKey(cacheKey)
                         placeholderMemoryCacheKey(cacheKey)
                     } else {
                         // Default size resolves to the page bounds: Coil
                         // downsamples the source to fit, the cheap initial decode.
                         memoryCacheKey(cacheKey)
-                        diskCacheKey(cacheKey)
                     }
                 }
                 .build()

--- a/bae-ios/bae/bae/Views/GalleryView.swift
+++ b/bae-ios/bae/bae/Views/GalleryView.swift
@@ -7,7 +7,7 @@ private let logger = Logger.bae("GalleryView")
 /// every image file the release has). Swipeable when there's more than one. An
 /// item already on disk renders from its `localPath`; a cloud-only item (no
 /// local path) has its bytes fetched on demand via `loadImage`, keyed by the
-/// item's id.
+/// item's id. Each page pinch-zooms and snaps back on release.
 struct GalleryView: View {
     let items: [BridgeGalleryItem]
     /// Fetches a cloud-only gallery item's bytes by its id, for items whose
@@ -56,14 +56,16 @@ struct GalleryView: View {
 
 /// One page of the gallery: a single view per `ForEach` element (so the paging
 /// container's element type stays stable) that renders an on-disk item from its
-/// path and fetches a cloud-only one on demand.
+/// path and fetches a cloud-only one on demand. Both kinds land in
+/// `ZoomableGalleryImage`, which handles the screen-fit-then-full-res decode and
+/// the pinch-to-zoom.
 private struct GalleryPage: View {
     let item: BridgeGalleryItem
     let loadImage: @Sendable (_ fileId: String) async throws -> Data
 
     var body: some View {
         if let path = item.localPath {
-            ImageView(path: path, pointSize: 1024, contentMode: .fit)
+            ZoomableGalleryImage(source: .local(path: path))
         }
         else {
             RemoteGalleryImage(fileId: item.id, loadImage: loadImage)
@@ -71,56 +73,157 @@ private struct GalleryPage: View {
     }
 }
 
+/// A zoomable gallery image with a two-stage decode that keeps huge JPEGs (e.g.
+/// 35 MB) responsive: a screen-fit thumbnail loads first, and the full-res
+/// decode runs only once the user starts pinching in. Pinch scales the image
+/// around the gesture anchor and releases back to fit, mirroring the macOS
+/// lightbox.
+private struct ZoomableGalleryImage: View {
+    let source: ImageLoader.Source
+
+    @Environment(\.displayScale)
+    private var displayScale
+    @State
+    private var thumbnail: UIImage?
+    @State
+    private var fullRes: UIImage?
+    @State
+    private var fullResTask: Task<Void, Never>?
+    @State
+    private var scale: CGFloat = 1
+    @State
+    private var anchor: UnitPoint = .center
+    @State
+    private var failed = false
+
+    var body: some View {
+        GeometryReader { geo in
+            Group {
+                if let image = fullRes ?? thumbnail {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(
+                            maxWidth: .infinity,
+                            maxHeight: .infinity
+                        )
+                        .scaleEffect(scale, anchor: anchor)
+                        .gesture(magnifyGesture)
+                }
+                else if failed {
+                    GalleryFailedView()
+                }
+                else {
+                    ProgressView().tint(.white)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Decode the screen-fit thumbnail once the page has its size. Each
+            // page is a distinct image, so this runs once per page.
+            .task {
+                await loadThumbnail(containerSize: geo.size)
+            }
+        }
+        // The full-res decode is gesture-driven, so it's an explicitly-managed
+        // task rather than a `.task`: cancel it if the page leaves while a big
+        // decode is still running.
+        .onDisappear {
+            fullResTask?.cancel()
+            fullResTask = nil
+        }
+    }
+
+    private var magnifyGesture: some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                anchor = value.startAnchor
+                scale = max(value.magnification, 1)
+                if value.magnification > 1.01,
+                    fullRes == nil,
+                    fullResTask == nil
+                {
+                    fullResTask = Task { await loadFullRes() }
+                }
+            }
+            .onEnded { _ in
+                withAnimation(.easeOut(duration: 0.25)) {
+                    scale = 1
+                }
+            }
+    }
+
+    private func loadThumbnail(containerSize: CGSize) async {
+        do {
+            thumbnail = try await ImageLoader.load(
+                source: source,
+                size: .fitTo(
+                    points: max(containerSize.width, containerSize.height)
+                ),
+                displayScale: displayScale
+            )
+        }
+        catch is CancellationError {
+            return
+        }
+        catch {
+            logger.warning(
+                "Failed to decode gallery image (\(source.description, privacy: .public)): \(error)"
+            )
+            failed = true
+        }
+    }
+
+    private func loadFullRes() async {
+        defer { fullResTask = nil }
+        do {
+            let loaded = try await ImageLoader.load(
+                source: source,
+                size: .native,
+                displayScale: displayScale
+            )
+            if !Task.isCancelled {
+                fullRes = loaded
+            }
+        }
+        catch is CancellationError {
+            return
+        }
+        catch {
+            logger.warning(
+                "Failed to decode full-res gallery image (\(source.description, privacy: .public)): \(error)"
+            )
+        }
+    }
+}
+
 /// A gallery image whose file isn't on disk here: fetch its bytes (downloaded
-/// from the release's cloud home and decrypted by core), decode off the main
-/// thread, and render it — a spinner while loading, a warning glyph on failure.
+/// from the release's cloud home and decrypted by core), then hand them to
+/// `ZoomableGalleryImage` to decode and display. A spinner shows while
+/// fetching, a warning glyph if the fetch fails.
 private struct RemoteGalleryImage: View {
     let fileId: String
     let loadImage: @Sendable (_ fileId: String) async throws -> Data
 
     @State
-    private var image: UIImage?
+    private var bytes: Data?
     @State
     private var failed = false
 
     var body: some View {
         Group {
-            if let image {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
+            if let bytes {
+                ZoomableGalleryImage(source: .data(bytes))
             }
             else if failed {
-                Image(systemName: "exclamationmark.triangle")
-                    .font(.largeTitle)
-                    .foregroundStyle(.white.opacity(0.7))
+                GalleryFailedView()
             }
             else {
-                ProgressView()
-                    .tint(.white)
+                ProgressView().tint(.white)
             }
         }
         .task(id: fileId) {
             do {
-                let data = try await loadImage(fileId)
-                let decoded = await Task.detached(priority: .userInitiated) {
-                    UIImage(data: data)
-                }.value
-                if Task.isCancelled {
-                    logger.debug(
-                        "gallery image decode cancelled: \(fileId, privacy: .public)"
-                    )
-                    return
-                }
-                if let decoded {
-                    image = decoded
-                }
-                else {
-                    logger.warning(
-                        "Couldn't decode gallery image \(fileId, privacy: .public) (\(data.count) bytes)"
-                    )
-                    failed = true
-                }
+                bytes = try await loadImage(fileId)
             }
             catch is CancellationError {
                 // The viewer was dismissed mid-fetch; leave state as-is.
@@ -135,5 +238,14 @@ private struct RemoteGalleryImage: View {
                 failed = true
             }
         }
+    }
+}
+
+/// The shared failure placeholder for a gallery page (fetch or decode failed).
+private struct GalleryFailedView: View {
+    var body: some View {
+        Image(systemName: "exclamationmark.triangle")
+            .font(.largeTitle)
+            .foregroundStyle(.white.opacity(0.7))
     }
 }

--- a/bae-ios/bae/bae/Views/GalleryView.swift
+++ b/bae-ios/bae/bae/Views/GalleryView.swift
@@ -163,6 +163,9 @@ private struct ZoomableGalleryImage: View {
             )
         }
         catch is CancellationError {
+            logger.debug(
+                "gallery thumbnail load cancelled: \(source.description, privacy: .public)"
+            )
             return
         }
         catch {
@@ -181,11 +184,18 @@ private struct ZoomableGalleryImage: View {
                 size: .native,
                 displayScale: displayScale
             )
-            if !Task.isCancelled {
-                fullRes = loaded
+            guard !Task.isCancelled else {
+                logger.debug(
+                    "full-res gallery load cancelled after decode: \(source.description, privacy: .public)"
+                )
+                return
             }
+            fullRes = loaded
         }
         catch is CancellationError {
+            logger.debug(
+                "full-res gallery load cancelled: \(source.description, privacy: .public)"
+            )
             return
         }
         catch {

--- a/bae-ios/bae/bae/Views/ImageView.swift
+++ b/bae-ios/bae/bae/Views/ImageView.swift
@@ -4,9 +4,9 @@ import os.log
 private let logger = Logger.bae("ImageView")
 
 /// Renders a cover image from an absolute on-disk path, decoding off the main
-/// thread to a point-sized `UIImage`. Shows the theme placeholder while loading
-/// or when the file is absent (the cover isn't synced yet). Re-decodes when the
-/// `path` changes.
+/// thread to a point-sized `UIImage` via the shared `ImageLoader`. Shows the
+/// theme placeholder while loading or when the file is absent (the cover isn't
+/// synced yet). Re-decodes when the `path` changes.
 struct ImageView: View {
     let path: String?
     /// Target point size for the thumbnail; pixels decoded are
@@ -40,48 +40,21 @@ struct ImageView: View {
             image = nil
             return
         }
-        let maxPixel = Int(pointSize * displayScale)
-        let decoded: UIImage? = await Task.detached(priority: .userInitiated) {
-            decodeThumbnail(path: path, maxPixelSize: maxPixel)
-        }.value
-        if Task.isCancelled {
-            return
-        }
-        if decoded == nil {
-            logger.warning(
-                "Failed to load cover at \(path, privacy: .public)"
+        do {
+            image = try await ImageLoader.load(
+                source: .local(path: path),
+                size: .fitTo(points: pointSize),
+                displayScale: displayScale
             )
         }
-        image = decoded
+        catch is CancellationError {
+            return
+        }
+        catch {
+            logger.warning(
+                "Failed to load cover at \(path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            image = nil
+        }
     }
-}
-
-/// Decode the image at `identifier` to a `UIImage` whose largest edge is at
-/// most `maxPixelSize` pixels, with the bytes-to-bitmap step forced eagerly so
-/// the image draws without main-thread decode work. Returns nil if the file
-/// can't be opened. `identifier` is the bridge's cache-bustable form
-/// (`<path>#v=<mtime>`); the file is opened at the bare path with the version
-/// stripped — the suffix only exists to change `.task(id:)`'s key on a cover
-/// change.
-private func decodeThumbnail(path identifier: String, maxPixelSize: Int) -> UIImage? {
-    let url = URL(fileURLWithPath: MediaPaths.fileSystemPath(of: identifier)) as CFURL
-    guard let source = CGImageSourceCreateWithURL(url, nil) else {
-        return nil
-    }
-    let options: [CFString: Any] = [
-        kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-        kCGImageSourceCreateThumbnailFromImageAlways: true,
-        kCGImageSourceCreateThumbnailWithTransform: true,
-        kCGImageSourceShouldCacheImmediately: true,
-    ]
-    guard
-        let cgImage = CGImageSourceCreateThumbnailAtIndex(
-            source,
-            0,
-            options as CFDictionary
-        )
-    else {
-        return nil
-    }
-    return UIImage(cgImage: cgImage)
 }

--- a/bae-ios/bae/bae/Views/ImageView.swift
+++ b/bae-ios/bae/bae/Views/ImageView.swift
@@ -48,6 +48,7 @@ struct ImageView: View {
             )
         }
         catch is CancellationError {
+            logger.debug("cover load cancelled: \(path, privacy: .public)")
             return
         }
         catch {

--- a/bae-ios/bae/project.yml
+++ b/bae-ios/bae/project.yml
@@ -31,6 +31,9 @@ targets:
       # desktop-only ones behind `#if !os(iOS)`).
       - path: ../../bae-macos/bae/bae/Logger.swift
       - path: ../../bae-macos/bae/bae/Theme.swift
+      # AppKit/UIKit-bridged via a `PlatformImage` typealias behind
+      # `#if canImport`, so it compiles AppKit-free on iOS.
+      - path: ../../bae-macos/bae/bae/ImageLoader.swift
       - path: ../../bae-macos/bae/bae/BridgeSortField+CaseIterable.swift
       - path: ../../bae-macos/bae/bae/Services/PlaybackStore.swift
       - path: ../../bae-macos/bae/bae/Services/PlaybackPositionEvent.swift

--- a/bae-macos/bae/bae/ImageLoader.swift
+++ b/bae-macos/bae/bae/ImageLoader.swift
@@ -1,5 +1,19 @@
-import AppKit
-import SwiftUI
+import CoreGraphics
+import Foundation
+import ImageIO
+
+#if canImport(AppKit)
+    import AppKit
+
+    /// The platform's image type: `NSImage` on macOS, `UIImage` on iOS. Decode
+    /// is identical on both (ImageIO / CoreGraphics); only the final wrapper
+    /// differs.
+    typealias PlatformImage = NSImage
+#elseif canImport(UIKit)
+    import UIKit
+
+    typealias PlatformImage = UIImage
+#endif
 
 enum ImageLoader {
     enum Source: Equatable {
@@ -9,6 +23,10 @@ enum ImageLoader {
         /// `MediaPaths.fileSystemPath(of:)` with the version stripped.
         case local(path: String)
         case remote(url: String)
+        /// Image bytes already in memory — a cloud-only gallery image the
+        /// caller fetched and decrypted itself (iOS lightbox). Decoded at the
+        /// requested size without any further fetch.
+        case data(Data)
 
         init(bridge: BridgeCoverImageSource) {
             switch bridge {
@@ -26,6 +44,8 @@ enum ImageLoader {
                 return "image at path: \(path)"
             case .remote(let url):
                 return "remote image: \(url)"
+            case .data(let bytes):
+                return "in-memory image: \(bytes.count) bytes"
             }
         }
     }
@@ -33,8 +53,10 @@ enum ImageLoader {
     /// Decode strategy for `load`. `.fitTo` takes the IDCT thumbnail
     /// path, decoding at most `points × displayScale` pixels. `.native`
     /// decodes the source at its full pixel resolution, eagerly, so
-    /// the returned NSImage is ready to draw without main-thread
-    /// decode work.
+    /// the returned image is ready to draw without main-thread
+    /// decode work. The lightbox loads `.fitTo` for the screen-fit view
+    /// and upgrades to `.native` only when the user zooms in, so a huge
+    /// (e.g. 35 MB) JPEG never decodes at full resolution until needed.
     enum Size {
         case fitTo(points: CGFloat)
         case native
@@ -42,26 +64,34 @@ enum ImageLoader {
 
     struct DecodeError: Error {}
 
-    /// Loads an image for `source` at the given `size`. Local sources
-    /// read directly from disk; remote sources call `fetchRemoteBytes`
-    /// to pull the raw bytes (production: `MediaPaths.fetchCoverBytes`;
-    /// previews: the stub closure). The decode runs on a background
-    /// task and produces an NSImage backed by an already-decoded
-    /// CGImage. Throws `CancellationError` if the surrounding task is
-    /// cancelled, or `DecodeError` if the source can't be opened or
+    /// A `.remote` source was loaded without a `fetchRemoteBytes` closure.
+    /// Callers that only use `.local`/`.data` omit the closure; passing
+    /// `.remote` without one is a programming error, surfaced rather than
+    /// masked.
+    struct RemoteFetchUnavailable: Error {}
+
+    /// Loads an image for `source` at the given `size`. Local sources read
+    /// directly from disk; `.data` sources decode bytes already in memory;
+    /// remote sources call `fetchRemoteBytes` to pull the raw bytes
+    /// (production: `MediaPaths.fetchCoverBytes`; previews: the stub closure).
+    /// The decode runs on a background task and produces an image backed by an
+    /// already-decoded CGImage. Throws `CancellationError` if the surrounding
+    /// task is cancelled, or `DecodeError` if the source can't be opened or
     /// decoded.
     static func load(
         source: Source,
         size: Size,
         displayScale: CGFloat,
-        fetchRemoteBytes: @Sendable (_ url: String) async throws -> Data
-    ) async throws -> NSImage {
+        fetchRemoteBytes: @Sendable (_ url: String) async throws -> Data = {
+            _ in throw RemoteFetchUnavailable()
+        }
+    ) async throws -> PlatformImage {
         switch source {
         case .local(let identifier):
             // Open the bare file path, not the cache-busting identifier: the
             // `#v=<mtime>` suffix is the cache key, not part of the filename.
             let path = MediaPaths.fileSystemPath(of: identifier)
-            return try await decodeAsNSImage(displayScale: displayScale) {
+            return try await decodeAsPlatformImage(displayScale: displayScale) {
                 let url = URL(fileURLWithPath: path) as CFURL
                 guard let cgSource = CGImageSourceCreateWithURL(url, nil)
                 else {
@@ -75,22 +105,38 @@ enum ImageLoader {
             }
         case .remote(let url):
             let bytes = try await fetchRemoteBytes(url)
-            return try await decodeAsNSImage(displayScale: displayScale) {
-                guard
-                    let cgSource = CGImageSourceCreateWithData(
-                        bytes as CFData,
-                        nil
-                    )
-                else {
-                    return nil
-                }
-                return decodeCGImage(
-                    from: cgSource,
-                    size: size,
-                    displayScale: displayScale
-                )
-            }
+            return try await decodeData(
+                bytes: bytes,
+                size: size,
+                displayScale: displayScale
+            )
+        case .data(let bytes):
+            return try await decodeData(
+                bytes: bytes,
+                size: size,
+                displayScale: displayScale
+            )
         }
+    }
+}
+
+/// Decodes in-memory image `bytes` to a platform image at the requested size.
+/// Shared by the `.remote` (post-fetch) and `.data` branches of `load`.
+private func decodeData(
+    bytes: Data,
+    size: ImageLoader.Size,
+    displayScale: CGFloat
+) async throws -> PlatformImage {
+    try await decodeAsPlatformImage(displayScale: displayScale) {
+        guard let cgSource = CGImageSourceCreateWithData(bytes as CFData, nil)
+        else {
+            return nil
+        }
+        return decodeCGImage(
+            from: cgSource,
+            size: size,
+            displayScale: displayScale
+        )
     }
 }
 
@@ -130,27 +176,37 @@ private func decodeCGImage(
     }
 }
 
-/// Runs `decoder` on a background task, wraps the resulting CGImage in
-/// an NSImage with point-sized dimensions (pixel dims divided by
-/// `displayScale`), and propagates cancellation after the decode
-/// completes. Throws `ImageLoader.DecodeError` if the decoder returns
-/// nil.
-private func decodeAsNSImage(
+/// Runs `decoder` on a background task, wraps the resulting CGImage in a
+/// platform image with point-sized dimensions (pixel dims divided by
+/// `displayScale`), and propagates cancellation after the decode completes.
+/// Throws `ImageLoader.DecodeError` if the decoder returns nil.
+private func decodeAsPlatformImage(
     displayScale: CGFloat,
     decoder: @Sendable @escaping () -> CGImage?
-) async throws -> NSImage {
-    let loaded: NSImage? =
+) async throws -> PlatformImage {
+    let loaded: PlatformImage? =
         await Task.detached(priority: .userInitiated) {
             guard let cg = decoder() else {
                 return nil
             }
-            return NSImage(
-                cgImage: cg,
-                size: NSSize(
-                    width: CGFloat(cg.width) / displayScale,
-                    height: CGFloat(cg.height) / displayScale
+            #if canImport(AppKit)
+                return NSImage(
+                    cgImage: cg,
+                    size: NSSize(
+                        width: CGFloat(cg.width) / displayScale,
+                        height: CGFloat(cg.height) / displayScale
+                    )
                 )
-            )
+            #elseif canImport(UIKit)
+                // scale == displayScale makes the point size pixel/scale,
+                // matching the NSImage sizing above. Orientation is `.up`:
+                // the thumbnail decode already applied any EXIF transform.
+                return UIImage(
+                    cgImage: cg,
+                    scale: displayScale,
+                    orientation: .up
+                )
+            #endif
         }
         .value
     try Task.checkCancellation()


### PR DESCRIPTION
The macOS lightbox already loaded a screen-fit thumbnail and only decoded the source at full resolution once you pinched in, and a pinch let you peek and then snapped back to fit on release. iOS and Android had neither behavior: each gallery page rendered a single fixed-size image with no zoom gesture, so a large (e.g. 35 MB) JPEG looked blurry the moment you tried to enlarge it and there was no way to inspect detail at all.

This brings both behaviors to iOS and Android by generalizing the piece macOS already relied on. `ImageLoader` becomes cross-platform: a `PlatformImage` typealias behind `canImport` (NSImage on macOS, UIImage on iOS) over the same ImageIO/CoreGraphics decode, plus a new `.data` source so an already-fetched, already-decrypted cloud image decodes through the same two-stage path (screen-fit thumbnail first, native full resolution only when the user starts zooming). iOS's `ImageView` now routes through that loader as well, dropping its duplicate thumbnail-decode path.

On iOS each gallery page is a `MagnifyGesture` + `scaleEffect` that scales around the pinch anchor and animates back to fit on release, kicking off the full-res decode the first time you zoom. Android mirrors it with a transform gesture over `graphicsLayer` (snap-back animated on pointer-up) and leans on Coil's downsample-to-bounds for the cheap first draw, requesting the original resolution on zoom and crossfading up from the cached downsample so the upgrade doesn't flash.

## Test plan
- [ ] iOS: open a release with a large cover and extra images; pinch a page — it zooms around the pinch point, sharpens, and snaps back on release; swipe still pages between images.
- [ ] iOS: a cloud-only image (no local copy) fetches, then zooms the same way.
- [ ] Android: same checks — pinch zooms and snaps back, pager swipe still works, cloud-only image fetches then zooms.
- [ ] macOS regression: lightbox still loads, zooms, and snaps back.