### PR TITLE
loc: localization generator + ICU MessageFormat master catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -773,6 +773,15 @@ dependencies = [
  "unicode-normalization",
  "uuid",
  "windows-native-keyring-store",
+]
+
+[[package]]
+name = "bae-loc"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -3664,7 +3673,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4317,9 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4853,7 +4862,22 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4867,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4881,18 +4905,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5098,7 +5122,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -5141,7 +5165,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta",
 ]
 
@@ -5873,6 +5897,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bae-bridge", "bae-core", "bae-windows-ffi"]
+members = ["bae-bridge", "bae-core", "bae-loc", "bae-windows-ffi"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -1,0 +1,31 @@
+# bae localization catalog — the single source of truth for strings that
+# originate in shared Rust logic (`core.*`) and shared chrome opted in by the UI
+# (`ui.*`). Source language: English. Each `value` is an ICU MessageFormat 1
+# string; `args` declares each placeholder's type so `loc-gen check` can verify
+# the catalog (and, once message enums exist, cross-check them).
+
+[messages."core.import.validation.empty_album_title"]
+comment = "Import edit: the album title field is blank."
+value = "Album title is required"
+
+[messages."core.import.validation.no_album_artist"]
+comment = "Import edit: no album artist was entered."
+value = "Album must have at least one artist"
+
+[messages."core.import.validation.invalid_year"]
+comment = "Import edit: the year field is not a number."
+value = "Year must be a number"
+
+[messages."core.identify.barcode.looking_up"]
+comment = "Identify: which barcode is being looked up, of how many."
+args = { position = "Int", total = "Int" }
+value = "Looking up barcode {position} of {total}"
+
+[messages."core.outbox.pending_deletes"]
+comment = "Storage queue: number of cloud deletes still pending."
+args = { count = "Int" }
+value = "{count, plural, one {# pending delete} other {# pending deletes}}"
+
+[messages."ui.library.remove_from_device"]
+comment = "Settings: button that removes the library from this device."
+value = "remove this library from this device"

--- a/bae-loc/Cargo.toml
+++ b/bae-loc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bae-loc"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+name = "bae_loc"
+
+[[bin]]
+name = "loc-gen"
+path = "src/bin/loc-gen.rs"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+toml = "1.1.2"

--- a/bae-loc/src/bin/loc-gen.rs
+++ b/bae-loc/src/bin/loc-gen.rs
@@ -1,0 +1,128 @@
+//! `loc-gen` — validate the master catalog and emit native resource files.
+//!
+//!   loc-gen check  [--catalog <path>]
+//!   loc-gen emit   --target {apple|android|windows} --out-dir <dir> [--catalog <path>]
+//!
+//! `--catalog` defaults to `bae-bridge/loc/catalog.toml` (relative to the
+//! working directory, i.e. the repo root the build scripts run from).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use bae_loc::{check, emit, Catalog};
+
+const SOURCE_LANGUAGE: &str = "en";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("loc-gen: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+struct Args {
+    subcommand: String,
+    catalog: PathBuf,
+    target: Option<String>,
+    out_dir: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let mut subcommand = None;
+    let mut catalog = PathBuf::from("bae-bridge/loc/catalog.toml");
+    let mut target = None;
+    let mut out_dir = None;
+
+    let mut i = 0;
+    while i < raw.len() {
+        match raw[i].as_str() {
+            "check" | "emit" => subcommand = Some(raw[i].clone()),
+            "--catalog" => catalog = PathBuf::from(value(&raw, &mut i)?),
+            "--target" => target = Some(value(&raw, &mut i)?.to_string()),
+            "--out-dir" => out_dir = Some(PathBuf::from(value(&raw, &mut i)?)),
+            other => return Err(format!("unexpected argument `{other}`")),
+        }
+        i += 1;
+    }
+    let subcommand = subcommand.ok_or("expected a subcommand: `check` or `emit`")?;
+    Ok(Args {
+        subcommand,
+        catalog,
+        target,
+        out_dir,
+    })
+}
+
+fn value<'a>(raw: &'a [String], i: &mut usize) -> Result<&'a str, String> {
+    *i += 1;
+    raw.get(*i)
+        .map(String::as_str)
+        .ok_or_else(|| format!("`{}` needs a value", raw[*i - 1]))
+}
+
+fn run() -> Result<(), String> {
+    let args = parse_args()?;
+    let src = fs::read_to_string(&args.catalog)
+        .map_err(|e| format!("reading {}: {e}", args.catalog.display()))?;
+    let catalog = Catalog::from_toml(&src).map_err(|e| format!("parsing catalog: {e}"))?;
+
+    // Both subcommands validate; emit must not write a broken catalog out.
+    if let Err(errs) = check::validate(&catalog) {
+        return Err(format!(
+            "{} catalog problem(s):\n  - {}",
+            errs.len(),
+            errs.join("\n  - ")
+        ));
+    }
+
+    match args.subcommand.as_str() {
+        "check" => {
+            println!("loc-gen: {} messages, catalog ok", catalog.messages.len());
+            Ok(())
+        }
+        "emit" => emit_target(&args, &catalog),
+        other => Err(format!("unknown subcommand `{other}`")),
+    }
+}
+
+fn emit_target(args: &Args, catalog: &Catalog) -> Result<(), String> {
+    let target = args.target.as_deref().ok_or("emit needs --target")?;
+    let out_dir = args.out_dir.as_ref().ok_or("emit needs --out-dir")?;
+
+    let (relative, contents) = match target {
+        "apple" => (
+            PathBuf::from("Core.xcstrings"),
+            emit::apple_xcstrings(catalog, SOURCE_LANGUAGE)?,
+        ),
+        "android" => (
+            PathBuf::from("values/core_strings.xml"),
+            emit::android_strings_xml(catalog),
+        ),
+        "windows" => (
+            PathBuf::from(format!("{SOURCE_LANGUAGE}-US/Core.resw")),
+            emit::windows_resw(catalog),
+        ),
+        other => {
+            return Err(format!(
+                "unknown --target `{other}` (apple|android|windows)"
+            ))
+        }
+    };
+
+    let path = out_dir.join(relative);
+    write_file(&path, &contents)?;
+    println!("loc-gen: wrote {}", path.display());
+    Ok(())
+}
+
+fn write_file(path: &Path, contents: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("creating {}: {e}", parent.display()))?;
+    }
+    fs::write(path, contents).map_err(|e| format!("writing {}: {e}", path.display()))
+}

--- a/bae-loc/src/check.rs
+++ b/bae-loc/src/check.rs
@@ -1,0 +1,135 @@
+//! Catalog internal-consistency validation, run by `loc-gen check`.
+//!
+//! This guards the catalog against the mistakes that would otherwise surface as
+//! a wrong or missing string at runtime: an undeclared placeholder, a declared
+//! argument the message never uses, a plural over a non-integer, a malformed MF1
+//! value, or an id outside the `core.`/`ui.` namespaces. A failure here fails
+//! the build (the pre-commit hook), so the catalog can't drift into an invalid
+//! shape unnoticed.
+//!
+//! The cross-check between catalog ids and the Rust message enums lands with the
+//! first message-bearing bridge enum; this module is the catalog-only half.
+
+use crate::mf1::{self, Node};
+use crate::{namespace_of, ArgType, Catalog};
+
+/// Validate every message. Returns all problems found (not just the first) so a
+/// catalog edit gets the full list in one pass.
+pub fn validate(cat: &Catalog) -> Result<(), Vec<String>> {
+    let mut errs = Vec::new();
+    for (id, msg) in &cat.messages {
+        if let Err(e) = namespace_of(id) {
+            errs.push(e);
+        }
+        let nodes = match mf1::parse(&msg.value) {
+            Ok(n) => n,
+            Err(e) => {
+                errs.push(format!("{id}: {e}"));
+                continue;
+            }
+        };
+        let referenced = mf1::referenced_args(&nodes);
+        for arg in &referenced {
+            if !msg.args.contains_key(arg) {
+                errs.push(format!(
+                    "{id}: `{{{arg}}}` is used but not declared in `args`"
+                ));
+            }
+        }
+        for arg in msg.args.keys() {
+            if !referenced.contains(arg) {
+                errs.push(format!("{id}: declared argument `{arg}` is never used"));
+            }
+        }
+        for node in &nodes {
+            if let Node::Plural { arg, .. } = node {
+                if msg.args.get(arg) != Some(&ArgType::Int) {
+                    errs.push(format!("{id}: plural argument `{arg}` must be `Int`"));
+                }
+            }
+        }
+    }
+    if errs.is_empty() {
+        Ok(())
+    } else {
+        Err(errs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cat(toml: &str) -> Catalog {
+        Catalog::from_toml(toml).expect("parses")
+    }
+
+    #[test]
+    fn accepts_a_well_formed_catalog() {
+        let c = cat(r#"
+[messages."core.outbox.pending_deletes"]
+args = { count = "Int" }
+value = "{count, plural, one {# pending delete} other {# pending deletes}}"
+
+[messages."core.identify.barcode.looking_up"]
+args = { position = "Int", total = "Int" }
+value = "Looking up barcode {position} of {total}"
+
+[messages."ui.library.remove_from_device"]
+value = "remove this library from this device"
+"#);
+        assert!(validate(&c).is_ok());
+    }
+
+    #[test]
+    fn flags_undeclared_placeholder() {
+        let c = cat(r#"
+[messages."core.x"]
+value = "hi {name}"
+"#);
+        let errs = validate(&c).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("not declared")), "{errs:?}");
+    }
+
+    #[test]
+    fn flags_unused_declared_arg() {
+        let c = cat(r#"
+[messages."core.x"]
+args = { name = "Str" }
+value = "no placeholder here"
+"#);
+        let errs = validate(&c).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("never used")), "{errs:?}");
+    }
+
+    #[test]
+    fn flags_non_int_plural_arg() {
+        let c = cat(r#"
+[messages."core.x"]
+args = { count = "Str" }
+value = "{count, plural, one {#} other {#}}"
+"#);
+        let errs = validate(&c).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("must be `Int`")), "{errs:?}");
+    }
+
+    #[test]
+    fn flags_bad_namespace() {
+        let c = cat(r#"
+[messages."misc.x"]
+value = "oops"
+"#);
+        assert!(validate(&c).is_err());
+    }
+
+    /// The shipping catalog must always be valid. This gates `cargo test`, so an
+    /// invalid edit to `bae-bridge/loc/catalog.toml` fails the build.
+    #[test]
+    fn real_catalog_is_valid() {
+        let src = include_str!("../../bae-bridge/loc/catalog.toml");
+        let cat = Catalog::from_toml(src).expect("real catalog parses");
+        if let Err(errs) = validate(&cat) {
+            panic!("real catalog invalid:\n  - {}", errs.join("\n  - "));
+        }
+    }
+}

--- a/bae-loc/src/emit.rs
+++ b/bae-loc/src/emit.rs
@@ -1,0 +1,307 @@
+//! Convert a parsed catalog into each platform's native resource file.
+//!
+//! Apple is the only target that needs structural conversion: ICU MessageFormat
+//! named args become positional `%lld`/`%@`, and a whole-message `plural`
+//! becomes a String Catalog `variations.plural`. Android and Windows store the
+//! MF1 string **verbatim** (their runtimes parse it) — the only work there is
+//! resource-file escaping and, for Android, sanitizing the dotted id into a
+//! legal resource name.
+//!
+//! Only the message shapes bae actually authors are handled; anything else
+//! (plural combined with extra args, a plural embedded mid-sentence) returns an
+//! error so the build fails loudly instead of emitting wrong output.
+
+use crate::mf1::{self, Node, PluralSelector};
+use crate::{ArgType, Catalog, Message};
+
+use crate::mf1::referenced_args as ordered_args;
+
+fn apple_specifier(ty: ArgType) -> &'static str {
+    match ty {
+        ArgType::Int => "lld",
+        ArgType::Str => "@",
+    }
+}
+
+/// Render a flat (non-plural) node run into an Apple format string. `count_arg`,
+/// when set, is the plural argument whose `#`/name both render as that single
+/// argument (always positional 1 inside a plural body).
+fn apple_flat(
+    nodes: &[Node],
+    msg: &Message,
+    order: &[String],
+    count_arg: Option<&str>,
+) -> Result<String, String> {
+    let mut out = String::new();
+    for n in nodes {
+        match n {
+            Node::Text(t) => out.push_str(&t.replace('%', "%%")),
+            Node::Pound => {
+                let arg = count_arg.ok_or("`#` used outside a plural")?;
+                let ty =
+                    msg.args.get(arg).copied().ok_or_else(|| {
+                        format!("plural argument `{arg}` is not declared in `args`")
+                    })?;
+                out.push_str(&format!("%{}", apple_specifier(ty)));
+            }
+            Node::Arg(name) => {
+                let ty = msg
+                    .args
+                    .get(name)
+                    .copied()
+                    .ok_or_else(|| format!("argument `{name}` is not declared in `args`"))?;
+                // The plural count and any single-arg message render
+                // non-positional (`%lld`); only genuinely multi-arg messages
+                // need positional specifiers.
+                if Some(name.as_str()) == count_arg || order.len() <= 1 {
+                    out.push_str(&format!("%{}", apple_specifier(ty)));
+                } else {
+                    let pos = order.iter().position(|a| a == name).unwrap() + 1;
+                    out.push_str(&format!("%{}${}", pos, apple_specifier(ty)));
+                }
+            }
+            Node::Plural { .. } => {
+                return Err("nested or embedded plural is not supported".to_string())
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn json_str(s: &str) -> serde_json::Value {
+    serde_json::Value::String(s.to_string())
+}
+
+fn string_unit(value: &str) -> serde_json::Value {
+    serde_json::json!({ "stringUnit": { "state": "translated", "value": value } })
+}
+
+/// Build the `.xcstrings` `localizations.<lang>` body for one message.
+fn apple_localization(msg: &Message, src_lang: &str) -> Result<serde_json::Value, String> {
+    let nodes = mf1::parse(&msg.value)?;
+    let order = ordered_args(&nodes);
+
+    // Whole-message plural -> variations.plural. Other plural shapes are errors.
+    if let [Node::Plural { arg, cases }] = nodes.as_slice() {
+        if msg.args.len() != 1 || !msg.args.contains_key(arg) {
+            return Err(format!(
+                "plural message `{}` must take exactly its count arg `{arg}`",
+                msg.value
+            ));
+        }
+        let mut variations = serde_json::Map::new();
+        for case in cases {
+            let cat = match &case.selector {
+                PluralSelector::Category(c) => c.as_cldr(),
+                PluralSelector::Exact(_) => {
+                    return Err("`=N` exact plural cases are not supported on Apple yet".to_string())
+                }
+            };
+            let rendered = apple_flat(&case.message, msg, &order, Some(arg))?;
+            variations.insert(cat.to_string(), string_unit(&rendered));
+        }
+        return Ok(serde_json::json!({
+            src_lang: { "variations": { "plural": variations } }
+        }));
+    }
+
+    if nodes.iter().any(|n| matches!(n, Node::Plural { .. })) {
+        return Err(format!(
+            "message `{}` embeds a plural mid-text; Apple needs a substitution, not yet supported",
+            msg.value
+        ));
+    }
+
+    let rendered = apple_flat(&nodes, msg, &order, None)?;
+    Ok(serde_json::json!({ src_lang: string_unit(&rendered) }))
+}
+
+/// Emit the source-language `Core.xcstrings` for the whole catalog.
+pub fn apple_xcstrings(cat: &Catalog, src_lang: &str) -> Result<String, String> {
+    let mut strings = serde_json::Map::new();
+    for (id, msg) in &cat.messages {
+        let mut entry = serde_json::Map::new();
+        if let Some(comment) = &msg.comment {
+            entry.insert("comment".to_string(), json_str(comment));
+        }
+        entry.insert(
+            "localizations".to_string(),
+            apple_localization(msg, src_lang)?,
+        );
+        strings.insert(id.clone(), serde_json::Value::Object(entry));
+    }
+    let doc = serde_json::json!({
+        "sourceLanguage": src_lang,
+        "strings": serde_json::Value::Object(strings),
+        "version": "1.0",
+    });
+    serde_json::to_string_pretty(&doc).map_err(|e| e.to_string())
+}
+
+/// Android resource names allow `[a-z0-9_]`; the dotted id maps by replacing
+/// `.` and `-` with `_`. The MF1 *value* is untouched.
+pub fn sanitize_android_id(id: &str) -> String {
+    id.replace(['.', '-'], "_")
+}
+
+/// Escape a string for storage inside an Android `<string>` resource so that
+/// `getString` returns it byte-for-byte (then handed to MessageFormat). Android
+/// resources are XML, so this is `xml_escape` plus the backslash-escaping the
+/// Android resource parser additionally requires for quotes.
+fn android_escape(s: &str) -> String {
+    let mut out = String::new();
+    for c in xml_escape(s).chars() {
+        match c {
+            '\'' => out.push_str("\\'"),
+            '"' => out.push_str("\\\""),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Emit `core_strings.xml`. Every message is a plain `<string>`; the MF1 value
+/// is stored verbatim (escaped) for `android.icu.text.MessageFormat`.
+pub fn android_strings_xml(cat: &Catalog) -> String {
+    let mut out = String::from("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<resources>\n");
+    for (id, msg) in &cat.messages {
+        out.push_str(&format!(
+            "    <string name=\"{}\">{}</string>\n",
+            sanitize_android_id(id),
+            android_escape(&msg.value),
+        ));
+    }
+    out.push_str("</resources>\n");
+    out
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Emit `Core.resw`. The dotted id is the resource name; the MF1 value is stored
+/// verbatim (XML-escaped) for the `MessageFormat` NuGet at runtime.
+pub fn windows_resw(cat: &Catalog) -> String {
+    let mut out = String::from(
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<root>\n  \
+         <resheader name=\"resmimetype\"><value>text/microsoft-resx</value></resheader>\n  \
+         <resheader name=\"version\"><value>2.0</value></resheader>\n",
+    );
+    for (id, msg) in &cat.messages {
+        out.push_str(&format!(
+            "  <data name=\"{}\" xml:space=\"preserve\"><value>{}</value></data>\n",
+            xml_escape(id),
+            xml_escape(&msg.value),
+        ));
+    }
+    out.push_str("</root>\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cat(toml: &str) -> Catalog {
+        Catalog::from_toml(toml).expect("catalog parses")
+    }
+
+    #[test]
+    fn apple_plain_and_multiarg() {
+        let c = cat(r#"
+[messages."core.error.not_found.release"]
+value = "that release couldn't be found"
+
+[messages."core.identify.barcode.looking_up"]
+args = { position = "Int", total = "Int" }
+value = "Looking up barcode {position} of {total}"
+"#);
+        let json = apple_xcstrings(&c, "en").unwrap();
+        // Multi-arg becomes positional; single message text passes through.
+        assert!(
+            json.contains("Looking up barcode %1$lld of %2$lld"),
+            "{json}"
+        );
+        assert!(json.contains("that release couldn't be found"), "{json}");
+        assert!(json.contains("\"sourceLanguage\": \"en\""));
+    }
+
+    #[test]
+    fn apple_plural_becomes_variations() {
+        let c = cat(r#"
+[messages."core.outbox.pending_deletes"]
+args = { count = "Int" }
+value = "{count, plural, one {# pending delete} other {# pending deletes}}"
+"#);
+        let json = apple_xcstrings(&c, "en").unwrap();
+        assert!(json.contains("\"plural\""), "{json}");
+        assert!(json.contains("%lld pending delete"), "{json}");
+        assert!(json.contains("%lld pending deletes"), "{json}");
+    }
+
+    #[test]
+    fn apple_rejects_plural_with_extra_arg() {
+        let c = cat(r#"
+[messages."core.bad"]
+args = { count = "Int", name = "Str" }
+value = "{count, plural, one {# thing for {name}} other {# things for {name}}}"
+"#);
+        assert!(apple_xcstrings(&c, "en").is_err());
+    }
+
+    #[test]
+    fn android_sanitizes_id_and_keeps_mf_verbatim() {
+        let c = cat(r#"
+[messages."core.outbox.pending_deletes"]
+args = { count = "Int" }
+value = "{count, plural, one {# pending delete} other {# pending deletes}}"
+
+[messages."core.error.not_found.release"]
+value = "that release couldn't be found"
+"#);
+        let xml = android_strings_xml(&c);
+        assert!(
+            xml.contains("name=\"core_outbox_pending_deletes\""),
+            "{xml}"
+        );
+        // MF1 braces kept verbatim for android.icu.text.MessageFormat.
+        assert!(
+            xml.contains("{count, plural, one {# pending delete}"),
+            "{xml}"
+        );
+        // Apostrophe escaped for the resource parser.
+        assert!(xml.contains("couldn\\'t"), "{xml}");
+    }
+
+    #[test]
+    fn windows_keeps_dotted_id_and_mf_verbatim() {
+        let c = cat(r#"
+[messages."core.identify.barcode.looking_up"]
+args = { position = "Int", total = "Int" }
+value = "Looking up barcode {position} of {total}"
+"#);
+        let resw = windows_resw(&c);
+        assert!(
+            resw.contains("name=\"core.identify.barcode.looking_up\""),
+            "{resw}"
+        );
+        assert!(
+            resw.contains("Looking up barcode {position} of {total}"),
+            "{resw}"
+        );
+    }
+
+    #[test]
+    fn android_id_sanitization() {
+        assert_eq!(sanitize_android_id("core.a.b-c"), "core_a_b_c");
+    }
+}

--- a/bae-loc/src/lib.rs
+++ b/bae-loc/src/lib.rs
@@ -1,0 +1,123 @@
+//! Localization catalog model and target conversion for bae.
+//!
+//! The master catalog (`bae-bridge/loc/catalog.toml`) is the single source of
+//! truth for strings that originate in shared Rust logic (`core.*`) plus shared
+//! chrome opted in by the UI (`ui.*`). Each message `value` is an ICU
+//! MessageFormat 1 string — the cross-platform standard. Android and Windows
+//! consume that string verbatim at runtime (`android.icu.text.MessageFormat` /
+//! the `MessageFormat` NuGet); only Apple needs a conversion to its String
+//! Catalog (`.xcstrings`) shape, which this crate performs.
+//!
+//! This crate is the generator's library guts; the `loc-gen` binary in
+//! `bae-bridge` drives it and adds the completeness check against the Rust
+//! message enums.
+
+pub mod check;
+pub mod emit;
+pub mod mf1;
+
+use std::collections::BTreeMap;
+
+/// The parsed master catalog. Keyed by dotted message id (e.g.
+/// `core.identify.barcode.looking_up`). `BTreeMap` so every emit is
+/// deterministically ordered — generated files diff cleanly.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Catalog {
+    pub messages: BTreeMap<String, Message>,
+}
+
+/// One catalog entry. `value` is an ICU MessageFormat 1 string.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Message {
+    /// Translator-facing note. Optional.
+    #[serde(default)]
+    pub comment: Option<String>,
+    /// Argument name -> type. Declared explicitly (not inferred from the MF
+    /// string) so the generator can type-check the catalog against the Rust
+    /// message enums. Empty for messages with no arguments.
+    #[serde(default)]
+    pub args: BTreeMap<String, ArgType>,
+    /// The ICU MessageFormat 1 source (English).
+    pub value: String,
+}
+
+/// The argument types the catalog distinguishes. `Int` covers the Rust integer
+/// widths that cross the bridge (`i32`/`i64`/`u32`/`u64`); `Str` is `String`.
+/// Kept minimal on purpose — extended when a real message needs another type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub enum ArgType {
+    Int,
+    Str,
+}
+
+/// A message id namespace. `core.*` is bridge-originated and completeness
+/// checked against the Rust message enums; `ui.*` is shared chrome opted in by
+/// the UI and is not checked (it has no Rust producer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Namespace {
+    Core,
+    Ui,
+}
+
+impl Catalog {
+    /// Parse a catalog from TOML source. Fails with the underlying TOML error
+    /// (surfaced, not masked) so a malformed catalog breaks the build loudly.
+    pub fn from_toml(src: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(src)
+    }
+}
+
+/// Classify a dotted id by its first segment. Unknown prefixes are an error so
+/// a typo'd namespace can't silently skip the completeness check.
+pub fn namespace_of(id: &str) -> Result<Namespace, String> {
+    match id.split('.').next() {
+        Some("core") => Ok(Namespace::Core),
+        Some("ui") => Ok(Namespace::Ui),
+        _ => Err(format!(
+            "message id {id:?} must start with `core.` or `ui.`"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_args_plural_and_plain() {
+        let src = r#"
+[messages."core.outbox.pending_deletes"]
+comment = "Storage queue: number of cloud deletes still pending."
+args = { count = "Int" }
+value = "{count, plural, one {# pending delete} other {# pending deletes}}"
+
+[messages."core.identify.barcode.looking_up"]
+args = { position = "Int", total = "Int" }
+value = "Looking up barcode {position} of {total}"
+
+[messages."ui.library.remove_from_device"]
+value = "remove this library from this device"
+"#;
+        let cat = Catalog::from_toml(src).expect("catalog parses");
+        assert_eq!(cat.messages.len(), 3);
+
+        let deletes = &cat.messages["core.outbox.pending_deletes"];
+        assert_eq!(deletes.args["count"], ArgType::Int);
+        assert!(deletes.value.contains("plural"));
+
+        let barcode = &cat.messages["core.identify.barcode.looking_up"];
+        assert_eq!(barcode.args.len(), 2);
+        assert_eq!(barcode.args["total"], ArgType::Int);
+
+        let chrome = &cat.messages["ui.library.remove_from_device"];
+        assert!(chrome.args.is_empty());
+        assert_eq!(chrome.comment, None);
+    }
+
+    #[test]
+    fn classifies_namespaces() {
+        assert_eq!(namespace_of("core.error.x").unwrap(), Namespace::Core);
+        assert_eq!(namespace_of("ui.button.ok").unwrap(), Namespace::Ui);
+        assert!(namespace_of("misc.oops").is_err());
+    }
+}

--- a/bae-loc/src/mf1.rs
+++ b/bae-loc/src/mf1.rs
@@ -1,0 +1,412 @@
+//! A focused parser for the ICU MessageFormat 1 subset bae authors.
+//!
+//! Supported: literal text, simple named arguments (`{name}`), and a `plural`
+//! argument (`{name, plural, one {# item} other {# items}}`) whose cases are
+//! CLDR categories (`zero`/`one`/`two`/`few`/`many`/`other`) or exact matches
+//! (`=0`). `#` inside a plural case is the formatted count. Apostrophe quoting
+//! follows ICU: `''` is a literal apostrophe, and `'{'` / `'}'` / `'#'` quote a
+//! literal special character.
+//!
+//! Deliberately narrow: `select`/`selectordinal`, number/date skeletons, and
+//! nested complex args are rejected with a clear error rather than mis-parsed,
+//! so an unsupported construct breaks the build instead of emitting wrong
+//! output. The set widens when a real message needs more.
+
+/// One node of a parsed message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Node {
+    Text(String),
+    /// A simple named argument: `{name}`.
+    Arg(String),
+    /// `#` — the formatted count, only meaningful inside a plural case.
+    Pound,
+    /// `{name, plural, <cases>}`.
+    Plural {
+        arg: String,
+        cases: Vec<PluralCase>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluralCase {
+    pub selector: PluralSelector,
+    pub message: Vec<Node>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluralSelector {
+    Category(PluralCategory),
+    /// `=N` exact match, checked before the category rules.
+    Exact(i64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluralCategory {
+    Zero,
+    One,
+    Two,
+    Few,
+    Many,
+    Other,
+}
+
+impl PluralCategory {
+    pub fn as_cldr(self) -> &'static str {
+        match self {
+            PluralCategory::Zero => "zero",
+            PluralCategory::One => "one",
+            PluralCategory::Two => "two",
+            PluralCategory::Few => "few",
+            PluralCategory::Many => "many",
+            PluralCategory::Other => "other",
+        }
+    }
+
+    fn from_keyword(kw: &str) -> Option<Self> {
+        Some(match kw {
+            "zero" => PluralCategory::Zero,
+            "one" => PluralCategory::One,
+            "two" => PluralCategory::Two,
+            "few" => PluralCategory::Few,
+            "many" => PluralCategory::Many,
+            "other" => PluralCategory::Other,
+            _ => return None,
+        })
+    }
+}
+
+/// Parse an MF1 source string into nodes. Returns a human-readable error on any
+/// unsupported or malformed construct.
+pub fn parse(src: &str) -> Result<Vec<Node>, String> {
+    let mut p = Parser {
+        chars: src.chars().collect(),
+        pos: 0,
+    };
+    let nodes = p.parse_message(true)?;
+    if p.pos != p.chars.len() {
+        return Err(format!("unexpected `}}` at offset {}", p.pos));
+    }
+    Ok(nodes)
+}
+
+struct Parser {
+    chars: Vec<char>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<char> {
+        self.chars.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        let c = self.chars.get(self.pos).copied();
+        if c.is_some() {
+            self.pos += 1;
+        }
+        c
+    }
+
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(c) if c.is_whitespace()) {
+            self.pos += 1;
+        }
+    }
+
+    /// Parse a run of message nodes. `top` distinguishes the whole-message call
+    /// (stops at end of input) from a plural case body (stops at the matching
+    /// `}`, which it consumes).
+    fn parse_message(&mut self, top: bool) -> Result<Vec<Node>, String> {
+        let mut nodes = Vec::new();
+        let mut text = String::new();
+        loop {
+            match self.peek() {
+                None => {
+                    if !top {
+                        return Err("unterminated `{` — missing `}`".to_string());
+                    }
+                    break;
+                }
+                Some('}') => {
+                    if top {
+                        // Caller (parse) flags the stray `}`.
+                        break;
+                    }
+                    self.bump(); // consume the closing brace of a case body
+                    break;
+                }
+                Some('\'') => {
+                    self.parse_quoted(&mut text)?;
+                }
+                Some('#') => {
+                    self.bump();
+                    flush(&mut nodes, &mut text);
+                    nodes.push(Node::Pound);
+                }
+                Some('{') => {
+                    flush(&mut nodes, &mut text);
+                    nodes.push(self.parse_arg()?);
+                }
+                Some(c) => {
+                    self.bump();
+                    text.push(c);
+                }
+            }
+        }
+        flush(&mut nodes, &mut text);
+        Ok(nodes)
+    }
+
+    /// At an apostrophe. ICU rules: `''` -> literal `'`; `'<special>'` quotes a
+    /// literal run until the next lone apostrophe; a lone apostrophe before a
+    /// non-special char is itself literal.
+    fn parse_quoted(&mut self, text: &mut String) -> Result<(), String> {
+        self.bump(); // opening '
+        match self.peek() {
+            Some('\'') => {
+                self.bump();
+                text.push('\'');
+                Ok(())
+            }
+            Some(c) if c == '{' || c == '}' || c == '#' => {
+                // Quoted literal run until the next apostrophe.
+                while let Some(c) = self.peek() {
+                    if c == '\'' {
+                        self.bump();
+                        return Ok(());
+                    }
+                    text.push(c);
+                    self.bump();
+                }
+                Err("unterminated apostrophe quote".to_string())
+            }
+            _ => {
+                // Lone apostrophe, literal.
+                text.push('\'');
+                Ok(())
+            }
+        }
+    }
+
+    /// At `{`. Parses either a simple `{name}` or `{name, plural, ...}`.
+    fn parse_arg(&mut self) -> Result<Node, String> {
+        self.bump(); // {
+        self.skip_ws();
+        let name = self.parse_ident()?;
+        self.skip_ws();
+        match self.bump() {
+            Some('}') => Ok(Node::Arg(name)),
+            Some(',') => {
+                self.skip_ws();
+                let kind = self.parse_ident()?;
+                if kind != "plural" {
+                    return Err(format!(
+                        "argument `{name}` uses unsupported `{kind}` (only `plural` is supported)"
+                    ));
+                }
+                self.skip_ws();
+                if self.bump() != Some(',') {
+                    return Err(format!("expected `,` after `plural` in `{name}`"));
+                }
+                let cases = self.parse_plural_cases()?;
+                Ok(Node::Plural { arg: name, cases })
+            }
+            other => Err(format!(
+                "expected `}}` or `,` after argument name `{name}`, found {other:?}"
+            )),
+        }
+    }
+
+    fn parse_plural_cases(&mut self) -> Result<Vec<PluralCase>, String> {
+        let mut cases = Vec::new();
+        loop {
+            self.skip_ws();
+            match self.peek() {
+                Some('}') => {
+                    self.bump();
+                    break;
+                }
+                None => return Err("unterminated plural — missing `}`".to_string()),
+                _ => {}
+            }
+            let selector = self.parse_selector()?;
+            self.skip_ws();
+            if self.bump() != Some('{') {
+                return Err("expected `{` to open a plural case body".to_string());
+            }
+            let message = self.parse_message(false)?;
+            cases.push(PluralCase { selector, message });
+        }
+        if cases.is_empty() {
+            return Err("plural has no cases".to_string());
+        }
+        if !cases
+            .iter()
+            .any(|c| matches!(c.selector, PluralSelector::Category(PluralCategory::Other)))
+        {
+            return Err("plural must include an `other` case".to_string());
+        }
+        Ok(cases)
+    }
+
+    fn parse_selector(&mut self) -> Result<PluralSelector, String> {
+        if self.peek() == Some('=') {
+            self.bump();
+            let mut digits = String::new();
+            while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+                digits.push(self.bump().unwrap());
+            }
+            if digits.is_empty() {
+                return Err("expected a number after `=` in a plural selector".to_string());
+            }
+            let n = digits
+                .parse::<i64>()
+                .map_err(|e| format!("bad `=` selector {digits:?}: {e}"))?;
+            return Ok(PluralSelector::Exact(n));
+        }
+        let kw = self.parse_ident()?;
+        PluralCategory::from_keyword(&kw)
+            .map(PluralSelector::Category)
+            .ok_or_else(|| format!("unknown plural selector `{kw}`"))
+    }
+
+    fn parse_ident(&mut self) -> Result<String, String> {
+        let mut s = String::new();
+        while let Some(c) = self.peek() {
+            if c.is_alphanumeric() || c == '_' || c == '.' {
+                s.push(c);
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        if s.is_empty() {
+            return Err(format!("expected an identifier at offset {}", self.pos));
+        }
+        Ok(s)
+    }
+}
+
+/// The argument names a message references, in order of first appearance
+/// (a plural's own argument included). The generator derives positional
+/// specifiers from this order, and the validator checks it against the declared
+/// `args`.
+pub fn referenced_args(nodes: &[Node]) -> Vec<String> {
+    let mut order = Vec::new();
+    fn walk(nodes: &[Node], order: &mut Vec<String>) {
+        for n in nodes {
+            match n {
+                Node::Arg(name) => {
+                    if !order.contains(name) {
+                        order.push(name.clone());
+                    }
+                }
+                Node::Plural { arg, cases } => {
+                    if !order.contains(arg) {
+                        order.push(arg.clone());
+                    }
+                    for c in cases {
+                        walk(&c.message, order);
+                    }
+                }
+                Node::Text(_) | Node::Pound => {}
+            }
+        }
+    }
+    walk(nodes, &mut order);
+    order
+}
+
+fn flush(nodes: &mut Vec<Node>, text: &mut String) {
+    if !text.is_empty() {
+        nodes.push(Node::Text(std::mem::take(text)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text() {
+        assert_eq!(
+            parse("that release couldn't be found").unwrap(),
+            vec![Node::Text("that release couldn't be found".to_string())]
+        );
+    }
+
+    #[test]
+    fn simple_args() {
+        assert_eq!(
+            parse("Looking up barcode {position} of {total}").unwrap(),
+            vec![
+                Node::Text("Looking up barcode ".to_string()),
+                Node::Arg("position".to_string()),
+                Node::Text(" of ".to_string()),
+                Node::Arg("total".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn plural_with_pound() {
+        let nodes =
+            parse("{count, plural, one {# pending delete} other {# pending deletes}}").unwrap();
+        let Node::Plural { arg, cases } = &nodes[0] else {
+            panic!("expected a plural node, got {nodes:?}");
+        };
+        assert_eq!(arg, "count");
+        assert_eq!(cases.len(), 2);
+        assert_eq!(
+            cases[0].selector,
+            PluralSelector::Category(PluralCategory::One)
+        );
+        assert_eq!(
+            cases[0].message,
+            vec![Node::Pound, Node::Text(" pending delete".to_string())]
+        );
+    }
+
+    #[test]
+    fn plural_exact_and_category() {
+        let nodes = parse("{n, plural, =0 {none} one {# thing} other {# things}}").unwrap();
+        let Node::Plural { cases, .. } = &nodes[0] else {
+            panic!("expected plural");
+        };
+        assert_eq!(cases[0].selector, PluralSelector::Exact(0));
+        assert_eq!(cases.len(), 3);
+    }
+
+    #[test]
+    fn rejects_select() {
+        let err = parse("{g, select, male {he} other {they}}").unwrap_err();
+        assert!(err.contains("only `plural`"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_plural_without_other() {
+        let err = parse("{n, plural, one {#}}").unwrap_err();
+        assert!(err.contains("`other`"), "got: {err}");
+    }
+
+    #[test]
+    fn apostrophe_quotes_a_literal_brace() {
+        assert_eq!(
+            parse("a '{' b").unwrap(),
+            vec![Node::Text("a { b".to_string())]
+        );
+    }
+
+    #[test]
+    fn double_apostrophe_is_literal() {
+        assert_eq!(
+            parse("it''s here").unwrap(),
+            vec![Node::Text("it's here".to_string())]
+        );
+    }
+
+    #[test]
+    fn rejects_stray_close_brace() {
+        assert!(parse("oops}").is_err());
+    }
+}


### PR DESCRIPTION
bae has no localization today, and the bridge ships pre-formatted English strings — so the first step toward localizing is establishing where strings live and how they reach each platform.

This introduces the foundation: a single master catalog (`bae-bridge/loc/catalog.toml`) authored in ICU MessageFormat 1 (the cross-platform standard), and `bae-loc` — a generator (`loc-gen`) that validates the catalog and emits each platform's native string resources. Android and Windows consume the MF1 pattern verbatim at runtime (`android.icu.text.MessageFormat` and the `MessageFormat` NuGet); only Apple needs structural conversion, to a String Catalog with `variations.plural` and positional specifiers.

Nothing consumes the generated resources yet, so this wires nothing into the platform builds and changes no bridge types. The catalog's validity is gated by a test over the real file; the bridge-enum cross-check (every keyed message variant has a catalog entry) lands with the first message enum in the next PR.

## Test plan
- `cargo test -p bae-loc` — 23 tests: MF1 parser, the three emitters, catalog validation, and real-catalog validity.
- `loc-gen check` + `loc-gen emit` smoke-tested for apple/android/windows; generated output inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx