### PR TITLE
loc: compose the download-queue summary in the UI

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -101,6 +101,11 @@ comment = "Storage queue: count currently uploading."
 args = { count = "Int" }
 value = "{count} uploading"
 
+[messages."core.queue.downloading"]
+comment = "Storage queue: count currently downloading."
+args = { count = "Int" }
+value = "{count} downloading"
+
 [messages."core.queue.failed"]
 comment = "Storage queue: count that failed."
 args = { count = "Int" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1372,7 +1372,6 @@ fn convert_download_snapshot(
         downloads,
         total: convert_download_progress(snapshot.total),
         paused: snapshot.paused,
-        summary: snapshot.summary,
     }
 }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -198,6 +198,7 @@ mod queue_summary_tests {
             .expect("catalog parses");
         for key in [
             "core.queue.uploading",
+            "core.queue.downloading",
             "core.queue.failed",
             "core.queue.queued",
             "core.outbox.pending_deletes",
@@ -1584,7 +1585,6 @@ pub struct BridgeDownloadSnapshot {
     /// True when the user paused the download queue. Drives the pause/resume
     /// toggle in the Downloads pane.
     pub paused: bool,
-    pub summary: String,
 }
 
 /// The cloud-outbox processing snapshot the Storage Manager renders. The

--- a/bae-core/src/library/download_snapshot.rs
+++ b/bae-core/src/library/download_snapshot.rs
@@ -67,14 +67,11 @@ pub struct DownloadSnapshot {
     /// True when the user paused the download queue. Drives the pane's
     /// pause/resume toggle; the worker waits while set.
     pub paused: bool,
-    /// Pre-formatted one-line summary, e.g. `"1 downloading · 2 queued"`.
-    /// Empty when the queue is idle so the UI can hide the band.
-    pub summary: String,
 }
 
 /// Build the snapshot from the queue's ordered list of downloads and the
 /// user-driven pause flag. Pure over its inputs: counts roll up from each
-/// release's state and `summary` is pre-formatted so the UI renders it verbatim.
+/// release's state.
 pub fn build_download_snapshot(downloads: &[DownloadOp], paused: bool) -> DownloadSnapshot {
     let mut total = DownloadProgress::default();
     for op in downloads {
@@ -85,30 +82,11 @@ pub fn build_download_snapshot(downloads: &[DownloadOp], paused: bool) -> Downlo
         }
     }
 
-    let summary = format_summary(&total);
-
     DownloadSnapshot {
         downloads: downloads.to_vec(),
         total,
         paused,
-        summary,
     }
-}
-
-/// One-line summary, e.g. `"1 downloading · 2 queued"` / `"1 failed"`. Empty
-/// when the queue is idle so the UI can hide the band.
-fn format_summary(total: &DownloadProgress) -> String {
-    let mut parts = Vec::new();
-    if total.active > 0 {
-        parts.push(format!("{} downloading", total.active));
-    }
-    if total.failed > 0 {
-        parts.push(format!("{} failed", total.failed));
-    }
-    if total.queued > 0 {
-        parts.push(format!("{} queued", total.queued));
-    }
-    parts.join(" · ")
 }
 
 #[cfg(test)]
@@ -124,24 +102,6 @@ mod tests {
             created_at: 0,
             state,
         }
-    }
-
-    #[test]
-    fn summary_is_empty_when_idle() {
-        assert_eq!(format_summary(&DownloadProgress::default()), "");
-        assert_eq!(build_download_snapshot(&[], false).summary, "");
-    }
-
-    #[test]
-    fn summary_lists_active_states_in_order() {
-        assert_eq!(
-            format_summary(&DownloadProgress {
-                queued: 2,
-                active: 1,
-                failed: 1,
-            }),
-            "1 downloading · 1 failed · 2 queued"
-        );
     }
 
     #[test]
@@ -161,7 +121,6 @@ mod tests {
         assert_eq!(snap.total.active, 1);
         assert_eq!(snap.total.queued, 1);
         assert_eq!(snap.total.failed, 1);
-        assert_eq!(snap.summary, "1 downloading · 1 failed · 1 queued");
 
         // Order preserved for the pane.
         assert_eq!(snap.downloads.len(), 3);

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -6868,7 +6868,6 @@ mod tests {
             snap.downloads[0].state,
             crate::library::DownloadState::Queued
         );
-        assert_eq!(snap.summary, "1 queued");
         assert!(snap.paused);
 
         // Re-enqueuing the same release is a no-op: still one entry.
@@ -6879,7 +6878,6 @@ mod tests {
         manager.cancel_download(&release_id);
         let snap = manager.download_snapshot();
         assert!(snap.downloads.is_empty());
-        assert_eq!(snap.summary, "");
     }
 
     /// An already-pinned release is skipped at enqueue rather than re-downloaded.
@@ -6929,7 +6927,7 @@ mod tests {
         })
         .await;
         assert!(failed, "the pin should land Failed without a cloud home");
-        assert_eq!(manager.download_snapshot().summary, "1 failed");
+        assert_eq!(manager.download_snapshot().total.failed, 1);
 
         // Retry flips it back to Queued; with no cloud home it'll fail again,
         // but the immediate post-retry state is Queued (or already re-failed).

--- a/bae-macos/bae/bae/QueueSummary.swift
+++ b/bae-macos/bae/bae/QueueSummary.swift
@@ -41,3 +41,17 @@ extension BridgeOutboxSnapshot {
         return parts.joined(separator: " · ")
     }
 }
+
+extension BridgeDownloadSnapshot {
+    var summaryText: String {
+        var parts: [String] = []
+        for (key, count) in [
+            ("core.queue.downloading", total.active),
+            ("core.queue.failed", total.failed),
+            ("core.queue.queued", total.queued),
+        ] where count > 0 {
+            parts.append(QueueSummary.countLabel(key, count))
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -230,8 +230,8 @@ private struct DownloadsSection: View {
                     .font(.callout)
                     .foregroundStyle(.orange)
             }
-            else if !snapshot.summary.isEmpty {
-                Text(snapshot.summary)
+            else if !snapshot.summaryText.isEmpty {
+                Text(snapshot.summaryText)
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
Mirrors the outbox-summary conversion (#72) for the download queue. The summary ("1 downloading · 2 queued") was joined in bae-core (`format_summary`) and crossed the bridge pre-built.

The counts (queued/active/failed) already cross, so the macOS UI composes the line via the shared `QueueSummary` helper, localizing each count through the `Core` catalog. `format_summary` and `BridgeDownloadSnapshot.summary` are deleted; the bae-bridge cross-check now covers `core.queue.downloading`. macOS-only on the uniffi side.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes; download snapshot tests assert on the typed counts.
- macOS app builds; the Downloads header renders the composed summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx