### PR TITLE
loc: convert storage-transfer progress to typed action + counts

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -70,6 +70,27 @@ value = "mono"
 comment = "Audio format: two-channel audio."
 value = "stereo"
 
+[messages."core.transfer.action.pin"]
+comment = "Storage transfer: present-continuous verb while pinning a release for offline."
+value = "Pinning for offline"
+
+[messages."core.transfer.action.unpin"]
+comment = "Storage transfer: present-continuous verb while removing a release's local copy."
+value = "Removing local copy"
+
+[messages."core.transfer.action.manage"]
+comment = "Storage transfer: present-continuous verb while moving a release into the library."
+value = "Moving into library"
+
+[messages."core.transfer.action.unmanage"]
+comment = "Storage transfer: present-continuous verb while moving a release out of the library."
+value = "Moving out of library"
+
+[messages."core.transfer.files"]
+comment = "Storage transfer: which file of how many is being processed."
+args = { file_no = "Int", total = "Int" }
+value = "{file_no} of {total} files"
+
 [messages."core.identify.barcode.looking_up"]
 comment = "Identify: which barcode is being looked up, of how many."
 args = { position = "Int", total = "Int" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1648,12 +1648,16 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
         }),
         UiBusEvent::ReleaseTransferProgress {
             release_id,
+            action,
+            file_no,
+            total,
             percent,
-            label,
         } => Some(BridgeUiEvent::ReleaseTransferProgress {
             release_id,
+            action: crate::types::BridgeReleaseStorageAction::from_core(action),
+            file_no,
+            total,
             percent,
-            label,
         }),
         UiBusEvent::ReleaseTransferEnded { release_id } => {
             Some(BridgeUiEvent::ReleaseTransferEnded { release_id })

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -151,6 +151,42 @@ impl BridgeReleaseStorageAction {
             ReleaseStorageAction::Unmanage => Self::Unmanage,
         }
     }
+
+    fn transfer_loc_key(self) -> &'static str {
+        match self {
+            Self::Pin => "core.transfer.action.pin",
+            Self::Unpin => "core.transfer.action.unpin",
+            Self::Manage => "core.transfer.action.manage",
+            Self::Unmanage => "core.transfer.action.unmanage",
+        }
+    }
+}
+
+/// Localization key for a transfer's present-continuous progress verb
+/// ("Pinning for offline"). The UI resolves it against the `Core` table.
+#[uniffi::export]
+pub fn bridge_transfer_action_key(action: BridgeReleaseStorageAction) -> String {
+    action.transfer_loc_key().to_string()
+}
+
+#[cfg(test)]
+mod transfer_action_tests {
+    use super::BridgeReleaseStorageAction as A;
+
+    /// Every transfer verb key (and the file-count message) must exist.
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for action in [A::Pin, A::Unpin, A::Manage, A::Unmanage] {
+            assert!(
+                cat.messages.contains_key(action.transfer_loc_key()),
+                "catalog missing `{}`",
+                action.transfer_loc_key()
+            );
+        }
+        assert!(cat.messages.contains_key("core.transfer.files"));
+    }
 }
 
 /// Slim per-release summary: the projection list views render one row
@@ -1395,13 +1431,16 @@ pub enum BridgeUiEvent {
     OutboxChanged {
         snapshot: BridgeOutboxSnapshot,
     },
-    /// A pin/unpin/manage/unmanage transition advanced. `percent` is the
-    /// overall release progress; `label` is a ready-to-render line. The UI
-    /// shows a determinate bar on the release row until `ReleaseTransferEnded`.
+    /// A pin/unpin/manage/unmanage transition advanced. `percent` is the overall
+    /// release progress; `file_no`/`total` are present once per-file progress is
+    /// known (absent at the start). The UI composes the localized line and shows
+    /// a determinate bar on the release row until `ReleaseTransferEnded`.
     ReleaseTransferProgress {
         release_id: String,
+        action: BridgeReleaseStorageAction,
+        file_no: Option<u32>,
+        total: Option<u32>,
         percent: u8,
-        label: String,
     },
     /// A transition finished (success or failure) — the UI clears its transfer
     /// indicator. Failure text still arrives via the thrown error.

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -821,33 +821,6 @@ fn verb(action: ReleaseStorageAction) -> &'static str {
     }
 }
 
-/// Present-continuous action phrase for a storage transition — the leading part
-/// of a progress `label` ("Pinning for offline").
-fn transfer_action(action: ReleaseStorageAction) -> &'static str {
-    match action {
-        ReleaseStorageAction::Pin => "Pinning for offline",
-        ReleaseStorageAction::Unpin => "Removing local copy",
-        ReleaseStorageAction::Manage => "Moving into library",
-        ReleaseStorageAction::Unmanage => "Moving out of library",
-    }
-}
-
-/// The ready-to-render progress line for a transfer at file `file_no` of
-/// `total`, e.g. "Pinning for offline — 3 of 12 files · 42%". `file_no` is
-/// 1-based. Core owns the whole string — including the percent — so the UI
-/// renders it verbatim and never reassembles it from parts.
-fn transfer_label(
-    action: ReleaseStorageAction,
-    file_no: usize,
-    total: usize,
-    percent: u8,
-) -> String {
-    format!(
-        "{} — {file_no} of {total} files · {percent}%",
-        transfer_action(action)
-    )
-}
-
 /// Emits `ReleaseTransferEnded` on drop unless defused. `drive_transfer` holds
 /// one so an aborted transfer future (its bridge wrapper is dropped mid-flight)
 /// still clears the UI's transfer indicator; the normal exit defuses it after
@@ -954,8 +927,10 @@ pub enum LibraryEvent {
     /// the matching `ReleaseTransferEnded` arrives.
     ReleaseTransferProgress {
         release_id: String,
+        action: ReleaseStorageAction,
+        file_no: Option<u32>,
+        total: Option<u32>,
         percent: u8,
-        label: String,
     },
     /// A transition finished (success OR failure) — the UI clears its transfer
     /// indicator. On failure the user-facing reason still arrives via the
@@ -4768,11 +4743,13 @@ impl LibraryManager {
             armed: true,
         };
 
-        let emit_progress = |percent: u8, label: String| {
+        let emit_progress = |percent: u8, file_no: Option<u32>, total: Option<u32>| {
             self.emit(LibraryEvent::ReleaseTransferProgress {
                 release_id: release_id.to_string(),
+                action,
+                file_no,
+                total,
                 percent,
-                label,
             });
         };
 
@@ -4788,7 +4765,7 @@ impl LibraryManager {
                     // The first file count isn't known to be > 1 yet, and a bare
                     // "X of N" with file 1 reads as redundant; show the action
                     // alone until the first FileProgress reports real position.
-                    emit_progress(0, transfer_action(action).to_string());
+                    emit_progress(0, None, None);
                 }
                 TransferProgress::FileProgress {
                     file_index,
@@ -4804,7 +4781,8 @@ impl LibraryManager {
                     on_overall(overall);
                     emit_progress(
                         overall,
-                        transfer_label(action, file_index + 1, total_files, overall),
+                        Some(file_index as u32 + 1),
+                        Some(total_files as u32),
                     );
                 }
                 TransferProgress::Complete { .. } => break Ok(()),

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -426,13 +426,17 @@ impl UiEventBus {
                     }
                     Ok(LibraryEvent::ReleaseTransferProgress {
                         release_id,
+                        action,
+                        file_no,
+                        total,
                         percent,
-                        label,
                     }) => {
                         bus.emit(UiBusEvent::ReleaseTransferProgress {
                             release_id,
+                            action,
+                            file_no,
+                            total,
                             percent,
-                            label,
                         });
                     }
                     Ok(LibraryEvent::ReleaseTransferEnded { release_id }) => {

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -225,8 +225,10 @@ pub enum UiBusEvent {
     /// shows a determinate bar on the release row until `ReleaseTransferEnded`.
     ReleaseTransferProgress {
         release_id: String,
+        action: crate::album_detail::ReleaseStorageAction,
+        file_no: Option<u32>,
+        total: Option<u32>,
         percent: u8,
-        label: String,
     },
     /// A transition finished (success or failure) — the UI clears its transfer
     /// indicator. Failure text still arrives via the thrown error.

--- a/bae-macos/bae/bae/BridgeReleaseStorageAction+TransferProgress.swift
+++ b/bae-macos/bae/bae/BridgeReleaseStorageAction+TransferProgress.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension BridgeReleaseStorageAction {
+    /// Present-continuous progress verb ("Pinning for offline"), localized
+    /// against the generated `Core` table. bae-core decides the action; this is
+    /// the UI's locale rendering of it.
+    var transferProgressVerb: String {
+        NSLocalizedString(
+            bridgeTransferActionKey(action: self),
+            tableName: "Core",
+            bundle: .main,
+            comment: ""
+        )
+    }
+}
+
+/// The localized transfer-progress line, e.g. "Pinning for offline — 3 of 12
+/// files · 42%". Before per-file progress is known (`fileNo`/`total` nil), it's
+/// just the verb. bae-core owns the action and the counts; the UI composes and
+/// formats them for the current locale.
+func transferProgressLabel(
+    action: BridgeReleaseStorageAction,
+    fileNo: UInt32?,
+    total: UInt32?,
+    percent: UInt8
+) -> String {
+    guard let fileNo, let total else { return action.transferProgressVerb }
+    let files = String(
+        format: NSLocalizedString(
+            "core.transfer.files",
+            tableName: "Core",
+            bundle: .main,
+            comment: ""
+        ),
+        Int(fileNo),
+        Int(total)
+    )
+    let pct = (Double(percent) / 100).formatted(.percent)
+    return "\(action.transferProgressVerb) — \(files) · \(pct)"
+}

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -379,11 +379,22 @@ enum UiEventReducer {
         case .downloadQueueChanged(let snapshot):
             downloadStore.snapshot = snapshot
 
-        case .releaseTransferProgress(let releaseId, let percent, let label):
+        case .releaseTransferProgress(
+            let releaseId,
+            let action,
+            let fileNo,
+            let total,
+            let percent
+        ):
             libraryStore.handleReleaseTransferProgress(
                 releaseId: releaseId,
                 percent: percent,
-                label: label
+                label: transferProgressLabel(
+                    action: action,
+                    fileNo: fileNo,
+                    total: total,
+                    percent: percent
+                )
             )
 
         case .releaseTransferEnded(let releaseId):


### PR DESCRIPTION
Continues the status inversion. The pin/unpin/manage/unmanage progress line ("Pinning for offline — 3 of 12 files · 42%") was built in bae-core (`transfer_action`/`transfer_label`) and crossed the bridge as a `String` through both `LibraryEvent` and `UiBusEvent`.

It now crosses as `{ action: ReleaseStorageAction, file_no: Option, total: Option, percent }`, and the macOS `UiEventReducer` composes the localized line: the present-continuous verb resolves from the `Core` catalog (`bridge_transfer_action_key`), the file count from a parameterized message, and the percent via the native percent formatter (locale-aware). `transfer_action`/`transfer_label` are deleted.

Scoped tight: the store (`TransferState`) and the two views are unchanged — the reducer composes the label once, so the conversion stays at the boundary. A bae-bridge test cross-checks the verb keys and the file-count message. macOS-only on the uniffi side.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the storage-table and album-detail transfer bars render the composed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx