### PR TITLE
loc: convert invalid-candidate reasons to a typed reason (bae-core inversion)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -16,6 +16,24 @@ value = "Album must have at least one artist"
 comment = "Import edit: the year field is not a number."
 value = "Year must be a number"
 
+[messages."core.import.invalid.corrupt_audio"]
+comment = "Import scan: a folder's audio file is corrupt or zero-byte ({path} is the file path)."
+args = { path = "Str" }
+value = "corrupt or zero-byte audio file: {path}"
+
+[messages."core.import.invalid.corrupt_image"]
+comment = "Import scan: a folder's image is corrupt or zero-byte ({path} is the file path)."
+args = { path = "Str" }
+value = "corrupt or zero-byte image: {path}"
+
+[messages."core.import.invalid.cue_missing_audio"]
+comment = "Import scan: a CUE sheet references an audio file that isn't present."
+value = "CUE references a missing audio file"
+
+[messages."core.import.invalid.no_valid_audio"]
+comment = "Import scan: the folder has no usable audio files."
+value = "no valid audio files"
+
 [messages."core.import.prepare.parsing_metadata"]
 comment = "Import progress: preparing — parsing metadata."
 value = "Parsing metadata..."

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1594,7 +1594,7 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
                 folder_path: candidate.path.to_string_lossy().to_string(),
                 source_folder_name: candidate.name,
                 watched_folder_path: candidate.watched_folder_path,
-                reason: candidate.reason,
+                reason: crate::types::invalid_reason_to_bridge(candidate.reason),
             },
         }),
         UiBusEvent::ScanCandidateRemoved { key } => {

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -458,6 +458,73 @@ pub struct BridgeFolderCandidate {
     pub is_added: bool,
 }
 
+/// Mirror of bae-core's `InvalidReason`. The UI localizes each variant via its
+/// catalog key (`bridge_invalid_reason_key`), interpolating the path where set.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeInvalidReason {
+    CorruptAudioFile { path: String },
+    CorruptImage { path: String },
+    CueMissingAudio,
+    NoValidAudio,
+}
+
+impl BridgeInvalidReason {
+    pub(crate) fn loc_key(&self) -> &'static str {
+        match self {
+            Self::CorruptAudioFile { .. } => "core.import.invalid.corrupt_audio",
+            Self::CorruptImage { .. } => "core.import.invalid.corrupt_image",
+            Self::CueMissingAudio => "core.import.invalid.cue_missing_audio",
+            Self::NoValidAudio => "core.import.invalid.no_valid_audio",
+        }
+    }
+}
+
+pub(crate) fn invalid_reason_to_bridge(r: bae_core::import::InvalidReason) -> BridgeInvalidReason {
+    use bae_core::import::InvalidReason as R;
+    match r {
+        R::CorruptAudioFile { path } => BridgeInvalidReason::CorruptAudioFile { path },
+        R::CorruptImage { path } => BridgeInvalidReason::CorruptImage { path },
+        R::CueMissingAudio => BridgeInvalidReason::CueMissingAudio,
+        R::NoValidAudio => BridgeInvalidReason::NoValidAudio,
+    }
+}
+
+/// Localization key for an invalid-candidate reason — resolved by the UI against
+/// the `Core` string table; the UI interpolates the path arg where present.
+#[uniffi::export]
+pub fn bridge_invalid_reason_key(reason: BridgeInvalidReason) -> String {
+    reason.loc_key().to_string()
+}
+
+#[cfg(test)]
+mod invalid_reason_tests {
+    use super::BridgeInvalidReason;
+
+    /// Every invalid-reason key must exist in the catalog.
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        let reasons = [
+            BridgeInvalidReason::CorruptAudioFile {
+                path: String::new(),
+            },
+            BridgeInvalidReason::CorruptImage {
+                path: String::new(),
+            },
+            BridgeInvalidReason::CueMissingAudio,
+            BridgeInvalidReason::NoValidAudio,
+        ];
+        for r in &reasons {
+            assert!(
+                cat.messages.contains_key(r.loc_key()),
+                "catalog missing `{}`",
+                r.loc_key()
+            );
+        }
+    }
+}
+
 /// A leaf folder that looks like a release but failed validation — the import
 /// view surfaces it under the Skipped tab with a warning and the reason. Mirror
 /// of `bae_core::import::InvalidCandidate`; carries no files or identify state
@@ -470,9 +537,8 @@ pub struct BridgeInvalidCandidate {
     /// key for the candidate-list section. Match it against
     /// `BridgeWatchedFolder.path` for the section's display name.
     pub watched_folder_path: String,
-    /// Why the folder failed validation, ready to render next to the warning
-    /// icon (e.g. "corrupt or zero-byte audio file: 01.flac").
-    pub reason: String,
+    /// Why the folder failed validation — the UI localizes this typed reason.
+    pub reason: BridgeInvalidReason,
 }
 
 /// A folder the user watches for imports — one candidate-list group.

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -210,6 +210,21 @@ pub struct PreparedRelease {
 /// validation: corrupt or zero-byte audio, a corrupt image, or a CUE that
 /// references missing audio. Carries no files or identify state — it can't be
 /// imported — only enough to surface it under the Skipped tab with its reason.
+/// Why a candidate folder failed validation. The `Display` text is the terse
+/// internal form (used by the import-commit error channel); the UI localizes the
+/// typed variant for the Skipped tab.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InvalidReason {
+    #[error("corrupt or zero-byte audio file: {path}")]
+    CorruptAudioFile { path: String },
+    #[error("corrupt or zero-byte image: {path}")]
+    CorruptImage { path: String },
+    #[error("CUE references a missing audio file")]
+    CueMissingAudio,
+    #[error("no valid audio files")]
+    NoValidAudio,
+}
+
 #[derive(Debug, Clone)]
 pub struct InvalidCandidate {
     /// Root path of the folder that failed validation.
@@ -219,9 +234,8 @@ pub struct InvalidCandidate {
     /// Absolute path of the watched folder this was scanned from — the
     /// candidate-list group it belongs to. Equal to the scan root.
     pub watched_folder_path: String,
-    /// Why the folder failed validation, ready to render as the failure
-    /// reason next to the warning icon.
-    pub reason: String,
+    /// Why the folder failed validation — the UI localizes this typed reason.
+    pub reason: InvalidReason,
 }
 
 /// One item the scan callback yields per leaf folder: a valid release
@@ -648,12 +662,12 @@ fn tree_is_leaf_directory(tree: &FileTree, dir: &Path) -> bool {
 #[derive(Debug)]
 enum CategorizeOutcome {
     Valid(CategorizedFiles),
-    Invalid(String),
+    Invalid(InvalidReason),
 }
 
 /// Shorthand for a failed-validation leaf carrying `reason`.
-fn invalid(reason: impl Into<String>) -> Result<CategorizeOutcome, String> {
-    Ok(CategorizeOutcome::Invalid(reason.into()))
+fn invalid(reason: InvalidReason) -> Result<CategorizeOutcome, String> {
+    Ok(CategorizeOutcome::Invalid(reason))
 }
 
 /// Categorize files from a FileTree for a given release root.
@@ -697,7 +711,9 @@ fn categorize_files_from_tree(
                 .map_err(|e| format!("Failed to validate audio file {absolute_path:?}: {e}"))?;
             if entry.size == 0 || !valid {
                 info!("Invalid candidate: corrupt or zero-byte audio file {relative_path}");
-                return invalid(format!("corrupt or zero-byte audio file: {relative_path}"));
+                return invalid(InvalidReason::CorruptAudioFile {
+                    path: relative_path.to_string(),
+                });
             }
 
             all_audio.push(ScannedFile::new(
@@ -718,7 +734,9 @@ fn categorize_files_from_tree(
                 .map_err(|e| format!("Failed to validate image file {absolute_path:?}: {e}"))?;
             if entry.size == 0 || !valid {
                 info!("Invalid candidate: corrupt or zero-byte image {relative_path}");
-                return invalid(format!("corrupt or zero-byte image: {relative_path}"));
+                return invalid(InvalidReason::CorruptImage {
+                    path: relative_path.to_string(),
+                });
             }
 
             artwork.push(ScannedFile::new(
@@ -815,7 +833,7 @@ fn categorize_files_from_tree(
                 cue_sheet.tracks.len(),
                 on_disk_audio
             );
-            return invalid("CUE references a missing audio file");
+            return invalid(InvalidReason::CueMissingAudio);
         }
     }
 
@@ -888,7 +906,7 @@ fn categorize_files_from_tree(
                 .to_uppercase(),
             None => {
                 info!("Invalid candidate: no valid audio files after categorization");
-                return invalid("no valid audio files");
+                return invalid(InvalidReason::NoValidAudio);
             }
         };
         let audio = AudioContent::TrackFiles {
@@ -927,7 +945,7 @@ pub(crate) enum RawScanItem {
     Invalid {
         path: PathBuf,
         name: String,
-        reason: String,
+        reason: InvalidReason,
     },
 }
 
@@ -1051,7 +1069,7 @@ pub fn collect_release_candidate_files(release_root: &Path) -> Result<Categorize
     // the import-commit caller fails with why the folder is unusable.
     match categorize_files_from_tree(&tree, &PathBuf::new(), release_root)? {
         CategorizeOutcome::Valid(files) => Ok(files),
-        CategorizeOutcome::Invalid(reason) => Err(reason),
+        CategorizeOutcome::Invalid(reason) => Err(reason.to_string()),
     }
 }
 
@@ -1567,7 +1585,7 @@ FILE "album.ape" WAVE
         match &items[0] {
             ScanItem::Invalid(invalid) => {
                 assert!(
-                    invalid.reason.contains("audio"),
+                    matches!(invalid.reason, InvalidReason::CorruptAudioFile { .. }),
                     "reason names the audio fault, got: {}",
                     invalid.reason,
                 );

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -51,7 +51,7 @@ pub struct ParsedAlbum {
 pub use folder_registry::{ImportFolderRegistry, WatchedFolder};
 pub use folder_scanner::{
     scan_for_candidates_with_callback, CategorizedFiles, FileEntry, FolderCandidate,
-    InvalidCandidate, ScanItem,
+    InvalidCandidate, InvalidReason, ScanItem,
 };
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub use handle::{

--- a/bae-macos/bae/bae/BridgeInvalidReason+Localized.swift
+++ b/bae-macos/bae/bae/BridgeInvalidReason+Localized.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension BridgeInvalidReason {
+    /// The localized failure reason, resolved from the generated `Core` string
+    /// table via the key bae-core owns, with the file path interpolated where
+    /// the reason carries one.
+    var localizedText: String {
+        let format = NSLocalizedString(
+            bridgeInvalidReasonKey(reason: self),
+            tableName: "Core",
+            bundle: .main,
+            comment: ""
+        )
+        switch self {
+        case .corruptAudioFile(let path), .corruptImage(let path):
+            return String(format: format, path)
+        case .cueMissingAudio, .noValidAudio:
+            return format
+        }
+    }
+}

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -791,7 +791,7 @@ enum PreviewData {
             folderPath: "/Music/Downloads/Broken Rip",
             sourceFolderName: "Broken Rip",
             watchedFolderPath: "/Music/Downloads",
-            reason: "corrupt or zero-byte audio file: 03.flac"
+            reason: .corruptAudioFile(path: "03.flac")
         )
     ]
 

--- a/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
@@ -482,7 +482,7 @@ struct CandidateRow: View {
 /// is a no-op — its key isn't a real candidate).
 private struct InvalidCandidateRow: View {
     let displayName: String
-    let reason: String
+    let reason: BridgeInvalidReason
     /// Real filesystem path for Reveal in Finder.
     let revealPath: String
 
@@ -496,7 +496,7 @@ private struct InvalidCandidateRow: View {
                     .font(.callout)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text(reason)
+                Text(reason.localizedText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -506,7 +506,7 @@ private struct InvalidCandidateRow: View {
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
-        .help(reason)
+        .help(reason.localizedText)
         .contextMenu {
             Button("Reveal in Finder") {
                 SystemActions.revealInFinder(path: revealPath)


### PR DESCRIPTION
Continues the **bae-core** prose inversion. Import-scan failure reasons ("corrupt or zero-byte audio file: <path>", "no valid audio files", etc.) were built as `String`s in `folder_scanner` and carried through `InvalidCandidate`.

They now cross as a typed `InvalidReason { CorruptAudioFile{path} | CorruptImage{path} | CueMissingAudio | NoValidAudio }`: the bridge mirrors it (`BridgeInvalidReason` + `bridge_invalid_reason_key`), and the macOS Skipped tab resolves localized text from the `Core` catalog, interpolating the path.

The reason also feeds the import-commit error channel (`Err(String)`); `InvalidReason`'s `thiserror` `Display` keeps that path compiling (transitional English, localized when the error-rendering follow-up lands). A bae-bridge test cross-checks the keys. macOS-only display, fully verified.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the Skipped tab renders the reason from `Core.xcstrings` with the path interpolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx