### PR TITLE
loc: format per-file size natively (BridgeFile)

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1674,7 +1674,6 @@ fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeR
         id: f.id,
         original_filename: f.original_filename,
         file_size: f.file_size,
-        file_size_label: f.file_size_label,
         is_image: f.is_image,
         content_type: f.content_type,
         audio_format: f.audio_format.map(crate::types::audio_format_to_bridge),

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -353,8 +353,6 @@ pub struct BridgeFile {
     pub id: String,
     pub original_filename: String,
     pub file_size: i64,
-    /// Pre-formatted file size, e.g. "35 MB".
-    pub file_size_label: String,
     pub content_type: String,
     pub is_image: bool,
     /// Structured audio format; `None` for non-audio files. The UI composes the

--- a/bae-core/src/album_detail.rs
+++ b/bae-core/src/album_detail.rs
@@ -158,7 +158,6 @@ pub struct FileDetail {
     pub id: String,
     pub original_filename: String,
     pub file_size: i64,
-    pub file_size_label: String,
     pub is_image: bool,
     pub content_type: String,
     /// Structured audio format. `None` for non-audio files (images, cue sheets)

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -3450,7 +3450,6 @@ pub(crate) fn resolve_release(
                 }
             };
             FileDetail {
-                file_size_label: crate::util::format::format_bytes_signed(f.file_size),
                 is_image: f.content_type.is_image(),
                 content_type: f.content_type.to_string(),
                 audio_format,

--- a/bae-macos/bae/bae/BridgeFile+Size.swift
+++ b/bae-macos/bae/bae/BridgeFile+Size.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension BridgeFile {
+    /// File size formatted for the current locale, e.g. "35 MB". bae-core emits
+    /// the raw byte count; the UI formats it.
+    var fileSizeText: String {
+        Int64(fileSize).formatted(.byteCount(style: .file))
+    }
+}

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -1093,7 +1093,7 @@ struct ManageReleaseSheet: View {
                     }
                 }
                 TableColumn("Size", value: \.fileSize) { file in
-                    Text(file.fileSizeLabel)
+                    Text(file.fileSizeText)
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -1000,7 +1000,7 @@ private struct StorageFileCell: View {
                         .foregroundStyle(.secondary)
                 }
             case .size:
-                Text(file.fileSizeLabel)
+                Text(file.fileSizeText)
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .trailing)


### PR DESCRIPTION
Continues the numeric path. `BridgeFile` carried both `file_size` (raw) and `file_size_label` ("35 MB"); the label was pre-formatted in bae-core (`format_bytes_signed`).

The macOS file tables (album detail, storage manager) now format `file_size` natively via `.byteCount` (`BridgeFile.fileSizeText`). `file_size_label` is removed from `FileDetail` and `BridgeFile`; `format_bytes_signed` stays — other size labels still use it. No catalog (byte formatting, not a translatable message). The Windows FFI doesn't carry this label, so no cross-platform impact.

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean.
- macOS app builds; the Size columns render the natively-formatted byte count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx