### PR TITLE
loc: structure metadata-lookup failures (typed reason + provider status)

### DIFF
--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -119,6 +119,27 @@ comment = "Identify: which barcode is being looked up, of how many."
 args = { position = "Int", total = "Int" }
 value = "Looking up barcode {position} of {total}"
 
+[messages."core.lookup.failure.network"]
+comment = "Metadata lookup failed: couldn't reach the provider (no network response)."
+value = "Couldn't reach the metadata provider"
+
+[messages."core.lookup.failure.provider"]
+comment = "Metadata lookup failed: the provider returned an HTTP error response ({status} is the HTTP status code)."
+args = { status = "Int" }
+value = "The metadata provider returned an error ({status})"
+
+[messages."core.lookup.failure.provider_unknown"]
+comment = "Metadata lookup failed: the provider returned an error with no status code to show. No-status fallback for core.lookup.failure.provider."
+value = "The metadata provider returned an error"
+
+[messages."core.lookup.failure.timeout"]
+comment = "Metadata lookup failed: the request to the provider timed out."
+value = "The metadata provider timed out"
+
+[messages."core.lookup.failure.diagnostic"]
+comment = "Metadata lookup failed for a local reason (the typed variant carries no translated copy). Generic line shown alongside the opaque, log-only detail."
+value = "Couldn't look this up"
+
 [messages."core.queue.uploading"]
 comment = "Storage queue: count currently uploading."
 args = { count = "Int" }

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1100,6 +1100,89 @@ pub enum BridgeSignalRole {
     Filter,
 }
 
+/// Why a metadata lookup failed. Mirrors `bae_core::signals::LookupFailure`.
+/// The locale never crosses the bridge: the UI resolves a localized line per
+/// variant (`bridge_lookup_failure_key`) and renders `Provider`'s status as
+/// the message argument. `Diagnostic` carries opaque, log-only detail — never
+/// translated, never shown as primary copy.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeLookupFailure {
+    /// Transport/connection failure — no HTTP response.
+    Network,
+    /// An HTTP error response from the metadata provider, with its status
+    /// code when one was observed.
+    Provider { status: Option<u16> },
+    /// The request timed out before a response arrived.
+    Timeout,
+    /// A local error (DB load, "not found", a compute task panic). `detail`
+    /// is the opaque error chain — log-only, never translated.
+    Diagnostic { detail: String },
+}
+
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+fn lookup_failure_to_bridge(f: bae_core::signals::LookupFailure) -> BridgeLookupFailure {
+    use bae_core::signals::LookupFailure;
+    match f {
+        LookupFailure::Network => BridgeLookupFailure::Network,
+        LookupFailure::Provider { status } => BridgeLookupFailure::Provider { status },
+        LookupFailure::Timeout => BridgeLookupFailure::Timeout,
+        LookupFailure::Diagnostic { detail } => BridgeLookupFailure::Diagnostic { detail },
+    }
+}
+
+/// Localization key for a lookup failure's user-facing line, or `None` for
+/// `Diagnostic` (which has no translated copy — the UI shows a generic line
+/// plus the opaque `detail`). `Provider` resolves to one of two keys: the
+/// status-bearing line when a code was observed, or a no-status fallback when
+/// not — so the UI never has to decide which message a missing status takes.
+/// One source of these keys for every platform; the UI resolves the key
+/// through its string catalog.
+#[uniffi::export]
+pub fn bridge_lookup_failure_key(failure: BridgeLookupFailure) -> Option<String> {
+    match failure {
+        BridgeLookupFailure::Network => Some("core.lookup.failure.network".to_string()),
+        BridgeLookupFailure::Provider { status: Some(_) } => {
+            Some("core.lookup.failure.provider".to_string())
+        }
+        BridgeLookupFailure::Provider { status: None } => {
+            Some("core.lookup.failure.provider_unknown".to_string())
+        }
+        BridgeLookupFailure::Timeout => Some("core.lookup.failure.timeout".to_string()),
+        BridgeLookupFailure::Diagnostic { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod lookup_failure_tests {
+    use super::BridgeLookupFailure;
+
+    /// The keys the UI resolves (Network, Provider, Timeout) must exist in the
+    /// catalog; `Diagnostic` has no key (the UI renders a generic line plus
+    /// the opaque detail).
+    #[test]
+    fn keys_exist_in_catalog() {
+        let cat = bae_loc::Catalog::from_toml(include_str!("../loc/catalog.toml"))
+            .expect("catalog parses");
+        for failure in [
+            BridgeLookupFailure::Network,
+            BridgeLookupFailure::Provider { status: Some(503) },
+            BridgeLookupFailure::Provider { status: None },
+            BridgeLookupFailure::Timeout,
+        ] {
+            let key = super::bridge_lookup_failure_key(failure)
+                .expect("Network/Provider/Timeout carry keys");
+            assert!(cat.messages.contains_key(&key), "catalog missing `{key}`");
+        }
+        assert!(
+            super::bridge_lookup_failure_key(BridgeLookupFailure::Diagnostic {
+                detail: "x".to_string()
+            })
+            .is_none(),
+            "Diagnostic has no catalog key"
+        );
+    }
+}
+
 /// The live lookup/match state of one toolbar badge. Mirrors
 /// `bae_core::identify::SignalState`.
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
@@ -1108,7 +1191,7 @@ pub enum BridgeSignalState {
     Found { count: u32 },
     NoMatch,
     Skipped,
-    Failed { message: String },
+    Failed { failure: BridgeLookupFailure },
     Confirms { count: u32 },
 }
 
@@ -1139,7 +1222,9 @@ fn signal_state_to_bridge(s: bae_core::identify::SignalState) -> BridgeSignalSta
         SignalState::Found { count } => BridgeSignalState::Found { count },
         SignalState::NoMatch => BridgeSignalState::NoMatch,
         SignalState::Skipped => BridgeSignalState::Skipped,
-        SignalState::Failed { message } => BridgeSignalState::Failed { message },
+        SignalState::Failed { failure } => BridgeSignalState::Failed {
+            failure: lookup_failure_to_bridge(failure),
+        },
         SignalState::Confirms { count } => BridgeSignalState::Confirms { count },
     }
 }
@@ -1185,7 +1270,7 @@ pub enum BridgeDiscidProgress {
     /// No disc-ID artifacts (LOG/CUE) available for this candidate.
     Skipped,
     Failed {
-        message: String,
+        failure: BridgeLookupFailure,
     },
 }
 
@@ -1234,9 +1319,17 @@ pub struct BridgeReleaseGroup {
 /// The disc-ID signal. Mirrors `bae_core::signals::DiscIdSignal`.
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum BridgeDiscIdSignal {
-    Computed { disc_id: String, track_count: u32 },
-    Absent { track_count: u32 },
-    Failed { message: String, track_count: u32 },
+    Computed {
+        disc_id: String,
+        track_count: u32,
+    },
+    Absent {
+        track_count: u32,
+    },
+    Failed {
+        failure: BridgeLookupFailure,
+        track_count: u32,
+    },
 }
 
 /// The barcode signal — the UPC/EAN code payloads with their origins. Mirrors
@@ -2624,7 +2717,9 @@ fn discid_progress_to_bridge(p: bae_core::identify::DiscidProgress) -> BridgeDis
             n_results: results.len() as u32,
         },
         DiscidProgress::Skipped { .. } => BridgeDiscidProgress::Skipped,
-        DiscidProgress::Failed { message } => BridgeDiscidProgress::Failed { message },
+        DiscidProgress::Failed { failure } => BridgeDiscidProgress::Failed {
+            failure: lookup_failure_to_bridge(failure),
+        },
     }
 }
 
@@ -2685,10 +2780,10 @@ pub(crate) fn signals_to_bridge(s: bae_core::signals::Signals) -> BridgeSignals 
         },
         DiscIdSignal::Absent { track_count } => BridgeDiscIdSignal::Absent { track_count },
         DiscIdSignal::Failed {
-            message,
+            failure,
             track_count,
         } => BridgeDiscIdSignal::Failed {
-            message,
+            failure: lookup_failure_to_bridge(failure),
             track_count,
         },
     };

--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -5,6 +5,7 @@
 use crate::db::LibraryStatus;
 use crate::import::cover_art::CoverArtArchiveClient;
 use crate::import::search::{lookup_by_discid, DiscIdResult, MetadataResult};
+use crate::signals::LookupFailure;
 use std::path::PathBuf;
 
 /// Compute disc ID and track count for a release already in the library.
@@ -140,12 +141,12 @@ pub async fn lookup_and_resolve(
     cover_art_archive: &CoverArtArchiveClient,
     disc_id: &str,
     library_manager: &crate::library::LibraryManager,
-) -> Result<(Vec<MetadataResult>, Vec<LibraryStatus>), String> {
+) -> Result<(Vec<MetadataResult>, Vec<LibraryStatus>), LookupFailure> {
     use crate::db::LibraryCheck;
 
-    let result = lookup_by_discid(cover_art_archive, disc_id)
-        .await
-        .map_err(|e| format!("MusicBrainz lookup failed: {e}"))?;
+    // The MB lookup carries its own typed failure (Network / Provider /
+    // Timeout) — pass it through structured.
+    let result = lookup_by_discid(cover_art_archive, disc_id).await?;
 
     let matches: Vec<MetadataResult> = match result {
         DiscIdResult::NoMatches => return Ok((Vec::new(), Vec::new())),
@@ -153,11 +154,15 @@ pub async fn lookup_and_resolve(
         DiscIdResult::MultipleMatches(matches) => matches,
     };
 
+    // The in-library check is a local DB read — its failure is opaque
+    // diagnostic detail, not a provider verdict.
     let checks: Vec<LibraryCheck> = matches.iter().map(LibraryCheck::from).collect();
     let library_statuses = library_manager
         .check_releases_in_library(&checks)
         .await
-        .map_err(|e| format!("Failed to check library status: {e}"))?;
+        .map_err(|e| LookupFailure::Diagnostic {
+            detail: format!("Failed to check library status: {e}"),
+        })?;
     Ok((matches, library_statuses))
 }
 

--- a/bae-core/src/identify/service.rs
+++ b/bae-core/src/identify/service.rs
@@ -307,8 +307,8 @@ fn dispatch_effect(
                             },
                         );
                     }
-                    Err(message) => {
-                        emit_step(&event_tx, IdentifyEvent::DiscidLookupFailed { message });
+                    Err(failure) => {
+                        emit_step(&event_tx, IdentifyEvent::DiscidLookupFailed { failure });
                     }
                 }
             });

--- a/bae-core/src/identify/state.rs
+++ b/bae-core/src/identify/state.rs
@@ -16,7 +16,9 @@ use super::combine::{
 use super::toolbar::{SignalKind, SignalRole, SignalState, ToolbarSignal};
 use crate::db::LibraryStatus;
 use crate::import::search::MetadataResult;
-use crate::signals::{BarcodeSignal, DiscIdSignal, SignalOrigin, Signals, SourcedValue};
+use crate::signals::{
+    BarcodeSignal, DiscIdSignal, LookupFailure, SignalOrigin, Signals, SourcedValue,
+};
 use std::collections::HashSet;
 
 /// Per-signal progress for disc-ID. The UI reads this to render
@@ -40,7 +42,7 @@ pub enum DiscidProgress {
         track_count: u32,
     },
     Failed {
-        message: String,
+        failure: LookupFailure,
     },
 }
 
@@ -438,8 +440,8 @@ fn discid_progress_state(progress: &DiscidProgress) -> SignalState {
         DiscidProgress::Computing | DiscidProgress::LookingUp => SignalState::LookingUp,
         DiscidProgress::Done { results, .. } => found_or_no_match(results.len() as u32),
         DiscidProgress::Skipped { .. } => SignalState::Skipped,
-        DiscidProgress::Failed { message } => SignalState::Failed {
-            message: message.clone(),
+        DiscidProgress::Failed { failure } => SignalState::Failed {
+            failure: failure.clone(),
         },
     }
 }
@@ -461,8 +463,8 @@ fn settled_identity_state(
 ) -> SignalState {
     match disc_id {
         DiscIdSignal::Absent { .. } => SignalState::Skipped,
-        DiscIdSignal::Failed { message, .. } => SignalState::Failed {
-            message: message.clone(),
+        DiscIdSignal::Failed { failure, .. } => SignalState::Failed {
+            failure: failure.clone(),
         },
         DiscIdSignal::Computed { .. } => found_or_no_match(results.len() as u32),
     }
@@ -517,7 +519,7 @@ pub enum IdentifyEvent {
         track_count: u32,
     },
     DiscidLookupFailed {
-        message: String,
+        failure: LookupFailure,
     },
 
     // ── Barcode lookup completion ───────────────────────────────────
@@ -618,9 +620,9 @@ pub fn step(state: IdentifyState, event: IdentifyEvent) -> (IdentifyState, Vec<E
                 barcode,
                 context,
             },
-            IdentifyEvent::DiscidLookupFailed { message },
+            IdentifyEvent::DiscidLookupFailed { failure },
         ) => settle_if_ready(IdentifyState::Triangulating {
-            discid: DiscidProgress::Failed { message },
+            discid: DiscidProgress::Failed { failure },
             barcode,
             context,
         }),
@@ -807,9 +809,9 @@ fn apply_signals(
                 track_count: *track_count,
             }
         }
-        (DiscidProgress::Computing, DiscIdSignal::Failed { message, .. }) => {
+        (DiscidProgress::Computing, DiscIdSignal::Failed { failure, .. }) => {
             DiscidProgress::Failed {
-                message: message.clone(),
+                failure: failure.clone(),
             }
         }
         // Already past Computing — the disc-ID lookup is in flight or settled.
@@ -972,8 +974,8 @@ fn rerun(mut context: SignalsContext) -> (IdentifyState, Vec<Effect>) {
         DiscIdSignal::Absent { track_count } => DiscidProgress::Skipped {
             track_count: *track_count,
         },
-        DiscIdSignal::Failed { message, .. } => DiscidProgress::Failed {
-            message: message.clone(),
+        DiscIdSignal::Failed { failure, .. } => DiscidProgress::Failed {
+            failure: failure.clone(),
         },
     };
 
@@ -1922,7 +1924,7 @@ mod tests {
         let (state, _) = step(
             state,
             IdentifyEvent::DiscidLookupFailed {
-                message: "network error".to_string(),
+                failure: LookupFailure::Provider { status: Some(503) },
             },
         );
         let disc = state
@@ -1933,7 +1935,7 @@ mod tests {
         assert_eq!(
             disc.state,
             SignalState::Failed {
-                message: "network error".to_string()
+                failure: LookupFailure::Provider { status: Some(503) }
             }
         );
     }

--- a/bae-core/src/identify/toolbar.rs
+++ b/bae-core/src/identify/toolbar.rs
@@ -8,7 +8,7 @@
 //! Built by [`crate::identify::IdentifyState::toolbar`] and broadcast alongside
 //! each identify-state transition.
 
-use crate::signals::SignalOrigin;
+use crate::signals::{LookupFailure, SignalOrigin};
 
 /// Which kind of signal a badge represents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,8 +40,10 @@ pub enum SignalState {
     /// The signal had no source to run (no disc layout, no artwork) — it never
     /// produced a value to look up.
     Skipped,
-    /// An identity lookup failed.
-    Failed { message: String },
+    /// An identity lookup failed. Carries the typed reason; the UI resolves a
+    /// localized line per variant (and shows the opaque detail for
+    /// `Diagnostic`).
+    Failed { failure: LookupFailure },
     /// A catalog filter confirms `count` of the matched releases (their catno
     /// equals this candidate). `count == 0` renders as muted noise; `> 0`
     /// pinpoints the pressing with an accent check.

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -12,6 +12,7 @@ use crate::import::cover_art::{CoverArtArchiveClient, RemoteCover};
 use crate::import::types::MetadataSource;
 use crate::musicbrainz::{self, DiscIdRelease, ReleaseSearchParams, SearchRelease};
 use crate::retry::retry_with_backoff;
+use crate::signals::LookupFailure;
 use tracing::warn;
 
 /// A unified metadata search result from either MusicBrainz or Discogs.
@@ -341,11 +342,28 @@ pub async fn search_discogs_by_barcode(
         .collect())
 }
 
+/// Map a MusicBrainz wire failure to the typed `LookupFailure` the identify
+/// pipeline carries. The wire-level variants pass through structured (the HTTP
+/// status is preserved); a local/internal MB error becomes opaque `Diagnostic`
+/// detail. `NotFound` never reaches here — callers map it to "no matches"
+/// before this is called.
+fn mb_error_to_lookup_failure(e: musicbrainz::MusicBrainzError) -> LookupFailure {
+    use musicbrainz::MusicBrainzError;
+    match e {
+        MusicBrainzError::Network(_) => LookupFailure::Network,
+        MusicBrainzError::Timeout => LookupFailure::Timeout,
+        MusicBrainzError::Provider { status } => LookupFailure::Provider { status },
+        MusicBrainzError::NotFound(_) | MusicBrainzError::Other(_) => LookupFailure::Diagnostic {
+            detail: e.to_string(),
+        },
+    }
+}
+
 /// Lookup releases by MusicBrainz disc ID.
 pub async fn lookup_by_discid(
     cover_art_archive: &CoverArtArchiveClient,
     discid: &str,
-) -> Result<DiscIdResult, String> {
+) -> Result<DiscIdResult, LookupFailure> {
     let result = retry_with_backoff(3, "MusicBrainz DiscID lookup", || {
         musicbrainz::lookup_by_discid(discid)
     })
@@ -375,7 +393,7 @@ pub async fn lookup_by_discid(
             }
         }
         Err(musicbrainz::MusicBrainzError::NotFound(_)) => Ok(DiscIdResult::NoMatches),
-        Err(e) => Err(format!("DiscID lookup failed: {e}")),
+        Err(e) => Err(mb_error_to_lookup_failure(e)),
     }
 }
 

--- a/bae-core/src/musicbrainz.rs
+++ b/bae-core/src/musicbrainz.rs
@@ -347,12 +347,52 @@ pub struct ExternalUrls {
     pub discogs_release_url: Option<String>,
 }
 
+/// A MusicBrainz lookup failure, keeping the wire-level distinction the
+/// caller needs to localize: a transport failure that produced no HTTP
+/// response, a timeout, or an HTTP error *response* carrying a status. The
+/// status is preserved at the point of construction — flattening it into a
+/// formatted string here would destroy it for every consumer.
+///
+/// `Other` carries local/internal failures (URL construction, JSON parsing,
+/// reading the body) — diagnostic detail, never a provider verdict.
 #[derive(Debug, Error)]
 pub enum MusicBrainzError {
-    #[error("MusicBrainz API error: {0}")]
-    Api(String),
+    /// No release matched the DiscID (404 or an empty result set).
     #[error("No release found for DISCID: {0}")]
     NotFound(String),
+    /// The request never reached a response — connection refused, DNS
+    /// failure, a dropped body. Carries the underlying error for logging.
+    #[error("MusicBrainz network error: {0}")]
+    Network(String),
+    /// The request timed out before a response arrived.
+    #[error("MusicBrainz request timed out")]
+    Timeout,
+    /// MusicBrainz returned an HTTP error response. `status` is the HTTP
+    /// status code when one was observed (`None` when reqwest classified
+    /// a send error as carrying a status we couldn't read).
+    #[error("MusicBrainz returned an error response (status {status:?})")]
+    Provider { status: Option<u16> },
+    /// A local/internal failure (URL construction, JSON parsing, body read).
+    #[error("MusicBrainz API error: {0}")]
+    Other(String),
+}
+
+impl MusicBrainzError {
+    /// Classify a `reqwest::Error` from a `.send()` / body read into the
+    /// wire-level failure it represents. A timeout is distinct; an error
+    /// carrying an HTTP status is a `Provider` response; everything else
+    /// (connection, DNS, dropped body) is a transport `Network` failure.
+    fn from_reqwest(e: reqwest::Error) -> Self {
+        if e.is_timeout() {
+            MusicBrainzError::Timeout
+        } else if let Some(status) = e.status() {
+            MusicBrainzError::Provider {
+                status: Some(status.as_u16()),
+            }
+        } else {
+            MusicBrainzError::Network(e.to_string())
+        }
+    }
 }
 
 // ============================================================================
@@ -365,10 +405,10 @@ pub async fn lookup_by_discid(
 ) -> Result<(Vec<DiscIdRelease>, ExternalUrls), MusicBrainzError> {
     info!("MusicBrainz: Looking up DiscID '{}'", discid);
     let base_url = reqwest::Url::parse("https://musicbrainz.org/ws/2/discid/")
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to parse base URL: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to parse base URL: {}", e)))?;
     let url = base_url
         .join(discid)
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to construct DiscID URL: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to construct DiscID URL: {}", e)))?;
     let mut url_with_params = url.clone();
     url_with_params.set_query(Some(
         "inc=recordings+artist-credits+release-groups+url-rels+labels",
@@ -382,7 +422,7 @@ pub async fn lookup_by_discid(
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("HTTP request failed: {}", e)))?;
+        .map_err(MusicBrainzError::from_reqwest)?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -399,16 +439,15 @@ pub async fn lookup_by_discid(
         if status == 404 {
             return Err(MusicBrainzError::NotFound(discid.to_string()));
         }
-        return Err(MusicBrainzError::Api(format!(
-            "MusicBrainz API returned status {}: {}",
-            status, error_text
-        )));
+        return Err(MusicBrainzError::Provider {
+            status: Some(status.as_u16()),
+        });
     }
 
     let disc_response: DiscIdResponse = response
         .json()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to parse JSON: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to parse JSON: {}", e)))?;
 
     let mut external_urls = ExternalUrls {
         discogs_master_url: None,
@@ -457,19 +496,18 @@ async fn fetch_release_group_with_relations(
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("HTTP request failed: {}", e)))?;
+        .map_err(MusicBrainzError::from_reqwest)?;
 
     if !response.status().is_success() {
-        return Err(MusicBrainzError::Api(format!(
-            "MusicBrainz API returned status: {}",
-            response.status()
-        )));
+        return Err(MusicBrainzError::Provider {
+            status: Some(response.status().as_u16()),
+        });
     }
 
     response
         .json()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to parse JSON: {}", e)))
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to parse JSON: {}", e)))
 }
 
 /// Lookup a specific release by MusicBrainz release ID.
@@ -505,25 +543,24 @@ pub async fn lookup_release_by_id(
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("HTTP request failed: {}", e)))?;
+        .map_err(MusicBrainzError::from_reqwest)?;
 
     if !response.status().is_success() {
         if response.status() == 404 {
             return Err(MusicBrainzError::NotFound(release_id.to_string()));
         }
-        return Err(MusicBrainzError::Api(format!(
-            "MusicBrainz API returned status: {}",
-            response.status()
-        )));
+        return Err(MusicBrainzError::Provider {
+            status: Some(response.status().as_u16()),
+        });
     }
 
     let raw_json = response
         .text()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to read response body: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to read response body: {}", e)))?;
 
     let mb_response: MbReleaseResponse = serde_json::from_str(&raw_json)
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to parse JSON: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to parse JSON: {}", e)))?;
 
     #[cfg(debug_assertions)]
     {
@@ -621,19 +658,18 @@ pub async fn fetch_release_group_json(release_group_id: &str) -> Result<String, 
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("HTTP request failed: {}", e)))?;
+        .map_err(MusicBrainzError::from_reqwest)?;
 
     if !response.status().is_success() {
-        return Err(MusicBrainzError::Api(format!(
-            "MusicBrainz API returned status: {}",
-            response.status()
-        )));
+        return Err(MusicBrainzError::Provider {
+            status: Some(response.status().as_u16()),
+        });
     }
 
     let raw_json = response
         .text()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to read response body: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to read response body: {}", e)))?;
 
     release_group_json_cache()
         .lock()
@@ -678,7 +714,7 @@ pub async fn lookup_release_id_by_discogs_url(
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("HTTP request failed: {}", e)))?;
+        .map_err(MusicBrainzError::from_reqwest)?;
 
     if response.status() == 404 {
         discogs_url_lookup_cache()
@@ -689,16 +725,15 @@ pub async fn lookup_release_id_by_discogs_url(
     }
 
     if !response.status().is_success() {
-        return Err(MusicBrainzError::Api(format!(
-            "MusicBrainz API returned status: {}",
-            response.status()
-        )));
+        return Err(MusicBrainzError::Provider {
+            status: Some(response.status().as_u16()),
+        });
     }
 
     let lookup: UrlLookupResponse = response
         .json()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to parse JSON: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to parse JSON: {}", e)))?;
 
     // Find the first relation that has a release with an ID
     let release_id = lookup
@@ -868,7 +903,7 @@ pub async fn search_releases_with_params(
     params: &ReleaseSearchParams,
 ) -> Result<Vec<SearchRelease>, MusicBrainzError> {
     if !params.has_any_field() {
-        return Err(MusicBrainzError::Api(
+        return Err(MusicBrainzError::Other(
             "At least one search field must be provided".to_string(),
         ));
     }
@@ -896,7 +931,7 @@ pub async fn search_releases_with_params(
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("HTTP request failed: {}", e)))?;
+        .map_err(MusicBrainzError::from_reqwest)?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -913,16 +948,15 @@ pub async fn search_releases_with_params(
         if status == 404 {
             return Ok(Vec::new());
         }
-        return Err(MusicBrainzError::Api(format!(
-            "MusicBrainz API returned status {}: {}",
-            status, error_text
-        )));
+        return Err(MusicBrainzError::Provider {
+            status: Some(status.as_u16()),
+        });
     }
 
     let search_response: SearchResponse = response
         .json()
         .await
-        .map_err(|e| MusicBrainzError::Api(format!("Failed to parse JSON: {}", e)))?;
+        .map_err(|e| MusicBrainzError::Other(format!("Failed to parse JSON: {}", e)))?;
 
     #[cfg(debug_assertions)]
     {
@@ -941,7 +975,7 @@ pub async fn search_releases_with_params(
 
     if let Some(ref error_msg) = search_response.error {
         warn!("MusicBrainz API returned error: {}", error_msg);
-        return Err(MusicBrainzError::Api(format!(
+        return Err(MusicBrainzError::Other(format!(
             "MusicBrainz error: {}",
             error_msg
         )));

--- a/bae-core/src/signals/disc_id.rs
+++ b/bae-core/src/signals/disc_id.rs
@@ -1,6 +1,8 @@
 //! The disc-ID signal: a MusicBrainz disc ID derived from a candidate's
 //! LOG/CUE artifacts, or supplied directly for a physical CD.
 
+use super::LookupFailure;
+
 /// The disc-ID signal extracted from a candidate's files.
 ///
 /// Derived once during the extraction pass (or supplied for a CD). The
@@ -14,8 +16,13 @@ pub enum DiscIdSignal {
     Computed { disc_id: String, track_count: u32 },
     /// No LOG/CUE artifact to derive a disc ID from.
     Absent { track_count: u32 },
-    /// Derivation failed (e.g. the folder scan left a CUE unparsed).
-    Failed { message: String, track_count: u32 },
+    /// Derivation failed (re-identify resolution: DB load, "release not
+    /// found", a disc-ID compute task panic) — always a local error, hence
+    /// `LookupFailure::Diagnostic` in practice.
+    Failed {
+        failure: LookupFailure,
+        track_count: u32,
+    },
 }
 
 impl DiscIdSignal {

--- a/bae-core/src/signals/failure.rs
+++ b/bae-core/src/signals/failure.rs
@@ -1,0 +1,31 @@
+//! The typed reason a metadata lookup failed.
+//!
+//! The locale never crosses the bridge: bae-core emits this typed reason and a
+//! stable catalog key per variant; the UI renders the localized line. The HTTP
+//! status from the metadata provider is carried structured (never flattened
+//! into prose), so the UI can show it. `Diagnostic` is the one variant that
+//! carries free text — an opaque, log-only error chain that is never
+//! translated and never shown as primary copy.
+
+/// Why a metadata lookup failed, closed to exactly the cases the producers
+/// distinguish.
+///
+/// The MusicBrainz disc-ID lookup maps to `Network` / `Timeout` /
+/// `Provider`. Local failures (re-identify resolution, the in-library check,
+/// a disc-ID compute task panic) map to `Diagnostic` — they carry no provider
+/// verdict, only diagnostic detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LookupFailure {
+    /// A transport/connection failure that produced no HTTP response
+    /// (connection refused, DNS failure, a dropped body).
+    Network,
+    /// An HTTP error response from the metadata provider. `status` is the
+    /// HTTP status code when one was observed.
+    Provider { status: Option<u16> },
+    /// The request timed out before a response arrived.
+    Timeout,
+    /// A local error (DB load, "release not found", a disc-ID compute task
+    /// panic). `detail` is the opaque error chain — log-only, never
+    /// translated, never shown as primary user-facing copy.
+    Diagnostic { detail: String },
+}

--- a/bae-core/src/signals/mod.rs
+++ b/bae-core/src/signals/mod.rs
@@ -20,12 +20,14 @@
 
 pub mod barcode;
 pub mod disc_id;
+pub mod failure;
 pub mod origin;
 pub mod service;
 pub mod text;
 
 pub use barcode::BarcodeSignal;
 pub use disc_id::DiscIdSignal;
+pub use failure::LookupFailure;
 pub use origin::{SignalOrigin, SourcedValue};
 pub use service::{ExtractionService, ExtractionServiceHandle, ExtractionSource};
 pub use text::TextSignal;

--- a/bae-core/src/signals/service.rs
+++ b/bae-core/src/signals/service.rs
@@ -283,8 +283,8 @@ async fn run_extraction(
                     track_count,
                 },
                 Ok((None, track_count)) => DiscIdSignal::Absent { track_count },
-                Err(message) => DiscIdSignal::Failed {
-                    message,
+                Err(detail) => DiscIdSignal::Failed {
+                    failure: crate::signals::LookupFailure::Diagnostic { detail },
                     track_count: 0,
                 },
             };

--- a/bae-macos/bae/bae/Services/Store/IdentifyState.swift
+++ b/bae-macos/bae/bae/Services/Store/IdentifyState.swift
@@ -23,7 +23,7 @@ enum DiscidProgress: Equatable {
     case lookingUp
     case done(nResults: UInt32)
     case skipped
-    case failed(message: String)
+    case failed(failure: LookupFailure)
 
     init(bridge: BridgeDiscidProgress) {
         switch bridge {
@@ -31,7 +31,8 @@ enum DiscidProgress: Equatable {
         case .lookingUp: self = .lookingUp
         case .done(let n): self = .done(nResults: n)
         case .skipped: self = .skipped
-        case .failed(let m): self = .failed(message: m)
+        case .failed(let failure):
+            self = .failed(failure: LookupFailure(bridge: failure))
         }
     }
 }

--- a/bae-macos/bae/bae/Services/Store/SignalsToolbar.swift
+++ b/bae-macos/bae/bae/Services/Store/SignalsToolbar.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let logger = Logger.bae("SignalsToolbar")
 
 /// The interactive signals toolbar, mirrored from
 /// `bae_core::identify::ToolbarSignal` (via `BridgeSignalsToolbar`). Each
@@ -58,6 +61,87 @@ enum SignalRole: Equatable {
     }
 }
 
+/// Why a metadata lookup failed. Mirrors `bae_core::signals::LookupFailure`
+/// (via `BridgeLookupFailure`). The locale never crosses the bridge: core
+/// emits the typed reason and a stable catalog key; this resolves the
+/// localized line, rendering `provider`'s status as the message argument.
+/// `diagnostic` carries opaque, log-only detail — never primary copy.
+enum LookupFailure: Equatable {
+    case network
+    case provider(status: UInt16?)
+    case timeout
+    case diagnostic(detail: String)
+
+    init(bridge: BridgeLookupFailure) {
+        switch bridge {
+        case .network: self = .network
+        case .provider(let status): self = .provider(status: status)
+        case .timeout: self = .timeout
+        case .diagnostic(let detail): self = .diagnostic(detail: detail)
+        }
+    }
+
+    /// The bridge value this wraps — for resolving the catalog key core owns.
+    private var bridge: BridgeLookupFailure {
+        switch self {
+        case .network: .network
+        case .provider(let status): .provider(status: status)
+        case .timeout: .timeout
+        case .diagnostic(let detail): .diagnostic(detail: detail)
+        }
+    }
+
+    /// The localized one-line reason. `provider` formats the HTTP status into
+    /// the message (or a no-status fallback when absent); `diagnostic` has no
+    /// translated copy, so it renders a generic line — the opaque detail is
+    /// shown separately (`diagnosticDetail`), never as primary copy.
+    var localizedDescription: String {
+        switch self {
+        case .diagnostic:
+            // No translated copy — the opaque detail is shown separately.
+            return localizedCore("core.lookup.failure.diagnostic")
+        case .network, .timeout, .provider:
+            // Core owns the key for every typed variant (including the
+            // status-vs-no-status split for `provider`); the UI never picks it.
+            guard let key = bridgeLookupFailureKey(failure: bridge) else {
+                logger.warning(
+                    "no catalog key for lookup failure \(String(reflecting: self))"
+                )
+                return localizedCore("core.lookup.failure.diagnostic")
+            }
+            let format = localizedCore(key)
+            if case .provider(let status) = self, let status {
+                return String(format: format, NSNumber(value: status).intValue)
+            }
+            return format
+        }
+    }
+
+    /// The opaque, log-only detail for a `diagnostic` failure — shown as
+    /// secondary text, never translated. `nil` for the typed variants.
+    var diagnosticDetail: String? {
+        if case .diagnostic(let detail) = self {
+            return detail
+        }
+        return nil
+    }
+
+    /// The full badge line: the localized reason, with the opaque diagnostic
+    /// detail appended (so a local failure still surfaces its cause, never as
+    /// primary copy). The typed variants render their reason alone.
+    var badgeLine: String {
+        if let detail = diagnosticDetail {
+            return "\(localizedDescription): \(detail)"
+        }
+        return localizedDescription
+    }
+}
+
+/// Resolve a `core.*` catalog key through the app's String Catalog.
+private func localizedCore(_ key: String) -> String {
+    NSLocalizedString(key, tableName: "Core", bundle: .main, comment: "")
+}
+
 /// The live lookup/match state of one badge. Mirrors
 /// `bae_core::identify::SignalState`.
 enum SignalState: Equatable {
@@ -65,7 +149,7 @@ enum SignalState: Equatable {
     case found(count: UInt32)
     case noMatch
     case skipped
-    case failed(message: String)
+    case failed(failure: LookupFailure)
     case confirms(count: UInt32)
 
     init(bridge: BridgeSignalState) {
@@ -74,7 +158,8 @@ enum SignalState: Equatable {
         case .found(let count): self = .found(count: count)
         case .noMatch: self = .noMatch
         case .skipped: self = .skipped
-        case .failed(let message): self = .failed(message: message)
+        case .failed(let failure):
+            self = .failed(failure: LookupFailure(bridge: failure))
         case .confirms(let count): self = .confirms(count: count)
         }
     }

--- a/bae-macos/bae/bae/Views/Import/SignalsToolbarView.swift
+++ b/bae-macos/bae/bae/Views/Import/SignalsToolbarView.swift
@@ -510,8 +510,8 @@ private enum SignalBadgeStyle {
         case .skipped:
             return signal.kind == .discId
                 ? "No disc layout" : "No source to scan"
-        case .failed(let message):
-            return message
+        case .failed(let failure):
+            return failure.badgeLine
         case .confirms(let count):
             return count > 0
                 ? "Matches this pressing"

--- a/bae-macos/bae/bae/bae_bridgeFFI.h
+++ b/bae-macos/bae/bae/bae_bridgeFFI.h
@@ -967,6 +967,11 @@ RustBuffer uniffi_bae_bridge_fn_func_bridge_import_phase_key(RustBuffer phase, R
 RustBuffer uniffi_bae_bridge_fn_func_bridge_invalid_reason_key(RustBuffer reason, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_LOOKUP_FAILURE_KEY
+#define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_LOOKUP_FAILURE_KEY
+RustBuffer uniffi_bae_bridge_fn_func_bridge_lookup_failure_key(RustBuffer failure, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_PREPARE_STEP_KEY
 #define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_FN_FUNC_BRIDGE_PREPARE_STEP_KEY
 RustBuffer uniffi_bae_bridge_fn_func_bridge_prepare_step_key(RustBuffer step, RustCallStatus *_Nonnull out_status
@@ -1400,6 +1405,12 @@ uint16_t uniffi_bae_bridge_checksum_func_bridge_import_phase_key(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_INVALID_REASON_KEY
 #define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_INVALID_REASON_KEY
 uint16_t uniffi_bae_bridge_checksum_func_bridge_invalid_reason_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_LOOKUP_FAILURE_KEY
+#define UNIFFI_FFIDEF_UNIFFI_BAE_BRIDGE_CHECKSUM_FUNC_BRIDGE_LOOKUP_FAILURE_KEY
+uint16_t uniffi_bae_bridge_checksum_func_bridge_lookup_failure_key(void
     
 );
 #endif


### PR DESCRIPTION
Metadata-lookup failures crossed the bridge as free-form prose — `SignalState::Failed { message }` and the disc-id progress/signal `Failed` variants carried strings like "MusicBrainz lookup failed: …" / "provider returned 503", already English.

The failure is now a typed `BridgeLookupFailure`: `Network` / `Provider { status }` / `Timeout` / `Diagnostic { detail }`. The HTTP status was being flattened into prose inside `musicbrainz.rs` before any caller could structure it, so `Provider { status }` could never be truthful — this gives `MusicBrainzError` a status-carrying variant at the point of construction (distinguishing transport, timeout, and HTTP-status responses via the reqwest error) and threads it through `lookup_by_discid` → `lookup_and_resolve`. Local errors (DB load, not-found, compute-task) carry an opaque `detail` — log-only, never translated. The UI resolves `core.lookup.failure.*` keys and substitutes the provider status.

`search.rs` (the other `MusicBrainzError` consumer) is behaviorally unchanged — it routes the new variant through its existing `Display`-based handling.

## Test plan
- `cargo clippy` (bae-core, bae-bridge); `cargo test` incl. `lookup_failure_tests::keys_exist_in_catalog`
- macOS build green (full pre-commit gate)
- Trigger a disc-id lookup against an unreachable provider; confirm the toolbar badge renders the localized failure line