### PR TITLE
loc: format remaining size labels natively

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1287,7 +1287,6 @@ fn convert_outbox_snapshot(
                 cloud_key: op.cloud_key,
                 bytes_total: op.bytes_total,
                 bytes_done,
-                size_label: op.size_label,
                 created_at: op.created_at,
                 attempt_count: op.attempt_count,
                 state,
@@ -1356,7 +1355,7 @@ fn convert_download_snapshot(
                 release_id: op.release_id,
                 title: op.title,
                 file_count: op.file_count,
-                size_label: op.size_label,
+                total_size: op.total_size,
                 created_at: op.created_at,
                 state,
                 percent,
@@ -1730,7 +1729,6 @@ fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeR
             .collect(),
         file_count: summary.file_count,
         total_size: summary.total_size,
-        total_size_label: summary.total_size_label,
         cover_path: summary.cover_path,
     }
 }
@@ -1755,7 +1753,6 @@ fn convert_release_summary(s: bae_core::album_detail::ReleaseSummary) -> BridgeR
             .collect(),
         file_count: s.file_count,
         total_size: s.total_size,
-        total_size_label: s.total_size_label,
         cover_path: s.cover_path,
     }
 }

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -241,8 +241,6 @@ pub struct BridgeReleaseSummary {
     pub storage_actions: Vec<BridgeReleaseStorageAction>,
     pub file_count: i64,
     pub total_size: i64,
-    /// Pre-formatted total size, e.g. "350 MB".
-    pub total_size_label: String,
     /// Cache-bustable identifier for this release's own cover
     /// (`<path>#v=<mtime>`), or `None` when no cover is cached. Keyed on the
     /// release id so each release renders its own art; the image loader strips
@@ -279,8 +277,6 @@ pub struct BridgeRelease {
     pub total_duration_ms: i64,
     pub file_count: i64,
     pub total_size: i64,
-    /// Pre-formatted total size, e.g. "350 MB".
-    pub total_size_label: String,
     /// Cache-bustable identifier for this release's own cover
     /// (`<path>#v=<mtime>`), or `None` when no cover is cached. Mirrors
     /// `BridgeReleaseSummary.cover_path` so a summary rebuilt from this fat
@@ -677,8 +673,6 @@ impl BridgeWatchedFolder {
 pub struct BridgeFileInfo {
     pub name: String,
     pub size: u64,
-    /// Pre-formatted size, e.g. "35 MB".
-    pub size_label: String,
     /// Directory prefix for display, e.g. "Artwork/". `None` when the file
     /// sits at the candidate-folder root.
     pub dir_prefix: Option<String>,
@@ -698,16 +692,12 @@ pub struct BridgeArtworkFile {
 pub struct BridgeCueFlacPair {
     pub cue_name: String,
     pub cue_size: u64,
-    /// Pre-formatted CUE file size, e.g. "1 KB".
-    pub cue_size_label: String,
     /// Absolute filesystem path of the CUE file on disk.
     pub cue_local_path: String,
     pub flac_name: String,
     /// Absolute filesystem path of the audio file on disk.
     pub flac_local_path: String,
     pub total_size: u64,
-    /// Pre-formatted total size, e.g. "340 MB".
-    pub total_size_label: String,
     /// `None` when the CUE hasn't been parsed yet.
     pub track_count: Option<u32>,
 }
@@ -1517,8 +1507,6 @@ pub struct BridgeUploadOp {
     pub cloud_key: String,
     pub bytes_total: u64,
     pub bytes_done: u64,
-    /// Pre-formatted file size, e.g. `"70 MB"`.
-    pub size_label: String,
     /// Enqueue time as Unix epoch milliseconds, for the queued relative label.
     pub created_at: i64,
     pub attempt_count: i64,
@@ -1568,8 +1556,8 @@ pub struct BridgeDownloadOp {
     /// Album title for display.
     pub title: String,
     pub file_count: i64,
-    /// Pre-formatted total size, e.g. `"350 MB"`.
-    pub size_label: String,
+    /// Total size in bytes across the release's files. The UI formats it.
+    pub total_size: i64,
     /// Enqueue time as Unix epoch milliseconds, for the queued relative label.
     pub created_at: i64,
     pub state: BridgeDownloadState,
@@ -2746,7 +2734,6 @@ fn results_and_status_map(
 fn scanned_file_to_bridge(f: bae_core::import::folder_scanner::ScannedFile) -> BridgeFileInfo {
     BridgeFileInfo {
         name: f.relative_path,
-        size_label: f.size_label,
         size: f.size,
         dir_prefix: f.dir_prefix,
         file_name: f.file_name,
@@ -2782,12 +2769,10 @@ pub(crate) fn categorized_files_to_bridge(
                 .into_iter()
                 .map(|p| BridgeCueFlacPair {
                     cue_name: p.cue_file.relative_path,
-                    cue_size_label: p.cue_file.size_label,
                     cue_size: p.cue_file.size,
                     cue_local_path: p.cue_file.path.to_string_lossy().to_string(),
                     flac_name: p.audio_file.relative_path,
                     flac_local_path: p.audio_file.path.to_string_lossy().to_string(),
-                    total_size_label: p.total_size_label,
                     total_size: p.total_size,
                     track_count: p.cue_sheet.as_ref().map(|s| s.tracks.len() as u32),
                 })

--- a/bae-core/src/album_detail.rs
+++ b/bae-core/src/album_detail.rs
@@ -208,8 +208,6 @@ pub struct ReleaseSummary {
     pub storage_actions: Vec<ReleaseStorageAction>,
     pub file_count: i64,
     pub total_size: i64,
-    /// Pre-formatted total size, e.g. "350 MB".
-    pub total_size_label: String,
     /// Cache-bustable identifier for this release's own cover
     /// (`<path>#v=<mtime>`), or `None` when no cover is cached on disk. Keyed on
     /// the release id — covers are stored per release — so two releases of one
@@ -317,8 +315,7 @@ pub struct AlbumSummary {
 /// Resolved per-release storage summary for the Storage Manager view.
 /// Produced by `LibraryManager` from `DbReleaseStorageSummary`: derives
 /// `storage_state` from `releases.managed` and this device's
-/// `release_local_copy` row, and formats `total_size_label` via
-/// `crate::util::format::format_bytes_signed`.
+/// `release_local_copy` row. The UI formats `total_size` for the locale.
 #[derive(Debug, Clone)]
 pub struct ReleaseStorageSummary {
     pub release_id: String,
@@ -339,7 +336,6 @@ pub struct ReleaseStorageSummary {
     pub storage_actions: Vec<ReleaseStorageAction>,
     pub file_count: i64,
     pub total_size: i64,
-    pub total_size_label: String,
 }
 
 /// One row on the Storage Manager view: a release paired with its parent

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -43,8 +43,6 @@ pub struct ScannedFile {
     pub relative_path: String,
     /// File size in bytes
     pub size: u64,
-    /// Pre-formatted file size, e.g. "35 MB".
-    pub size_label: String,
     /// Directory prefix of relative_path (e.g. "Disc 1/"). `None` when the
     /// file is at the candidate-folder root.
     pub dir_prefix: Option<String>,
@@ -54,7 +52,6 @@ pub struct ScannedFile {
 
 impl ScannedFile {
     pub fn new(path: PathBuf, relative_path: String, size: u64) -> Self {
-        let size_label = crate::util::format::format_bytes(size);
         let (dir_prefix, file_name) = match relative_path.rfind('/') {
             Some(idx) => (
                 Some(relative_path[..=idx].to_string()),
@@ -66,7 +63,6 @@ impl ScannedFile {
             path,
             relative_path,
             size,
-            size_label,
             dir_prefix,
             file_name,
         }
@@ -87,8 +83,6 @@ pub struct ScannedCueFlacPair {
     pub cue_sheet: Option<crate::cue_flac::CueSheet>,
     /// Combined size of CUE + audio file.
     pub total_size: u64,
-    /// Pre-formatted combined size.
-    pub total_size_label: String,
 }
 
 /// The audio content type of a release - mutually exclusive
@@ -865,7 +859,6 @@ fn categorize_files_from_tree(
                 audio_file,
                 cue_sheet,
                 total_size,
-                total_size_label: crate::util::format::format_bytes(total_size),
             });
         }
 

--- a/bae-core/src/import/track_to_file_mapper.rs
+++ b/bae-core/src/import/track_to_file_mapper.rs
@@ -680,7 +680,6 @@ mod tests {
                     audio_file: scanned("/album/Album.flac"),
                     cue_sheet: None,
                     total_size: 2048,
-                    total_size_label: "2 KB".to_string(),
                 }],
                 format_label: "CUE+FLAC".to_string(),
             },

--- a/bae-core/src/library/download_queue.rs
+++ b/bae-core/src/library/download_queue.rs
@@ -243,7 +243,7 @@ mod tests {
             release_id: release_id.to_string(),
             title: "Test Album".to_string(),
             file_count: 3,
-            size_label: "350 MB".to_string(),
+            total_size: 350_000_000,
             created_at: 0,
             state: DownloadState::Queued,
         }

--- a/bae-core/src/library/download_snapshot.rs
+++ b/bae-core/src/library/download_snapshot.rs
@@ -37,8 +37,8 @@ pub struct DownloadOp {
     /// Album title for display.
     pub title: String,
     pub file_count: i64,
-    /// Pre-formatted total size, e.g. `"350 MB"`.
-    pub size_label: String,
+    /// Total size in bytes across the release's files. The UI formats it.
+    pub total_size: i64,
     /// Enqueue time as Unix epoch milliseconds, for the "queued 2m ago"
     /// relative label the UI renders.
     pub created_at: i64,
@@ -98,7 +98,7 @@ mod tests {
             release_id: release_id.to_string(),
             title: "Test Album".to_string(),
             file_count: 3,
-            size_label: "350 MB".to_string(),
+            total_size: 350_000_000,
             created_at: 0,
             state,
         }

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -131,7 +131,7 @@ fn resolve_queue_item(raw: DbQueueItem) -> QueueItem {
 
 /// Produces a resolved `ReleaseStorageSummary` from a raw
 /// `DbReleaseStorageSummary`: derives `storage_state` from `managed` + this
-/// device's `release_local_copy` row and formats `total_size_label`. The raw
+/// device's `release_local_copy` row. The raw
 /// `primary_release_id` comes from SQL's `COALESCE(a.primary_release_id,
 /// <first release id>)` and is non-null by construction: every album has at
 /// least one release (enforced by `delete_release`).
@@ -155,7 +155,6 @@ fn resolve_release_storage_summary(
             .expect("album has at least one release"),
         file_count: raw.file_count,
         total_size: raw.total_size,
-        total_size_label: crate::util::format::format_bytes_signed(raw.total_size),
     }
 }
 
@@ -192,8 +191,7 @@ fn resolve_album_summary(
 }
 
 /// Resolve a raw release-summary aggregate: derives `storage_state` from
-/// `managed` + this device's `release_local_copy` row and formats
-/// `total_size_label` via `crate::util::format::format_bytes_signed`.
+/// `managed` + this device's `release_local_copy` row.
 /// `has_cloud_home` is read once by the caller and passed down (DI) so
 /// `storage_actions` reflects whether managed storage exists at all.
 /// `resolve_cover` maps the release's own id to its cover identifier.
@@ -218,8 +216,8 @@ fn resolve_release_summary(
 /// Single source of truth for `ReleaseSummary` construction. Both
 /// `resolve_release_summary` (from a SQL-aggregated `DbReleaseSummary`
 /// row) and `resolve_release` (from the fat `DbReleaseDetail` with its
-/// own `files` vec) route through here so the `total_size_label`
-/// formatting and the `storage_actions` derivation stay in one place.
+/// own `files` vec) route through here so the `storage_actions`
+/// derivation stays in one place.
 /// `cover_path` is the release's own cover identifier, resolved by the
 /// caller (which holds the cover existence/version logic).
 fn build_release_summary(
@@ -243,7 +241,6 @@ fn build_release_summary(
         ),
         file_count,
         total_size,
-        total_size_label: crate::util::format::format_bytes_signed(total_size),
         cover_path,
     }
 }
@@ -4484,7 +4481,7 @@ impl LibraryManager {
 
     /// Enqueue releases to pin for offline. Skips ids already in the queue (any
     /// state) or already pinned; for each new one, resolves its title /
-    /// file_count / size_label from its storage summary so the Downloads pane
+    /// file_count / total_size from its storage summary so the Downloads pane
     /// can render the row without a re-query. Spawns the single worker on the
     /// first enqueue, then wakes it. Emits a fresh `DownloadQueueChanged`.
     pub async fn enqueue_pins(&self, release_ids: Vec<String>) {
@@ -4516,7 +4513,7 @@ impl LibraryManager {
                 release_id: release_id.clone(),
                 title: summary.album_title,
                 file_count: summary.file_count,
-                size_label: summary.total_size_label,
+                total_size: summary.total_size,
                 created_at: enqueued_at,
                 state: crate::library::DownloadState::Queued,
             };

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -52,9 +52,6 @@ pub struct UploadOp {
     pub title: Option<String>,
     pub cloud_key: String,
     pub bytes_total: u64,
-    /// Pre-formatted file size, e.g. `"70 MB"`. The UI renders this beside
-    /// the title so users see how much is being shipped.
-    pub size_label: String,
     /// Enqueue time as Unix epoch milliseconds, for the queued relative label.
     pub created_at: i64,
     pub attempt_count: i64,
@@ -178,7 +175,6 @@ pub(crate) async fn build_outbox_snapshot(
                     }
                 }
 
-                let size_label = crate::util::format::format_bytes(bytes_total);
                 uploads.push(UploadOp {
                     id: row.id,
                     file_id: row.file_id,
@@ -186,7 +182,6 @@ pub(crate) async fn build_outbox_snapshot(
                     title: row.title,
                     cloud_key: row.cloud_key,
                     bytes_total,
-                    size_label,
                     created_at: row.created_at,
                     attempt_count: row.attempt_count,
                     state,

--- a/bae-core/src/signals/service.rs
+++ b/bae-core/src/signals/service.rs
@@ -1644,7 +1644,6 @@ FILE \"audio.wav\" WAVE\n  \
             audio_file: flac.clone(),
             cue_sheet: None,
             total_size: 5_000_100,
-            total_size_label: "5 MB".to_string(),
         };
         let categorized = CategorizedFiles {
             audio: AudioContent::CueFlacPairs {

--- a/bae-core/src/util/format.rs
+++ b/bae-core/src/util/format.rs
@@ -1,7 +1,6 @@
 //! Pure formatters: `fn data → String` with no state, no I/O, no context.
 //!
 //! Examples: `format_duration_label(ms) → "3:07"`,
-//! `format_bytes_signed(i64) → "350 MB"`,
 //! `compute_track_labels(format, side, …) → (String, String)`.
 //!
 //! Zero dependencies on the database, the filesystem, or any struct
@@ -35,23 +34,6 @@ pub fn format_duration_label_unsigned(ms: Option<u64>) -> String {
     }
 }
 
-/// Format a byte count as a human-readable string.
-/// "0 B", "512 B", "42 KB", "350 MB", "1.2 GB".
-pub fn format_bytes(bytes: u64) -> String {
-    let kb = bytes as f64 / 1024.0;
-    if kb < 1.0 {
-        return format!("{} B", bytes);
-    }
-    let mb = kb / 1024.0;
-    if mb < 1.0 {
-        return format!("{:.0} KB", kb);
-    }
-    if mb >= 1024.0 {
-        return format!("{:.1} GB", mb / 1024.0);
-    }
-    format!("{:.0} MB", mb)
-}
-
 /// Format an ETA from progress, total size, and download rate.
 /// Returns empty string when ETA can't be computed (rate is zero or download complete).
 pub fn format_eta(progress: f64, total_bytes: u64, bytes_per_sec: u64) -> String {
@@ -71,15 +53,6 @@ pub fn format_eta(progress: f64, total_bytes: u64, bytes_per_sec: u64) -> String
     let hours = minutes / 60;
     let mins = minutes % 60;
     format!("{}h {}m remaining", hours, mins)
-}
-
-/// Format a byte count (signed i64) as a human-readable string.
-/// Used for database fields that store sizes as i64.
-pub fn format_bytes_signed(bytes: i64) -> String {
-    if bytes < 0 {
-        return String::new();
-    }
-    format_bytes(bytes as u64)
 }
 
 /// Convert a 1-indexed side number to a letter (1=A, 2=B, ..., 26=Z).
@@ -193,43 +166,6 @@ mod tests {
     fn duration_label_unsigned() {
         assert_eq!(format_duration_label_unsigned(Some(187_000)), "3:07");
         assert_eq!(format_duration_label_unsigned(None), "");
-    }
-
-    #[test]
-    fn bytes_zero() {
-        assert_eq!(format_bytes(0), "0 B");
-    }
-
-    #[test]
-    fn bytes_small() {
-        assert_eq!(format_bytes(512), "512 B");
-        assert_eq!(format_bytes(1023), "1023 B");
-    }
-
-    #[test]
-    fn bytes_kilobytes() {
-        assert_eq!(format_bytes(1024), "1 KB");
-        assert_eq!(format_bytes(6000), "6 KB");
-        assert_eq!(format_bytes(1200), "1 KB");
-    }
-
-    #[test]
-    fn bytes_megabytes() {
-        assert_eq!(format_bytes(2_500_000), "2 MB");
-        assert_eq!(format_bytes(35_000_000), "33 MB");
-        assert_eq!(format_bytes(350_000_000), "334 MB");
-    }
-
-    #[test]
-    fn bytes_gigabytes() {
-        assert_eq!(format_bytes(1_200_000_000), "1.1 GB");
-        assert_eq!(format_bytes(5_368_709_120), "5.0 GB");
-    }
-
-    #[test]
-    fn bytes_signed() {
-        assert_eq!(format_bytes_signed(35_000_000), "33 MB");
-        assert_eq!(format_bytes_signed(-1), "");
     }
 
     #[test]

--- a/bae-macos/bae/bae/BridgeDownloadOp+Size.swift
+++ b/bae-macos/bae/bae/BridgeDownloadOp+Size.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension BridgeDownloadOp {
+    /// Total release size formatted for the current locale, e.g. "350 MB".
+    /// bae-core emits the raw byte count; the UI formats it.
+    var totalSizeText: String {
+        totalSize.formatted(.byteCount(style: .file))
+    }
+}

--- a/bae-macos/bae/bae/BridgeUploadOp+Size.swift
+++ b/bae-macos/bae/bae/BridgeUploadOp+Size.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension BridgeUploadOp {
+    /// File size formatted for the current locale, e.g. "70 MB". bae-core emits
+    /// the raw byte count; the UI formats it.
+    var sizeText: String {
+        Int64(bytesTotal).formatted(.byteCount(style: .file))
+    }
+}

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -234,7 +234,6 @@ enum PreviewData {
                     totalDurationMs: 2_340_000,
                     fileCount: 0,
                     totalSize: 0,
-                    totalSizeLabel: "0 bytes",
                     coverPath: nil,
                 )
             ],
@@ -300,7 +299,6 @@ enum PreviewData {
                     totalDurationMs: 2_340_000,
                     fileCount: 0,
                     totalSize: 0,
-                    totalSizeLabel: "0 bytes",
                     coverPath: nil,
                 )
             ],
@@ -368,7 +366,6 @@ enum PreviewData {
                     totalDurationMs: 2_340_000,
                     fileCount: 0,
                     totalSize: 0,
-                    totalSizeLabel: "0 bytes",
                     coverPath: nil,
                 )
             }
@@ -794,14 +791,12 @@ enum PreviewData {
     private static func previewArtworkFile(
         name: String,
         size: UInt64,
-        sizeLabel: String,
         localPath: String
     ) -> BridgeArtworkFile {
         BridgeArtworkFile(
             file: BridgeFileInfo(
                 name: name,
                 size: size,
-                sizeLabel: sizeLabel,
                 dirPrefix: nil,
                 fileName: name,
                 localPath: localPath
@@ -819,12 +814,10 @@ enum PreviewData {
             BridgeCueFlacPair(
                 cueName: "Album Title.cue",
                 cueSize: 1200,
-                cueSizeLabel: "1 KB",
                 cueLocalPath: "/tmp/fake/Album Title.cue",
                 flacName: "Album Title.flac",
                 flacLocalPath: "/tmp/fake/Album Title.flac",
                 totalSize: 340_000_000,
-                totalSizeLabel: "324 MB",
                 trackCount: 9,
             )
         ]),
@@ -832,19 +825,16 @@ enum PreviewData {
             previewArtworkFile(
                 name: "Front.png",
                 size: 2_500_000,
-                sizeLabel: "2 MB",
                 localPath: "/tmp/fake/Front.png"
             ),
             previewArtworkFile(
                 name: "Back.png",
                 size: 1_800_000,
-                sizeLabel: "2 MB",
                 localPath: "/tmp/fake/Back.png"
             ),
             previewArtworkFile(
                 name: "Matrix.png",
                 size: 900_000,
-                sizeLabel: "879 KB",
                 localPath: "/tmp/fake/Matrix.png"
             ),
         ],
@@ -852,7 +842,6 @@ enum PreviewData {
             BridgeFileInfo(
                 name: "info.log",
                 size: 6000,
-                sizeLabel: "6 KB",
                 dirPrefix: nil,
                 fileName: "info.log",
                 localPath: "/tmp/fake/info.log"
@@ -963,7 +952,6 @@ enum PreviewData {
                         BridgeFileInfo(
                             name: "Track \(i).flac",
                             size: UInt64(35_000_000 + i * 2_000_000),
-                            sizeLabel: "\(33 + i * 2) MB",
                             dirPrefix: nil,
                             fileName: "Track \(i).flac",
                             localPath: "/tmp/fake/Track \(i).flac",
@@ -974,7 +962,6 @@ enum PreviewData {
                 previewArtworkFile(
                     name: "Front.png",
                     size: 2_500_000,
-                    sizeLabel: "2 MB",
                     localPath: "/tmp/fake/Front.png"
                 )
             ],
@@ -982,7 +969,6 @@ enum PreviewData {
                 BridgeFileInfo(
                     name: "info.log",
                     size: 6000,
-                    sizeLabel: "6 KB",
                     dirPrefix: nil,
                     fileName: "info.log",
                     localPath: "/tmp/fake/info.log"
@@ -990,7 +976,6 @@ enum PreviewData {
                 BridgeFileInfo(
                     name: "notes.txt",
                     size: 1200,
-                    sizeLabel: "1 KB",
                     dirPrefix: nil,
                     fileName: "notes.txt",
                     localPath: "/tmp/fake/notes.txt"

--- a/bae-macos/bae/bae/Services/Store/CandidateFiles.swift
+++ b/bae-macos/bae/bae/Services/Store/CandidateFiles.swift
@@ -5,7 +5,8 @@ import Foundation
 struct FileInfo: Equatable {
     /// Relative path within the candidate root, e.g. "Disc 1/track.flac".
     let name: String
-    let sizeLabel: String
+    /// File size in bytes. bae-core emits the raw count; the UI formats it.
+    let size: UInt64
     /// Directory portion of `name` with trailing slash. `nil` when the file
     /// sits at the candidate-folder root.
     let dirPrefix: String?
@@ -14,9 +15,14 @@ struct FileInfo: Equatable {
     /// Absolute filesystem path of the file on disk.
     let localPath: String
 
+    /// File size formatted for the current locale, e.g. "35 MB".
+    var sizeText: String {
+        Int64(size).formatted(.byteCount(style: .file))
+    }
+
     init(bridge: BridgeFileInfo) {
         name = bridge.name
-        sizeLabel = bridge.sizeLabel
+        size = bridge.size
         dirPrefix = bridge.dirPrefix
         fileName = bridge.fileName
         localPath = bridge.localPath
@@ -42,23 +48,35 @@ struct ArtworkFile: Equatable {
 
 struct CueFlacPair: Equatable {
     let cueName: String
-    let cueSizeLabel: String
+    /// CUE file size in bytes. The UI formats it.
+    let cueSize: UInt64
     /// Absolute filesystem path of the CUE file on disk.
     let cueLocalPath: String
     let flacName: String
     /// Absolute filesystem path of the audio file on disk.
     let flacLocalPath: String
-    let totalSizeLabel: String
+    /// Combined CUE + audio size in bytes. The UI formats it.
+    let totalSize: UInt64
     /// `nil` when the CUE hasn't been parsed yet.
     let trackCount: UInt32?
 
+    /// CUE file size formatted for the current locale, e.g. "1 KB".
+    var cueSizeText: String {
+        Int64(cueSize).formatted(.byteCount(style: .file))
+    }
+
+    /// Combined size formatted for the current locale, e.g. "340 MB".
+    var totalSizeText: String {
+        Int64(totalSize).formatted(.byteCount(style: .file))
+    }
+
     init(bridge: BridgeCueFlacPair) {
         cueName = bridge.cueName
-        cueSizeLabel = bridge.cueSizeLabel
+        cueSize = bridge.cueSize
         cueLocalPath = bridge.cueLocalPath
         flacName = bridge.flacName
         flacLocalPath = bridge.flacLocalPath
-        totalSizeLabel = bridge.totalSizeLabel
+        totalSize = bridge.totalSize
         trackCount = bridge.trackCount
     }
 }

--- a/bae-macos/bae/bae/Services/Store/ReleaseSummary.swift
+++ b/bae-macos/bae/bae/Services/Store/ReleaseSummary.swift
@@ -42,7 +42,6 @@ final class ReleaseSummary: Identifiable {
     var storageActions: [BridgeReleaseStorageAction]
     var fileCount: Int64
     var totalSize: Int64
-    var totalSizeLabel: String
     /// Cache-bustable identifier for this release's own cover
     /// (`<path>#v=<mtime>`), or `nil` when none is cached. Keyed on the release
     /// id so each release renders its own art; `ImageView` strips the `#v=…`
@@ -55,6 +54,12 @@ final class ReleaseSummary: Identifiable {
     /// mid-transfer must not clear the in-flight indicator).
     var transfer: TransferState? = nil
 
+    /// Total release size formatted for the current locale, e.g. "350 MB".
+    /// bae-core emits the raw byte count; the UI formats it.
+    var totalSizeText: String {
+        totalSize.formatted(.byteCount(style: .file))
+    }
+
     init(from bridge: BridgeReleaseSummary) {
         id = bridge.id
         albumId = bridge.albumId
@@ -63,7 +68,6 @@ final class ReleaseSummary: Identifiable {
         storageActions = bridge.storageActions
         fileCount = bridge.fileCount
         totalSize = bridge.totalSize
-        totalSizeLabel = bridge.totalSizeLabel
         coverPath = bridge.coverPath
     }
 
@@ -78,7 +82,6 @@ final class ReleaseSummary: Identifiable {
         storageActions = bridge.storageActions
         fileCount = bridge.fileCount
         totalSize = bridge.totalSize
-        totalSizeLabel = bridge.totalSizeLabel
         coverPath = bridge.coverPath
     }
 
@@ -100,9 +103,6 @@ final class ReleaseSummary: Identifiable {
         if totalSize != bridge.totalSize {
             totalSize = bridge.totalSize
         }
-        if totalSizeLabel != bridge.totalSizeLabel {
-            totalSizeLabel = bridge.totalSizeLabel
-        }
         if coverPath != bridge.coverPath {
             coverPath = bridge.coverPath
         }
@@ -123,9 +123,6 @@ final class ReleaseSummary: Identifiable {
         }
         if totalSize != bridge.totalSize {
             totalSize = bridge.totalSize
-        }
-        if totalSizeLabel != bridge.totalSizeLabel {
-            totalSizeLabel = bridge.totalSizeLabel
         }
         if coverPath != bridge.coverPath {
             coverPath = bridge.coverPath

--- a/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
@@ -192,7 +192,7 @@ struct ImportFilePane: View {
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                             Spacer()
-                            Text(pair.totalSizeLabel)
+                            Text(pair.totalSizeText)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .padding(.leading, 8)
@@ -222,7 +222,7 @@ struct ImportFilePane: View {
                         }
                         .buttonStyle(.plain)
                         Spacer()
-                        Text(pair.cueSizeLabel)
+                        Text(pair.cueSizeText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .padding(.leading, 8)
@@ -286,7 +286,7 @@ struct ImportFilePane: View {
                         .truncationMode(.middle)
                 }
                 Spacer()
-                Text(file.sizeLabel)
+                Text(file.sizeText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.leading, 8)

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -265,7 +265,7 @@ private struct DownloadRow: View {
             Text(op.title)
                 .lineLimit(1)
 
-            Text("\(op.fileCount) files · \(op.sizeLabel)")
+            Text("\(op.fileCount) files · \(op.totalSizeText)")
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
@@ -523,7 +523,7 @@ private struct OutboxUploadRow: View {
             Text(op.title ?? op.cloudKey)
                 .lineLimit(1)
 
-            Text(op.sizeLabel)
+            Text(op.sizeText)
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundStyle(.secondary)

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -931,7 +931,7 @@ private struct StorageReleaseCell: View {
                     .monospacedDigit()
                     .frame(maxWidth: .infinity, alignment: .trailing)
             case .size:
-                Text(release.totalSizeLabel)
+                Text(release.totalSizeText)
                     .monospacedDigit()
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }


### PR DESCRIPTION
Removes the remaining pre-formatted byte-size labels (`total_size_label`, `size_label`, `cue_size_label`); the raw byte counts already cross, so the macOS UI formats them natively via `.byteCount(style: .file)` (computed `*SizeText` properties), mirroring the merged per-file `BridgeFile.fileSizeText`. `format_bytes` / `format_bytes_signed` became dead and are removed with their tests.

**Entanglement resolved:** `enqueue_pins` copied a release-summary's `total_size_label` into `DownloadOp.size_label` — the one type with no raw byte sibling crossing. The agent gave `DownloadOp`/`BridgeDownloadOp` a raw `total_size: i64` (from the summary's existing `total_size`) so the download-row UI formats it.

*(Implemented by a product-engineer subagent; verified: clippy core (lib + tests, 775 passed) + bridge clean, macOS BUILD SUCCEEDED, full pre-commit gate passed, `size_label`/`sizeLabel` grep empty across core/bridge.)*

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; `cargo test -p bae-core --lib` green.
- macOS app builds; the storage table / import panes render native byte counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx