### PR TITLE
loc: format upload throughput / ETA / bytes natively (outbox)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -121,6 +121,21 @@ comment = "Storage queue: count waiting to transfer."
 args = { count = "Int" }
 value = "{count} queued"
 
+[messages."core.outbox.bytes_progress"]
+comment = "Storage queue: aggregate bytes uploaded of the total ({done}/{total} are pre-formatted byte counts)."
+args = { done = "Str", total = "Str" }
+value = "{done} of {total}"
+
+[messages."core.outbox.throughput"]
+comment = "Storage queue: upload speed ({rate} is a pre-formatted byte count, e.g. '5.2 MB')."
+args = { rate = "Str" }
+value = "{rate}/s"
+
+[messages."core.outbox.eta"]
+comment = "Storage queue: estimated time remaining ({duration} is a pre-formatted duration)."
+args = { duration = "Str" }
+value = "{duration} remaining"
+
 [messages."core.outbox.pending_deletes"]
 comment = "Storage queue: number of cloud deletes still pending."
 args = { count = "Int" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1321,10 +1321,7 @@ fn convert_outbox_snapshot(
         pending_deletes: snapshot.pending_deletes,
         paused: snapshot.paused,
         throughput_bps: snapshot.throughput_bps,
-        throughput_label: snapshot.throughput_label,
         eta_seconds: snapshot.eta_seconds,
-        eta_label: snapshot.eta_label,
-        bytes_label: snapshot.bytes_label,
     }
 }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -202,6 +202,9 @@ mod queue_summary_tests {
             "core.queue.failed",
             "core.queue.queued",
             "core.outbox.pending_deletes",
+            "core.outbox.bytes_progress",
+            "core.outbox.throughput",
+            "core.outbox.eta",
         ] {
             assert!(cat.messages.contains_key(key), "catalog missing `{key}`");
         }
@@ -1615,17 +1618,10 @@ pub struct BridgeOutboxSnapshot {
     /// True when the user has paused the upload pipeline. Drives the
     /// pause/resume toggle and suppresses throughput/ETA in the UI.
     pub paused: bool,
-    /// Rolling-window upload throughput in bytes per second.
+    /// Rolling-window upload throughput in bytes per second. The UI formats it.
     pub throughput_bps: u64,
-    /// Pre-formatted throughput label, e.g. `"5.2 MB/s"`. Empty when idle.
-    pub throughput_label: String,
-    /// Estimated seconds remaining at the current rate.
+    /// Estimated seconds remaining at the current rate. The UI formats it.
     pub eta_seconds: Option<u64>,
-    /// Pre-formatted ETA, e.g. `"2m 14s remaining"`. Empty when not computable.
-    pub eta_label: String,
-    /// Pre-formatted bytes-done/total label, e.g. `"1.2 GB of 14.4 GB"`.
-    /// Empty when there's nothing to upload.
-    pub bytes_label: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -114,20 +114,12 @@ pub struct OutboxSnapshot {
     /// suppresses the throughput display.
     pub paused: bool,
     /// Rolling-window upload throughput in bytes per second. Zero when the
-    /// queue is idle or has been idle long enough for the window to drain.
+    /// queue is idle or has been idle long enough for the window to drain. The
+    /// UI formats it as a localized rate; aggregate bytes come from `total`.
     pub throughput_bps: u64,
-    /// Pre-formatted throughput label, e.g. `"5.2 MB/s"`. Empty when
-    /// `throughput_bps` is zero.
-    pub throughput_label: String,
-    /// Estimated seconds remaining at the current rate. `None` when
-    /// throughput is zero or no bytes remain.
+    /// Estimated seconds remaining at the current rate. `None` when throughput
+    /// is zero or no bytes remain. The UI formats it.
     pub eta_seconds: Option<u64>,
-    /// Pre-formatted ETA label, e.g. `"7s remaining"` / `"2m 14s remaining"`.
-    /// Empty when ETA isn't computable.
-    pub eta_label: String,
-    /// Pre-formatted aggregate progress label, e.g. `"1.2 GB of 14.4 GB"`.
-    /// Empty when there's nothing to upload.
-    pub bytes_label: String,
 }
 
 /// Build the snapshot from the outbox rows, the in-flight upload map (file_id →
@@ -221,24 +213,12 @@ pub(crate) async fn build_outbox_snapshot(
     } else {
         throughput.bytes_per_sec()
     };
-    let throughput_label = crate::util::format::format_speed(throughput_bps);
     let bytes_remaining = total.bytes_total.saturating_sub(total.bytes_done);
     let eta_seconds = if paused || throughput_bps == 0 || bytes_remaining == 0 {
         None
     } else {
         Some(bytes_remaining / throughput_bps)
     };
-    let eta_label = format_eta_label(eta_seconds);
-    let bytes_label = if total.bytes_total == 0 {
-        String::new()
-    } else {
-        format!(
-            "{} of {}",
-            crate::util::format::format_bytes(total.bytes_done),
-            crate::util::format::format_bytes(total.bytes_total),
-        )
-    };
-
     Ok(OutboxSnapshot {
         uploads,
         deletes,
@@ -247,30 +227,8 @@ pub(crate) async fn build_outbox_snapshot(
         pending_deletes,
         paused,
         throughput_bps,
-        throughput_label,
         eta_seconds,
-        eta_label,
-        bytes_label,
     })
-}
-
-/// Pre-format an ETA as `"7s remaining"` / `"2m 14s remaining"` /
-/// `"1h 5m remaining"`. Empty when `None`.
-fn format_eta_label(eta_seconds: Option<u64>) -> String {
-    let Some(seconds) = eta_seconds else {
-        return String::new();
-    };
-    if seconds < 60 {
-        return format!("{seconds}s remaining");
-    }
-    let minutes = seconds / 60;
-    let secs = seconds % 60;
-    if minutes < 60 {
-        return format!("{minutes}m {secs}s remaining");
-    }
-    let hours = minutes / 60;
-    let mins = minutes % 60;
-    format!("{hours}h {mins}m remaining")
 }
 
 #[cfg(test)]

--- a/bae-core/src/util/format.rs
+++ b/bae-core/src/util/format.rs
@@ -52,15 +52,6 @@ pub fn format_bytes(bytes: u64) -> String {
     format!("{:.0} MB", mb)
 }
 
-/// Format a download speed in bytes/sec as a human-readable string (e.g. "2.3 MB/s").
-/// Returns empty string when rate is zero.
-pub fn format_speed(bytes_per_sec: u64) -> String {
-    if bytes_per_sec == 0 {
-        return String::new();
-    }
-    format!("{}/s", format_bytes(bytes_per_sec))
-}
-
 /// Format an ETA from progress, total size, and download rate.
 /// Returns empty string when ETA can't be computed (rate is zero or download complete).
 pub fn format_eta(progress: f64, total_bytes: u64, bytes_per_sec: u64) -> String {

--- a/bae-macos/bae/bae/BridgeOutboxSnapshot+Progress.swift
+++ b/bae-macos/bae/bae/BridgeOutboxSnapshot+Progress.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// `Core`-table lookup for the outbox progress strings.
+private func coreMessage(_ key: String) -> String {
+    NSLocalizedString(key, tableName: "Core", bundle: .main, comment: "")
+}
+
+extension BridgeOutboxSnapshot {
+    /// Aggregate bytes uploaded of the total, e.g. "1.2 GB of 14.4 GB". Empty
+    /// when there's nothing to upload. The byte counts format per locale.
+    var bytesProgressText: String {
+        guard total.bytesTotal > 0 else { return "" }
+        return String(
+            format: coreMessage("core.outbox.bytes_progress"),
+            Int64(total.bytesDone).formatted(.byteCount(style: .file)),
+            Int64(total.bytesTotal).formatted(.byteCount(style: .file))
+        )
+    }
+
+    /// Upload throughput, e.g. "5.2 MB/s". Empty when idle.
+    var throughputText: String {
+        guard throughputBps > 0 else { return "" }
+        return String(
+            format: coreMessage("core.outbox.throughput"),
+            Int64(throughputBps).formatted(.byteCount(style: .file))
+        )
+    }
+
+    /// Estimated time remaining, e.g. "2 min 14 sec remaining". Empty when not
+    /// computable.
+    var etaText: String {
+        guard let eta = etaSeconds else { return "" }
+        let duration = Duration.seconds(Int64(eta))
+            .formatted(
+                .units(
+                    allowed: [.hours, .minutes, .seconds],
+                    width: .abbreviated
+                )
+            )
+        return String(format: coreMessage("core.outbox.eta"), duration)
+    }
+}

--- a/bae-macos/bae/bae/Services/Store/OutboxStore.swift
+++ b/bae-macos/bae/bae/Services/Store/OutboxStore.swift
@@ -39,10 +39,7 @@ class OutboxStore {
             pendingDeletes: 0,
             paused: false,
             throughputBps: 0,
-            throughputLabel: "",
             etaSeconds: nil,
-            etaLabel: "",
-            bytesLabel: "",
         )
     }
 }

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -485,20 +485,20 @@ private struct OutboxMasterProgress: View {
                 // active otherwise.
                 .opacity(snapshot.paused ? 0.4 : 1)
             HStack(spacing: 8) {
-                Text(snapshot.bytesLabel)
+                Text(snapshot.bytesProgressText)
                     .font(.caption)
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
-                if !snapshot.throughputLabel.isEmpty {
+                if !snapshot.throughputText.isEmpty {
                     Text("·").foregroundStyle(.tertiary)
-                    Text(snapshot.throughputLabel)
+                    Text(snapshot.throughputText)
                         .font(.caption)
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
-                if !snapshot.etaLabel.isEmpty {
+                if !snapshot.etaText.isEmpty {
                     Text("·").foregroundStyle(.tertiary)
-                    Text(snapshot.etaLabel)
+                    Text(snapshot.etaText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
Continues the numeric path. The upload-progress labels (throughput "5.2 MB/s", ETA "2m 14s remaining", bytes "1.2 GB of 14.4 GB") were built in bae-core (`format_speed` / `format_eta_label` / `format_bytes`) and crossed the bridge pre-built.

The raw values (`throughput_bps`, `eta_seconds`, `total.bytes_done`/`bytes_total`) already cross, so the macOS UI formats them natively: byte counts via `.byteCount`, the ETA via `Duration`'s units style, joined with localized connectives (`core.outbox.bytes_progress` "{done} of {total}", `.throughput` "{rate}/s", `.eta` "{duration} remaining"). `format_speed` and `format_eta_label` are deleted (`format_bytes` stays — file sizes still use it). A bae-bridge test cross-checks the new keys.

**Windows adoption needed (for the parallel cross-platform work):** `bae-windows-ffi`'s `FfiOutboxSnapshot` and `bae-windows`'s `OutboxSnapshot.cs` / `MainWindow.xaml.cs` read `throughput_label`/`eta_label`/`bytes_label` — they need the same field removal plus a C# native composition from the raw `throughput_bps`/`eta_seconds`/bytes (mirroring the macOS extension here), same as the outbox-summary follow-up did.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the Sync queue footer renders the natively-formatted bytes / throughput / ETA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx