### PR TITLE
loc: convert audio format to a structured record the UI composes

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -62,6 +62,14 @@ value = "Downloading..."
 comment = "Import progress: encrypting and storing the files."
 value = "Storing files..."
 
+[messages."core.audio.channels.mono"]
+comment = "Audio format: single-channel audio."
+value = "mono"
+
+[messages."core.audio.channels.stereo"]
+comment = "Audio format: two-channel audio."
+value = "stereo"
+
 [messages."core.identify.barcode.looking_up"]
 comment = "Identify: which barcode is being looked up, of how many."
 args = { position = "Int", total = "Int" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1678,7 +1678,7 @@ fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeR
         file_size_label: f.file_size_label,
         is_image: f.is_image,
         content_type: f.content_type,
-        audio_format_label: f.audio_format_label,
+        audio_format: f.audio_format.map(crate::types::audio_format_to_bridge),
     };
     let convert_gallery_item = |g: bae_core::album_detail::GalleryItem| BridgeGalleryItem {
         id: g.id,

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -292,9 +292,57 @@ pub struct BridgeFile {
     pub file_size_label: String,
     pub content_type: String,
     pub is_image: bool,
-    /// Audio-format descriptor, e.g. "FLAC · 44.1 kHz · 16-bit · stereo".
-    /// `None` for non-audio files. The UI renders it as-is.
-    pub audio_format_label: Option<String>,
+    /// Structured audio format; `None` for non-audio files. The UI composes the
+    /// one-line descriptor from it.
+    pub audio_format: Option<BridgeAudioFormat>,
+}
+
+/// Mirror of bae-core's `AudioFormat`. The UI composes "FLAC · 44.1 kHz ·
+/// 16-bit · stereo" from these parts: the codec is a proper noun, the channel
+/// count maps to a localized word (`bridge_audio_channels_key`), and numbers
+/// format per locale.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeAudioFormat {
+    pub codec: String,
+    pub sample_rate_hz: i64,
+    pub bits_per_sample: Option<i64>,
+    pub bitrate_kbps: Option<i64>,
+    pub channels: i64,
+}
+
+pub(crate) fn audio_format_to_bridge(f: bae_core::album_detail::AudioFormat) -> BridgeAudioFormat {
+    BridgeAudioFormat {
+        codec: f.codec,
+        sample_rate_hz: f.sample_rate_hz,
+        bits_per_sample: f.bits_per_sample,
+        bitrate_kbps: f.bitrate_kbps,
+        channels: f.channels,
+    }
+}
+
+/// Localization key for a channel count's word ("mono"/"stereo"), or `None` for
+/// counts the UI renders as "{n}ch". One source of the keys for every platform.
+#[uniffi::export]
+pub fn bridge_audio_channels_key(channels: i64) -> Option<String> {
+    match channels {
+        1 => Some("core.audio.channels.mono".to_string()),
+        2 => Some("core.audio.channels.stereo".to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod audio_format_tests {
+    /// The channel-word keys the UI resolves must exist in the catalog.
+    #[test]
+    fn channel_keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for channels in [1_i64, 2] {
+            let key = super::bridge_audio_channels_key(channels).expect("1 and 2 have words");
+            assert!(cat.messages.contains_key(&key), "catalog missing `{key}`");
+        }
+    }
 }
 
 #[derive(Debug, Clone, uniffi::Record)]

--- a/bae-core/src/album_detail.rs
+++ b/bae-core/src/album_detail.rs
@@ -161,11 +161,23 @@ pub struct FileDetail {
     pub file_size_label: String,
     pub is_image: bool,
     pub content_type: String,
-    /// One-line audio-format descriptor for display, e.g.
-    /// "FLAC · 44.1 kHz · 16-bit · stereo" or "MP3 · 320 kbps · 44.1 kHz ·
-    /// stereo". `None` for non-audio files (images, cue sheets) and for audio
-    /// files with no stored format row.
-    pub audio_format_label: Option<String>,
+    /// Structured audio format. `None` for non-audio files (images, cue sheets)
+    /// and for audio files with no stored format row.
+    pub audio_format: Option<AudioFormat>,
+}
+
+/// Structured audio-format descriptor. The UI composes the one-line label
+/// ("FLAC · 44.1 kHz · 16-bit · stereo") from these parts: the codec is a
+/// proper noun, the channel count maps to a localized word, and the numbers
+/// format per locale. `bits_per_sample` present means lossless (show the bit
+/// depth); absent means lossy (show `bitrate_kbps` instead).
+#[derive(Debug, Clone)]
+pub struct AudioFormat {
+    pub codec: String,
+    pub sample_rate_hz: i64,
+    pub bits_per_sample: Option<i64>,
+    pub bitrate_kbps: Option<i64>,
+    pub channels: i64,
 }
 
 /// Resolved release summary: the slim projection that list views (storage

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -3432,7 +3432,7 @@ pub(crate) fn resolve_release(
         .files
         .into_iter()
         .map(|f| {
-            let audio_format_label = match file_format.get(f.id.as_str()) {
+            let audio_format = match file_format.get(f.id.as_str()) {
                 Some(af) => {
                     // Lossy codecs store no bit depth; show the average bitrate
                     // (file bytes over the file's audio duration) when the full
@@ -3454,13 +3454,13 @@ pub(crate) fn resolve_release(
                     } else {
                         None
                     };
-                    Some(crate::util::format::format_audio_label(
-                        af.content_type.display_name(),
-                        af.sample_rate,
-                        af.bits_per_sample,
-                        af.channels,
+                    Some(crate::album_detail::AudioFormat {
+                        codec: af.content_type.display_name().to_string(),
+                        sample_rate_hz: af.sample_rate,
+                        bits_per_sample: af.bits_per_sample,
                         bitrate_kbps,
-                    ))
+                        channels: af.channels,
+                    })
                 }
                 None => {
                     // A non-audio file (image, cue) legitimately has no format
@@ -3478,7 +3478,7 @@ pub(crate) fn resolve_release(
                 file_size_label: crate::util::format::format_bytes_signed(f.file_size),
                 is_image: f.content_type.is_image(),
                 content_type: f.content_type.to_string(),
-                audio_format_label,
+                audio_format,
                 id: f.id,
                 original_filename: f.original_filename,
                 file_size: f.file_size,

--- a/bae-core/src/util/format.rs
+++ b/bae-core/src/util/format.rs
@@ -91,52 +91,6 @@ pub fn format_bytes_signed(bytes: i64) -> String {
     format_bytes(bytes as u64)
 }
 
-/// A sample rate in Hz as kHz, e.g. 44100 → "44.1 kHz", 48000 → "48 kHz",
-/// 88200 → "88.2 kHz". Whole-kHz rates drop the decimal.
-fn format_sample_rate(hz: i64) -> String {
-    if hz % 1000 == 0 {
-        format!("{} kHz", hz / 1000)
-    } else {
-        format!("{:.1} kHz", hz as f64 / 1000.0)
-    }
-}
-
-/// A channel count as a word: 1 → "mono", 2 → "stereo", otherwise "Nch".
-fn format_channels(channels: i64) -> String {
-    match channels {
-        1 => "mono".to_string(),
-        2 => "stereo".to_string(),
-        n => format!("{n}ch"),
-    }
-}
-
-/// One-line audio-format descriptor, e.g.
-/// "FLAC · 44.1 kHz · 16-bit · stereo" (lossless) or
-/// "MP3 · 320 kbps · 44.1 kHz · stereo" (lossy). Bit depth is shown when
-/// `bits_per_sample` is present (lossless); otherwise the average `bitrate_kbps`
-/// is shown when known — lossy codecs define no bit depth, so the average
-/// bitrate stands in its place.
-pub fn format_audio_label(
-    codec: &str,
-    sample_rate: i64,
-    bits_per_sample: Option<i64>,
-    channels: i64,
-    bitrate_kbps: Option<i64>,
-) -> String {
-    let mut parts = vec![codec.to_string()];
-    if bits_per_sample.is_none() {
-        if let Some(kbps) = bitrate_kbps {
-            parts.push(format!("{kbps} kbps"));
-        }
-    }
-    parts.push(format_sample_rate(sample_rate));
-    if let Some(bits) = bits_per_sample {
-        parts.push(format!("{bits}-bit"));
-    }
-    parts.push(format_channels(channels));
-    parts.join(" · ")
-}
-
 /// Convert a 1-indexed side number to a letter (1=A, 2=B, ..., 26=Z).
 fn side_letter(side: i32) -> char {
     (b'A' + (side - 1) as u8) as char
@@ -224,47 +178,6 @@ pub fn group_tracks_by_side(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn audio_label_lossless_shows_bit_depth() {
-        // FLAC: bit depth present, no bitrate.
-        assert_eq!(
-            format_audio_label("FLAC", 44_100, Some(16), 2, None),
-            "FLAC · 44.1 kHz · 16-bit · stereo"
-        );
-        // A whole-kHz rate drops the decimal; bitrate is ignored when bit depth
-        // is known.
-        assert_eq!(
-            format_audio_label("FLAC", 96_000, Some(24), 2, Some(9000)),
-            "FLAC · 96 kHz · 24-bit · stereo"
-        );
-    }
-
-    #[test]
-    fn audio_label_lossy_shows_bitrate() {
-        // MP3: no bit depth, average bitrate leads the rate.
-        assert_eq!(
-            format_audio_label("MP3", 44_100, None, 2, Some(320)),
-            "MP3 · 320 kbps · 44.1 kHz · stereo"
-        );
-        // Unknown bitrate (no duration) drops that part rather than guessing.
-        assert_eq!(
-            format_audio_label("MP3", 44_100, None, 2, None),
-            "MP3 · 44.1 kHz · stereo"
-        );
-    }
-
-    #[test]
-    fn audio_label_channel_words() {
-        assert_eq!(
-            format_audio_label("FLAC", 48_000, Some(16), 1, None),
-            "FLAC · 48 kHz · 16-bit · mono"
-        );
-        assert_eq!(
-            format_audio_label("FLAC", 48_000, Some(24), 6, None),
-            "FLAC · 48 kHz · 24-bit · 6ch"
-        );
-    }
 
     #[test]
     fn duration_label_basic() {

--- a/bae-macos/bae/bae/BridgeAudioFormat+Format.swift
+++ b/bae-macos/bae/bae/BridgeAudioFormat+Format.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension BridgeAudioFormat {
+    /// One-line descriptor composed for the current locale, e.g.
+    /// "FLAC · 44.1 kHz · 16-bit · stereo" (lossless) or
+    /// "MP3 · 320 kbps · 44.1 kHz · stereo" (lossy). The codec is a proper noun;
+    /// the channel word is localized; numbers use the locale's formatter. bae-core
+    /// owns the parts and the lossy/lossless split (`bitsPerSample == nil`); this
+    /// is the UI's locale rendering of them.
+    var text: String {
+        var parts = [codec]
+        if bitsPerSample == nil, let kbps = bitrateKbps {
+            parts.append("\(kbps.formatted()) kbps")
+        }
+        parts.append(sampleRateText)
+        if let bits = bitsPerSample {
+            parts.append("\(bits.formatted())-bit")
+        }
+        parts.append(channelsText)
+        return parts.joined(separator: " · ")
+    }
+
+    private var sampleRateText: String {
+        let khz = Double(sampleRateHz) / 1000.0
+        let number = khz.formatted(.number.precision(.fractionLength(0...1)))
+        return "\(number) kHz"
+    }
+
+    private var channelsText: String {
+        if let key = bridgeAudioChannelsKey(channels: channels) {
+            return NSLocalizedString(
+                key,
+                tableName: "Core",
+                bundle: .main,
+                comment: ""
+            )
+        }
+        return "\(channels.formatted())ch"
+    }
+}

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -1086,8 +1086,8 @@ struct ManageReleaseSheet: View {
                 TableColumn("Format") { file in
                     // Audio files carry a label; non-audio files (images, cue)
                     // have none, so their Format cell is simply empty.
-                    if let label = file.audioFormatLabel {
-                        Text(label)
+                    if let format = file.audioFormat {
+                        Text(format.text)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -994,8 +994,8 @@ private struct StorageFileCell: View {
             case .format:
                 // Audio files carry a label; non-audio files (images, cue)
                 // have none, so their Format cell is simply empty.
-                if let label = file.audioFormatLabel {
-                    Text(label)
+                if let format = file.audioFormat {
+                    Text(format.text)
                         .lineLimit(1)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
Continues the inversion with the **structured-record** pattern — the UI composes a multi-part label from typed fields, mixing a proper-noun passthrough, a localized word, and locale-formatted numbers.

The one-line audio descriptor ("FLAC · 44.1 kHz · 16-bit · stereo") was built in bae-core (`format_audio_label`) and crossed the bridge as a `String`. It now crosses as a typed `AudioFormat { codec, sample_rate_hz, bits_per_sample, bitrate_kbps, channels }`, and the macOS UI composes the line: the codec is a passthrough, the channel count maps to a localized word (mono/stereo via `bridge_audio_channels_key` against the `Core` catalog; "Nch" otherwise), and numbers format per locale. The lossy/lossless split stays structurally encoded (`bits_per_sample.is_none()`), so the UI's choice is mechanical, not a domain judgment.

`format_audio_label` / `format_sample_rate` / `format_channels` are deleted with their tests; a bae-bridge test cross-checks the channel keys. macOS-only on the uniffi side.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the Format columns in album detail and the storage table render the composed descriptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx