### PR TITLE
loc: structure track position (Side/Disc keys in the UI)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -75,6 +75,16 @@ value = "mono"
 comment = "Audio format: two-channel audio."
 value = "stereo"
 
+[messages."core.track.side"]
+comment = "Track grouping: header for a physical side, e.g. 'Side A' ({letter} is the side letter A/B/C… computed by core)."
+args = { letter = "Str" }
+value = "Side {letter}"
+
+[messages."core.track.disc"]
+comment = "Track grouping: header for a disc in a multi-disc release, e.g. 'Disc 2' ({disc} is the disc number computed by core)."
+args = { disc = "Int" }
+value = "Disc {disc}"
+
 [messages."core.cloud.s3_compatible"]
 comment = "Cloud provider: any S3-compatible storage."
 value = "S3-compatible"

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1664,8 +1664,7 @@ fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeR
         track_number: t.track_number,
         duration_ms: t.duration_ms,
         artist_names: t.artist_names,
-        side_label: t.side_label,
-        position_label: t.position_label,
+        position: crate::types::BridgeTrackPosition::from_core(t.position),
     };
     let summary = rel.summary;
     BridgeRelease {
@@ -1690,7 +1689,7 @@ fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeR
             .track_groups
             .into_iter()
             .map(|g| BridgeTrackGroup {
-                side_label: g.side_label,
+                side: crate::types::BridgeTrackSide::from_core(g.side),
                 tracks: g.tracks.into_iter().map(convert_track).collect(),
             })
             .collect(),

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -319,9 +319,65 @@ impl BridgeIdentityChoice {
     }
 }
 
+/// Structured track position. The case carries the domain decision (sided
+/// physical medium / multi-disc digital / flat single-disc); the UI composes
+/// the position string ("A1", "2-3", "5") mechanically from the fields and
+/// resolves the "Side"/"Disc" header word from `bridge_track_*` catalog keys.
+/// No prose crosses the bridge — only the side letter, disc/track numbers, and
+/// the case.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeTrackPosition {
+    /// Vinyl/cassette: header "Side {side_letter}", position "{side_letter}{number}".
+    Sided { side_letter: String, number: i32 },
+    /// Multi-disc digital: header "Disc {disc}", position "{disc}-{number}".
+    Disc { disc: i32, number: i32 },
+    /// Single-disc digital: position "{number}", no header.
+    Flat { number: i32 },
+}
+
+impl BridgeTrackPosition {
+    pub(crate) fn from_core(p: bae_core::album_detail::TrackPosition) -> Self {
+        use bae_core::album_detail::TrackPosition;
+        match p {
+            TrackPosition::Sided {
+                side_letter,
+                number,
+            } => Self::Sided {
+                side_letter,
+                number,
+            },
+            TrackPosition::Disc { disc, number } => Self::Disc { disc, number },
+            TrackPosition::Flat { number } => Self::Flat { number },
+        }
+    }
+}
+
+/// A track group's side discriminant — the header the UI renders ("Side A" /
+/// "Disc 2"). `Flat` means no header (single-disc digital). Distinct from
+/// `BridgeTrackPosition` because a header carries no per-track number.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeTrackSide {
+    Sided { side_letter: String },
+    Disc { disc: i32 },
+    Flat,
+}
+
+impl BridgeTrackSide {
+    pub(crate) fn from_core(s: bae_core::album_detail::TrackSide) -> Self {
+        use bae_core::album_detail::TrackSide;
+        match s {
+            TrackSide::Sided { side_letter } => Self::Sided { side_letter },
+            TrackSide::Disc { disc } => Self::Disc { disc },
+            TrackSide::Flat => Self::Flat,
+        }
+    }
+}
+
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeTrackGroup {
-    pub side_label: String,
+    /// The group's side discriminant; the UI renders the "Side A" / "Disc 2"
+    /// header from it (`Flat` means no header).
+    pub side: BridgeTrackSide,
     pub tracks: Vec<BridgeTrack>,
 }
 
@@ -336,10 +392,46 @@ pub struct BridgeTrack {
     /// artists when it has per-track artist rows, otherwise the album
     /// artists). Always populated.
     pub artist_names: String,
-    /// Human-readable side label: "Side A", "Disc 2", or empty for single-side digital
-    pub side_label: String,
-    /// Human-readable track position: "A1", "1", "1-2", etc.
-    pub position_label: String,
+    /// Structured position: the UI composes "A1"/"2-3"/"5" from the case.
+    pub position: BridgeTrackPosition,
+}
+
+/// Localization key for a track group's header word, given its side, or `None`
+/// for `Flat` (single-disc digital has no header). The UI resolves the key and
+/// substitutes the side letter / disc number the side carries.
+#[uniffi::export]
+pub fn bridge_track_header_key(side: BridgeTrackSide) -> Option<String> {
+    match side {
+        BridgeTrackSide::Sided { .. } => Some("core.track.side".to_string()),
+        BridgeTrackSide::Disc { .. } => Some("core.track.disc".to_string()),
+        BridgeTrackSide::Flat => None,
+    }
+}
+
+#[cfg(test)]
+mod track_position_tests {
+    use super::BridgeTrackSide;
+
+    /// The header keys the UI resolves (Side, Disc) must exist; the flat case
+    /// has no header word, so no key.
+    #[test]
+    fn keys_exist() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for side in [
+            BridgeTrackSide::Sided {
+                side_letter: "A".to_string(),
+            },
+            BridgeTrackSide::Disc { disc: 2 },
+        ] {
+            let key = super::bridge_track_header_key(side).expect("Sided and Disc carry keys");
+            assert!(cat.messages.contains_key(&key), "catalog missing `{key}`");
+        }
+        assert!(
+            super::bridge_track_header_key(BridgeTrackSide::Flat).is_none(),
+            "flat single-disc has no header word, no key"
+        );
+    }
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -1689,12 +1781,10 @@ pub struct BridgeReleaseTrack {
     pub title: String,
     pub artist: Option<String>,
     pub duration_ms: Option<u64>,
+    /// Raw position string as the metadata source reports it ("A1", "1",
+    /// "1-2", or arbitrary prose). Shown verbatim in the import preview.
     pub position: String,
     pub side: u32,
-    /// Human-readable side label: "Side A", "Disc 2", or empty for single-side digital
-    pub side_label: String,
-    /// Human-readable track position: "A1", "1", "1-2", etc.
-    pub position_label: String,
 }
 
 /// Mirror of `bae_core::import::ReleaseUserEdit` — a normalized, validated
@@ -2445,8 +2535,6 @@ pub(crate) fn release_detail_to_bridge(
                 duration_ms: t.duration_ms,
                 position: t.position,
                 side: t.side,
-                side_label: t.side_label,
-                position_label: t.position_label,
             })
             .collect(),
         cover_art,
@@ -2505,8 +2593,6 @@ pub(crate) fn release_detail_from_bridge(
                 duration_ms: t.duration_ms,
                 position: t.position,
                 side: t.side,
-                side_label: t.side_label,
-                position_label: t.position_label,
             })
             .collect(),
         cover_art: d

--- a/bae-core/src/album_detail.rs
+++ b/bae-core/src/album_detail.rs
@@ -29,9 +29,12 @@
 //! UI side can intern the summary portion into the "summaries" slice and the
 //! detail portion into the "details" slice from a single event payload.
 //!
-//! Tracks carry pre-formatted `side_label` / `position_label`. A *side* is a
-//! contiguous playback unit (one CD disc, one vinyl face, one cassette face);
-//! label formatting depends on the release's physical format.
+//! Tracks carry a structured [`TrackPosition`] instead of pre-formatted prose.
+//! A *side* is a contiguous playback unit (one CD disc, one vinyl face, one
+//! cassette face); which case applies depends on the release's physical format.
+//! The side letter (A/B/C…) and the disc-vs-side decision are domain logic and
+//! stay here; only the words "Side"/"Disc" are the UI's, resolved from catalog
+//! keys.
 
 use crate::db::{DbAlbum, DbReleaseLocalCopy};
 
@@ -123,7 +126,34 @@ pub fn available_storage_actions(
     }
 }
 
-/// Track with resolved artist names and display labels.
+/// Where a track sits in its release, in structured form. The case carries the
+/// domain decision (sided physical medium vs. multi-disc digital vs. flat
+/// single-disc digital); the UI composes the position string ("A1", "2-3", "5")
+/// mechanically from the fields and resolves the "Side"/"Disc" header word from
+/// a catalog key. No prose lives here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrackPosition {
+    /// Vinyl/cassette: header "Side A", position "A1". `side_letter` is the
+    /// letter for the face (A/B/C…); `number` is the within-side track number.
+    Sided { side_letter: String, number: i32 },
+    /// Multi-disc digital (CD etc.): header "Disc 2", position "2-3".
+    Disc { disc: i32, number: i32 },
+    /// Single-disc digital: position "5", no header.
+    Flat { number: i32 },
+}
+
+/// A track group's side discriminant — what the UI renders as the "Side A" /
+/// "Disc 2" header. `Flat` is single-disc digital: one group, no header.
+/// Separate from [`TrackPosition`] because a header carries no per-track number
+/// (every track on a side shares one `TrackSide`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrackSide {
+    Sided { side_letter: String },
+    Disc { disc: i32 },
+    Flat,
+}
+
+/// Track with resolved artist names and a structured display position.
 #[derive(Debug, Clone)]
 pub struct TrackDetail {
     pub id: String,
@@ -136,17 +166,16 @@ pub struct TrackDetail {
     /// populated so UI consumers can render a row label without joining
     /// artist data themselves.
     pub artist_names: String,
-    /// Human-readable side label: "Side A", "Disc 2", or empty for single-side digital.
-    pub side_label: String,
-    /// Human-readable track position: "A1", "1", "1-2", etc.
-    pub position_label: String,
+    /// Structured position: the UI composes "A1"/"2-3"/"5" from the case.
+    pub position: TrackPosition,
 }
 
-/// A group of tracks sharing the same side (e.g., "Side A", "Disc 2").
-/// For single-side releases, there's one group with an empty label.
+/// A group of tracks sharing the same side. `side` is the group's discriminant
+/// (the UI renders the "Side A" / "Disc 2" header from it; `Flat` means no
+/// header). For single-side releases, there's one `Flat` group.
 #[derive(Debug, Clone)]
 pub struct TrackGroup {
-    pub side_label: String,
+    pub side: TrackSide,
     pub tracks: Vec<TrackDetail>,
 }
 

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1838,8 +1838,6 @@ mod tests {
             duration_ms: None,
             position: position.to_string(),
             side,
-            side_label: String::new(),
-            position_label: position.to_string(),
         }
     }
 

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -12,7 +12,6 @@ use crate::import::cover_art::{CoverArtArchiveClient, RemoteCover};
 use crate::import::types::MetadataSource;
 use crate::musicbrainz::{self, DiscIdRelease, ReleaseSearchParams, SearchRelease};
 use crate::retry::retry_with_backoff;
-use crate::util::format::compute_track_labels;
 use tracing::warn;
 
 /// A unified metadata search result from either MusicBrainz or Discogs.
@@ -93,12 +92,11 @@ pub struct ReleaseTrack {
     pub title: String,
     pub artist: Option<String>,
     pub duration_ms: Option<u64>,
+    /// Raw position string as the metadata source reports it ("A1", "1",
+    /// "1-2", or arbitrary prose like "Bonus"). The import preview shows it
+    /// verbatim; it is not the structured library-display position.
     pub position: String,
     pub side: u32,
-    /// Human-readable side label: "Side A", "Disc 2", or empty for single-side digital
-    pub side_label: String,
-    /// Human-readable track position: "A1", "1", "1-2", etc.
-    pub position_label: String,
 }
 
 /// Disc ID lookup result.
@@ -476,8 +474,6 @@ fn build_mb_detail(
                     .clone()
                     .unwrap_or_else(|| t.position.map(|p| p.to_string()).unwrap_or_default()),
                 side,
-                side_label: String::new(),
-                position_label: String::new(),
             });
         }
 
@@ -488,25 +484,7 @@ fn build_mb_detail(
         };
     }
 
-    let has_multiple_sides = tracks
-        .iter()
-        .map(|t| t.side)
-        .collect::<std::collections::HashSet<_>>()
-        .len()
-        > 1;
     let format = mb_response.media.first().and_then(|m| m.format.clone());
-    let format_str = format.as_deref();
-    for track in &mut tracks {
-        let (side_label, position_label) =
-            compute_track_labels(format_str, track.side as i32, None, has_multiple_sides);
-        track.side_label = side_label;
-        track.position_label = if track.position.is_empty() {
-            position_label
-        } else {
-            track.position.clone()
-        };
-    }
-
     let artist = mb_response.artist_credit.first().map(|ac| ac.name.clone());
     let (label, catalog_number) = mb_response
         .label_info
@@ -601,12 +579,6 @@ fn build_discogs_detail(release: &crate::discogs::DiscogsRelease) -> ImportSearc
     } else {
         Some(release.format.join(", "))
     };
-    let has_multiple_sides = processed
-        .iter()
-        .map(|pt| pt.side)
-        .collect::<std::collections::HashSet<_>>()
-        .len()
-        > 1;
 
     let tracks: Vec<ReleaseTrack> = processed
         .iter()
@@ -614,13 +586,6 @@ fn build_discogs_detail(release: &crate::discogs::DiscogsRelease) -> ImportSearc
             let source_track = release.tracklist.iter().find(|t| {
                 pt.original_positions.iter().any(|p| p == &t.position) && t.type_ != "heading"
             });
-
-            let (side_label, position_label) = compute_track_labels(
-                format_string.as_deref(),
-                pt.side,
-                Some(pt.track_number),
-                has_multiple_sides,
-            );
 
             let duration_ms = source_track
                 .and_then(|t| t.duration.as_ref())
@@ -631,8 +596,6 @@ fn build_discogs_detail(release: &crate::discogs::DiscogsRelease) -> ImportSearc
                 duration_ms,
                 position: pt.position.clone(),
                 side: pt.side as u32,
-                side_label,
-                position_label,
             }
         })
         .collect();

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -3327,7 +3327,7 @@ pub(crate) fn resolve_release(
             } else {
                 join_artist_names(&entry.artists)
             };
-            let (side_label, position_label) = crate::util::format::compute_track_labels(
+            let position = crate::util::format::compute_track_position(
                 release.pressing.format.as_deref(),
                 entry.track.side,
                 entry.track.track_number,
@@ -3340,8 +3340,7 @@ pub(crate) fn resolve_release(
                 track_number: entry.track.track_number,
                 duration_ms: entry.track.duration_ms,
                 artist_names,
-                side_label,
-                position_label,
+                position,
             }
         })
         .collect();

--- a/bae-core/src/util/format.rs
+++ b/bae-core/src/util/format.rs
@@ -1,6 +1,6 @@
 //! Pure formatters: `fn data → String` with no state, no I/O, no context.
 //!
-//! Examples: `compute_track_labels(format, side, …) → (String, String)`.
+//! Examples: `compute_track_position(format, side, …) → TrackPosition`.
 //!
 //! Zero dependencies on the database, the filesystem, or any struct
 //! definition outside this file. Tests are `#[cfg(test)]` at the bottom.
@@ -58,57 +58,67 @@ pub fn is_digital_format(format: Option<&str>) -> bool {
     matches!(detect_format(format), FormatKind::Digital)
 }
 
-/// Compute side_label and position_label for a track given the release format and side count.
-pub fn compute_track_labels(
+/// Compute the structured [`TrackPosition`] for a track given the release
+/// format and side count. Picks the case (sided physical / multi-disc digital /
+/// flat) and fills its domain fields; the UI composes the position string and
+/// resolves the header word. `side` is 1-indexed.
+pub fn compute_track_position(
     format: Option<&str>,
     side: i32,
     track_number: Option<i32>,
     has_multiple_sides: bool,
-) -> (String, String) {
+) -> crate::album_detail::TrackPosition {
+    use crate::album_detail::TrackPosition;
     let num = track_number.unwrap_or(1);
     match detect_format(format) {
-        FormatKind::Vinyl => {
-            let letter = side_letter(side);
-            let side_label = format!("Side {letter}");
-            let position_label = format!("{letter}{num}");
-            (side_label, position_label)
-        }
-        FormatKind::Cassette => {
-            let letter = side_letter(side);
-            let side_label = format!("Side {letter}");
-            let position_label = format!("{letter}{num}");
-            (side_label, position_label)
-        }
+        FormatKind::Vinyl | FormatKind::Cassette => TrackPosition::Sided {
+            side_letter: side_letter(side).to_string(),
+            number: num,
+        },
         FormatKind::Digital => {
-            let position_label = if has_multiple_sides {
-                format!("{side}-{num}")
+            if has_multiple_sides {
+                TrackPosition::Disc {
+                    disc: side,
+                    number: num,
+                }
             } else {
-                num.to_string()
-            };
-            let side_label = if has_multiple_sides {
-                format!("Disc {side}")
-            } else {
-                String::new()
-            };
-            (side_label, position_label)
+                TrackPosition::Flat { number: num }
+            }
         }
     }
 }
 
-/// Group pre-sorted tracks by consecutive side_label.
+/// The side a track belongs to — the grouping discriminant. Every track on a
+/// side yields the same value, so consecutive-equal grouping lands one group
+/// per side. Carries no per-track number (a header has none).
+fn track_side(position: &crate::album_detail::TrackPosition) -> crate::album_detail::TrackSide {
+    use crate::album_detail::{TrackPosition, TrackSide};
+    match position {
+        TrackPosition::Sided { side_letter, .. } => TrackSide::Sided {
+            side_letter: side_letter.clone(),
+        },
+        TrackPosition::Disc { disc, .. } => TrackSide::Disc { disc: *disc },
+        TrackPosition::Flat { .. } => TrackSide::Flat,
+    }
+}
+
+/// Group pre-sorted tracks by consecutive side. Two tracks share a group when
+/// their positions resolve to the same [`TrackSide`] (same side letter, same
+/// disc, or both flat).
 pub fn group_tracks_by_side(
     tracks: &[crate::album_detail::TrackDetail],
 ) -> Vec<crate::album_detail::TrackGroup> {
     let mut groups: Vec<crate::album_detail::TrackGroup> = Vec::new();
     for track in tracks {
+        let side = track_side(&track.position);
         if let Some(last) = groups.last_mut() {
-            if last.side_label == track.side_label {
+            if last.side == side {
                 last.tracks.push(track.clone());
                 continue;
             }
         }
         groups.push(crate::album_detail::TrackGroup {
-            side_label: track.side_label.clone(),
+            side,
             tracks: vec![track.clone()],
         });
     }
@@ -119,42 +129,107 @@ pub fn group_tracks_by_side(
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_vinyl_labels() {
-        let (side, pos) = compute_track_labels(Some("2xLP, Vinyl"), 1, Some(2), true);
-        assert_eq!(side, "Side A");
-        assert_eq!(pos, "A2");
+    use crate::album_detail::{TrackDetail, TrackPosition};
 
-        let (side, pos) = compute_track_labels(Some("Vinyl"), 3, Some(1), true);
-        assert_eq!(side, "Side C");
-        assert_eq!(pos, "C1");
+    fn sided(letter: &str, number: i32) -> TrackPosition {
+        TrackPosition::Sided {
+            side_letter: letter.to_string(),
+            number,
+        }
     }
 
     #[test]
-    fn test_cassette_labels() {
-        let (side, pos) = compute_track_labels(Some("Cassette"), 2, Some(3), true);
-        assert_eq!(side, "Side B");
-        assert_eq!(pos, "B3");
+    fn test_vinyl_position() {
+        assert_eq!(
+            compute_track_position(Some("2xLP, Vinyl"), 1, Some(2), true),
+            sided("A", 2)
+        );
+        assert_eq!(
+            compute_track_position(Some("Vinyl"), 3, Some(1), true),
+            sided("C", 1)
+        );
+    }
+
+    #[test]
+    fn test_cassette_position() {
+        assert_eq!(
+            compute_track_position(Some("Cassette"), 2, Some(3), true),
+            sided("B", 3)
+        );
     }
 
     #[test]
     fn test_cd_single_disc() {
-        let (side, pos) = compute_track_labels(Some("CD"), 1, Some(5), false);
-        assert_eq!(side, "");
-        assert_eq!(pos, "5");
+        assert_eq!(
+            compute_track_position(Some("CD"), 1, Some(5), false),
+            TrackPosition::Flat { number: 5 }
+        );
     }
 
     #[test]
     fn test_cd_multi_disc() {
-        let (side, pos) = compute_track_labels(Some("2xCD"), 2, Some(3), true);
-        assert_eq!(side, "Disc 2");
-        assert_eq!(pos, "2-3");
+        assert_eq!(
+            compute_track_position(Some("2xCD"), 2, Some(3), true),
+            TrackPosition::Disc { disc: 2, number: 3 }
+        );
     }
 
     #[test]
     fn test_no_format() {
-        let (side, pos) = compute_track_labels(None, 1, Some(1), false);
-        assert_eq!(side, "");
-        assert_eq!(pos, "1");
+        assert_eq!(
+            compute_track_position(None, 1, Some(1), false),
+            TrackPosition::Flat { number: 1 }
+        );
+    }
+
+    fn track(id: &str, position: TrackPosition) -> TrackDetail {
+        TrackDetail {
+            id: id.to_string(),
+            title: String::new(),
+            side: 1,
+            track_number: None,
+            duration_ms: None,
+            artist_names: String::new(),
+            position,
+        }
+    }
+
+    #[test]
+    fn group_by_side_splits_on_side_letter() {
+        use crate::album_detail::TrackSide;
+        let tracks = vec![
+            track("a1", sided("A", 1)),
+            track("a2", sided("A", 2)),
+            track("b1", sided("B", 1)),
+        ];
+        let groups = group_tracks_by_side(&tracks);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(
+            groups[0].side,
+            TrackSide::Sided {
+                side_letter: "A".to_string()
+            }
+        );
+        assert_eq!(groups[0].tracks.len(), 2);
+        assert_eq!(
+            groups[1].side,
+            TrackSide::Sided {
+                side_letter: "B".to_string()
+            }
+        );
+        assert_eq!(groups[1].tracks.len(), 1);
+    }
+
+    #[test]
+    fn group_by_side_single_flat_group() {
+        use crate::album_detail::TrackSide;
+        let tracks = vec![
+            track("1", TrackPosition::Flat { number: 1 }),
+            track("2", TrackPosition::Flat { number: 2 }),
+        ];
+        let groups = group_tracks_by_side(&tracks);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].side, TrackSide::Flat);
+        assert_eq!(groups[0].tracks.len(), 2);
     }
 }

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -154,15 +154,13 @@ enum PreviewData {
         _ names: [String],
         artist: String,
         side: Int32 = 1,
-        sideLabel: String = "",
-        positionPrefix: String = "",
+        position: (Int) -> BridgeTrackPosition = {
+            .flat(number: Int32($0 + 1))
+        },
     ) -> [BridgeTrack] {
         names.enumerated()
             .map { index, name in
                 let durationMs = Int64((170 + (index * 37) % 170) * 1000)
-                let posLabel =
-                    positionPrefix.isEmpty
-                    ? "\(index + 1)" : "\(positionPrefix)\(index + 1)"
                 return BridgeTrack(
                     id: "t-d\(side)-\(index + 1)",
                     title: name,
@@ -170,10 +168,38 @@ enum PreviewData {
                     trackNumber: Int32(index + 1),
                     durationMs: durationMs,
                     artistNames: artist,
-                    sideLabel: sideLabel,
-                    positionLabel: posLabel,
+                    position: position(index),
                 )
             }
+    }
+
+    /// A two-part release's tracks plus the matching per-side groups, so the
+    /// preview renders real "Side A" / "Disc 2" headers. Vinyl sides get
+    /// `.sided` with the letter supplied (A/B); digital gets `.disc` (1/2).
+    private static func twoSide(
+        artist: String,
+        isVinyl: Bool,
+        disc1: [String],
+        disc2: [String],
+    ) -> (tracks: [BridgeTrack], groups: [BridgeTrackGroup]) {
+        func side(
+            _ sideNumber: Int32,
+            letter: String,
+            names: [String],
+        ) -> (tracks: [BridgeTrack], group: BridgeTrackGroup) {
+            let tracks = makeTracks(names, artist: artist, side: sideNumber) {
+                index in
+                isVinyl
+                    ? .sided(sideLetter: letter, number: Int32(index + 1))
+                    : .disc(disc: sideNumber, number: Int32(index + 1))
+            }
+            let groupSide: BridgeTrackSide =
+                isVinyl ? .sided(sideLetter: letter) : .disc(disc: sideNumber)
+            return (tracks, BridgeTrackGroup(side: groupSide, tracks: tracks))
+        }
+        let (tracks1, group1) = side(1, letter: "A", names: disc1)
+        let (tracks2, group2) = side(2, letter: "B", names: disc2)
+        return (tracks1 + tracks2, [group1, group2])
     }
 
     private static func makeDetail(
@@ -211,7 +237,7 @@ enum PreviewData {
                     tracks: makeTracks(tracks, artist: artist),
                     trackGroups: [
                         BridgeTrackGroup(
-                            sideLabel: "",
+                            side: .flat,
                             tracks: makeTracks(tracks, artist: artist)
                         )
                     ],
@@ -237,21 +263,12 @@ enum PreviewData {
         format: String,
     ) -> BridgeAlbumDetail {
         let isVinyl = format.contains("Vinyl") || format.contains("Cassette")
-        let allTracks =
-            makeTracks(
-                disc1,
-                artist: artist,
-                side: 1,
-                sideLabel: isVinyl ? "Side A" : "Disc 1",
-                positionPrefix: isVinyl ? "A" : "",
-            )
-            + makeTracks(
-                disc2,
-                artist: artist,
-                side: 2,
-                sideLabel: isVinyl ? "Side B" : "Disc 2",
-                positionPrefix: isVinyl ? "B" : "",
-            )
+        let sides = twoSide(
+            artist: artist,
+            isVinyl: isVinyl,
+            disc1: disc1,
+            disc2: disc2,
+        )
         return BridgeAlbumDetail(
             album: BridgeAlbum(
                 id: id,
@@ -276,10 +293,8 @@ enum PreviewData {
                     country: "US",
                     storageState: .unmanaged,
                     storageActions: [],
-                    tracks: allTracks,
-                    trackGroups: [
-                        BridgeTrackGroup(sideLabel: "", tracks: allTracks)
-                    ],
+                    tracks: sides.tracks,
+                    trackGroups: sides.groups,
                     files: [],
                     imageFiles: [],
                     galleryItems: [],
@@ -311,26 +326,27 @@ enum PreviewData {
                 let isVinyl =
                     rel.format.contains("Vinyl")
                     || rel.format.contains("Cassette")
-                let allTracks: [BridgeTrack] =
-                    if let disc2 = rel.disc2 {
-                        makeTracks(
-                            rel.tracks,
-                            artist: artist,
-                            side: 1,
-                            sideLabel: isVinyl ? "Side A" : "Disc 1",
-                            positionPrefix: isVinyl ? "A" : "",
+                let allTracks: [BridgeTrack]
+                let groups: [BridgeTrackGroup]
+                if let disc2 = rel.disc2 {
+                    let sides = twoSide(
+                        artist: artist,
+                        isVinyl: isVinyl,
+                        disc1: rel.tracks,
+                        disc2: disc2,
+                    )
+                    allTracks = sides.tracks
+                    groups = sides.groups
+                }
+                else {
+                    allTracks = makeTracks(rel.tracks, artist: artist)
+                    groups = [
+                        BridgeTrackGroup(
+                            side: .flat,
+                            tracks: allTracks
                         )
-                            + makeTracks(
-                                disc2,
-                                artist: artist,
-                                side: 2,
-                                sideLabel: isVinyl ? "Side B" : "Disc 2",
-                                positionPrefix: isVinyl ? "B" : "",
-                            )
-                    }
-                    else {
-                        makeTracks(rel.tracks, artist: artist)
-                    }
+                    ]
+                }
                 return BridgeRelease(
                     id: releaseIds[index],
                     albumId: id,
@@ -344,9 +360,7 @@ enum PreviewData {
                     storageState: .unmanaged,
                     storageActions: [],
                     tracks: allTracks,
-                    trackGroups: [
-                        BridgeTrackGroup(sideLabel: "", tracks: allTracks)
-                    ],
+                    trackGroups: groups,
                     files: [],
                     imageFiles: [],
                     galleryItems: [],
@@ -848,8 +862,6 @@ enum PreviewData {
                     durationMs: ms,
                     position: "\(i)",
                     side: 1,
-                    sideLabel: "",
-                    positionLabel: "\(i)",
                 )
             }
         return BridgeReleaseDetail(

--- a/bae-macos/bae/bae/Services/Store/Track.swift
+++ b/bae-macos/bae/bae/Services/Store/Track.swift
@@ -1,19 +1,45 @@
 import Foundation
+import os.log
+
+private let logger = Logger.bae("Track")
 
 struct Track: Identifiable {
     let id: String
     var title: String
     var durationMs: Int64?
     var artistNames: String
-    var positionLabel: String
+    var position: BridgeTrackPosition
 
     var durationLabel: String { DurationClock.text(durationMs) }
+
+    /// The position string composed mechanically from the structured case:
+    /// "A1" (sided), "2-3" (multi-disc), "5" (flat). No translatable word,
+    /// so the UI builds it directly; numbers format per locale.
+    var positionText: String { position.positionText }
 
     init(from bridge: BridgeTrack) {
         id = bridge.id
         title = bridge.title
         durationMs = bridge.durationMs
         artistNames = bridge.artistNames
-        positionLabel = bridge.positionLabel
+        position = bridge.position
+    }
+}
+
+extension BridgeTrackPosition {
+    /// Mechanical compose of the position string from the case. Numbers format
+    /// for the current locale; the side letter is a bare proper-noun letter.
+    var positionText: String {
+        switch self {
+        case .sided(let sideLetter, let number):
+            return "\(sideLetter)\(number.formatted())"
+        case .disc(let disc, let number):
+            return "\(disc.formatted())-\(number.formatted())"
+        case .flat(let number):
+            return number.formatted()
+        @unknown default:
+            logger.warning("unhandled BridgeTrackPosition case in positionText")
+            return ""
+        }
     }
 }

--- a/bae-macos/bae/bae/Services/Store/TrackGroup.swift
+++ b/bae-macos/bae/bae/Services/Store/TrackGroup.swift
@@ -1,11 +1,50 @@
 import Foundation
+import os.log
+
+private let logger = Logger.bae("TrackGroup")
 
 struct TrackGroup {
-    var sideLabel: String
+    var side: BridgeTrackSide
     var tracks: [Track]
 
+    /// The group header for the current locale: "Side A" / "Disc 2", or empty
+    /// for a flat single-disc group (no header). bae-core decides the case and
+    /// the side letter / disc number; the UI resolves the "Side"/"Disc" word
+    /// from the catalog key and substitutes the number.
+    var sideHeaderText: String { side.sideHeaderText }
+
     init(from bridge: BridgeTrackGroup) {
-        sideLabel = bridge.sideLabel
+        side = bridge.side
         tracks = bridge.tracks.map(Track.init(from:))
+    }
+}
+
+extension BridgeTrackSide {
+    /// The localized group header ("Side A" / "Disc 2"), or empty for the flat
+    /// case. The word comes from the catalog key bae-core owns; the side letter
+    /// / disc number is substituted in.
+    var sideHeaderText: String {
+        guard let key = bridgeTrackHeaderKey(side: self) else { return "" }
+        let format = NSLocalizedString(
+            key,
+            tableName: "Core",
+            bundle: .main,
+            comment: ""
+        )
+        switch self {
+        case .sided(let sideLetter):
+            return String(format: format, sideLetter)
+        case .disc(let disc):
+            // The "Disc {disc}" catalog value compiles to "Disc %lld"; pass a
+            // 64-bit Int so the C-variadic width matches (Int32 would misread).
+            return String(format: format, Int(disc))
+        case .flat:
+            // Unreachable: the guard already returned for the keyless flat
+            // side. Swift still requires the case for exhaustiveness.
+            return ""
+        @unknown default:
+            logger.warning("unhandled BridgeTrackSide case in sideHeaderText")
+            return ""
+        }
     }
 }

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -842,8 +842,8 @@ struct AlbumTrackListView: View {
                 groupIndex,
                 group in
                 let globalOffset = offsets[groupIndex]
-                if !group.sideLabel.isEmpty {
-                    Text(group.sideLabel)
+                if !group.sideHeaderText.isEmpty {
+                    Text(group.sideHeaderText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .padding(.top, groupIndex == 0 ? 0 : 16)
@@ -1024,11 +1024,11 @@ private struct TrackRowView: View {
     }
 
     private var trackNumberLabel: some View {
-        if track.positionLabel.isEmpty {
+        if track.positionText.isEmpty {
             Text("-")
         }
         else {
-            Text(track.positionLabel)
+            Text(track.positionText)
         }
     }
 }

--- a/bae-macos/bae/bae/bae_bridgeFFI.h
+++ b/bae-macos/bae/bae/bae_bridgeFFI.h
@@ -972,6 +972,11 @@ RustBuffer uniffi_bae_bridge_fn_func_bridge_invalid_reason_key(RustBuffer reason
 RustBuffer uniffi_bae_bridge_fn_func_bridge_prepare_step_key(RustBuffer step, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_TRACK_HEADER_KEY
+#define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_TRACK_HEADER_KEY
+RustBuffer uniffi_bae_bridge_fn_func_bridge_track_header_key(RustBuffer side, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_TRANSFER_ACTION_KEY
 #define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_TRANSFER_ACTION_KEY
 RustBuffer uniffi_bae_bridge_fn_func_bridge_transfer_action_key(RustBuffer action, RustCallStatus *_Nonnull out_status
@@ -1401,6 +1406,12 @@ uint16_t uniffi_bae_bridge_checksum_func_bridge_invalid_reason_key(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_PREPARE_STEP_KEY
 #define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_PREPARE_STEP_KEY
 uint16_t uniffi_bae_bridge_checksum_func_bridge_prepare_step_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_TRACK_HEADER_KEY
+#define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_TRACK_HEADER_KEY
+uint16_t uniffi_bae_bridge_checksum_func_bridge_track_header_key(void
     
 );
 #endif


### PR DESCRIPTION
Tracks crossed the bridge with pre-formatted position prose — `side_label` ("Side A" / "Disc 2") and `position_label` ("A1", "1-2") — so "Side"/"Disc" were baked in English. The words can't localize while the bridge ships them already rendered.

`BridgeTrack`/`BridgeTrackGroup` now carry a structured `BridgeTrackPosition` (`Sided { side_letter, number }` / `Disc { disc, number }` / `Flat { number }`). The domain decision — which case, which side-letter, vinyl-vs-digital — stays in core (`compute_track_position`, renamed from `compute_track_labels`; `group_tracks_by_side` regroups on the structured position). The UI composes the position string mechanically and resolves only the words "Side"/"Disc" through the `core.track.*` catalog keys.

`BridgeReleaseTrack`/core `ReleaseTrack` carried the same two fields, but nothing read them — the import-search preview renders the raw `position` the metadata source reports, which can be arbitrary prose ("Bonus") that doesn't fit Sided/Disc/Flat. Those two dead fields are deleted; the raw `position` passthrough stays.

## Test plan
- `cargo clippy` (bae-core, bae-bridge) clean; `cargo test -p bae-core -p bae-bridge` (CI invocation with `bae-core/test-utils`) — structured-position cases, grouping tests, and the new `track_position::keys_exist` pass
- macOS build green (full pre-commit gate)
- Open an album with vinyl sides and one with multiple discs; confirm side headers and track positions render