### PR TITLE
fix(ci): gate library_dir to its desktop callers (Android dead-code)

### DIFF
--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -1212,6 +1212,9 @@ impl LibraryManager {
 
     /// The library's on-disk directory. The import layer reads/writes its
     /// sibling appdata files (e.g. the watched-folder registry) under it.
+    /// Only the desktop import modules call this, so it isn't compiled on
+    /// mobile (where it would otherwise be dead code).
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub(crate) fn library_dir(&self) -> &LibraryDir {
         &self.library_dir
     }


### PR DESCRIPTION
The Android (and iOS) build has been failing to compile bae-core: `LibraryManager::library_dir` is flagged as never-used on mobile, because its only callers — the import `handle`/`service` modules — are gated `#[cfg(not(any(target_os = "ios", target_os = "android")))]`. The accessor wasn't, so on mobile it became dead code under `-D warnings`.

This gates the method with the same cfg as its callers. Desktop (macOS/Linux/Windows) keeps it; mobile drops it alongside the import modules that use it.

Pre-existing failure, unrelated to the localization workstream but surfaced while driving it toward green.

## Test plan
- Host clippy (bae-core, bae-bridge) clean — desktop keeps the method.
- Android CI cross-compiles bae-core without the dead-code error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx