### PR TITLE
loc: map cloud provider name in the UI, not the bridge

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -75,6 +75,14 @@ value = "mono"
 comment = "Audio format: two-channel audio."
 value = "stereo"
 
+[messages."core.cloud.s3_compatible"]
+comment = "Cloud provider: any S3-compatible storage."
+value = "S3-compatible"
+
+[messages."core.cloud.local_only"]
+comment = "Cloud provider: the library syncs nowhere (local only)."
+value = "Local only"
+
 [messages."core.transfer.action.pin"]
 comment = "Storage transfer: present-continuous verb while pinning a release for offline."
 value = "Pinning for offline"

--- a/bae-bridge/src/bridge_utils.rs
+++ b/bae-bridge/src/bridge_utils.rs
@@ -29,7 +29,6 @@ pub(crate) fn build_bridge_config(config: &bae_core::config::Config) -> BridgeCo
             .provider
             .as_ref()
             .map(|provider| BridgeSyncConfig {
-                cloud_provider_label: bae_core::config::cloud_provider_label(Some(provider)),
                 provider: bridge_sync_provider(provider, &config.cloud_home),
                 cloud_account_display: config.cloud_account_display(),
             }),

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -50,7 +50,7 @@ fn local_library(
             .expect("library path is UTF-8 by construction")
             .to_string(),
         name,
-        cloud_provider_label: bae_core::config::cloud_provider_label(cloud_provider),
+        cloud_provider: cloud_provider.map(bridge_cloud_provider),
         is_active,
     }
 }
@@ -86,9 +86,11 @@ use tracing::info;
 use bae_core::config::Config;
 use bae_core::library::{CancellationToken, RestoreFromCodeError};
 
+#[cfg(feature = "oauth-providers")]
+use crate::types::bridge_cloud_provider_to_core;
 use crate::types::{
-    bridge_cloud_provider, bridge_cloud_provider_to_core, BridgeCloudProvider, BridgeError,
-    BridgeLibrary, BridgeRestoreCodeInfo, BridgeRestoreSource,
+    bridge_cloud_provider, BridgeCloudProvider, BridgeError, BridgeLibrary, BridgeRestoreCodeInfo,
+    BridgeRestoreSource,
 };
 
 #[cfg(feature = "cloudkit")]
@@ -179,15 +181,6 @@ pub fn set_ca_cert_dir(dirs: String) {
 #[uniffi::export]
 pub fn init_keyring() {
     bae_core::config::init_keyring();
-}
-
-/// Short display label for a cloud provider ("S3-compatible", "iCloud", …).
-/// The restore and onboarding flows hold a bare provider (not a full library),
-/// so they call this to render its name. `BridgeLibrary.cloud_provider_label`
-/// covers the library-row case. Both delegate to the one mapping in bae-core.
-#[uniffi::export]
-pub fn cloud_provider_label(provider: BridgeCloudProvider) -> String {
-    bae_core::config::cloud_provider_label(Some(&bridge_cloud_provider_to_core(provider)))
 }
 
 /// Discover local libraries in ~/.bae/libraries/, returning each as a
@@ -331,7 +324,6 @@ pub fn decode_restore_code(code: String) -> Result<BridgeRestoreCodeInfo, Bridge
     Ok(BridgeRestoreCodeInfo {
         library_id: info.library_id,
         library_name: info.library_name,
-        cloud_provider_label: bae_core::config::cloud_provider_label(Some(&info.cloud_provider)),
         cloud_provider: bridge_cloud_provider(&info.cloud_provider),
         needs_oauth: info.needs_oauth,
     })

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -82,10 +82,10 @@ pub struct BridgeLibrary {
     pub id: String,
     pub name: String,
     pub path: String,
-    /// Short label naming the library's cloud provider for display
-    /// ("S3-compatible", "iCloud", …), or "Local only" when it syncs nowhere.
-    /// Pre-built in core so the UI renders it directly.
-    pub cloud_provider_label: String,
+    /// The library's cloud provider, or `None` when it syncs nowhere
+    /// (local-only). The UI renders the name: brand names pass through, the
+    /// generic cases resolve a catalog key.
+    pub cloud_provider: Option<BridgeCloudProvider>,
     pub is_active: bool,
 }
 
@@ -404,6 +404,53 @@ mod audio_format_tests {
         for channels in [1_i64, 2] {
             let key = super::bridge_audio_channels_key(channels).expect("1 and 2 have words");
             assert!(cat.messages.contains_key(&key), "catalog missing `{key}`");
+        }
+    }
+}
+
+/// Localization key for a cloud provider's display name, or `None` for the
+/// brand-name providers the UI passes through verbatim (iCloud, Google Drive,
+/// Dropbox, OneDrive). `None` provider means local-only. One source of these
+/// keys for every platform; the UI resolves the key through its string catalog.
+#[uniffi::export]
+pub fn bridge_cloud_provider_label_key(provider: Option<BridgeCloudProvider>) -> Option<String> {
+    match provider {
+        None => Some("core.cloud.local_only".to_string()),
+        Some(BridgeCloudProvider::S3) => Some("core.cloud.s3_compatible".to_string()),
+        Some(
+            BridgeCloudProvider::CloudKit
+            | BridgeCloudProvider::GoogleDrive
+            | BridgeCloudProvider::Dropbox
+            | BridgeCloudProvider::OneDrive,
+        ) => None,
+    }
+}
+
+#[cfg(test)]
+mod cloud_provider_tests {
+    use super::BridgeCloudProvider;
+
+    /// The cloud-provider keys the UI resolves (local-only, S3) must exist; the
+    /// brand-name providers have no key (the UI hardcodes them).
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for provider in [None, Some(BridgeCloudProvider::S3)] {
+            let key = super::bridge_cloud_provider_label_key(provider)
+                .expect("local-only and S3 carry keys");
+            assert!(cat.messages.contains_key(&key), "catalog missing `{key}`");
+        }
+        for provider in [
+            BridgeCloudProvider::CloudKit,
+            BridgeCloudProvider::GoogleDrive,
+            BridgeCloudProvider::Dropbox,
+            BridgeCloudProvider::OneDrive,
+        ] {
+            assert!(
+                super::bridge_cloud_provider_label_key(Some(provider)).is_none(),
+                "brand-name providers pass through, no key"
+            );
         }
     }
 }
@@ -1846,10 +1893,6 @@ pub struct BridgeConfig {
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeSyncConfig {
     pub provider: BridgeSyncProvider,
-    /// Short label naming `provider` for display ("S3-compatible", "iCloud",
-    /// …). Pre-built in core so the UI renders it directly instead of
-    /// switching on `provider`.
-    pub cloud_provider_label: String,
     /// Display name for the connected account (e.g. "s3://bucket", "iCloud").
     pub cloud_account_display: Option<String>,
 }
@@ -2032,10 +2075,6 @@ pub struct BridgeRestoreCodeInfo {
     pub library_id: String,
     pub library_name: String,
     pub cloud_provider: BridgeCloudProvider,
-    /// Short label naming `cloud_provider` for display ("S3-compatible",
-    /// "iCloud", …). Pre-built in core so the UI renders it directly instead
-    /// of switching on `cloud_provider`.
-    pub cloud_provider_label: String,
     pub needs_oauth: bool,
 }
 
@@ -2260,6 +2299,9 @@ pub(crate) fn bridge_cloud_provider(p: &bae_core::config::CloudProvider) -> Brid
     }
 }
 
+/// Only the OAuth sign-in and authorize flows still map a bare bridge provider
+/// back to core; gated so non-OAuth builds don't carry a dead mapping.
+#[cfg(feature = "oauth-providers")]
 pub(crate) fn bridge_cloud_provider_to_core(
     p: BridgeCloudProvider,
 ) -> bae_core::config::CloudProvider {

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -152,21 +152,6 @@ pub fn install_test_keyring() {
 /// duplicate it would have to keep mapping back and forth.
 pub use coven::config::CloudProvider;
 
-/// Short label naming a library's cloud provider for display, or "Local only"
-/// when it syncs nowhere. The single source of truth for these names — the UI
-/// renders the returned string rather than switching on the provider itself.
-pub fn cloud_provider_label(provider: Option<&CloudProvider>) -> String {
-    match provider {
-        None => "Local only",
-        Some(CloudProvider::S3) => "S3-compatible",
-        Some(CloudProvider::CloudKit) => "iCloud",
-        Some(CloudProvider::GoogleDrive) => "Google Drive",
-        Some(CloudProvider::Dropbox) => "Dropbox",
-        Some(CloudProvider::OneDrive) => "OneDrive",
-    }
-    .to_string()
-}
-
 /// Parse an RFC 3339 timestamp into Unix epoch milliseconds. coven and bae's
 /// own queue both store sync/created times as RFC 3339 text, but the UI only
 /// needs an instant, so this is the one place that maps the text to epoch

--- a/bae-macos/bae/bae/BridgeCloudProvider+DisplayName.swift
+++ b/bae-macos/bae/bae/BridgeCloudProvider+DisplayName.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension BridgeCloudProvider {
+    /// The provider's display name. Brand names pass through verbatim
+    /// (proper nouns, not translated); the generic "S3-compatible" case
+    /// resolves the catalog key bae-core owns. bae-core chooses the provider;
+    /// this is the UI's locale rendering of it.
+    var displayName: String {
+        switch self {
+        case .cloudKit: return "iCloud"
+        case .googleDrive: return "Google Drive"
+        case .dropbox: return "Dropbox"
+        case .oneDrive: return "OneDrive"
+        case .s3:
+            return localizedCloudProviderName(provider: self)
+        // A provider Rust added that this Swift hasn't mapped yet: show the raw
+        // case so it reads as visibly unhandled rather than rendering blank.
+        @unknown default: return "\(self)"
+        }
+    }
+}
+
+extension BridgeSyncProvider {
+    /// The connected provider's display name. `BridgeSyncProvider` carries the
+    /// connection details; the name is just its provider, so this maps to the
+    /// `BridgeCloudProvider` case and reuses its `displayName`.
+    var displayName: String {
+        switch self {
+        case .s3: return BridgeCloudProvider.s3.displayName
+        case .googleDrive: return BridgeCloudProvider.googleDrive.displayName
+        case .dropbox: return BridgeCloudProvider.dropbox.displayName
+        case .oneDrive: return BridgeCloudProvider.oneDrive.displayName
+        case .cloudKit: return BridgeCloudProvider.cloudKit.displayName
+        @unknown default: return "\(self)"
+        }
+    }
+}
+
+/// Resolve a cloud provider's name through the catalog. Used for the
+/// translatable cases (S3-compatible, and local-only when `provider` is nil) —
+/// the brand-name providers return `nil` from the bridge and use `displayName`
+/// directly, so they shouldn't reach the fallback below.
+func localizedCloudProviderName(provider: BridgeCloudProvider?) -> String {
+    guard let key = bridgeCloudProviderLabelKey(provider: provider) else {
+        // No catalog key means a brand-name provider (proper noun); its
+        // passthrough name is correct. `provider` is non-nil here because nil
+        // maps to the local-only key above, so force-unwrap surfaces a logic
+        // error rather than rendering a blank label.
+        return provider!.displayName
+    }
+    return NSLocalizedString(key, tableName: "Core", bundle: .main, comment: "")
+}

--- a/bae-macos/bae/bae/Views/Settings/CloudProviderConnectedSection.swift
+++ b/bae-macos/bae/bae/Views/Settings/CloudProviderConnectedSection.swift
@@ -7,7 +7,7 @@ struct CloudProviderConnectedSection: View {
     var body: some View {
         Group {
             LabeledContent("Provider") {
-                Text(config.cloudProviderLabel)
+                Text(config.provider.displayName)
             }
             if let account = config.cloudAccountDisplay {
                 LabeledContent("Account") {
@@ -63,7 +63,6 @@ struct CloudProviderConnectedSection: View {
                         region: "us-east-1",
                         endpoint: "https://s3.example.com"
                     ),
-                    cloudProviderLabel: cloudProviderLabel(provider: .s3),
                     cloudAccountDisplay: "s3://my-bucket"
                 ),
                 onDisconnect: {},

--- a/bae-macos/bae/bae/Views/Settings/SyncSetupWizard.swift
+++ b/bae-macos/bae/bae/Views/Settings/SyncSetupWizard.swift
@@ -162,7 +162,7 @@ struct SyncSetupWizard: View {
         case .selectProvider:
             "Set Up Sync"
         case .configure(let provider):
-            cloudProviderLabel(provider: provider)
+            provider.displayName
         }
     }
 
@@ -315,7 +315,7 @@ struct SyncSetupWizard: View {
             Section {
                 VStack(spacing: 12) {
                     Text(
-                        "Opens your browser to authorize bae with \(cloudProviderLabel(provider: provider))."
+                        "Opens your browser to authorize bae with \(provider.displayName)."
                     )
                     .font(.callout)
                     .foregroundStyle(.secondary)
@@ -326,7 +326,7 @@ struct SyncSetupWizard: View {
                         Button(
                             isWorking
                                 ? "Connecting..."
-                                : "Connect \(cloudProviderLabel(provider: provider))"
+                                : "Connect \(provider.displayName)"
                         ) {
                             connectOAuth(provider: provider)
                         }

--- a/bae-macos/bae/bae/Views/WelcomeView.swift
+++ b/bae-macos/bae/bae/Views/WelcomeView.swift
@@ -238,7 +238,7 @@ struct WelcomeView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(entry.info.libraryName)
                                 .font(.body.bold())
-                            Text(entry.info.cloudProviderLabel)
+                            Text(entry.info.cloudProvider.displayName)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -274,7 +274,7 @@ struct WelcomeView: View {
                             HStack(spacing: 8) {
                                 ZStack(alignment: .trailing) {
                                     Button(
-                                        "Connect \(entry.info.cloudProviderLabel)"
+                                        "Connect \(entry.info.cloudProvider.displayName)"
                                     ) {
                                         restoreCodeInput = entry.code
                                         decodedRestore = .success(entry.info)
@@ -419,7 +419,7 @@ struct WelcomeView: View {
                     if case .success(let info) = decodedRestore {
                         LabeledContent(
                             "Provider",
-                            value: info.cloudProviderLabel
+                            value: info.cloudProvider.displayName
                         )
                         LabeledContent("Library", value: info.libraryName)
                         #if BAE_OAUTH_PROVIDERS
@@ -510,8 +510,7 @@ struct WelcomeView: View {
                     .font(.callout)
                 }
                 else {
-                    Button("Connect \(cloudProviderLabel(provider: provider))")
-                    {
+                    Button("Connect \(provider.displayName)") {
                         doOAuthAuthorize(provider: provider)
                     }
                 }
@@ -526,7 +525,7 @@ struct WelcomeView: View {
         // bridge symbol that isn't there.
         Picker("Cloud provider", selection: $restoreProvider) {
             ForEach(availableCloudProviders(), id: \.self) { provider in
-                Text(cloudProviderLabel(provider: provider)).tag(provider)
+                Text(provider.displayName).tag(provider)
             }
         }
         .onChange(of: restoreProvider) {
@@ -610,7 +609,7 @@ struct WelcomeView: View {
                 }
                 else {
                     Button(
-                        "Connect \(cloudProviderLabel(provider: restoreProvider))"
+                        "Connect \(restoreProvider.displayName)"
                     ) {
                         doOAuthAuthorize(provider: restoreProvider)
                     }


### PR DESCRIPTION
The pre-formatted `cloud_provider_label` ("S3-compatible" / "iCloud" / "Local only" / "Google Drive" …) was built in bae-core and crossed the bridge. The provider **enum** already crosses; the label was redundant prose.

Now the macOS UI maps the provider enum to a name: brand names (iCloud/Google Drive/Dropbox/OneDrive) pass through as proper nouns, while the genuinely translatable cases — "S3-compatible" and "Local only" — resolve through the `Core` catalog via a single-source uniffi key fn `bridge_cloud_provider_label_key` (matching the `bridge_audio_channels_key` pattern, so the key strings live in Rust, not duplicated in Swift). The library-entry type now carries `cloud_provider: Option<BridgeCloudProvider>` instead of the label; `cloud_provider_label` (the bridge fn + the core fn) is deleted. A bae-bridge test cross-checks the keys.

`cloud_account_display` is left as-is (mostly passthrough). macOS-only on the uniffi side; iOS/Windows adoption follows separately.

*(Implemented by a product-engineer subagent; reviewed + verified: clippy core/bridge clean, `cargo test -p bae-bridge --lib` green, macOS BUILD SUCCEEDED, full pre-commit gate passed.)*

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-bridge --lib` cross-check passes.
- macOS app builds; the sync settings + welcome screens render the provider name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx