### PR TITLE
Cover sheet preview: lift remote covers into a PreviewData fixture

### DIFF
--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -317,6 +317,42 @@ enum PreviewData {
         query: "glass"
     )
 
+    // MARK: - Cover sheet
+
+    /// Remote cover candidates (front + back) for the CoverSheetView preview.
+    static let remoteCovers: [BridgeRemoteCover] = [
+        remoteCover(
+            url: "https://example.com/cover1.jpg",
+            thumbnailUrl: "https://example.com/thumb1.jpg",
+            label: "Front"
+        ),
+        remoteCover(
+            url: "https://example.com/cover2.jpg",
+            thumbnailUrl: "https://example.com/thumb2.jpg",
+            label: "Back"
+        ),
+    ]
+
+    private static func remoteCover(
+        url: String,
+        thumbnailUrl: String,
+        label: String
+    ) -> BridgeRemoteCover {
+        BridgeRemoteCover(
+            coverChoice: BridgeCoverChoice(
+                selection: .remoteCover(
+                    selection: BridgeRemoteCoverSelection(
+                        url: url,
+                        source: .musicBrainz
+                    )
+                ),
+                previewSource: .remote(url: url),
+                thumbnailSource: .remote(url: thumbnailUrl)
+            ),
+            label: label
+        )
+    }
+
     // MARK: - Album Details
 
     private static func makeTracks(

--- a/bae-macos/bae/bae/Views/CoverSheetView.swift
+++ b/bae-macos/bae/bae/Views/CoverSheetView.swift
@@ -162,45 +162,13 @@ struct CoverSheetView: View {
     }
 }
 
-private func previewRemoteCover(
-    url: String,
-    thumbnailUrl: String,
-    label: String
-) -> BridgeRemoteCover {
-    let selection = BridgeRemoteCoverSelection(
-        url: url,
-        source: .musicBrainz
-    )
-    return BridgeRemoteCover(
-        coverChoice: BridgeCoverChoice(
-            selection: .remoteCover(selection: selection),
-            previewSource: .remote(url: url),
-            thumbnailSource: .remote(url: thumbnailUrl)
-        ),
-        label: label
-    )
-}
-
 #Preview("Cover Sheet") {
     CoverSheetView(
         releaseImages: [
             (id: "file-1", name: "cover.jpg", path: nil),
             (id: "file-2", name: "back.jpg", path: nil),
         ],
-        fetchRemoteCovers: {
-            [
-                previewRemoteCover(
-                    url: "https://example.com/cover1.jpg",
-                    thumbnailUrl: "https://example.com/thumb1.jpg",
-                    label: "Front"
-                ),
-                previewRemoteCover(
-                    url: "https://example.com/cover2.jpg",
-                    thumbnailUrl: "https://example.com/thumb2.jpg",
-                    label: "Back"
-                ),
-            ]
-        },
+        fetchRemoteCovers: { PreviewData.remoteCovers },
         onSelectRemote: { _ in },
         onSelectReleaseImage: { _ in },
         onDone: {},


### PR DESCRIPTION
`CoverSheetView`'s "Cover Sheet" preview built its two remote-cover candidates through a file-scope `previewRemoteCover` helper. Move them to `PreviewData.remoteCovers` (with a private builder) and delete the now-unused helper — `BridgeRemoteCover` gets a sample home alongside the rest of the preview data, and the preview reads `fetchRemoteCovers: { PreviewData.remoteCovers }`.

## Test plan
- [ ] macOS build passes; the Cover Sheet preview shows the same two remote covers.
- [ ] CI environment audit reports zero findings.