### PR TITLE
Edit-metadata previews: share a BridgeRawReleaseEdit fixture

### DIFF
--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -1031,6 +1031,39 @@ enum PreviewData {
             trackIdPrefix: "import-track"
         )
 
+    /// A raw release edit for the EditMetadataForm / EditMetadataSheet previews:
+    /// the album + pressing fields plus `trackCount` tracks. Blank track artists
+    /// (the default) exercise the "track artist falls back to album artist"
+    /// placeholder path the form renders — both previews wrap that form.
+    static func editMetadataSeed(
+        trackCount: Int,
+        blankTrackArtists: Bool = true
+    ) -> BridgeRawReleaseEdit {
+        BridgeRawReleaseEdit(
+            albumTitle: "Album Title",
+            albumArtistText: "Artist Name",
+            pressing: BridgeRawPressingEdit(
+                year: "1997",
+                format: "CD",
+                label: "Some Label",
+                catalogNumber: "CAT-0001",
+                country: "US",
+                barcode: "000000000000"
+            ),
+            tracks: (1...trackCount)
+                .map { n in
+                    BridgeRawTrackEdit(
+                        id: "t-\(n)",
+                        title: "Track Title \(n)",
+                        artistText: blankTrackArtists
+                            ? "" : "Track Artist \(n)",
+                        side: 1,
+                        trackNumber: Int32(n)
+                    )
+                }
+        )
+    }
+
     /// Per-track audio candidate (nine FLAC files) plus one cover image and two
     /// documents — the track-files counterpart to `candidateFiles` (CUE+FLAC).
     static let candidateFilesTracks = CandidateFiles(

--- a/bae-macos/bae/bae/Views/EditMetadataForm.swift
+++ b/bae-macos/bae/bae/Views/EditMetadataForm.swift
@@ -466,28 +466,7 @@ private struct FieldChrome: ViewModifier {
 #Preview("Edit Metadata Form") {
     @Previewable
     @State
-    var form = BridgeRawReleaseEdit(
-        albumTitle: "Album Title",
-        albumArtistText: "Artist Name",
-        pressing: BridgeRawPressingEdit(
-            year: "1997",
-            format: "CD",
-            label: "Some Label",
-            catalogNumber: "CAT-11601",
-            country: "US",
-            barcode: "008811160128"
-        ),
-        tracks: (1...13)
-            .map { n in
-                BridgeRawTrackEdit(
-                    id: "t-\(n)",
-                    title: "Track Title \(n)",
-                    artistText: "",
-                    side: 1,
-                    trackNumber: Int32(n)
-                )
-            }
-    )
+    var form = PreviewData.editMetadataSeed(trackCount: 13)
     ScrollView {
         EditMetadataForm(form: $form)
             .padding(20)

--- a/bae-macos/bae/bae/Views/EditMetadataSheet.swift
+++ b/bae-macos/bae/bae/Views/EditMetadataSheet.swift
@@ -193,34 +193,7 @@ struct EditMetadataSheet: View {
 
 #Preview("Edit Metadata") {
     EditMetadataSheet(
-        initialForm: BridgeRawReleaseEdit(
-            albumTitle: "Album Title",
-            albumArtistText: "Artist Name",
-            pressing: BridgeRawPressingEdit(
-                year: "2024",
-                format: "Vinyl",
-                label: "Some Label",
-                catalogNumber: "CAT-001",
-                country: "US",
-                barcode: ""
-            ),
-            tracks: [
-                BridgeRawTrackEdit(
-                    id: "t-1",
-                    title: "Track One",
-                    artistText: "",
-                    side: 1,
-                    trackNumber: 1
-                ),
-                BridgeRawTrackEdit(
-                    id: "t-2",
-                    title: "Track Two",
-                    artistText: "",
-                    side: 1,
-                    trackNumber: 2
-                ),
-            ]
-        ),
+        initialForm: PreviewData.editMetadataSeed(trackCount: 2),
         onSave: { _ in },
         onCancel: {},
     )


### PR DESCRIPTION
`EditMetadataSheet` and `EditMetadataForm` each hand-built a `BridgeRawReleaseEdit` (album + nested pressing + track array) inline, while `PreviewData.confirmEditValues` already centralizes that shape for the import previews. These two were the outliers.

Adds `PreviewData.editMetadataSeed(trackCount:blankTrackArtists:)` and routes both previews through it. The track count (2 / 13) and the blank-track-artist case (which the form renders as "track artist falls back to album artist") stay as parameters, preserving each preview's scenario.

## Test plan
- [ ] macOS build passes; both edit-metadata previews render as before.
- [ ] CI environment audit reports zero findings.