### PR TITLE
loc: format track/playback durations natively

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -245,7 +245,6 @@ impl AppHandle {
                     id: t.id,
                     title: t.title,
                     duration_ms: t.duration_ms,
-                    duration_label: t.duration_label,
                     album_id: t.album_id,
                     album_title: t.album_title,
                     artist_name: t.artist_name,
@@ -1400,7 +1399,6 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
                 album_title: t.track_info.album_title,
                 cover_image_id: t.track_info.cover_image_id,
                 duration_ms: t.duration_ms,
-                duration_label: t.duration_label,
             }),
         }),
         UiBusEvent::PlaybackPlaying {
@@ -1412,7 +1410,6 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             album_title,
             cover_image_id,
             duration_ms,
-            duration_label,
         } => Some(BridgeUiEvent::PlaybackPlaying {
             track_id,
             track_title,
@@ -1422,7 +1419,6 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             album_title,
             cover_image_id,
             duration_ms,
-            duration_label,
         }),
         UiBusEvent::PlaybackPaused {
             track_id,
@@ -1433,7 +1429,6 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             album_title,
             cover_image_id,
             duration_ms,
-            duration_label,
         } => Some(BridgeUiEvent::PlaybackPaused {
             track_id,
             track_title,
@@ -1443,20 +1438,15 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             album_title,
             cover_image_id,
             duration_ms,
-            duration_label,
         }),
         UiBusEvent::PlaybackProgress {
             position_ms,
             duration_ms,
             progress,
-            elapsed_label,
-            remaining_label,
         } => Some(BridgeUiEvent::PlaybackProgress {
             position_ms,
             duration_ms,
             progress,
-            elapsed_label,
-            remaining_label,
         }),
         UiBusEvent::VolumeChanged { volume } => Some(BridgeUiEvent::VolumeChanged { volume }),
         UiBusEvent::MuteChanged { is_muted } => Some(BridgeUiEvent::MuteChanged { is_muted }),
@@ -1475,7 +1465,6 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
                     title: i.title,
                     artist_names: i.artist_names,
                     duration_ms: i.duration_ms,
-                    duration_label: i.duration_label,
                     album_title: i.album_title,
                     cover_image_id: i.cover_image_id,
                 })
@@ -1487,32 +1476,18 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
 
         // ── Preview ────────────────────────────────────────────────
         UiBusEvent::PreviewIdle => Some(BridgeUiEvent::PreviewIdle),
-        UiBusEvent::PreviewPlaying {
-            path,
-            duration_ms,
-            duration_label,
-        } => Some(BridgeUiEvent::PreviewPlaying {
-            path,
-            duration_ms,
-            duration_label,
-        }),
-        UiBusEvent::PreviewPaused {
-            path,
-            duration_ms,
-            duration_label,
-        } => Some(BridgeUiEvent::PreviewPaused {
-            path,
-            duration_ms,
-            duration_label,
-        }),
+        UiBusEvent::PreviewPlaying { path, duration_ms } => {
+            Some(BridgeUiEvent::PreviewPlaying { path, duration_ms })
+        }
+        UiBusEvent::PreviewPaused { path, duration_ms } => {
+            Some(BridgeUiEvent::PreviewPaused { path, duration_ms })
+        }
         UiBusEvent::PreviewProgress {
             position_ms,
             progress,
-            elapsed_label,
         } => Some(BridgeUiEvent::PreviewProgress {
             position_ms,
             progress,
-            elapsed_label,
         }),
 
         // ── Candidate-scoped ───────────────────────────────────────
@@ -1688,7 +1663,6 @@ fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeR
         side: t.side,
         track_number: t.track_number,
         duration_ms: t.duration_ms,
-        duration_label: t.duration_label,
         artist_names: t.artist_names,
         side_label: t.side_label,
         position_label: t.position_label,

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -332,8 +332,6 @@ pub struct BridgeTrack {
     pub side: i32,
     pub track_number: Option<i32>,
     pub duration_ms: Option<i64>,
-    /// Pre-formatted duration, e.g. "3:07". Empty if duration is None.
-    pub duration_label: String,
     /// Effective comma-joined artist names for display (the track's own
     /// artists when it has per-track artist rows, otherwise the album
     /// artists). Always populated.
@@ -505,7 +503,6 @@ pub struct BridgeLoadingTrackInfo {
     pub album_title: String,
     pub cover_image_id: Option<String>,
     pub duration_ms: u64,
-    pub duration_label: String,
 }
 
 #[derive(Debug, Clone, uniffi::Enum)]
@@ -526,7 +523,6 @@ pub enum BridgePlaybackState {
         album_title: String,
         cover_image_id: Option<String>,
         duration_ms: u64,
-        duration_label: String,
     },
     Paused {
         track_id: String,
@@ -537,23 +533,14 @@ pub enum BridgePlaybackState {
         album_title: String,
         cover_image_id: Option<String>,
         duration_ms: u64,
-        duration_label: String,
     },
 }
 
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum BridgePreviewState {
     Idle,
-    Playing {
-        path: String,
-        duration_ms: u64,
-        duration_label: String,
-    },
-    Paused {
-        path: String,
-        duration_ms: u64,
-        duration_label: String,
-    },
+    Playing { path: String, duration_ms: u64 },
+    Paused { path: String, duration_ms: u64 },
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -1323,7 +1310,6 @@ pub enum BridgeUiEvent {
         album_title: String,
         cover_image_id: Option<String>,
         duration_ms: u64,
-        duration_label: String,
     },
     PlaybackPaused {
         track_id: String,
@@ -1334,7 +1320,6 @@ pub enum BridgeUiEvent {
         album_title: String,
         cover_image_id: Option<String>,
         duration_ms: u64,
-        duration_label: String,
     },
     /// Position update — goes to NSView. Carries both regular ticks from the
     /// position listener and one-off updates emitted after a seek completes.
@@ -1344,8 +1329,6 @@ pub enum BridgeUiEvent {
         /// update reads it from the event instead of the now-playing slice.
         duration_ms: u64,
         progress: f64,
-        elapsed_label: String,
-        remaining_label: String,
     },
     VolumeChanged {
         volume: f32,
@@ -1372,18 +1355,15 @@ pub enum BridgeUiEvent {
     PreviewPlaying {
         path: String,
         duration_ms: u64,
-        duration_label: String,
     },
     PreviewPaused {
         path: String,
         duration_ms: u64,
-        duration_label: String,
     },
     /// High-frequency tick — goes to NSView, not store.
     PreviewProgress {
         position_ms: u64,
         progress: f64,
-        elapsed_label: String,
     },
 
     // ── Candidate-scoped (key inlined) ─────────────────────────────
@@ -1709,8 +1689,6 @@ pub struct BridgeReleaseTrack {
     pub title: String,
     pub artist: Option<String>,
     pub duration_ms: Option<u64>,
-    /// Pre-formatted duration, e.g. "3:07". Empty if duration is None.
-    pub duration_label: String,
     pub position: String,
     pub side: u32,
     /// Human-readable side label: "Side A", "Disc 2", or empty for single-side digital
@@ -1934,8 +1912,6 @@ pub struct BridgeTrackSearchResult {
     pub id: String,
     pub title: String,
     pub duration_ms: Option<i64>,
-    /// Pre-formatted duration, e.g. "3:07". Empty if duration is None.
-    pub duration_label: String,
     pub album_id: String,
     pub album_title: String,
     pub artist_name: String,
@@ -1999,8 +1975,6 @@ pub struct BridgeQueueItem {
     pub title: String,
     pub artist_names: String,
     pub duration_ms: Option<i64>,
-    /// Pre-formatted duration, e.g. "3:07". Empty if duration is None.
-    pub duration_label: String,
     pub album_title: String,
     pub cover_image_id: Option<String>,
 }
@@ -2468,7 +2442,6 @@ pub(crate) fn release_detail_to_bridge(
             .map(|t| BridgeReleaseTrack {
                 title: t.title,
                 artist: t.artist,
-                duration_label: t.duration_label,
                 duration_ms: t.duration_ms,
                 position: t.position,
                 side: t.side,
@@ -2530,7 +2503,6 @@ pub(crate) fn release_detail_from_bridge(
                 title: t.title,
                 artist: t.artist,
                 duration_ms: t.duration_ms,
-                duration_label: t.duration_label,
                 position: t.position,
                 side: t.side,
                 side_label: t.side_label,

--- a/bae-core/src/album_detail.rs
+++ b/bae-core/src/album_detail.rs
@@ -123,7 +123,7 @@ pub fn available_storage_actions(
     }
 }
 
-/// Track with resolved artist names and pre-formatted display labels.
+/// Track with resolved artist names and display labels.
 #[derive(Debug, Clone)]
 pub struct TrackDetail {
     pub id: String,
@@ -131,8 +131,6 @@ pub struct TrackDetail {
     pub side: i32,
     pub track_number: Option<i32>,
     pub duration_ms: Option<i64>,
-    /// Pre-formatted duration, e.g. "3:07". Empty if duration unknown.
-    pub duration_label: String,
     /// Effective artist names for display — the track's own artists when it
     /// has per-track artist rows, otherwise the album artists. Always
     /// populated so UI consumers can render a row label without joining
@@ -415,14 +413,12 @@ pub struct AlbumSearchResult {
     pub artist_name: String,
 }
 
-/// Resolved track search result. Produced from `DbTrackSearchResult` by
-/// formatting the duration label via `crate::util::format::format_duration_label`.
+/// Resolved track search result, produced from `DbTrackSearchResult`.
 #[derive(Debug, Clone)]
 pub struct TrackSearchResult {
     pub id: String,
     pub title: String,
     pub duration_ms: Option<i64>,
-    pub duration_label: String,
     pub album_id: String,
     pub album_title: String,
     pub artist_name: String,

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1836,7 +1836,6 @@ mod tests {
             title: title.to_string(),
             artist: artist.map(str::to_string),
             duration_ms: None,
-            duration_label: String::new(),
             position: position.to_string(),
             side,
             side_label: String::new(),

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -93,8 +93,6 @@ pub struct ReleaseTrack {
     pub title: String,
     pub artist: Option<String>,
     pub duration_ms: Option<u64>,
-    /// Pre-formatted duration, e.g. "3:07".
-    pub duration_label: String,
     pub position: String,
     pub side: u32,
     /// Human-readable side label: "Side A", "Disc 2", or empty for single-side digital
@@ -473,7 +471,6 @@ fn build_mb_detail(
                     .unwrap_or_default(),
                 artist: t.artist_credit.first().map(|ac| ac.name.clone()),
                 duration_ms: t.length,
-                duration_label: crate::util::format::format_duration_label_unsigned(t.length),
                 position: t
                     .number
                     .clone()
@@ -632,7 +629,6 @@ fn build_discogs_detail(release: &crate::discogs::DiscogsRelease) -> ImportSearc
                 title: pt.title.clone(),
                 artist: source_track.and_then(|t| t.artists.first().map(|a| a.name.clone())),
                 duration_ms,
-                duration_label: crate::util::format::format_duration_label_unsigned(duration_ms),
                 position: pt.position.clone(),
                 side: pt.side as u32,
                 side_label,

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -115,14 +115,12 @@ pub(crate) async fn playback_info_from_track_release(
     })
 }
 
-/// Produces a resolved `QueueItem` from a raw `DbQueueItem` by formatting
-/// the duration label.
+/// Produces a resolved `QueueItem` from a raw `DbQueueItem`.
 fn resolve_queue_item(raw: DbQueueItem) -> QueueItem {
     QueueItem {
         track_id: raw.track_id,
         title: raw.title,
         artist_names: raw.artist_names,
-        duration_label: crate::util::format::format_duration_label(raw.duration_ms),
         duration_ms: raw.duration_ms,
         album_title: raw.album_title,
         cover_image_id: raw.cover_image_id,
@@ -332,12 +330,11 @@ fn resolve_album_search_result(raw: DbAlbumSearchResult) -> AlbumSearchResult {
     }
 }
 
-/// Resolve a raw track search result by formatting the duration label.
+/// Resolve a raw track search result into its display-ready shape.
 fn resolve_track_search_result(raw: DbTrackSearchResult) -> TrackSearchResult {
     TrackSearchResult {
         id: raw.id,
         title: raw.title,
-        duration_label: crate::util::format::format_duration_label(raw.duration_ms),
         duration_ms: raw.duration_ms,
         album_id: raw.album_id,
         album_title: raw.album_title,
@@ -3337,7 +3334,6 @@ pub(crate) fn resolve_release(
                 has_multiple_sides,
             );
             TrackDetail {
-                duration_label: crate::util::format::format_duration_label(entry.track.duration_ms),
                 id: entry.track.id,
                 title: entry.track.title,
                 side: entry.track.side,

--- a/bae-core/src/playback/format.rs
+++ b/bae-core/src/playback/format.rs
@@ -5,35 +5,6 @@ pub fn format_time(ms: u64) -> String {
     format_minutes_seconds(ms)
 }
 
-/// Format an elapsed time label, accounting for pregap.
-/// During pregap (position < pregap_ms), shows "-0:02" style countdown.
-///
-/// `duration_ms` clamps position so elapsed never exceeds the duration label.
-/// The decoder position can overshoot the declared track duration slightly
-/// because a file's metadata duration can round differently than its actual
-/// sample count. Clamping here keeps the displayed elapsed time from exceeding
-/// the label.
-pub fn format_elapsed(position_ms: u64, duration_ms: u64, pregap_ms: Option<i64>) -> String {
-    let position_ms = position_ms.min(duration_ms);
-    let offset = pregap_ms.unwrap_or(0).max(0) as u64;
-    if position_ms < offset {
-        // Ceil remaining seconds so -0:01 shows until the exact pregap boundary.
-        let remaining = offset - position_ms;
-        let total_seconds = remaining.div_ceil(1000);
-        let minutes = total_seconds / 60;
-        let seconds = total_seconds % 60;
-        format!("-{}:{:02}", minutes, seconds)
-    } else {
-        format_time(position_ms - offset)
-    }
-}
-
-/// Format a duration label, subtracting pregap.
-pub fn format_duration(duration_ms: u64, pregap_ms: Option<i64>) -> String {
-    let offset = pregap_ms.unwrap_or(0).max(0) as u64;
-    format_time(duration_ms.saturating_sub(offset))
-}
-
 /// Format remaining time as "-M:SS".
 /// During pregap, remaining includes the pregap countdown plus the full track.
 pub fn format_remaining(position_ms: u64, duration_ms: u64, pregap_ms: Option<i64>) -> String {
@@ -106,71 +77,6 @@ mod tests {
         for (ms, expected) in cases {
             assert_eq!(format_time(ms), expected, "ms: {ms}");
         }
-    }
-
-    // -- format_elapsed --
-    //
-    // During a CUE/FLAC pregap the decoder is already playing audio (the gap
-    // between INDEX 00 and INDEX 01) but the track hasn't "started" yet.
-    // The elapsed display counts down with a minus sign, like a CD player:
-    //   -0:02, -0:01, then 0:00 at the track boundary, 0:01, 0:02, ...
-    //
-    // The countdown uses ceiling so that -0:01 holds until the exact pregap
-    // boundary. This gives every displayed value ~1 second of real time.
-
-    #[test]
-    fn format_elapsed_no_pregap() {
-        assert_eq!(format_elapsed(0, 240_000, None), "0:00");
-        assert_eq!(format_elapsed(63_000, 240_000, None), "1:03");
-    }
-
-    #[test]
-    fn format_elapsed_pregap_countdown_uses_ceiling() {
-        // 2-second pregap. Countdown ceils remaining time to whole seconds.
-        let pregap = Some(2000);
-        assert_eq!(format_elapsed(0, 12_000, pregap), "-0:02"); // 2000ms left -> 2s
-        assert_eq!(format_elapsed(500, 12_000, pregap), "-0:02"); // 1500ms left -> ceil -> 2s
-        assert_eq!(format_elapsed(999, 12_000, pregap), "-0:02"); // 1001ms left -> ceil -> 2s
-        assert_eq!(format_elapsed(1000, 12_000, pregap), "-0:01"); // 1000ms left -> ceil -> 1s
-        assert_eq!(format_elapsed(1001, 12_000, pregap), "-0:01"); // 999ms left -> ceil -> 1s
-        assert_eq!(format_elapsed(1999, 12_000, pregap), "-0:01"); // 1ms left -> ceil -> 1s
-    }
-
-    #[test]
-    fn format_elapsed_counts_up_after_pregap() {
-        let pregap = Some(2000);
-        assert_eq!(format_elapsed(2000, 12_000, pregap), "0:00"); // exactly at boundary
-        assert_eq!(format_elapsed(3000, 12_000, pregap), "0:01");
-        assert_eq!(format_elapsed(5000, 12_000, pregap), "0:03");
-    }
-
-    #[test]
-    fn format_elapsed_clamps_to_duration() {
-        // Decoder position can overshoot declared duration (see doc comment).
-        // Elapsed must never exceed the duration label.
-        assert_eq!(format_elapsed(241_000, 240_000, None), "4:00");
-        assert_eq!(format_elapsed(12_100, 12_000, Some(2000)), "0:10");
-    }
-
-    #[test]
-    fn format_elapsed_negative_pregap_treated_as_zero() {
-        // Negative pregap_ms is invalid; treat as no pregap.
-        assert_eq!(format_elapsed(500, 60_000, Some(-100)), "0:00");
-    }
-
-    // -- format_duration --
-    //
-    // Duration excludes pregap so the user sees actual track length.
-
-    #[test]
-    fn format_duration_no_pregap() {
-        assert_eq!(format_duration(240_000, None), "4:00");
-    }
-
-    #[test]
-    fn format_duration_subtracts_pregap() {
-        // 4:02 total with 2-second pregap -> 4:00 track duration.
-        assert_eq!(format_duration(242_000, Some(2000)), "4:00");
     }
 
     // -- compute_progress --

--- a/bae-core/src/playback/progress/mod.rs
+++ b/bae-core/src/playback/progress/mod.rs
@@ -15,16 +15,8 @@ use tracing::warn;
 #[derive(Debug, Clone)]
 pub enum PreviewState {
     Idle,
-    Playing {
-        path: String,
-        duration_ms: u64,
-        duration_label: String,
-    },
-    Paused {
-        path: String,
-        duration_ms: u64,
-        duration_label: String,
-    },
+    Playing { path: String, duration_ms: u64 },
+    Paused { path: String, duration_ms: u64 },
 }
 
 /// Progress updates during playback.
@@ -44,8 +36,6 @@ pub enum PlaybackProgress {
         duration_ms: u64,
         track_id: String,
         progress: f64,
-        elapsed_label: String,
-        remaining_label: String,
     },
     /// Queue was updated — contains current queue state
     QueueUpdated {
@@ -91,8 +81,6 @@ pub enum PlaybackProgress {
         duration_ms: u64,
         track_id: String,
         progress: f64,
-        elapsed_label: String,
-        remaining_label: String,
     },
     /// Internal: seek skipped because position difference was < 100ms.
     SeekSkipped {
@@ -111,7 +99,6 @@ pub enum PlaybackProgress {
     PreviewPositionUpdate {
         position_ms: u64,
         progress: f64,
-        elapsed_label: String,
     },
 }
 

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -76,8 +76,6 @@ fn log_streaming_decode_failure(context: &str, error: StreamingDecodeError) -> O
 #[derive(Debug, Clone)]
 pub struct PositionDisplay {
     pub progress: f64,
-    pub elapsed_label: String,
-    pub remaining_label: String,
 }
 
 /// Track metadata resolved once at prepare time, cached for the duration of playback.
@@ -102,7 +100,6 @@ pub struct PlaybackTrackInfo {
 pub struct LoadingTrack {
     pub track_info: PlaybackTrackInfo,
     pub duration_ms: u64,
-    pub duration_label: String,
 }
 
 /// Playback commands sent to the service
@@ -205,12 +202,10 @@ pub enum PlaybackState {
     Playing {
         track_info: PlaybackTrackInfo,
         duration_ms: u64,
-        duration_label: String,
     },
     Paused {
         track_info: PlaybackTrackInfo,
         duration_ms: u64,
-        duration_label: String,
     },
     Loading {
         track_id: String,
@@ -393,16 +388,13 @@ impl PlaybackHandle {
     }
 }
 
-/// The pregap-adjusted total duration (ms + formatted label) a prepared track
-/// reports to the UI — the same value `Playing`/`Paused`/`Loading` all carry.
-fn pregap_adjusted_duration(prepared: &PlaybackPreparedTrack) -> (u64, String) {
+/// The pregap-adjusted total duration (ms) a prepared track reports to the UI
+/// — the same value `Playing`/`Paused`/`Loading` all carry.
+fn pregap_adjusted_duration(prepared: &PlaybackPreparedTrack) -> u64 {
     let raw_dur = prepared.duration.as_millis() as u64;
-    let pregap_ms = prepared.pregap_ms;
-    let (_, adjusted_dur) = crate::playback::format::adjust_for_pregap(0, raw_dur, pregap_ms);
-    (
-        adjusted_dur,
-        crate::playback::format::format_duration(raw_dur, pregap_ms),
-    )
+    let (_, adjusted_dur) =
+        crate::playback::format::adjust_for_pregap(0, raw_dur, prepared.pregap_ms);
+    adjusted_dur
 }
 
 impl PlaybackPreparedTrack {
@@ -776,16 +768,8 @@ impl PlaybackService {
             crate::playback::format::adjust_for_pregap(position_ms, raw_dur_ms, pregap_ms);
         let progress =
             crate::playback::format::compute_progress(position_ms, raw_dur_ms, pregap_ms);
-        let elapsed_label =
-            crate::playback::format::format_elapsed(position_ms, raw_dur_ms, pregap_ms);
-        let remaining_label =
-            crate::playback::format::format_remaining(position_ms, raw_dur_ms, pregap_ms);
 
-        *self.last_position_display.lock().unwrap() = Some(PositionDisplay {
-            progress,
-            elapsed_label: elapsed_label.clone(),
-            remaining_label: remaining_label.clone(),
-        });
+        *self.last_position_display.lock().unwrap() = Some(PositionDisplay { progress });
 
         emit_progress(
             &self.progress_tx,
@@ -794,8 +778,6 @@ impl PlaybackService {
                 duration_ms: adjusted_dur_ms,
                 track_id,
                 progress,
-                elapsed_label,
-                remaining_label,
             },
         );
     }
@@ -803,33 +785,30 @@ impl PlaybackService {
     /// The fields the Playing and Paused states share, read from the current
     /// prepared track. Position data is excluded — it flows through
     /// PositionUpdate/Seeked events.
-    fn current_state_fields(&self) -> (PlaybackTrackInfo, u64, String) {
+    fn current_state_fields(&self) -> (PlaybackTrackInfo, u64) {
         let track_info = self
             .current_track_info
             .clone()
             .expect("no current_track_info");
         let prepared = self.current_prepared.as_ref().expect("no current_prepared");
-        let (duration_ms, duration_label) = pregap_adjusted_duration(prepared);
-        (track_info, duration_ms, duration_label)
+        (track_info, pregap_adjusted_duration(prepared))
     }
 
     /// Build a Playing state from the current prepared track and track info.
     fn make_playing_state(&self) -> PlaybackState {
-        let (track_info, duration_ms, duration_label) = self.current_state_fields();
+        let (track_info, duration_ms) = self.current_state_fields();
         PlaybackState::Playing {
             track_info,
             duration_ms,
-            duration_label,
         }
     }
 
     /// Build a Paused state from the current prepared track and track info.
     fn make_paused_state(&self) -> PlaybackState {
-        let (track_info, duration_ms, duration_label) = self.current_state_fields();
+        let (track_info, duration_ms) = self.current_state_fields();
         PlaybackState::Paused {
             track_info,
             duration_ms,
-            duration_label,
         }
     }
 
@@ -1029,12 +1008,8 @@ impl PlaybackService {
                         *current_position_shared.lock().unwrap() = Some(actual_pos);
                         let raw_pos_ms = actual_pos.as_millis() as u64;
                         let progress = crate::playback::format::compute_progress(raw_pos_ms, fmt.duration_ms, fmt.pregap_ms);
-                        let elapsed_label = crate::playback::format::format_elapsed(raw_pos_ms, fmt.duration_ms, fmt.pregap_ms);
-                        let remaining_label = crate::playback::format::format_remaining(raw_pos_ms, fmt.duration_ms, fmt.pregap_ms);
                         *last_position_display.lock().unwrap() = Some(PositionDisplay {
                             progress,
-                            elapsed_label: elapsed_label.clone(),
-                            remaining_label: remaining_label.clone(),
                         });
                         let (adjusted_pos_ms, adjusted_dur_ms) =
                             crate::playback::format::adjust_for_pregap(raw_pos_ms, fmt.duration_ms, fmt.pregap_ms);
@@ -1045,8 +1020,6 @@ impl PlaybackService {
                                 duration_ms: adjusted_dur_ms,
                                 track_id: fmt.track_id.clone(),
                                 progress,
-                                elapsed_label,
-                                remaining_label,
                             },
                         );
                     }
@@ -1976,7 +1949,7 @@ impl PlaybackService {
         // Metadata is resolved now: re-emit Loading carrying the target track's
         // info so the bar switches from the prior track to the target while the
         // first audio bytes are still downloading.
-        let (loading_duration_ms, loading_duration_label) = pregap_adjusted_duration(&prepared);
+        let loading_duration_ms = pregap_adjusted_duration(&prepared);
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::StateChanged {
@@ -1985,7 +1958,6 @@ impl PlaybackService {
                     resolved: Some(LoadingTrack {
                         track_info: prepared.track_info.clone(),
                         duration_ms: loading_duration_ms,
-                        duration_label: loading_duration_label,
                     }),
                 },
             },
@@ -2538,13 +2510,11 @@ impl PlaybackService {
             PreviewState::Paused {
                 path: path.clone(),
                 duration_ms: dur_ms,
-                duration_label: crate::playback::format::format_time(dur_ms),
             }
         } else {
             PreviewState::Playing {
                 path: path.clone(),
                 duration_ms: dur_ms,
-                duration_label: crate::playback::format::format_time(dur_ms),
             }
         };
 
@@ -2572,7 +2542,6 @@ impl PlaybackService {
                             PlaybackProgress::PreviewPositionUpdate {
                                 position_ms: actual_pos_ms,
                                 progress: crate::playback::format::compute_progress(actual_pos_ms, fmt.duration_ms, fmt.pregap_ms),
-                                elapsed_label: crate::playback::format::format_elapsed(actual_pos_ms, fmt.duration_ms, fmt.pregap_ms),
                             },
                         );
                     }
@@ -2741,7 +2710,6 @@ impl PlaybackService {
         };
 
         let dur_ms = self.preview_duration.as_millis() as u64;
-        let duration_label = crate::playback::format::format_time(dur_ms);
         match preview_output.get_state() {
             crate::playback::audio_output::AudioState::Playing => {
                 preview_output.set_state(crate::playback::audio_output::AudioState::Paused);
@@ -2759,7 +2727,6 @@ impl PlaybackService {
                     PlaybackProgress::PreviewStateChanged(PreviewState::Paused {
                         path,
                         duration_ms: dur_ms,
-                        duration_label,
                     }),
                 );
             }
@@ -2771,7 +2738,6 @@ impl PlaybackService {
                     PlaybackProgress::PreviewStateChanged(PreviewState::Playing {
                         path,
                         duration_ms: dur_ms,
-                        duration_label,
                     }),
                 );
             }
@@ -2850,7 +2816,6 @@ impl PlaybackService {
                 PlaybackProgress::PreviewPositionUpdate {
                     position_ms: pos_ms,
                     progress: crate::playback::format::compute_progress(pos_ms, dur_ms, None),
-                    elapsed_label: crate::playback::format::format_elapsed(pos_ms, dur_ms, None),
                 },
             );
         }
@@ -2980,7 +2945,7 @@ impl PlaybackService {
             "Seek: position {:?}, seek_to {}",
             position, decode.target_sample
         );
-        let (loading_duration_ms, loading_duration_label) = pregap_adjusted_duration(prepared);
+        let loading_duration_ms = pregap_adjusted_duration(prepared);
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::StateChanged {
@@ -2989,7 +2954,6 @@ impl PlaybackService {
                     resolved: Some(LoadingTrack {
                         track_info: prepared.track_info.clone(),
                         duration_ms: loading_duration_ms,
-                        duration_label: loading_duration_label,
                     }),
                 },
             },

--- a/bae-core/src/queue.rs
+++ b/bae-core/src/queue.rs
@@ -5,14 +5,13 @@
 //! `LibraryManager` turns it into `QueueItem` via `resolve_queue_item`.
 
 /// Display-ready queue entry: a track with the album/artist context the UI
-/// needs, plus a pre-formatted duration label.
+/// needs.
 #[derive(Debug, Clone)]
 pub struct QueueItem {
     pub track_id: String,
     pub title: String,
     pub artist_names: String,
     pub duration_ms: Option<i64>,
-    pub duration_label: String,
     pub album_title: String,
     pub cover_image_id: Option<String>,
 }

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -98,7 +98,6 @@ impl UiEventBus {
                             crate::playback::PlaybackState::Playing {
                                 track_info,
                                 duration_ms,
-                                duration_label,
                             } => UiBusEvent::PlaybackPlaying {
                                 track_id: track_info.track_id.clone(),
                                 track_title: track_info.track_title.clone(),
@@ -108,12 +107,10 @@ impl UiEventBus {
                                 album_title: track_info.album_title.clone(),
                                 cover_image_id: track_info.cover_image_id.clone(),
                                 duration_ms: *duration_ms,
-                                duration_label: duration_label.clone(),
                             },
                             crate::playback::PlaybackState::Paused {
                                 track_info,
                                 duration_ms,
-                                duration_label,
                             } => UiBusEvent::PlaybackPaused {
                                 track_id: track_info.track_id.clone(),
                                 track_title: track_info.track_title.clone(),
@@ -123,7 +120,6 @@ impl UiEventBus {
                                 album_title: track_info.album_title.clone(),
                                 cover_image_id: track_info.cover_image_id.clone(),
                                 duration_ms: *duration_ms,
-                                duration_label: duration_label.clone(),
                             },
                         };
                         bus.emit(bus_event);
@@ -132,32 +128,24 @@ impl UiEventBus {
                         position_ms,
                         duration_ms,
                         progress,
-                        elapsed_label,
-                        remaining_label,
                         ..
                     } => {
                         bus.emit(UiBusEvent::PlaybackProgress {
                             position_ms,
                             duration_ms,
                             progress,
-                            elapsed_label,
-                            remaining_label,
                         });
                     }
                     PlaybackProgress::Seeked {
                         position_ms,
                         duration_ms,
                         progress,
-                        elapsed_label,
-                        remaining_label,
                         ..
                     } => {
                         bus.emit(UiBusEvent::PlaybackProgress {
                             position_ms,
                             duration_ms,
                             progress,
-                            elapsed_label,
-                            remaining_label,
                         });
                     }
                     PlaybackProgress::QueueUpdated {
@@ -204,20 +192,16 @@ impl UiEventBus {
                             crate::playback::PreviewState::Playing {
                                 path,
                                 duration_ms,
-                                duration_label,
                             } => UiBusEvent::PreviewPlaying {
                                 path: path.clone(),
                                 duration_ms: *duration_ms,
-                                duration_label: duration_label.clone(),
                             },
                             crate::playback::PreviewState::Paused {
                                 path,
                                 duration_ms,
-                                duration_label,
                             } => UiBusEvent::PreviewPaused {
                                 path: path.clone(),
                                 duration_ms: *duration_ms,
-                                duration_label: duration_label.clone(),
                             },
                         };
                         bus.emit(bus_event);
@@ -225,12 +209,10 @@ impl UiEventBus {
                     PlaybackProgress::PreviewPositionUpdate {
                         position_ms,
                         progress,
-                        elapsed_label,
                     } => {
                         bus.emit(UiBusEvent::PreviewProgress {
                             position_ms,
                             progress,
-                            elapsed_label,
                         });
                     }
                     PlaybackProgress::PlaybackError { message } => {

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -30,7 +30,6 @@ pub enum UiBusEvent {
         album_title: String,
         cover_image_id: Option<String>,
         duration_ms: u64,
-        duration_label: String,
     },
     PlaybackPaused {
         track_id: String,
@@ -41,7 +40,6 @@ pub enum UiBusEvent {
         album_title: String,
         cover_image_id: Option<String>,
         duration_ms: u64,
-        duration_label: String,
     },
     /// Position update — goes to NSView. Carries both regular ticks from the
     /// position listener and one-off updates emitted after a seek completes.
@@ -51,8 +49,6 @@ pub enum UiBusEvent {
         /// update reads it from the event instead of the now-playing slice.
         duration_ms: u64,
         progress: f64,
-        elapsed_label: String,
-        remaining_label: String,
     },
     VolumeChanged {
         volume: f32,
@@ -81,18 +77,15 @@ pub enum UiBusEvent {
     PreviewPlaying {
         path: String,
         duration_ms: u64,
-        duration_label: String,
     },
     PreviewPaused {
         path: String,
         duration_ms: u64,
-        duration_label: String,
     },
     /// High-frequency tick — goes to NSView, not store.
     PreviewProgress {
         position_ms: u64,
         progress: f64,
-        elapsed_label: String,
     },
 
     // ── Candidate-scoped (key inlined) ─────────────────────────────

--- a/bae-core/src/util/format.rs
+++ b/bae-core/src/util/format.rs
@@ -1,6 +1,6 @@
 //! Pure formatters: `fn data → String` with no state, no I/O, no context.
 //!
-//! Examples: `format_duration_label(ms) → "3:07"`,
+//! Examples: `format_minutes_seconds(ms) → "3:07"`,
 //! `compute_track_labels(format, side, …) → (String, String)`.
 //!
 //! Zero dependencies on the database, the filesystem, or any struct
@@ -11,12 +11,6 @@
 //! module that needs the same deterministic formatting (e.g.
 //! `import/search.rs`).
 
-/// Format a duration in milliseconds as "M:SS" (e.g., "3:07", "14:59").
-/// Returns an empty string for None or negative values.
-pub fn format_duration_label(ms: Option<i64>) -> String {
-    format_duration_label_unsigned(ms.filter(|&m| m >= 0).map(|m| m as u64))
-}
-
 /// Format an unsigned millisecond duration as a bare "M:SS" clock label
 /// (e.g. "3:07", "14:59"). Seconds floor to the whole second.
 pub fn format_minutes_seconds(ms: u64) -> String {
@@ -24,14 +18,6 @@ pub fn format_minutes_seconds(ms: u64) -> String {
     let minutes = total_seconds / 60;
     let seconds = total_seconds % 60;
     format!("{}:{:02}", minutes, seconds)
-}
-
-/// Format a duration in milliseconds (unsigned) as "M:SS".
-pub fn format_duration_label_unsigned(ms: Option<u64>) -> String {
-    match ms {
-        Some(ms) => format_minutes_seconds(ms),
-        None => String::new(),
-    }
 }
 
 /// Format an ETA from progress, total size, and download rate.
@@ -144,28 +130,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn duration_label_basic() {
-        assert_eq!(format_duration_label(Some(0)), "0:00");
-        assert_eq!(format_duration_label(Some(5_000)), "0:05");
-        assert_eq!(format_duration_label(Some(63_000)), "1:03");
-        assert_eq!(format_duration_label(Some(187_000)), "3:07");
-        assert_eq!(format_duration_label(Some(899_000)), "14:59");
-    }
-
-    #[test]
-    fn duration_label_none() {
-        assert_eq!(format_duration_label(None), "");
-    }
-
-    #[test]
-    fn duration_label_negative() {
-        assert_eq!(format_duration_label(Some(-100)), "");
-    }
-
-    #[test]
-    fn duration_label_unsigned() {
-        assert_eq!(format_duration_label_unsigned(Some(187_000)), "3:07");
-        assert_eq!(format_duration_label_unsigned(None), "");
+    fn minutes_seconds_basic() {
+        assert_eq!(format_minutes_seconds(0), "0:00");
+        assert_eq!(format_minutes_seconds(5_000), "0:05");
+        assert_eq!(format_minutes_seconds(63_000), "1:03");
+        assert_eq!(format_minutes_seconds(187_000), "3:07");
+        assert_eq!(format_minutes_seconds(899_000), "14:59");
     }
 
     #[test]

--- a/bae-macos/bae/bae/DurationClock.swift
+++ b/bae-macos/bae/bae/DurationClock.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Renders a millisecond duration as a "M:SS" clock label (e.g. "3:07") for the
+/// current locale. bae-core emits the raw `duration_ms`; the UI formats it.
+enum DurationClock {
+    /// "M:SS" for a duration in ms (e.g. "3:07"); "" when absent or negative.
+    static func text(_ ms: Int64?) -> String {
+        guard let ms, ms >= 0 else { return "" }
+        return Duration.milliseconds(ms)
+            .formatted(.time(pattern: .minuteSecond(padMinuteToLength: 1)))
+    }
+
+    /// "-M:SS" remaining clock label from a position within a duration (e.g.
+    /// "-1:23"). Both inputs are the pregap-adjusted track time core emits, so
+    /// elapsed is just `position` and remaining is `duration − position`,
+    /// clamped at zero.
+    static func remaining(positionMs: UInt64, durationMs: UInt64) -> String {
+        let left = durationMs > positionMs ? durationMs - positionMs : 0
+        return "-" + text(Int64(left))
+    }
+}

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -18,7 +18,6 @@ enum PreviewData {
             title: "Static Dreams",
             artistNames: "The Midnight Signal",
             durationMs: 210_000,
-            durationLabel: "3:30",
             albumTitle: "Neon Frequencies",
             coverImageId: nil
         ),
@@ -27,7 +26,6 @@ enum PreviewData {
             title: "Frequency Drift",
             artistNames: "The Midnight Signal",
             durationMs: 240_000,
-            durationLabel: "4:00",
             albumTitle: "Neon Frequencies",
             coverImageId: nil
         ),
@@ -36,7 +34,6 @@ enum PreviewData {
             title: "Tide Pool",
             artistNames: "Glass Harbor",
             durationMs: 198_000,
-            durationLabel: "3:18",
             albumTitle: "Pacific Standard",
             coverImageId: nil
         ),
@@ -45,7 +42,6 @@ enum PreviewData {
             title: "Harbor Lights",
             artistNames: "Glass Harbor",
             durationMs: 225_000,
-            durationLabel: "3:45",
             albumTitle: "Pacific Standard",
             coverImageId: nil
         ),
@@ -54,7 +50,6 @@ enum PreviewData {
             title: "Axiom",
             artistNames: "Velvet Mathematics",
             durationMs: 187_000,
-            durationLabel: "3:07",
             albumTitle: "Proof by Induction",
             coverImageId: nil
         ),
@@ -100,7 +95,6 @@ enum PreviewData {
                     id: "t-03",
                     title: "Tide Pool",
                     durationMs: 198_000,
-                    durationLabel: "3:18",
                     albumId: "a-02",
                     albumTitle: "Pacific Standard",
                     artistName: "Glass Harbor"
@@ -109,7 +103,6 @@ enum PreviewData {
                     id: "t-05",
                     title: "Axiom",
                     durationMs: 187_000,
-                    durationLabel: "3:07",
                     albumId: "a-03",
                     albumTitle: "Proof by Induction",
                     artistName: "Velvet Mathematics"
@@ -167,11 +160,6 @@ enum PreviewData {
         names.enumerated()
             .map { index, name in
                 let durationMs = Int64((170 + (index * 37) % 170) * 1000)
-                let totalSeconds = durationMs / 1000
-                let minutes = totalSeconds / 60
-                let seconds = totalSeconds % 60
-                let durationLabel =
-                    "\(minutes):\(String(format: "%02d", seconds))"
                 let posLabel =
                     positionPrefix.isEmpty
                     ? "\(index + 1)" : "\(positionPrefix)\(index + 1)"
@@ -181,7 +169,6 @@ enum PreviewData {
                     side: side,
                     trackNumber: Int32(index + 1),
                     durationMs: durationMs,
-                    durationLabel: durationLabel,
                     artistNames: artist,
                     sideLabel: sideLabel,
                     positionLabel: posLabel,
@@ -855,16 +842,10 @@ enum PreviewData {
         let tracks: [BridgeReleaseTrack] = (1...9)
             .map { i in
                 let ms = UInt64(180_000 + i * 15000)
-                let totalSeconds = ms / 1000
-                let minutes = totalSeconds / 60
-                let seconds = totalSeconds % 60
-                let durationLabel =
-                    "\(minutes):\(String(format: "%02d", seconds))"
                 return BridgeReleaseTrack(
                     title: "Track Title \(i)",
                     artist: i == 5 ? "Featured Artist" : nil,
                     durationMs: ms,
-                    durationLabel: durationLabel,
                     position: "\(i)",
                     side: 1,
                     sideLabel: "",

--- a/bae-macos/bae/bae/Services/MediaControlService.swift
+++ b/bae-macos/bae/bae/Services/MediaControlService.swift
@@ -112,8 +112,7 @@ final class MediaControlService: @unchecked Sendable {
             _,
             let albumTitle,
             let coverImageId,
-            let durationMs,
-            _
+            let durationMs
         ):
             setNowPlaying(
                 trackTitle: trackTitle,
@@ -134,8 +133,7 @@ final class MediaControlService: @unchecked Sendable {
             _,
             let albumTitle,
             let coverImageId,
-            let durationMs,
-            _
+            let durationMs
         ):
             setNowPlaying(
                 trackTitle: trackTitle,
@@ -198,7 +196,7 @@ final class MediaControlService: @unchecked Sendable {
         let infoCenter = MPNowPlayingInfoCenter.default()
 
         switch state {
-        case .playing(let path, let durationMs, _):
+        case .playing(let path, let durationMs):
             setPreviewNowPlaying(
                 path: path,
                 durationMs: durationMs,
@@ -206,7 +204,7 @@ final class MediaControlService: @unchecked Sendable {
                 on: infoCenter
             )
 
-        case .paused(let path, let durationMs, _):
+        case .paused(let path, let durationMs):
             setPreviewNowPlaying(
                 path: path,
                 durationMs: durationMs,

--- a/bae-macos/bae/bae/Services/PlaybackPositionEvent.swift
+++ b/bae-macos/bae/bae/Services/PlaybackPositionEvent.swift
@@ -5,8 +5,9 @@ import Foundation
 /// Position ticks arrive at display rate during playback — far too frequent
 /// for `@Observable` to drive without thrashing the view tree. The store
 /// publishes them as a Combine signal so only the progress bar reacts.
-/// `.position` carries the bridge's pre-formatted labels and `[0,1]` ratio;
-/// `.reset` clears the bar when playback stops.
+/// `.position` carries the elapsed/remaining clock labels (formatted in the
+/// reducer from raw ms) and the `[0,1]` ratio; `.reset` clears the bar when
+/// playback stops.
 enum PlaybackPositionEvent {
     case position(progress: Double, elapsed: String, remaining: String)
     case reset

--- a/bae-macos/bae/bae/Services/PlaybackStore.swift
+++ b/bae-macos/bae/bae/Services/PlaybackStore.swift
@@ -98,7 +98,6 @@ struct NowPlayingTrack {
     let albumId: String
     let coverImageId: String?
     let durationMs: UInt64
-    let durationLabel: String
 }
 
 enum NowPlaying {

--- a/bae-macos/bae/bae/Services/Store/PreviewState.swift
+++ b/bae-macos/bae/bae/Services/Store/PreviewState.swift
@@ -2,22 +2,17 @@ import Foundation
 
 enum PreviewState: Equatable {
     case idle
-    case playing(path: String, durationMs: UInt64, durationLabel: String)
-    case paused(path: String, durationMs: UInt64, durationLabel: String)
+    case playing(path: String, durationMs: UInt64)
+    case paused(path: String, durationMs: UInt64)
 
-    var active:
-        (
-            path: String, isPlaying: Bool, durationMs: UInt64,
-            durationLabel: String
-        )?
-    {
+    var active: (path: String, isPlaying: Bool, durationMs: UInt64)? {
         switch self {
         case .idle:
             nil
-        case .playing(let path, let durationMs, let durationLabel):
-            (path, true, durationMs, durationLabel)
-        case .paused(let path, let durationMs, let durationLabel):
-            (path, false, durationMs, durationLabel)
+        case .playing(let path, let durationMs):
+            (path, true, durationMs)
+        case .paused(let path, let durationMs):
+            (path, false, durationMs)
         }
     }
 }

--- a/bae-macos/bae/bae/Services/Store/QueueItem.swift
+++ b/bae-macos/bae/bae/Services/Store/QueueItem.swift
@@ -3,7 +3,7 @@ import Foundation
 struct QueueItem: Identifiable, Equatable {
     let trackId: String
     let title: String
-    let durationLabel: String
+    let durationMs: Int64?
     let albumTitle: String
     let coverImageId: String?
 
@@ -11,10 +11,12 @@ struct QueueItem: Identifiable, Equatable {
         trackId
     }
 
+    var durationLabel: String { DurationClock.text(durationMs) }
+
     init(bridge: BridgeQueueItem) {
         trackId = bridge.trackId
         title = bridge.title
-        durationLabel = bridge.durationLabel
+        durationMs = bridge.durationMs
         albumTitle = bridge.albumTitle
         coverImageId = bridge.coverImageId
     }

--- a/bae-macos/bae/bae/Services/Store/SearchResults.swift
+++ b/bae-macos/bae/bae/Services/Store/SearchResults.swift
@@ -31,15 +31,17 @@ struct AlbumSearchResult: Equatable, Identifiable {
 struct TrackSearchResult: Equatable, Identifiable {
     let id: String
     let title: String
-    let durationLabel: String
+    let durationMs: Int64?
     let albumId: String
     let albumTitle: String
     let artistName: String
 
+    var durationLabel: String { DurationClock.text(durationMs) }
+
     init(bridge: BridgeTrackSearchResult) {
         id = bridge.id
         title = bridge.title
-        durationLabel = bridge.durationLabel
+        durationMs = bridge.durationMs
         albumId = bridge.albumId
         albumTitle = bridge.albumTitle
         artistName = bridge.artistName

--- a/bae-macos/bae/bae/Services/Store/Track.swift
+++ b/bae-macos/bae/bae/Services/Store/Track.swift
@@ -3,14 +3,16 @@ import Foundation
 struct Track: Identifiable {
     let id: String
     var title: String
-    var durationLabel: String
+    var durationMs: Int64?
     var artistNames: String
     var positionLabel: String
+
+    var durationLabel: String { DurationClock.text(durationMs) }
 
     init(from bridge: BridgeTrack) {
         id = bridge.id
         title = bridge.title
-        durationLabel = bridge.durationLabel
+        durationMs = bridge.durationMs
         artistNames = bridge.artistNames
         positionLabel = bridge.positionLabel
     }

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -29,8 +29,7 @@ enum UiEventReducer {
             let albumId,
             let albumTitle,
             let coverImageId,
-            let durationMs,
-            let durationLabel
+            let durationMs
         ):
             playbackStore.nowPlaying = .playing(
                 NowPlayingTrack(
@@ -40,7 +39,6 @@ enum UiEventReducer {
                     albumId: albumId,
                     coverImageId: coverImageId,
                     durationMs: durationMs,
-                    durationLabel: durationLabel,
                 )
             )
             let state = BridgePlaybackState.playing(
@@ -52,7 +50,6 @@ enum UiEventReducer {
                 albumTitle: albumTitle,
                 coverImageId: coverImageId,
                 durationMs: durationMs,
-                durationLabel: durationLabel,
             )
             appService.mediaControlService.updateNowPlaying(
                 state: state,
@@ -67,8 +64,7 @@ enum UiEventReducer {
             let albumId,
             let albumTitle,
             let coverImageId,
-            let durationMs,
-            let durationLabel
+            let durationMs
         ):
             playbackStore.nowPlaying = .paused(
                 NowPlayingTrack(
@@ -78,7 +74,6 @@ enum UiEventReducer {
                     albumId: albumId,
                     coverImageId: coverImageId,
                     durationMs: durationMs,
-                    durationLabel: durationLabel,
                 )
             )
             let state = BridgePlaybackState.paused(
@@ -90,7 +85,6 @@ enum UiEventReducer {
                 albumTitle: albumTitle,
                 coverImageId: coverImageId,
                 durationMs: durationMs,
-                durationLabel: durationLabel,
             )
             appService.mediaControlService.updateNowPlaying(
                 state: state,
@@ -110,8 +104,7 @@ enum UiEventReducer {
                         artistNames: track.artistNames,
                         albumId: track.albumId,
                         coverImageId: track.coverImageId,
-                        durationMs: track.durationMs,
-                        durationLabel: track.durationLabel
+                        durationMs: track.durationMs
                     )
                 )
             }
@@ -140,15 +133,16 @@ enum UiEventReducer {
         case .playbackProgress(
             let positionMs,
             let durationMs,
-            let progress,
-            let elapsedLabel,
-            let remainingLabel
+            let progress
         ):
             playbackStore.playbackPositionSubject.send(
                 .position(
                     progress: progress,
-                    elapsed: elapsedLabel,
-                    remaining: remainingLabel
+                    elapsed: DurationClock.text(Int64(positionMs)),
+                    remaining: DurationClock.remaining(
+                        positionMs: positionMs,
+                        durationMs: durationMs
+                    )
                 )
             )
             appService.mediaControlService.updatePosition(
@@ -178,31 +172,27 @@ enum UiEventReducer {
             playbackStore.queueItemsAddedSubject.send(Int(count))
 
         // ── Preview ────────────────────────────────────────────────────
-        case .previewPlaying(let path, let durationMs, let durationLabel):
+        case .previewPlaying(let path, let durationMs):
             importStore.previewState = .playing(
                 path: path,
-                durationMs: durationMs,
-                durationLabel: durationLabel
+                durationMs: durationMs
             )
             appService.mediaControlService.updateNowPlayingForPreview(
                 state: .playing(
                     path: path,
-                    durationMs: durationMs,
-                    durationLabel: durationLabel
+                    durationMs: durationMs
                 )
             )
 
-        case .previewPaused(let path, let durationMs, let durationLabel):
+        case .previewPaused(let path, let durationMs):
             importStore.previewState = .paused(
                 path: path,
-                durationMs: durationMs,
-                durationLabel: durationLabel
+                durationMs: durationMs
             )
             appService.mediaControlService.updateNowPlayingForPreview(
                 state: .paused(
                     path: path,
-                    durationMs: durationMs,
-                    durationLabel: durationLabel
+                    durationMs: durationMs
                 )
             )
 
@@ -213,9 +203,12 @@ enum UiEventReducer {
                 state: .idle
             )
 
-        case .previewProgress(let positionMs, let progress, let elapsedLabel):
+        case .previewProgress(let positionMs, let progress):
             importStore.previewProgressSubject.send(
-                .position(progress: progress, elapsed: elapsedLabel)
+                .position(
+                    progress: progress,
+                    elapsed: DurationClock.text(Int64(positionMs))
+                )
             )
             appService.mediaControlService.updatePreviewPosition(
                 positionMs: positionMs

--- a/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
@@ -14,8 +14,8 @@ struct ImportFilePane: View {
     private var previewingPath: String? {
         switch previewState {
         case .idle: nil
-        case .playing(let path, _, _): path
-        case .paused(let path, _, _): path
+        case .playing(let path, _): path
+        case .paused(let path, _): path
         }
     }
 
@@ -385,8 +385,7 @@ extension View {
         onError: { _ in },
         previewState: .playing(
             path: "/tmp/fake/Track 3.flac",
-            durationMs: 195_000,
-            durationLabel: "3:15"
+            durationMs: 195_000
         ),
     )
     .frame(width: 300, height: 500)

--- a/bae-macos/bae/bae/Views/MainAppView.swift
+++ b/bae-macos/bae/bae/Views/MainAppView.swift
@@ -69,8 +69,7 @@ struct MainAppView: View {
                 PreviewOverlay(
                     path: preview.path,
                     isPlaying: preview.isPlaying,
-                    durationMs: preview.durationMs,
-                    durationLabel: preview.durationLabel
+                    durationMs: preview.durationMs
                 )
             }
 

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -39,7 +39,6 @@ struct NowPlayingBarContainer: View {
             coverPath: coverPath,
             isPlaying: np.isPlaying,
             isLoading: np.loadingTrackId != nil,
-            durationLabel: track?.durationLabel,
             durationMs: track?.durationMs,
             volume: playbackStore.volume,
             isMuted: playbackStore.isMuted,
@@ -101,7 +100,6 @@ struct NowPlayingBar: View {
     let coverPath: String?
     let isPlaying: Bool
     let isLoading: Bool
-    let durationLabel: String?
     let durationMs: UInt64?
     let volume: Float
     let isMuted: Bool
@@ -231,7 +229,6 @@ struct NowPlayingBar: View {
 
     private var progressBar: some View {
         PlaybackProgressRepresentable(
-            durationLabel: durationLabel,
             durationMs: durationMs,
             onSeek: onSeek,
         )
@@ -378,7 +375,7 @@ struct NowPlayingBar: View {
 
 /// Preview host that provides the state bindings NowPlayingBar needs.
 /// The playback position publisher defaults to `Empty()` — the NSView
-/// renders from the static `durationLabel` / `durationMs` props.
+/// renders the duration clock from the static `durationMs` prop.
 private struct NowPlayingBarPreview: View {
     let trackTitle: String?
     let artistNames: String?
@@ -402,7 +399,6 @@ private struct NowPlayingBarPreview: View {
             coverPath: nil,
             isPlaying: isPlaying,
             isLoading: isLoading,
-            durationLabel: "3:42",
             durationMs: 222_000,
             volume: volume,
             isMuted: isMuted,

--- a/bae-macos/bae/bae/Views/PlaybackProgressNSView.swift
+++ b/bae-macos/bae/bae/Views/PlaybackProgressNSView.swift
@@ -95,9 +95,9 @@ class PlaybackProgressNSView: NSView {
         }
     }
 
-    func setDuration(_ label: String, durationMs: UInt64) {
+    func setDuration(durationMs: UInt64) {
         self.durationMs = durationMs
-        durationField.stringValue = label
+        durationField.stringValue = DurationClock.text(Int64(durationMs))
     }
 
     func clearDuration() {
@@ -162,7 +162,6 @@ extension EnvironmentValues {
 struct PlaybackProgressRepresentable: NSViewRepresentable {
     @Environment(\.playbackPositionPublisher)
     private var positionPublisher
-    let durationLabel: String?
     let durationMs: UInt64?
     let onSeek: (Double) -> Void
 
@@ -184,8 +183,8 @@ struct PlaybackProgressRepresentable: NSViewRepresentable {
     }
 
     private func applyDuration(to view: PlaybackProgressNSView) {
-        if let durationLabel, let durationMs {
-            view.setDuration(durationLabel, durationMs: durationMs)
+        if let durationMs {
+            view.setDuration(durationMs: durationMs)
         }
         else {
             view.clearDuration()

--- a/bae-macos/bae/bae/Views/PreviewOverlay.swift
+++ b/bae-macos/bae/bae/Views/PreviewOverlay.swift
@@ -6,7 +6,6 @@ struct PreviewOverlay: View {
     let path: String
     let isPlaying: Bool
     let durationMs: UInt64
-    let durationLabel: String
 
     var body: some View {
         ModalOverlay(
@@ -43,7 +42,6 @@ struct PreviewOverlay: View {
                         .buttonStyle(.plain)
                         PreviewProgressRepresentable(
                             durationMs: durationMs,
-                            durationLabel: durationLabel,
                             onSeek: { previewAudio.previewSeekByRatio($0) },
                         )
                         .frame(height: 20)

--- a/bae-macos/bae/bae/Views/PreviewProgressNSView.swift
+++ b/bae-macos/bae/bae/Views/PreviewProgressNSView.swift
@@ -87,9 +87,9 @@ class PreviewProgressNSView: NSView {
         }
     }
 
-    func setDuration(_ label: String, durationMs: UInt64) {
+    func setDuration(durationMs: UInt64) {
         self.durationMs = durationMs
-        durationField.stringValue = label
+        durationField.stringValue = DurationClock.text(Int64(durationMs))
     }
 
     func reset() {
@@ -134,7 +134,6 @@ struct PreviewProgressRepresentable: NSViewRepresentable {
     @Environment(\.previewProgressPublisher)
     private var publisher
     let durationMs: UInt64
-    let durationLabel: String
     let onSeek: (Double) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -144,14 +143,14 @@ struct PreviewProgressRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> PreviewProgressNSView {
         let view = PreviewProgressNSView()
         view.onSeek = onSeek
-        view.setDuration(durationLabel, durationMs: durationMs)
+        view.setDuration(durationMs: durationMs)
         context.coordinator.subscribe(to: publisher, view: view)
         return view
     }
 
     func updateNSView(_ view: PreviewProgressNSView, context _: Context) {
         view.onSeek = onSeek
-        view.setDuration(durationLabel, durationMs: durationMs)
+        view.setDuration(durationMs: durationMs)
     }
 
     class Coordinator {


### PR DESCRIPTION
The big numeric sweep: the pre-formatted "M:SS" `duration_label` (and the playback `elapsed_label`/`remaining_label`) were built in bae-core and crossed ~13 bridge types. Every one had a raw `duration_ms`/`position_ms` sibling already crossing, so they're removed and the macOS UI formats the raw ms natively via a shared `DurationClock` helper (`Duration.milliseconds(ms).formatted(.time(pattern: .minuteSecond(padMinuteToLength: 1)))`).

To minimize churn, the store models (`Track`, `QueueItem`, `TrackSearchResult`, `PreviewState`) now expose `durationLabel` as a **computed** property over `durationMs`, so the view read-sites are unchanged. `util::format` and `playback::format` lose all the now-dead M:SS helpers (`format_duration_label`, `format_minutes_seconds`, `format_elapsed`, `format_duration`, …) with their tests; `format_minutes_seconds`/`format_time`/`format_remaining`/`compute_progress` stay (still reached by the slider-drag ratio formatters).

**Flagged for a follow-up:** `bae-bridge/src/utils.rs` still exposes `format_time_at_ratio`/`format_remaining_at_ratio` — free fns that format raw ms *passed from* the UI during slider drags. Not `*_label` fields, but they do return "M:SS" across the bridge; out of scope for this slice.

*(Implemented by a product-engineer subagent; verified: clippy core (lib + tests) + bridge clean, 771 core lib tests pass, macOS BUILD SUCCEEDED, full pre-commit gate passed, `duration_label`/`elapsed_label`/`remaining_label` grep empty across core/bridge.)*

## Test plan
- `cargo clippy` core (lib + tests) + bridge clean; core lib tests green.
- macOS app builds; track lists, queue, now-playing, and the progress bars render native "M:SS".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwECkEnQD5nvmoT2q2mVwx