### PR TITLE
loc: compose the release-group meta line in the UI (year span + pressings)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -62,6 +62,11 @@ value = "Downloading..."
 comment = "Import progress: encrypting and storing the files."
 value = "Storing files..."
 
+[messages."core.import.pressings"]
+comment = "Release-group card: number of pressings grouped under it."
+args = { count = "Int" }
+value = "{count, plural, one {# pressing} other {# pressings}}"
+
 [messages."core.audio.channels.mono"]
 comment = "Audio format: single-channel audio."
 value = "mono"

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -208,6 +208,17 @@ mod queue_summary_tests {
     }
 }
 
+#[cfg(test)]
+mod release_group_tests {
+    /// The pressing-count plural key the release-group card composes from.
+    #[test]
+    fn pressings_key_exists() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        assert!(cat.messages.contains_key("core.import.pressings"));
+    }
+}
+
 /// Slim per-release summary: the projection list views render one row
 /// per release (storage manager, release pickers, etc.). The fat
 /// sibling is `BridgeRelease` — composition at the resolver layer in
@@ -1096,8 +1107,10 @@ pub struct BridgeReleaseGroup {
     /// Editorial URL for the group on its source (release-group on
     /// MusicBrainz, master on Discogs). `None` for an ungrouped result.
     pub group_url: Option<String>,
-    /// Pre-formatted year span + pressing count, e.g. "1992 – 2012 · 4 pressings".
-    pub meta_label: String,
+    /// Earliest and latest pressing year for the UI's "1992 – 2012" span; both
+    /// `None` when no pressing carries a year. Pressing count is `pressings.len()`.
+    pub year_min: Option<i32>,
+    pub year_max: Option<i32>,
     pub pressings: Vec<BridgeMetadataResult>,
 }
 
@@ -2566,7 +2579,8 @@ pub(crate) fn release_group_to_bridge(
         cover_art: g.cover_art.map(remote_cover_data_to_bridge),
         source_label: g.source_label,
         group_url: g.group_url,
-        meta_label: g.meta_label,
+        year_min: g.year_min,
+        year_max: g.year_max,
         pressings: g
             .pressings
             .into_iter()

--- a/bae-core/src/import/release_group.rs
+++ b/bae-core/src/import/release_group.rs
@@ -30,8 +30,11 @@ pub struct ReleaseGroup {
     /// MusicBrainz, master on Discogs). `None` for an ungrouped result, which
     /// has no group page to open.
     pub group_url: Option<String>,
-    /// Pre-formatted year span + pressing count, e.g. "1992 – 2012 · 4 pressings".
-    pub meta_label: String,
+    /// Earliest and latest pressing year, for the UI's "1992 – 2012" span. Both
+    /// `None` when no pressing carries a year. The UI pluralizes the pressing
+    /// count from `pressings.len()`.
+    pub year_min: Option<i32>,
+    pub year_max: Option<i32>,
     pub pressings: Vec<MetadataResult>,
 }
 
@@ -59,7 +62,9 @@ impl ReleaseGroup {
         let title = first.title.clone();
         let artist = pressings.iter().find_map(|p| p.artist.clone());
         let cover_art = pressings.iter().find_map(|p| p.cover_art.clone());
-        let meta_label = group_meta_label(&pressings);
+        let years: Vec<i32> = pressings.iter().filter_map(|p| p.year).collect();
+        let year_min = years.iter().min().copied();
+        let year_max = years.iter().max().copied();
         Self {
             id,
             title,
@@ -67,7 +72,8 @@ impl ReleaseGroup {
             cover_art,
             source_label: source.display_name().to_string(),
             group_url,
-            meta_label,
+            year_min,
+            year_max,
             pressings,
         }
     }
@@ -118,26 +124,6 @@ pub fn group_results(results: Vec<MetadataResult>) -> Vec<ReleaseGroup> {
             }
         })
         .collect()
-}
-
-/// "1992 – 2012 · 4 pressings" — the year span across the pressings plus the
-/// pressing count. The span collapses to a single year when the pressings
-/// don't differ, and drops out entirely when none carries a year.
-fn group_meta_label(pressings: &[MetadataResult]) -> String {
-    let years: Vec<i32> = pressings.iter().filter_map(|p| p.year).collect();
-    let count = pressings.len();
-    let count_label = if count == 1 {
-        "1 pressing".to_string()
-    } else {
-        format!("{count} pressings")
-    };
-    match (years.iter().min(), years.iter().max()) {
-        (Some(&min), Some(&max)) if min != max => {
-            format!("{min} \u{2013} {max} \u{00b7} {count_label}")
-        }
-        (Some(&y), Some(_)) => format!("{y} \u{00b7} {count_label}"),
-        _ => count_label,
-    }
 }
 
 #[cfg(test)]
@@ -204,7 +190,8 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].id, "rel-1");
         assert_eq!(groups[0].group_url, None);
-        assert_eq!(groups[0].meta_label, "1999 \u{00b7} 1 pressing");
+        assert_eq!(groups[0].year_min, Some(1999));
+        assert_eq!(groups[0].year_max, Some(1999));
     }
 
     #[test]
@@ -217,31 +204,32 @@ mod tests {
     }
 
     #[test]
-    fn meta_label_spans_distinct_years() {
+    fn year_span_uses_min_and_max() {
         let groups = group_results(vec![
             result("rel-1", Some("g"), Some(1992)),
             result("rel-2", Some("g"), Some(2006)),
             result("rel-3", Some("g"), Some(2012)),
         ]);
-        assert_eq!(
-            groups[0].meta_label,
-            "1992 \u{2013} 2012 \u{00b7} 3 pressings"
-        );
+        assert_eq!(groups[0].year_min, Some(1992));
+        assert_eq!(groups[0].year_max, Some(2012));
+        assert_eq!(groups[0].pressings.len(), 3);
     }
 
     #[test]
-    fn meta_label_collapses_equal_years() {
+    fn year_span_collapses_when_equal() {
         let groups = group_results(vec![
             result("rel-1", Some("g"), Some(1994)),
             result("rel-2", Some("g"), Some(1994)),
         ]);
-        assert_eq!(groups[0].meta_label, "1994 \u{00b7} 2 pressings");
+        assert_eq!(groups[0].year_min, Some(1994));
+        assert_eq!(groups[0].year_max, Some(1994));
     }
 
     #[test]
-    fn meta_label_drops_year_when_none_present() {
+    fn year_span_is_none_when_no_year() {
         let groups = group_results(vec![result("rel-1", Some("g"), None)]);
-        assert_eq!(groups[0].meta_label, "1 pressing");
+        assert_eq!(groups[0].year_min, None);
+        assert_eq!(groups[0].year_max, None);
     }
 
     #[test]

--- a/bae-macos/bae/bae/BridgeReleaseGroup+MetaLabel.swift
+++ b/bae-macos/bae/bae/BridgeReleaseGroup+MetaLabel.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension BridgeReleaseGroup {
+    /// The card's secondary line, composed for the locale: the year span across
+    /// the pressings plus the pluralized pressing count, e.g. "1992 – 2012 · 4
+    /// pressings". Collapses to a single year when they match, and drops the
+    /// span when no pressing carries a year. bae-core owns the years and count;
+    /// the UI formats them.
+    var metaLabel: String {
+        let countLabel = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "core.import.pressings",
+                tableName: "Core",
+                bundle: .main,
+                comment: ""
+            ),
+            pressings.count
+        )
+        guard let lo = yearMin, let hi = yearMax else { return countLabel }
+        let span = lo == hi ? "\(lo)" : "\(lo) \u{2013} \(hi)"
+        return "\(span) \u{00b7} \(countLabel)"
+    }
+}

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -1031,7 +1031,8 @@ enum PreviewData {
             coverArt: nil,
             sourceLabel: "MusicBrainz",
             groupUrl: "https://musicbrainz.org/release-group/group-preview",
-            metaLabel: "1988 \u{2013} 1996 \u{00b7} 2 pressings",
+            yearMin: 1988,
+            yearMax: 1996,
             pressings: exactPressings,
         )
     )
@@ -1059,7 +1060,8 @@ enum PreviewData {
                 coverArt: nil,
                 sourceLabel: "MusicBrainz",
                 groupUrl: "https://musicbrainz.org/release-group/grp-1",
-                metaLabel: "1996 \u{00b7} 2 pressings",
+                yearMin: 1996,
+                yearMax: 1996,
                 pressings: [
                     BridgeMetadataResult(
                         source: .musicBrainz,
@@ -1090,7 +1092,8 @@ enum PreviewData {
                 coverArt: nil,
                 sourceLabel: "MusicBrainz",
                 groupUrl: "https://musicbrainz.org/release-group/grp-2",
-                metaLabel: "2005 \u{00b7} 1 pressing",
+                yearMin: 2005,
+                yearMax: 2005,
                 pressings: [
                     BridgeMetadataResult(
                         source: .musicBrainz,


### PR DESCRIPTION
Continues the composite inversion. The release-group card's secondary line ("1992 – 2012 · 4 pressings") was joined in bae-core (`group_meta_label`) and crossed the bridge pre-built.

The pressings already cross (count = `pressings.len()`), so only the year span needed surfacing: `BridgeReleaseGroup` now carries `year_min`/`year_max`, and the macOS card composes the line via a computed `metaLabel` — the year span (collapsing when equal, dropped when no year) plus the pluralized pressing count (`core.import.pressings`). `group_meta_label` is deleted; its tests now assert the typed span.

The card's `Text(group.metaLabel)` is unchanged — `metaLabel` became a computed extension. A bae-bridge test cross-checks the plural key. macOS-only on the uniffi side.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the release-group card renders the composed span + pluralized count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx