### PR TITLE
loc: convert edit-validation messages to a typed, localized reason

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
         cargo clippy -p bae-core --tests --features bae-core/test-utils -- -D warnings
         cargo clippy -p bae-bridge -- -D warnings
 
+    - name: Run localization + bridge tests
+      run: |
+        cargo test -p bae-loc
+        cargo test -p bae-bridge --lib
+
     - name: Build macOS app
       id: build_macos
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ name = "bae-bridge"
 version = "0.1.0"
 dependencies = [
  "bae-core",
+ "bae-loc",
  "libsqlite3-sys",
  "serde_json",
  "thiserror 2.0.18",

--- a/bae-bridge/Cargo.toml
+++ b/bae-bridge/Cargo.toml
@@ -36,6 +36,10 @@ tracing-oslog = "0.3"
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = "0.2"
 
+[dev-dependencies]
+# The validation-reason ↔ catalog cross-check test loads the master catalog.
+bae-loc = { path = "../bae-loc" }
+
 [features]
 default = []
 # Enables the OAuth cloud-provider surface (sign-in + the desktop/host OAuth

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1893,9 +1893,33 @@ pub fn shape_release_edit(
             edit: crate::types::release_user_edit_to_bridge(edit),
         },
         Err(e) => crate::types::BridgeShapeResult::Invalid {
-            message: e.to_string(),
+            reason: validation_reason_from_core(e),
         },
     }
+}
+
+/// Map bae-core's validation error to its bridge mirror. Kept here, not as a
+/// `From` in bae-core, so bae-core stays unaware of bridge types.
+#[cfg(feature = "desktop")]
+fn validation_reason_from_core(
+    e: bae_core::import::EditValidationError,
+) -> crate::types::BridgeValidationReason {
+    use crate::types::BridgeValidationReason as R;
+    use bae_core::import::EditValidationError as E;
+    match e {
+        E::EmptyAlbumTitle => R::EmptyAlbumTitle,
+        E::NoAlbumArtist => R::NoAlbumArtist,
+        E::InvalidYear => R::InvalidYear,
+    }
+}
+
+/// The localization key for a validation reason, resolved by the UI against the
+/// generated `Core` string table. One exported mapping keeps every platform's
+/// keys identical.
+#[cfg(feature = "desktop")]
+#[uniffi::export]
+pub fn bridge_validation_reason_key(reason: crate::types::BridgeValidationReason) -> String {
+    reason.loc_key().to_string()
 }
 
 /// Seed the editor's raw form from a wire edit — the inverse of

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1488,15 +1488,64 @@ pub struct BridgeRawTrackEdit {
     pub track_number: Option<i32>,
 }
 
-/// Outcome of shaping a raw edit form (`shape_release_edit`). `Valid`
-/// carries the savable wire edit; `Invalid` carries the display-ready reason
-/// the form can't be saved (rendered in bae-core from
-/// `EditValidationError`). The editor enables Save on `Valid` and shows the
-/// message on `Invalid` — it never builds the message itself.
+/// Why a release edit can't be saved. An FFI mirror of bae-core's
+/// `EditValidationError`; the UI renders each variant by resolving its
+/// localization key — see `bridge_validation_reason_key`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeValidationReason {
+    EmptyAlbumTitle,
+    NoAlbumArtist,
+    InvalidYear,
+}
+
+impl BridgeValidationReason {
+    /// The catalog key the UI resolves against the generated `Core` string
+    /// table — the single source of the variant→key mapping for every platform.
+    /// Only the desktop edit flow produces a validation reason, so the mapping
+    /// is compiled there (and under test for the cross-check).
+    #[cfg(any(feature = "desktop", test))]
+    pub(crate) fn loc_key(self) -> &'static str {
+        match self {
+            Self::EmptyAlbumTitle => "core.import.validation.empty_album_title",
+            Self::NoAlbumArtist => "core.import.validation.no_album_artist",
+            Self::InvalidYear => "core.import.validation.invalid_year",
+        }
+    }
+}
+
+/// Outcome of shaping a raw edit form (`shape_release_edit`). `Valid` carries
+/// the savable wire edit; `Invalid` carries the typed reason it can't be saved.
+/// The editor enables Save on `Valid` and renders the localized reason on
+/// `Invalid` — bae-core decides which reason, the UI localizes it.
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum BridgeShapeResult {
     Valid { edit: BridgeReleaseUserEdit },
-    Invalid { message: String },
+    Invalid { reason: BridgeValidationReason },
+}
+
+#[cfg(test)]
+mod validation_reason_tests {
+    use super::BridgeValidationReason;
+
+    /// Every validation reason's localization key must exist in the master
+    /// catalog, so a renamed key or a dropped catalog entry fails the build
+    /// instead of rendering a raw key in the UI.
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for reason in [
+            BridgeValidationReason::EmptyAlbumTitle,
+            BridgeValidationReason::NoAlbumArtist,
+            BridgeValidationReason::InvalidYear,
+        ] {
+            assert!(
+                cat.messages.contains_key(reason.loc_key()),
+                "catalog is missing key `{}`",
+                reason.loc_key()
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, uniffi::Record)]

--- a/bae-macos/bae/bae/BridgeValidationReason+Localized.swift
+++ b/bae-macos/bae/bae/BridgeValidationReason+Localized.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension BridgeValidationReason {
+    /// The localized reason text, resolved from the generated `Core` string
+    /// table via the key bae-core owns (`bridgeValidationReasonKey`). bae-core
+    /// decides which reason; this is the UI's locale rendering of it.
+    var localizedMessage: String {
+        NSLocalizedString(
+            bridgeValidationReasonKey(reason: self),
+            tableName: "Core",
+            bundle: .main,
+            comment: ""
+        )
+    }
+}

--- a/bae-macos/bae/bae/Views/EditMetadataSheet.swift
+++ b/bae-macos/bae/bae/Views/EditMetadataSheet.swift
@@ -127,12 +127,12 @@ struct EditMetadataSheet: View {
         return nil
     }
 
-    /// The reason the form can't be saved, shaped by bae-core from its
-    /// `EditValidationError`, or `nil` when the form is savable. Shown below
-    /// the form so a disabled Save button always states why.
+    /// The localized reason the form can't be saved, or `nil` when the form is
+    /// savable. bae-core picks the reason; the UI localizes it. Shown below the
+    /// form so a disabled Save button always states why.
     private var validationMessage: String? {
-        if case .invalid(let message) = shapeReleaseEdit(raw: form) {
-            return message
+        if case .invalid(let reason) = shapeReleaseEdit(raw: form) {
+            return reason.localizedMessage
         }
         return nil
     }

--- a/bae-macos/bae/bae/Views/Import/ImportView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportView.swift
@@ -43,8 +43,10 @@ func commitImport(
     switch shapeReleaseEdit(raw: rawEdit) {
     case .valid(let edit):
         userEdit = edit
-    case .invalid(let message):
-        store.mutateCandidate(forKey: key) { $0.error = message }
+    case .invalid(let reason):
+        store.mutateCandidate(forKey: key) {
+            $0.error = reason.localizedMessage
+        }
         return
     }
     do {


### PR DESCRIPTION
The first real bridge conversion of the localization workstream, end-to-end on macOS — proof the architecture works.

`shape_release_edit` returned `Invalid { message: String }`, with bae-core rendering the English validation prose. It now returns `Invalid { reason: BridgeValidationReason }` (an FFI mirror of bae-core's `EditValidationError`), and the macOS editor resolves that reason to localized text via `bridge_validation_reason_key` against the generated `Core` string catalog — bae-core decides *which* reason, the UI localizes it. The variant→key mapping is one exported function, so every platform shares it.

A bae-bridge test cross-checks every reason key against the master catalog, now gated in CI alongside the bae-loc tests, so a renamed key or dropped catalog entry fails the build instead of surfacing a raw key.

## Test plan
- `cargo test -p bae-loc` + `cargo test -p bae-bridge --lib` (the cross-check) — now run in CI.
- macOS app builds with the regenerated bindings; `xcstringstool` compiles the catalog; the import-edit validation message renders from `Core.xcstrings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx