### PR TITLE
loc: convert BridgeError to a typed model (errors as data, not prose)

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -101,9 +101,7 @@ impl AppHandle {
                 .library_manager()
                 .get_album_page(&sort, offset, limit)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })?;
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
 
             Ok(albums.into_iter().map(convert_album_summary).collect())
         })
@@ -115,9 +113,7 @@ impl AppHandle {
                 .library_manager()
                 .get_album_count()
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })
+                .map_err(|e| BridgeError::database(format!("{e}")))
         })
     }
 
@@ -144,9 +140,7 @@ impl AppHandle {
                 .library_manager()
                 .file_local_path(&file_id)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })?;
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
             Ok(path.and_then(|p| p.to_str().map(|s| s.to_string())))
         })
     }
@@ -158,11 +152,10 @@ impl AppHandle {
                 .library_manager()
                 .find_album_detail(&album_id)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })?
+                .map_err(|e| BridgeError::database(format!("{e}")))?
                 .ok_or_else(|| BridgeError::NotFound {
-                    msg: format!("Album '{album_id}' not found"),
+                    entity: crate::types::BridgeEntityKind::Album,
+                    id: album_id.to_string(),
                 })?;
 
             Ok(convert_album_detail(detail))
@@ -181,9 +174,7 @@ impl AppHandle {
                 .library_manager()
                 .find_release_detail(&release_id)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })?;
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
             Ok(detail.map(convert_release_detail))
         })
     }
@@ -206,9 +197,7 @@ impl AppHandle {
                 .library_manager()
                 .get_storage_page(&core_sort, core_filter, offset, limit)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })?;
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
 
             Ok(BridgeStoragePage {
                 rows: page.rows.into_iter().map(convert_storage_row).collect(),
@@ -226,9 +215,7 @@ impl AppHandle {
                 .library_manager()
                 .get_storage_count(core_filter)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })
+                .map_err(|e| BridgeError::database(format!("{e}")))
         })
     }
 
@@ -238,9 +225,7 @@ impl AppHandle {
             .library_manager()
             .search_library(&query, 50)
             .await
-            .map_err(|e| BridgeError::Database {
-                msg: format!("{e}"),
-            })?;
+            .map_err(|e| BridgeError::database(format!("{e}")))?;
         Ok(BridgeSearchResults {
             albums: results
                 .albums
@@ -387,7 +372,7 @@ impl AppHandle {
                 .library_manager()
                 .resolve_to_track_ids(&ids)
                 .await
-                .map_err(|e| BridgeError::Database { msg: e.to_string() })
+                .map_err(BridgeError::database)
         })
     }
 
@@ -438,21 +423,21 @@ impl AppHandle {
         self.app_services
             .library_manager()
             .rename_library(&library_id, &name)
-            .map_err(|e| BridgeError::Config { msg: e.to_string() })
+            .map_err(BridgeError::config)
     }
 
     pub fn lock_active_library(&self) -> Result<(), BridgeError> {
         self.app_services
             .library_manager()
             .forget_encryption_key()
-            .map_err(|e| BridgeError::Internal { msg: e })
+            .map_err(BridgeError::internal)
     }
 
     pub fn get_discogs_token(&self) -> Result<Option<String>, BridgeError> {
         self.app_services
             .library_manager()
             .get_discogs_token()
-            .map_err(|msg| BridgeError::Config { msg })
+            .map_err(BridgeError::config)
     }
 
     // Discogs token writes live on the desktop-only import service (see the
@@ -488,9 +473,7 @@ impl AppHandle {
             .library_manager()
             .change_cover(&album_id, &release_id, core_selection)
             .await
-            .map_err(|e| BridgeError::Internal {
-                msg: format!("{e}"),
-            })
+            .map_err(|e| BridgeError::internal(format!("{e}")))
     }
 
     pub fn set_primary_release(
@@ -503,9 +486,7 @@ impl AppHandle {
                 .library_manager()
                 .set_album_primary_release(&album_id, &release_id)
                 .await
-                .map_err(|e| BridgeError::Internal {
-                    msg: format!("{e}"),
-                })
+                .map_err(|e| BridgeError::internal(format!("{e}")))
         })
     }
 
@@ -525,7 +506,7 @@ impl AppHandle {
             async move { services.library_manager().unpin_release(&release_id).await },
         )
         .await
-        .map_err(|msg| BridgeError::Internal { msg })
+        .map_err(BridgeError::internal)
     }
 
     pub async fn manage_release(
@@ -542,7 +523,7 @@ impl AppHandle {
                 .await
         })
         .await
-        .map_err(|msg| BridgeError::Internal { msg })
+        .map_err(BridgeError::internal)
     }
 
     pub async fn unmanage_release(
@@ -558,7 +539,7 @@ impl AppHandle {
                 .await
         })
         .await
-        .map_err(|msg| BridgeError::Internal { msg })
+        .map_err(BridgeError::internal)
     }
 
     pub fn delete_release(&self, release_id: String) {
@@ -602,14 +583,14 @@ impl AppHandle {
                 .await
         })
         .await
-        .map_err(|msg| BridgeError::Config { msg })
+        .map_err(BridgeError::config)
     }
 
     pub fn disconnect_cloud_provider(&self) -> Result<(), BridgeError> {
         self.app_services
             .library_manager()
             .disconnect_cloud_provider()
-            .map_err(|msg| BridgeError::Config { msg })
+            .map_err(BridgeError::config)
     }
 
     /// Warning text for the disconnect-sync confirmation when releases live
@@ -623,14 +604,14 @@ impl AppHandle {
                     .library_manager()
                     .disconnect_warning_message(),
             )
-            .map_err(|msg| BridgeError::Internal { msg })
+            .map_err(BridgeError::internal)
     }
 
     pub fn generate_restore_code(&self) -> Result<String, BridgeError> {
         self.app_services
             .library_manager()
             .generate_restore_code()
-            .map_err(|msg| BridgeError::Config { msg })
+            .map_err(BridgeError::config)
     }
 
     /// Forget the active local library on this device: delete its key, clear the
@@ -641,7 +622,7 @@ impl AppHandle {
         self.app_services
             .library_manager()
             .forget_library()
-            .map_err(|e| BridgeError::Config { msg: e })?;
+            .map_err(BridgeError::config)?;
 
         info!("Forgot local library");
         Ok(())
@@ -661,7 +642,7 @@ impl AppHandle {
         let snapshot = self
             .runtime
             .block_on(self.app_services.library_manager().outbox_snapshot())
-            .map_err(|e| BridgeError::Internal { msg: e.to_string() })?;
+            .map_err(BridgeError::internal)?;
         Ok(convert_outbox_snapshot(snapshot))
     }
 
@@ -669,14 +650,14 @@ impl AppHandle {
     pub fn retry_outbox(&self) -> Result<(), BridgeError> {
         self.runtime
             .block_on(self.app_services.library_manager().retry_outbox_now())
-            .map_err(|e| BridgeError::Internal { msg: e.to_string() })
+            .map_err(BridgeError::internal)
     }
 
     /// Cancel one queued outbox entry by id (dequeues it; the local file stays).
     pub fn cancel_outbox_item(&self, id: i64) -> Result<(), BridgeError> {
         self.runtime
             .block_on(self.app_services.library_manager().cancel_outbox_item(id))
-            .map_err(|e| BridgeError::Internal { msg: e.to_string() })
+            .map_err(BridgeError::internal)
     }
 
     /// Pause or resume the cloud-upload pipeline. While paused, new enqueues
@@ -751,7 +732,7 @@ impl AppHandle {
             .library_manager()
             .load_gallery_image(&release_id, &file_id)
             .await
-            .map_err(|e| BridgeError::Import { msg: e.to_string() })
+            .map_err(BridgeError::import)
     }
 }
 
@@ -768,7 +749,7 @@ impl AppHandle {
         let storage = bridge_home_storage_to_core(storage);
         self.spawn_on_runtime(async move { services.library_manager().use_cloudkit(storage).await })
             .await
-            .map_err(|msg| BridgeError::Config { msg })
+            .map_err(BridgeError::config)
     }
 }
 
@@ -796,7 +777,7 @@ impl AppHandle {
                 .await
         })
         .await
-        .map_err(|msg| BridgeError::Config { msg })
+        .map_err(BridgeError::config)
     }
 }
 
@@ -821,7 +802,7 @@ impl AppHandle {
             .save_discogs_token(&token)
             .await
             .map(BridgeDiscogsSaveOutcome::from)
-            .map_err(|e| BridgeError::Config { msg: e })
+            .map_err(BridgeError::config)
     }
 
     /// Re-check a stored `Unvalidated` key against Discogs. No-op when no key is
@@ -832,14 +813,14 @@ impl AppHandle {
             .import()
             .revalidate_discogs_token()
             .await
-            .map_err(|e| BridgeError::Config { msg: e })
+            .map_err(BridgeError::config)
     }
 
     pub fn remove_discogs_token(&self) -> Result<(), BridgeError> {
         self.app_services
             .import()
             .remove_discogs_token()
-            .map_err(|e| BridgeError::Config { msg: e })
+            .map_err(BridgeError::config)
     }
 
     /// Register the platform artwork analyzer. Called once at app boot
@@ -926,11 +907,11 @@ impl AppHandle {
         library_manager
             .re_identify_release(&release_id, core_choice)
             .await
-            .map_err(|e| BridgeError::Import { msg: e.to_string() })?;
+            .map_err(BridgeError::import)?;
         library_manager
             .get_album_id_for_release(&release_id)
             .await
-            .map_err(|e| BridgeError::Database { msg: e.to_string() })
+            .map_err(BridgeError::database)
     }
 
     /// The current watched-folder list. The UI fetches this when the import
@@ -948,14 +929,14 @@ impl AppHandle {
         self.app_services
             .import()
             .add_watched_folder(path)
-            .map_err(|e| BridgeError::Import { msg: e })
+            .map_err(BridgeError::import)
     }
 
     pub fn remove_watched_folder(&self, path: String) -> Result<(), BridgeError> {
         self.app_services
             .import()
             .remove_watched_folder(path)
-            .map_err(|e| BridgeError::Import { msg: e })
+            .map_err(BridgeError::import)
     }
 
     /// Mark the candidate at `path` skipped or unskipped. Persists the change and
@@ -965,7 +946,7 @@ impl AppHandle {
         self.app_services
             .import()
             .set_candidate_skipped(path, skipped)
-            .map_err(|e| BridgeError::Import { msg: e })
+            .map_err(BridgeError::import)
     }
 
     /// Scan every watched folder, streaming results back as
@@ -975,7 +956,7 @@ impl AppHandle {
         self.app_services
             .import()
             .scan_watched_folders()
-            .map_err(|e| BridgeError::Import { msg: e })
+            .map_err(BridgeError::import)
     }
 
     /// Search for releases with library status check in one call. Cancelled
@@ -1028,7 +1009,7 @@ impl AppHandle {
             .import()
             .search_with_status(core_query)
             .await
-            .map_err(|e| BridgeError::Import { msg: e })?;
+            .map_err(BridgeError::import)?;
 
         Ok(crate::types::BridgeCandidateSearchResults {
             tab,
@@ -1052,9 +1033,7 @@ impl AppHandle {
                 .library_manager()
                 .is_source_folder_name_imported(&name)
                 .await
-                .map_err(|e| BridgeError::Database {
-                    msg: format!("{e}"),
-                })
+                .map_err(|e| BridgeError::database(format!("{e}")))
         })
     }
 
@@ -1085,7 +1064,7 @@ impl AppHandle {
                 user_edit,
             )
             .map(|_| ())
-            .map_err(|e| BridgeError::Import { msg: e })
+            .map_err(BridgeError::import)
     }
 
     /// Project the embedded tags of a folder's audio files into the
@@ -1102,7 +1081,7 @@ impl AppHandle {
             .import()
             .preview_file_tags_for_folder(std::path::PathBuf::from(&folder_path))
             .await
-            .map_err(|e| BridgeError::Import { msg: e })?;
+            .map_err(BridgeError::import)?;
         Ok(crate::types::release_user_edit_to_bridge(edit))
     }
 
@@ -1119,7 +1098,7 @@ impl AppHandle {
             .library_manager()
             .apply_release_metadata_user_edit(&release_id, &core_edit)
             .await
-            .map_err(|e| BridgeError::Import { msg: e.to_string() })
+            .map_err(BridgeError::import)
     }
 
     /// Seed the EditMetadataSheet's raw form from a library release's current
@@ -1134,7 +1113,7 @@ impl AppHandle {
             .library_manager()
             .release_edit_seed(&release_id)
             .await
-            .map_err(|e| BridgeError::Import { msg: e.to_string() })?;
+            .map_err(BridgeError::import)?;
         Ok(crate::types::raw_release_edit_to_bridge(raw))
     }
 
@@ -1153,7 +1132,7 @@ impl AppHandle {
             .library_manager()
             .reset_metadata_to_source(&release_id)
             .await
-            .map_err(|e| BridgeError::Import { msg: e.to_string() })?;
+            .map_err(BridgeError::import)?;
         Ok(crate::types::release_user_edit_to_bridge(edit))
     }
 
@@ -1168,7 +1147,7 @@ impl AppHandle {
             .import()
             .prefetch_release(&release_id, source.to_core())
             .await
-            .map_err(|e| BridgeError::Import { msg: e })?;
+            .map_err(BridgeError::import)?;
         Ok(crate::types::release_detail_to_bridge(
             detail,
             local_track_count,
@@ -1184,7 +1163,7 @@ impl AppHandle {
             .import()
             .fetch_remote_covers(&release_id)
             .await
-            .map_err(|e| BridgeError::Import { msg: e })?;
+            .map_err(BridgeError::import)?;
         Ok(covers
             .into_iter()
             .map(crate::types::remote_cover_data_to_bridge)
@@ -1200,7 +1179,7 @@ impl AppHandle {
             .import()
             .fetch_cover_bytes(url)
             .await
-            .map_err(|e| BridgeError::Import { msg: e })
+            .map_err(BridgeError::import)
     }
 }
 
@@ -1230,9 +1209,7 @@ impl AppHandle {
             .library_manager()
             .export_track(&track_id, std::path::Path::new(&output_path), core_format)
             .await
-            .map_err(|e| BridgeError::Export {
-                msg: format!("{e}"),
-            })
+            .map_err(|e| BridgeError::export(format!("{e}")))
     }
 }
 

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -28,11 +28,12 @@ pub fn init_app(
 fn bootstrap_error_to_bridge(e: BootstrapError) -> BridgeError {
     match e {
         BootstrapError::LibraryNotFound(id) => BridgeError::NotFound {
-            msg: format!("Library '{id}' not found"),
+            entity: crate::types::BridgeEntityKind::Library,
+            id,
         },
-        BootstrapError::Config(msg) => BridgeError::Config { msg },
-        BootstrapError::Database(msg) => BridgeError::Database { msg },
-        BootstrapError::Internal(msg) => BridgeError::Internal { msg },
+        BootstrapError::Config(msg) => BridgeError::config(msg),
+        BootstrapError::Database(msg) => BridgeError::database(msg),
+        BootstrapError::Internal(msg) => BridgeError::internal(msg),
     }
 }
 

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -4,9 +4,8 @@
 //! that AppHandle will later open).
 
 fn parse_oauth_tokens(json: &str) -> Result<bae_core::oauth::OAuthTokens, BridgeError> {
-    serde_json::from_str(json).map_err(|e| BridgeError::Config {
-        msg: format!("Invalid OAuth token JSON: {e}"),
-    })
+    serde_json::from_str(json)
+        .map_err(|e| BridgeError::config(format!("Invalid OAuth token JSON: {e}")))
 }
 
 /// The cloud providers this build supports, in display order: the credential /
@@ -104,9 +103,9 @@ fn get_cloudkit_ops() -> Option<std::sync::Arc<dyn bae_core::storage::cloud::clo
 fn restore_error_to_bridge(error: RestoreFromCodeError) -> BridgeError {
     match error {
         RestoreFromCodeError::Cancelled => BridgeError::Cancelled,
-        RestoreFromCodeError::Restore(error) => BridgeError::Internal {
-            msg: format!("Failed to restore library: {error}"),
-        },
+        RestoreFromCodeError::Restore(error) => {
+            BridgeError::internal(format!("Failed to restore library: {error}"))
+        }
     }
 }
 
@@ -211,9 +210,7 @@ pub fn create_library(name: Option<String>) -> Result<BridgeLibrary, BridgeError
         Some(n) => bae_core::library::create_library(n, ids.as_ref()),
         None => bae_core::library::create_library_default(ids.as_ref()),
     }
-    .map_err(|e| BridgeError::Config {
-        msg: format!("{e}"),
-    })?;
+    .map_err(|e| BridgeError::config(format!("{e}")))?;
 
     Ok(local_library_active(&config))
 }
@@ -276,9 +273,8 @@ pub fn restore_from_cloud(
                 secret_key,
             },
             BridgeRestoreSource::CloudKit => {
-                let ops = get_cloudkit_ops().ok_or_else(|| BridgeError::Internal {
-                    msg: "CloudKit driver not set".to_string(),
-                })?;
+                let ops = get_cloudkit_ops()
+                    .ok_or_else(|| BridgeError::internal("CloudKit driver not set".to_string()))?;
                 RestoreSource::CloudKit { ops }
             }
             BridgeRestoreSource::GoogleDrive {
@@ -320,9 +316,7 @@ pub fn restore_from_cloud(
             |status| info!("{}", status),
         )
         .await
-        .map_err(|e| BridgeError::Internal {
-            msg: format!("Failed to restore library: {e}"),
-        })?;
+        .map_err(|e| BridgeError::internal(format!("Failed to restore library: {e}")))?;
 
         Ok(local_library_active(&config))
     })
@@ -332,7 +326,7 @@ pub fn restore_from_cloud(
 #[uniffi::export]
 pub fn decode_restore_code(code: String) -> Result<BridgeRestoreCodeInfo, BridgeError> {
     let info = bae_core::sync::restore_code::decode_restore_code_info(&code)
-        .map_err(|e| BridgeError::Config { msg: e.to_string() })?;
+        .map_err(BridgeError::config)?;
 
     Ok(BridgeRestoreCodeInfo {
         library_id: info.library_id,
@@ -395,9 +389,9 @@ impl RestoreFromCodeOperation {
         {
             let mut started = self.started.lock().expect("restore started mutex poisoned");
             if *started {
-                return Err(BridgeError::Internal {
-                    msg: "restore operation already started".to_string(),
-                });
+                return Err(BridgeError::internal(
+                    "restore operation already started".to_string(),
+                ));
             }
             *started = true;
         }
@@ -445,13 +439,10 @@ pub fn oauth_authorize(provider: BridgeCloudProvider) -> Result<String, BridgeEr
         let clock = std::sync::Arc::new(bae_core::clock::SystemClock);
         let tokens = bae_core::oauth::authorize_provider(core_provider, cancel, clock.as_ref())
             .await
-            .map_err(|e| BridgeError::Config {
-                msg: format!("OAuth authorization failed: {e}"),
-            })?;
+            .map_err(|e| BridgeError::config(format!("OAuth authorization failed: {e}")))?;
 
-        serde_json::to_string(&tokens).map_err(|e| BridgeError::Internal {
-            msg: format!("Failed to serialize tokens: {e}"),
-        })
+        serde_json::to_string(&tokens)
+            .map_err(|e| BridgeError::internal(format!("Failed to serialize tokens: {e}")))
     });
 
     // Clean up
@@ -480,16 +471,15 @@ pub struct BridgeOAuthRequest {
 #[uniffi::export]
 pub fn set_oauth_client_creds(creds_json: String) -> Result<(), BridgeError> {
     let parsed: std::collections::HashMap<String, serde_json::Value> =
-        serde_json::from_str(&creds_json).map_err(|e| BridgeError::Config {
-            msg: format!("Invalid OAuth creds JSON: {e}"),
-        })?;
+        serde_json::from_str(&creds_json)
+            .map_err(|e| BridgeError::config(format!("Invalid OAuth creds JSON: {e}")))?;
     let mut creds = std::collections::HashMap::new();
     for (provider, value) in parsed {
         let client_id = value
             .get("client_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| BridgeError::Config {
-                msg: format!("OAuth creds for {provider} missing client_id"),
+            .ok_or_else(|| {
+                BridgeError::config(format!("OAuth creds for {provider} missing client_id"))
             })?
             .to_string();
         let client_secret = value
@@ -522,9 +512,7 @@ pub fn oauth_begin(
 ) -> Result<BridgeOAuthRequest, BridgeError> {
     let core_provider = bridge_cloud_provider_to_core(provider);
     let req = bae_core::oauth::build_authorize_request_for_provider(core_provider, &redirect_uri)
-        .map_err(|e| BridgeError::Config {
-        msg: format!("OAuth begin failed: {e}"),
-    })?;
+        .map_err(|e| BridgeError::config(format!("OAuth begin failed: {e}")))?;
     Ok(BridgeOAuthRequest {
         auth_url: req.auth_url,
         verifier: req.verifier,
@@ -554,12 +542,9 @@ pub fn oauth_complete(
         )
         .await
     })
-    .map_err(|e| BridgeError::Config {
-        msg: format!("OAuth token exchange failed: {e}"),
-    })?;
-    serde_json::to_string(&tokens).map_err(|e| BridgeError::Internal {
-        msg: format!("Failed to serialize tokens: {e}"),
-    })
+    .map_err(|e| BridgeError::config(format!("OAuth token exchange failed: {e}")))?;
+    serde_json::to_string(&tokens)
+        .map_err(|e| BridgeError::internal(format!("Failed to serialize tokens: {e}")))
 }
 
 /// Cancel an in-progress OAuth flow. Signals the callback server to shut down
@@ -580,8 +565,7 @@ pub fn oauth_cancel() {
 /// Validates the key against the stored fingerprint, then saves it to the keyring.
 #[uniffi::export]
 pub fn unlock_library(library_id: String, key_hex: String) -> Result<(), BridgeError> {
-    bae_core::library::unlock_library(&library_id, &key_hex)
-        .map_err(|e| BridgeError::Config { msg: e.to_string() })
+    bae_core::library::unlock_library(&library_id, &key_hex).map_err(BridgeError::config)
 }
 
 /// Validate restore form fields for a given cloud provider.

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1870,22 +1870,74 @@ pub enum BridgeExportFormat {
     Mp3,
 }
 
+/// The kind of diagnostic failure. The UI shows one generic localized line per
+/// category; `detail` is the underlying Rust error chain — logged and offered in
+/// a copyable disclosure, never translated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeErrorCategory {
+    Database,
+    Config,
+    Internal,
+    Import,
+    Export,
+}
+
+/// What a `NotFound` was looking for, so the UI can localize "… not found".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeEntityKind {
+    Library,
+    Album,
+    Release,
+    Track,
+    File,
+}
+
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum BridgeError {
-    #[error("Cancelled")]
+    /// The user cancelled — the UI shows nothing.
+    #[error("cancelled")]
     Cancelled,
-    #[error("Not found: {msg}")]
-    NotFound { msg: String },
-    #[error("Configuration error: {msg}")]
-    Config { msg: String },
-    #[error("Database error: {msg}")]
-    Database { msg: String },
-    #[error("Internal error: {msg}")]
-    Internal { msg: String },
-    #[error("Import error: {msg}")]
-    Import { msg: String },
-    #[error("Export error: {msg}")]
-    Export { msg: String },
+    /// A specific entity was missing. User-facing and keyed; the UI localizes it.
+    #[error("not found: {entity:?} {id}")]
+    NotFound {
+        entity: BridgeEntityKind,
+        id: String,
+    },
+    /// A diagnostic failure. The UI shows a generic per-category line; `detail`
+    /// is the opaque Rust error chain for logs / a copyable disclosure, never
+    /// translated.
+    #[error("{category:?}: {detail}")]
+    Diagnostic {
+        category: BridgeErrorCategory,
+        detail: String,
+    },
+}
+
+impl BridgeError {
+    pub(crate) fn diagnostic(
+        category: BridgeErrorCategory,
+        detail: impl std::fmt::Display,
+    ) -> Self {
+        BridgeError::Diagnostic {
+            category,
+            detail: detail.to_string(),
+        }
+    }
+    pub(crate) fn database(detail: impl std::fmt::Display) -> Self {
+        Self::diagnostic(BridgeErrorCategory::Database, detail)
+    }
+    pub(crate) fn config(detail: impl std::fmt::Display) -> Self {
+        Self::diagnostic(BridgeErrorCategory::Config, detail)
+    }
+    pub(crate) fn internal(detail: impl std::fmt::Display) -> Self {
+        Self::diagnostic(BridgeErrorCategory::Internal, detail)
+    }
+    pub(crate) fn import(detail: impl std::fmt::Display) -> Self {
+        Self::diagnostic(BridgeErrorCategory::Import, detail)
+    }
+    pub(crate) fn export(detail: impl std::fmt::Display) -> Self {
+        Self::diagnostic(BridgeErrorCategory::Export, detail)
+    }
 }
 
 #[cfg(feature = "cloudkit")]

--- a/bae-bridge/src/utils.rs
+++ b/bae-bridge/src/utils.rs
@@ -3,12 +3,8 @@ use crate::types::BridgeError;
 /// Read a text file with automatic encoding detection.
 #[uniffi::export]
 pub fn read_text_file(path: String) -> Result<String, BridgeError> {
-    let decoded =
-        bae_core::text_encoding::read_text_file(std::path::Path::new(&path)).map_err(|e| {
-            BridgeError::Internal {
-                msg: format!("Failed to read file: {e}"),
-            }
-        })?;
+    let decoded = bae_core::text_encoding::read_text_file(std::path::Path::new(&path))
+        .map_err(|e| BridgeError::internal(format!("Failed to read file: {e}")))?;
     Ok(decoded.text)
 }
 

--- a/bae-macos/bae/bae/Views/Settings/SyncSetupWizard.swift
+++ b/bae-macos/bae/bae/Views/Settings/SyncSetupWizard.swift
@@ -420,8 +420,10 @@ struct SyncSetupWizard: View {
     /// sentence in `msg`, but its `localizedDescription` is the reflected
     /// enum, so unwrap the case instead.
     private func connectErrorMessage(_ error: Error) -> String {
-        if case BridgeError.Config(let msg) = error {
-            return msg.contains("denied") ? "Access denied" : msg
+        if case BridgeError.Diagnostic(let category, let detail) = error,
+            category == .config
+        {
+            return detail.contains("denied") ? "Access denied" : detail
         }
         #if BAE_CLOUDKIT
             if case CloudKitError.Storage(let msg) = error {


### PR DESCRIPTION
The amended thinness rule says the bridge emits data, not prose. `BridgeError` did the opposite — free-form `{msg}` strings (Database/Config/Internal/Import/Export) plus a `NotFound` carrying a sentence.

This collapses those into a typed model: `Diagnostic { category, detail }` (a category enum plus the opaque Rust error chain, logged but never translated) and `NotFound { entity, id }`. The ~70 construction sites across handle/setup/init/utils reduce to per-category constructors (`BridgeError::database(e)`, etc.).

This is the structural prerequisite for localizing errors. The UI's localized *rendering* of the typed error — mapping category/entity to catalog messages — is a focused follow-up: uniffi owns `BridgeError.errorDescription`, so localizing the display means touching the `error.localizedDescription` sites rather than one extension. For now those show the typed error's `#[error]` text (functional English); the structural change is in place.

## Test plan
- `cargo clippy -p bae-bridge --features oauth-providers,cloudkit,desktop -- -D warnings` — clean.
- macOS app builds; the one site that matched the old `.Config` now matches `.Diagnostic(category: .config)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx