### PR TITLE
loc: convert import progress to a typed step (bae-core prose inversion)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -16,6 +16,34 @@ value = "Album must have at least one artist"
 comment = "Import edit: the year field is not a number."
 value = "Year must be a number"
 
+[messages."core.import.prepare.parsing_metadata"]
+comment = "Import progress: preparing — parsing metadata."
+value = "Parsing metadata..."
+
+[messages."core.import.prepare.writing_cover_art"]
+comment = "Import progress: preparing — writing cover art."
+value = "Writing cover art..."
+
+[messages."core.import.prepare.discovering_files"]
+comment = "Import progress: preparing — discovering files."
+value = "Discovering files..."
+
+[messages."core.import.prepare.validating_tracks"]
+comment = "Import progress: preparing — validating tracks."
+value = "Validating tracks..."
+
+[messages."core.import.prepare.saving_to_database"]
+comment = "Import progress: preparing — saving to the database."
+value = "Saving to database..."
+
+[messages."core.import.phase.acquire"]
+comment = "Import progress: downloading or ripping the files."
+value = "Downloading..."
+
+[messages."core.import.phase.store"]
+comment = "Import progress: encrypting and storing the files."
+value = "Storing files..."
+
 [messages."core.identify.barcode.looking_up"]
 comment = "Identify: which barcode is being looked up, of how many."
 args = { position = "Int", total = "Int" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1543,13 +1543,11 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
         UiBusEvent::CandidateImportImporting {
             key,
             progress_percent,
-            phase,
-            status_text,
+            step,
         } => Some(BridgeUiEvent::CandidateImportImporting {
             key,
             progress_percent,
-            phase,
-            status_text,
+            step: step.map(crate::types::import_step_to_bridge),
         }),
         UiBusEvent::CandidateImportComplete {
             key,

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -546,21 +546,119 @@ pub struct BridgeCandidateFiles {
     pub documents: Vec<BridgeFileInfo>,
 }
 
-#[derive(Debug, Clone, uniffi::Enum)]
-pub enum BridgeImportStatus {
-    Importing {
-        progress_percent: u32,
-        /// "acquire" (ripping/downloading) or "store" (encrypting/storing), or nil for folder imports
-        phase: Option<String>,
-        /// Human-readable status text (e.g. "Downloading cover art...")
-        status_text: Option<String>,
-    },
-    Complete {
-        album_id: String,
-    },
-    Error {
-        message: String,
-    },
+/// Phase-0 preparation step, mirroring bae-core's `PrepareStep`. The UI
+/// localizes each variant via its catalog key (`bridge_prepare_step_key`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgePrepareStep {
+    ParsingMetadata,
+    WritingCoverArt,
+    DiscoveringFiles,
+    ValidatingTracks,
+    SavingToDatabase,
+}
+
+impl BridgePrepareStep {
+    pub(crate) fn loc_key(self) -> &'static str {
+        match self {
+            Self::ParsingMetadata => "core.import.prepare.parsing_metadata",
+            Self::WritingCoverArt => "core.import.prepare.writing_cover_art",
+            Self::DiscoveringFiles => "core.import.prepare.discovering_files",
+            Self::ValidatingTracks => "core.import.prepare.validating_tracks",
+            Self::SavingToDatabase => "core.import.prepare.saving_to_database",
+        }
+    }
+}
+
+/// Pipeline phase, mirroring bae-core's `ImportPhase`. Localized via
+/// `bridge_import_phase_key`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeImportPhase {
+    Acquire,
+    Store,
+}
+
+impl BridgeImportPhase {
+    pub(crate) fn loc_key(self) -> &'static str {
+        match self {
+            Self::Acquire => "core.import.phase.acquire",
+            Self::Store => "core.import.phase.store",
+        }
+    }
+}
+
+/// Which step of an import is in progress, mirroring bae-core's `ImportStep`.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeImportStep {
+    Preparing { step: BridgePrepareStep },
+    Running { phase: BridgeImportPhase },
+}
+
+pub(crate) fn import_step_to_bridge(s: bae_core::import::ImportStep) -> BridgeImportStep {
+    use bae_core::import::{ImportPhase, ImportStep, PrepareStep};
+    match s {
+        ImportStep::Preparing(p) => BridgeImportStep::Preparing {
+            step: match p {
+                PrepareStep::ParsingMetadata => BridgePrepareStep::ParsingMetadata,
+                PrepareStep::WritingCoverArt => BridgePrepareStep::WritingCoverArt,
+                PrepareStep::DiscoveringFiles => BridgePrepareStep::DiscoveringFiles,
+                PrepareStep::ValidatingTracks => BridgePrepareStep::ValidatingTracks,
+                PrepareStep::SavingToDatabase => BridgePrepareStep::SavingToDatabase,
+            },
+        },
+        ImportStep::Running(phase) => BridgeImportStep::Running {
+            phase: match phase {
+                ImportPhase::Acquire => BridgeImportPhase::Acquire,
+                ImportPhase::Store => BridgeImportPhase::Store,
+            },
+        },
+    }
+}
+
+/// Localization key for a prepare step — resolved by the UI against the `Core`
+/// string table. One source for every platform.
+#[uniffi::export]
+pub fn bridge_prepare_step_key(step: BridgePrepareStep) -> String {
+    step.loc_key().to_string()
+}
+
+/// Localization key for an import phase.
+#[uniffi::export]
+pub fn bridge_import_phase_key(phase: BridgeImportPhase) -> String {
+    phase.loc_key().to_string()
+}
+
+#[cfg(test)]
+mod import_step_tests {
+    use super::{BridgeImportPhase, BridgePrepareStep};
+
+    /// Every import-step key must exist in the catalog, so a renamed key fails
+    /// the build instead of rendering a raw key in the progress UI.
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        let prepare = [
+            BridgePrepareStep::ParsingMetadata,
+            BridgePrepareStep::WritingCoverArt,
+            BridgePrepareStep::DiscoveringFiles,
+            BridgePrepareStep::ValidatingTracks,
+            BridgePrepareStep::SavingToDatabase,
+        ];
+        for step in prepare {
+            assert!(
+                cat.messages.contains_key(step.loc_key()),
+                "catalog missing `{}`",
+                step.loc_key()
+            );
+        }
+        for phase in [BridgeImportPhase::Acquire, BridgeImportPhase::Store] {
+            assert!(
+                cat.messages.contains_key(phase.loc_key()),
+                "catalog missing `{}`",
+                phase.loc_key()
+            );
+        }
+    }
 }
 
 /// One pressing under a release-group card. The card carries the album's
@@ -1091,8 +1189,7 @@ pub enum BridgeUiEvent {
     CandidateImportImporting {
         key: String,
         progress_percent: u32,
-        phase: Option<String>,
-        status_text: Option<String>,
+        step: Option<BridgeImportStep>,
     },
     CandidateImportComplete {
         key: String,

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -64,7 +64,7 @@ pub use progress::ImportProgressHandle;
 pub use service::ImportService;
 pub use types::{
     CoverSelection, EditValidationError, IdentityChoice, ImportCommand, ImportPhase,
-    ImportProgress, MetadataPointer, MetadataRef, MetadataSource, PrepareStep, PressingEdit,
-    RawPressingEdit, RawReleaseEdit, RawTrackEdit, ReleaseIdentity, ReleaseUserEdit, StorageMode,
-    TrackFile, TrackUserEdit,
+    ImportProgress, ImportStep, MetadataPointer, MetadataRef, MetadataSource, PrepareStep,
+    PressingEdit, RawPressingEdit, RawReleaseEdit, RawTrackEdit, ReleaseIdentity, ReleaseUserEdit,
+    StorageMode, TrackFile, TrackUserEdit,
 };

--- a/bae-core/src/import/types.rs
+++ b/bae-core/src/import/types.rs
@@ -516,22 +516,6 @@ pub enum ImportPhase {
     Store,
 }
 
-impl ImportPhase {
-    pub fn key(&self) -> &'static str {
-        match self {
-            Self::Acquire => "acquire",
-            Self::Store => "store",
-        }
-    }
-
-    pub fn display_text(&self) -> &'static str {
-        match self {
-            Self::Acquire => "Downloading...",
-            Self::Store => "Storing files...",
-        }
-    }
-}
-
 /// Steps during phase 0 preparation (in ImportHandle, before pipeline starts)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrepareStep {
@@ -542,17 +526,12 @@ pub enum PrepareStep {
     SavingToDatabase,
 }
 
-impl PrepareStep {
-    /// Human-readable display text for UI
-    pub fn display_text(&self) -> &'static str {
-        match self {
-            PrepareStep::ParsingMetadata => "Parsing metadata...",
-            PrepareStep::WritingCoverArt => "Writing cover art...",
-            PrepareStep::DiscoveringFiles => "Discovering files...",
-            PrepareStep::ValidatingTracks => "Validating tracks...",
-            PrepareStep::SavingToDatabase => "Saving to database...",
-        }
-    }
+/// Which step of an import is in progress, for the candidate progress UI. The
+/// UI localizes each step; bae-core no longer renders display text for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportStep {
+    Preparing(PrepareStep),
+    Running(ImportPhase),
 }
 
 /// Maps a logical track to the audio file that contains its samples.

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -293,24 +293,21 @@ impl UiEventBus {
                                 Some(UiBusEvent::CandidateImportImporting {
                                     key: candidate_key.clone(),
                                     progress_percent: 0,
-                                    phase: None,
-                                    status_text: Some(step.display_text().to_string()),
+                                    step: Some(crate::import::ImportStep::Preparing(step)),
                                 })
                             }
                             ImportProgress::Started { .. } => {
                                 Some(UiBusEvent::CandidateImportImporting {
                                     key: candidate_key.clone(),
                                     progress_percent: 0,
-                                    phase: None,
-                                    status_text: None,
+                                    step: None,
                                 })
                             }
                             ImportProgress::Progress { percent, phase, .. } => {
                                 Some(UiBusEvent::CandidateImportImporting {
                                     key: candidate_key.clone(),
                                     progress_percent: percent as u32,
-                                    phase: phase.map(|p| p.key().to_string()),
-                                    status_text: phase.map(|p| p.display_text().to_string()),
+                                    step: phase.map(crate::import::ImportStep::Running),
                                 })
                             }
                             ImportProgress::Complete { id, album_id, .. } => {

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -118,8 +118,7 @@ pub enum UiBusEvent {
     CandidateImportImporting {
         key: String,
         progress_percent: u32,
-        phase: Option<String>,
-        status_text: Option<String>,
+        step: Option<crate::import::ImportStep>,
     },
     CandidateImportComplete {
         key: String,

--- a/bae-macos/bae/bae/BridgeImportStep+Localized.swift
+++ b/bae-macos/bae/bae/BridgeImportStep+Localized.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension BridgeImportStep {
+    /// The localized progress text for this step, resolved from the generated
+    /// `Core` string table via the key bae-core owns. bae-core decides the step;
+    /// this is the UI's locale rendering of it.
+    var localizedText: String {
+        let key: String
+        switch self {
+        case .preparing(let step):
+            key = bridgePrepareStepKey(step: step)
+        case .running(let phase):
+            key = bridgeImportPhaseKey(phase: phase)
+        }
+        return NSLocalizedString(
+            key,
+            tableName: "Core",
+            bundle: .main,
+            comment: ""
+        )
+    }
+}

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -775,8 +775,7 @@ enum PreviewData {
     static let importStatuses: [String: ImportStatus] = [
         "/Music/Downloads/Compilation Vol. 3": .importing(
             progressPercent: 45,
-            phase: nil,
-            statusText: "Storing files..."
+            step: .running(phase: .store)
         ),
         // A completed import — tabs under Added via its import status.
         "/Music/Downloads/EP Release": .complete(

--- a/bae-macos/bae/bae/Services/Store/ImportStatus.swift
+++ b/bae-macos/bae/bae/Services/Store/ImportStatus.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum ImportStatus: Equatable {
-    case importing(progressPercent: UInt32, phase: String?, statusText: String?)
+    case importing(progressPercent: UInt32, step: BridgeImportStep?)
     case complete(albumId: String, releaseId: String)
     case error(message: String)
 }

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -236,14 +236,12 @@ enum UiEventReducer {
         case .candidateImportImporting(
             let key,
             let progressPercent,
-            let phase,
-            let statusText
+            let step
         ):
             importStore.mutateCandidate(forKey: key) {
                 $0.importStatus = .importing(
                     progressPercent: progressPercent,
-                    phase: phase,
-                    statusText: statusText
+                    step: step
                 )
             }
 

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
@@ -329,12 +329,12 @@ struct ImportConfirmationView<
         }
         else if let status = importStatus {
             switch status {
-            case .importing(_, _, let statusText):
+            case .importing(_, let step):
                 HStack(spacing: 6) {
                     ProgressView()
                         .controlSize(.small)
-                    if let statusText {
-                        Text(statusText)
+                    if let step {
+                        Text(step.localizedText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(2)

--- a/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportResultPane.swift
@@ -144,8 +144,7 @@ struct ImportResultPane<Top: View, Pane: View>: View {
             storagePinned: $storagePinned,
             importStatus: .importing(
                 progressPercent: 45,
-                phase: nil,
-                statusText: "Storing files..."
+                step: .running(phase: .store)
             ),
             importing: true
         )


### PR DESCRIPTION
The first inversion of **bae-core's** prose production — the deepest part of the workstream. Until now, validation and errors were converted in bae-bridge; this reaches into bae-core itself.

Import progress text ("Parsing metadata...", "Storing files...") was computed in bae-core (`PrepareStep`/`ImportPhase::display_text()`) and carried through `UiBusEvent` as a `String`. It now crosses as a typed `ImportStep { Preparing(PrepareStep) | Running(ImportPhase) }`: the core event carries the enum, the bridge mirrors it (`BridgeImportStep` + `bridge_prepare_step_key` / `bridge_import_phase_key`), and the macOS UI resolves the localized progress text from the `Core` catalog.

`display_text()`/`key()` are deleted from core; the dead `BridgeImportStatus` (which also carried a prose `Error` variant) is removed. A bae-bridge test cross-checks the step keys against the catalog (gated in CI). Import is desktop-only (its modules are `cfg(not(mobile))`), so this is fully macOS-verified with no mobile/Windows consumer.

## Test plan
- `cargo clippy` core + bridge (all features) clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the import progress UI renders the step from `Core.xcstrings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx