### PR TITLE
loc: compose the sync-queue summary in the UI (outbox)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -96,6 +96,21 @@ comment = "Identify: which barcode is being looked up, of how many."
 args = { position = "Int", total = "Int" }
 value = "Looking up barcode {position} of {total}"
 
+[messages."core.queue.uploading"]
+comment = "Storage queue: count currently uploading."
+args = { count = "Int" }
+value = "{count} uploading"
+
+[messages."core.queue.failed"]
+comment = "Storage queue: count that failed."
+args = { count = "Int" }
+value = "{count} failed"
+
+[messages."core.queue.queued"]
+comment = "Storage queue: count waiting to transfer."
+args = { count = "Int" }
+value = "{count} queued"
+
 [messages."core.outbox.pending_deletes"]
 comment = "Storage queue: number of cloud deletes still pending."
 args = { count = "Int" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1320,7 +1320,6 @@ fn convert_outbox_snapshot(
         total: convert_upload_progress(snapshot.total),
         pending_deletes: snapshot.pending_deletes,
         paused: snapshot.paused,
-        summary: snapshot.summary,
         throughput_bps: snapshot.throughput_bps,
         throughput_label: snapshot.throughput_label,
         eta_seconds: snapshot.eta_seconds,

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -189,6 +189,24 @@ mod transfer_action_tests {
     }
 }
 
+#[cfg(test)]
+mod queue_summary_tests {
+    /// The queue-summary keys the UI composes from must exist in the catalog.
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for key in [
+            "core.queue.uploading",
+            "core.queue.failed",
+            "core.queue.queued",
+            "core.outbox.pending_deletes",
+        ] {
+            assert!(cat.messages.contains_key(key), "catalog missing `{key}`");
+        }
+    }
+}
+
 /// Slim per-release summary: the projection list views render one row
 /// per release (storage manager, release pickers, etc.). The fat
 /// sibling is `BridgeRelease` — composition at the resolver layer in
@@ -1584,7 +1602,6 @@ pub struct BridgeOutboxSnapshot {
     /// True when the user has paused the upload pipeline. Drives the
     /// pause/resume toggle and suppresses throughput/ETA in the UI.
     pub paused: bool,
-    pub summary: String,
     /// Rolling-window upload throughput in bytes per second.
     pub throughput_bps: u64,
     /// Pre-formatted throughput label, e.g. `"5.2 MB/s"`. Empty when idle.

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -6692,7 +6692,6 @@ mod tests {
         assert_eq!(snap.uploads[0].bytes_total, 1000);
         assert_eq!(snap.uploads[0].state, UploadState::Queued);
         assert_eq!(snap.per_release.get(&release.id).map(|p| p.queued), Some(1));
-        assert_eq!(snap.summary, "1 queued");
 
         // In flight now: the in-memory map flips it to active, starting at zero
         // bytes done.
@@ -6742,7 +6741,6 @@ mod tests {
             UploadState::Failed { last_error } => assert_eq!(last_error, "boom"),
             other => panic!("expected Failed, got {other:?}"),
         }
-        assert_eq!(snap.summary, "1 failed");
 
         // Reset backoff clears the timestamp but keeps the failure record.
         manager.database.reset_cloud_outbox_backoff().await.unwrap();
@@ -6757,7 +6755,6 @@ mod tests {
         assert!(snap.uploads.is_empty());
         assert_eq!(snap.total.failed, 0);
         assert!(!snap.per_release.contains_key(&release.id));
-        assert_eq!(snap.summary, "");
     }
 
     /// The real `ReleaseUploadObserver` drives the snapshot's live byte count:

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -113,9 +113,6 @@ pub struct OutboxSnapshot {
     /// pause/resume toggle in the Storage Manager's bottom panel and
     /// suppresses the throughput display.
     pub paused: bool,
-    /// Pre-formatted one-line summary, e.g. `"2 uploading · 1 failed · 3 queued"`.
-    /// Empty when the queue is idle so the UI can hide the band.
-    pub summary: String,
     /// Rolling-window upload throughput in bytes per second. Zero when the
     /// queue is idle or has been idle long enough for the window to drain.
     pub throughput_bps: u64,
@@ -215,7 +212,6 @@ pub(crate) async fn build_outbox_snapshot(
     }
 
     let pending_deletes = deletes.len() as u32;
-    let summary = format_summary(&total, pending_deletes);
 
     // When paused, hide throughput/ETA — uploads aren't flowing so the rolling
     // window decays toward zero anyway, and rendering "2.3 MB/s" beside a
@@ -250,7 +246,6 @@ pub(crate) async fn build_outbox_snapshot(
         total,
         pending_deletes,
         paused,
-        summary,
         throughput_bps,
         throughput_label,
         eta_seconds,
@@ -278,30 +273,6 @@ fn format_eta_label(eta_seconds: Option<u64>) -> String {
     format!("{hours}h {mins}m remaining")
 }
 
-/// One-line summary, e.g. `"2 uploading · 1 failed · 3 queued"`. Empty when the
-/// queue is idle so the UI can hide the band.
-fn format_summary(total: &UploadProgress, pending_deletes: u32) -> String {
-    let mut parts = Vec::new();
-    if total.active > 0 {
-        parts.push(format!("{} uploading", total.active));
-    }
-    if total.failed > 0 {
-        parts.push(format!("{} failed", total.failed));
-    }
-    if total.queued > 0 {
-        parts.push(format!("{} queued", total.queued));
-    }
-    if pending_deletes > 0 {
-        let noun = if pending_deletes == 1 {
-            "delete"
-        } else {
-            "deletes"
-        };
-        parts.push(format!("{pending_deletes} pending {noun}"));
-    }
-    parts.join(" · ")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,21 +285,6 @@ mod tests {
             bytes_done: 0,
             bytes_total: 0,
         }
-    }
-
-    #[test]
-    fn summary_is_empty_when_idle() {
-        assert_eq!(format_summary(&progress(0, 0, 0), 0), "");
-    }
-
-    #[test]
-    fn summary_lists_active_states_only() {
-        assert_eq!(
-            format_summary(&progress(3, 2, 1), 0),
-            "2 uploading · 1 failed · 3 queued"
-        );
-        assert_eq!(format_summary(&progress(0, 0, 0), 1), "1 pending delete");
-        assert_eq!(format_summary(&progress(0, 0, 0), 2), "2 pending deletes");
     }
 
     #[test]

--- a/bae-macos/bae/bae/QueueSummary.swift
+++ b/bae-macos/bae/bae/QueueSummary.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Locale-aware composition of a storage-queue summary line from the typed
+/// counts bae-core emits, e.g. "2 uploading · 1 failed · 3 queued · 1 pending
+/// delete". Empty when the queue is idle so the band stays hidden. bae-core owns
+/// the counts; the UI composes and localizes them.
+enum QueueSummary {
+    /// Localized "{count} <state>" — or the pluralized pending-delete line —
+    /// resolved against the `Core` table with a locale-formatted count.
+    static func countLabel(_ key: String, _ count: UInt32) -> String {
+        String.localizedStringWithFormat(
+            NSLocalizedString(
+                key,
+                tableName: "Core",
+                bundle: .main,
+                comment: ""
+            ),
+            Int(count)
+        )
+    }
+}
+
+extension BridgeOutboxSnapshot {
+    var summaryText: String {
+        var parts: [String] = []
+        for (key, count) in [
+            ("core.queue.uploading", total.active),
+            ("core.queue.failed", total.failed),
+            ("core.queue.queued", total.queued),
+        ] where count > 0 {
+            parts.append(QueueSummary.countLabel(key, count))
+        }
+        if pendingDeletes > 0 {
+            parts.append(
+                QueueSummary.countLabel(
+                    "core.outbox.pending_deletes",
+                    pendingDeletes
+                )
+            )
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/bae-macos/bae/bae/Services/Store/OutboxStore.swift
+++ b/bae-macos/bae/bae/Services/Store/OutboxStore.swift
@@ -38,7 +38,6 @@ class OutboxStore {
             ),
             pendingDeletes: 0,
             paused: false,
-            summary: "",
             throughputBps: 0,
             throughputLabel: "",
             etaSeconds: nil,

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -422,8 +422,8 @@ private struct OutboxSection: View {
                     .font(.callout)
                     .foregroundStyle(.orange)
             }
-            else if !snapshot.summary.isEmpty {
-                Text(snapshot.summary)
+            else if !snapshot.summaryText.isEmpty {
+                Text(snapshot.summaryText)
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
Continues the status inversion. The upload-queue summary ("2 uploading · 1 failed · 3 queued · 1 pending delete") was joined in bae-core (`format_summary`) and crossed the bridge pre-built.

The counts (queued/active/failed) and `pending_deletes` already cross as typed fields, so the summary was pure derived duplication — the plan's "cleanest deletion." The macOS UI now composes the line: each count localizes via the `Core` catalog, and pending deletes pluralize through the existing `core.outbox.pending_deletes` key. `format_summary` and `BridgeOutboxSnapshot.summary` are deleted; a bae-bridge test cross-checks the queue keys.

The download-queue summary follows in a separate PR (it shares the `QueueSummary` helper and the failed/queued keys). macOS-only on the uniffi side.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes; the outbox snapshot tests assert on the typed counts (the summary-string assertions are gone with the string).
- macOS app builds; the Sync queue header renders the composed summary with pluralized pending deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx