### PR TITLE
fix(ci): drop unused bae-core deps, ignore the SQLite link dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,12 +726,10 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "axum",
- "base64",
  "chardetng",
  "chrono",
  "coven",
  "cpal",
- "crc32fast",
  "dirs",
  "discid",
  "dotenvy",
@@ -741,7 +739,6 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hex",
- "if-addrs",
  "image",
  "keyring-core",
  "libc",
@@ -761,7 +758,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha1 0.10.6",
  "sha2 0.10.9",
  "strsim",
  "tempfile",
@@ -2511,16 +2507,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "if-addrs"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/bae-bridge/Cargo.toml
+++ b/bae-bridge/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[package.metadata.cargo-machete]
+# libsqlite3-sys is a link/build dependency (bundled SQLite with the session
+# extension); it has no direct `use` here, so cargo-machete misreads it as unused.
+ignored = ["libsqlite3-sys"]
+
 [lib]
 name = "bae_bridge"
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -21,9 +21,7 @@ thiserror = "1.0"
 keyring-core = "0.7"
 uuid = { version = "1.0", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
-sha1 = "0.10"
 sha2 = "0.10"
-base64 = "0.22"
 hex = "0.4"
 aws-config = { version = "1.8", default-features = false, features = ["credentials-process", "rt-tokio", "sso"] }
 aws-sdk-s3 = { version = "1.122", default-features = false, features = ["rt-tokio", "sigv4a"] }
@@ -38,8 +36,6 @@ regex = "1.11"
 strsim = "0.11"
 unicode-normalization = "0.1"
 libc = "0.2"
-crc32fast = "1.4"
-if-addrs = "0.14"
 chardetng = "0.1"
 encoding_rs = "0.8"
 rtrb = "0.3.2"


### PR DESCRIPTION
The Test job's `cargo-machete` gate has been failing on `main` (and therefore on every PR), unrelated to any one change: bae-core declared `sha1`, `base64`, `crc32fast`, and `if-addrs` as direct dependencies with zero references in its source, and bae-bridge's `libsqlite3-sys` is a link-only dependency (bundled SQLite + the session extension) that cargo-machete can't observe being used.

This removes the four dead bae-core deps and marks `libsqlite3-sys` ignored. The same crates still pulled in transitively (sha1/base64/crc32fast via other deps) are untouched.

Surfaced while driving the localization work to green — it's the same Rust gate every i18n PR runs through.

## Test plan
- `cargo machete` → "no unused dependencies".
- Pre-commit macOS build compiles bae-core/bae-bridge without the removed deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx