### PR TITLE
loc: localize macOS UI chrome

### DIFF
--- a/bae-macos/bae/bae/BaeApp.swift
+++ b/bae-macos/bae/bae/BaeApp.swift
@@ -57,7 +57,7 @@ struct BaeApp: App {
         if let name = appDelegate.appService?.configStore.config.libraryName,
             !name.isEmpty
         {
-            return "\(name) — bae"
+            return String(localized: "\(name) — bae")
         }
         return "bae"
     }
@@ -181,9 +181,11 @@ struct BaeApp: App {
     private var lockConfirmMessage: String {
         let name =
             appDelegate.appService?.configStore.config.libraryName
-            ?? "This library"
-        return
-            "\(name)'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+            ?? String(localized: "This library")
+        return String(
+            localized:
+                "\(name)'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+        )
     }
 
     /// Pre-shell content: shown before any library has been opened.
@@ -449,7 +451,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             }
             catch {
                 uiStore.showError(
-                    "Couldn't add folder: \(error.localizedDescription)"
+                    String(
+                        localized:
+                            "Couldn't add folder: \(error.localizedDescription)"
+                    )
                 )
             }
             uiStore.navigateToImport()

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -1,0 +1,36966 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "%@ - %@": {
+      "comment": "Search results track row: artist and album; first %@ is artist, second %@ is album title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ - %2$@"
+          }
+        }
+      }
+    },
+    "%@ · from %@": {
+      "comment": "Import signal badge popover: header combining the signal label and its origin; args are the signal label and origin label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · from %2$@"
+          }
+        }
+      }
+    },
+    "%@ — %lld of %lld": {
+      "comment": "Cover picker: source label and position; args are the cover label, current index, total count",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$lld of %3$lld"
+          }
+        }
+      }
+    },
+    "%@ — bae": {
+      "comment": "Main window title when a library is loaded; %@ is the library name, followed by the bae wordmark",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — bae"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@ — bae"
+          }
+        }
+      }
+    },
+    "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch.": {
+      "comment": "Lock Library confirmation alert body; %@ is the library name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%@'s encryption key will be removed from the keychain. This session keeps working; you'll need to re-enter the key on next launch."
+          }
+        }
+      }
+    },
+    "%lld files · %@": {
+      "comment": "Download/upload row: file count and total size; %lld is file count, %@ is formatted size",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "ar": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "he": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "uk": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "bg": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "cs": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        },
+        "hr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld file · %2$@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%1$lld files · %2$@"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld releases": {
+      "comment": "Storage Manager footer / signal badge: release count; %lld is the count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "ar": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "he": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "uk": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "bg": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "cs": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "hr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld tracks": {
+      "comment": "Track count beside the Tracks header / file pane / confirm summary; %lld is the count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "ar": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "he": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "uk": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "bg": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "cs": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        },
+        "hr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld track"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "%lld tracks"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "(%@)": {
+      "comment": "Search results: album year shown in parentheses; %@ is the year",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "(%@)"
+          }
+        }
+      }
+    },
+    "64-character hex-encoded encryption key": {
+      "comment": "Restore form: help text for the Encryption Key field",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "64-character hex-encoded encryption key"
+          }
+        }
+      }
+    },
+    "API key": {
+      "comment": "Discogs settings: API-key text field title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API key"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "API key"
+          }
+        }
+      }
+    },
+    "About": {
+      "comment": "Settings window: About tab label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
+          }
+        }
+      }
+    },
+    "Access Key": {
+      "comment": "S3 sync: access key secure field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access Key"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access Key"
+          }
+        }
+      }
+    },
+    "Access denied": {
+      "comment": "Sync wizard: error message when the provider denies authorization",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access denied"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Access denied"
+          }
+        }
+      }
+    },
+    "Account": {
+      "comment": "Cloud sync section: label for the connected account row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Account"
+          }
+        }
+      }
+    },
+    "Add": {
+      "comment": "Open panel button: add the selected folder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add"
+          }
+        }
+      }
+    },
+    "Add Next": {
+      "comment": "Album card context menu: enqueue next",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add Next"
+          }
+        }
+      }
+    },
+    "Add a folder to import music from": {
+      "comment": "Import empty state: prompt to add the first watched folder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to import music from"
+          }
+        }
+      }
+    },
+    "Add a folder to watch for imports": {
+      "comment": "Import candidate list: help tooltip on the add-folder button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a folder to watch for imports"
+          }
+        }
+      }
+    },
+    "Add sort criterion": {
+      "comment": "Album grid: tooltip for adding a sort criterion",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add sort criterion"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add sort criterion"
+          }
+        }
+      }
+    },
+    "Add to Queue": {
+      "comment": "Menu item: append to the playback queue",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add to Queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add to Queue"
+          }
+        }
+      }
+    },
+    "Added": {
+      "comment": "Import candidate list: tab for already-imported candidates",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Added"
+          }
+        }
+      }
+    },
+    "Album": {
+      "comment": "Storage table column / edit-metadata section / import search: album",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album"
+          }
+        }
+      }
+    },
+    "Album art": {
+      "comment": "Now-playing bar: accessibility label for the album art button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album art"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album art"
+          }
+        }
+      }
+    },
+    "Album artist": {
+      "comment": "Edit-metadata: album artist field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album artist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album artist"
+          }
+        }
+      }
+    },
+    "Album title": {
+      "comment": "Edit-metadata: album title field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Album title"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Album title"
+          }
+        }
+      }
+    },
+    "Albums": {
+      "comment": "Search results: albums section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albums"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Albums"
+          }
+        }
+      }
+    },
+    "All": {
+      "comment": "Storage Manager filter: all releases",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "All"
+          }
+        }
+      }
+    },
+    "Another release of this album is in your library": {
+      "comment": "Import confirm: info banner when a different release of the album is already imported",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Another release of this album is in your library"
+          }
+        }
+      }
+    },
+    "Any S3-compatible storage (AWS, Backblaze, Minio, ...)": {
+      "comment": "Sync wizard: S3 provider blurb (example service names are brands)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+          }
+        }
+      }
+    },
+    "Are you sure you want to delete this release? This cannot be undone.": {
+      "comment": "Album detail: delete-release confirmation message",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Are you sure you want to delete this release? This cannot be undone."
+          }
+        }
+      }
+    },
+    "Artist": {
+      "comment": "Storage table column / edit-metadata field / import search: artist",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artist"
+          }
+        }
+      }
+    },
+    "Artists, albums, tracks": {
+      "comment": "Title bar: library search field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Artists, albums, tracks"
+          }
+        }
+      }
+    },
+    "Audio": {
+      "comment": "Import file pane: section header for audio files",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Audio"
+          }
+        }
+      }
+    },
+    "Authorizing...": {
+      "comment": "OAuth row: authorization in progress",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorizing..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Authorizing..."
+          }
+        }
+      }
+    },
+    "Back": {
+      "comment": "Restore screen: go back to the chooser",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Back"
+          }
+        }
+      }
+    },
+    "Barcode": {
+      "comment": "Edit-metadata / import search: barcode field label & placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Barcode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Barcode"
+          }
+        }
+      }
+    },
+    "Browsable — stored unencrypted": {
+      "comment": "Sync wizard: browsable (unencrypted) storage option",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Browsable — stored unencrypted"
+          }
+        }
+      }
+    },
+    "Bucket": {
+      "comment": "S3 sync: bucket field label / placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bucket"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Bucket"
+          }
+        }
+      }
+    },
+    "CUE sheet": {
+      "comment": "Import signal badge popover: origin label for a CUE-sheet signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CUE sheet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CUE sheet"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "comment": "Generic cancel button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "Cancel Upload": {
+      "comment": "Storage table context menu: cancel an in-flight upload",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Upload"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel Upload"
+          }
+        }
+      }
+    },
+    "Cancel this download": {
+      "comment": "Download row: tooltip for the cancel button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel this download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cancel this download"
+          }
+        }
+      }
+    },
+    "Catalog": {
+      "comment": "Import pressing row / signal badge: catalog provenance label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catalog"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog"
+          }
+        }
+      }
+    },
+    "Catalog #": {
+      "comment": "Import search: tab for catalog-number search",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catalog #"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog #"
+          }
+        }
+      }
+    },
+    "Catalog number": {
+      "comment": "Edit-metadata: pressing catalog number field label & placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catalog number"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Catalog number"
+          }
+        }
+      }
+    },
+    "Change Cover": {
+      "comment": "Cover sheet title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Cover"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover"
+          }
+        }
+      }
+    },
+    "Change Cover...": {
+      "comment": "Album detail menu: open the change-cover sheet",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Cover..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Change Cover..."
+          }
+        }
+      }
+    },
+    "Check for Updates...": {
+      "comment": "App menu item (after About) that triggers a Sparkle update check",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Check for Updates..."
+          }
+        }
+      }
+    },
+    "Choose a scanned folder to search for metadata": {
+      "comment": "Import: placeholder description when no folder is selected",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Choose a scanned folder to search for metadata"
+          }
+        }
+      }
+    },
+    "Clear": {
+      "comment": "Queue panel: clear the queue",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clear"
+          }
+        }
+      }
+    },
+    "Click to exclude": {
+      "comment": "Import signal badge popover: hint to exclude an active signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click to exclude"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to exclude"
+          }
+        }
+      }
+    },
+    "Click to include": {
+      "comment": "Import signal badge popover: hint to re-include an excluded signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click to include"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Click to include"
+          }
+        }
+      }
+    },
+    "Close": {
+      "comment": "Re-identify / import confirm pane: close button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close"
+          }
+        }
+      }
+    },
+    "Close Library": {
+      "comment": "File menu: close the active library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Close Library"
+          }
+        }
+      }
+    },
+    "Cloud": {
+      "comment": "Storage state: release stored cloud-only",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud"
+          }
+        }
+      }
+    },
+    "Cloud provider": {
+      "comment": "Restore form: cloud provider picker label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud provider"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cloud provider"
+          }
+        }
+      }
+    },
+    "Collapse the sync queue": {
+      "comment": "Storage Manager: tooltip to collapse the sync queue",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Collapse the sync queue"
+          }
+        }
+      }
+    },
+    "Committing identity...": {
+      "comment": "Re-identify sheet: committing progress label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Committing identity..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Committing identity..."
+          }
+        }
+      }
+    },
+    "Confirm import": {
+      "comment": "Import: title of the docked confirmation pane",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm import"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm import"
+          }
+        }
+      }
+    },
+    "Connect": {
+      "comment": "Sync wizard: button to connect the configured S3 storage",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect"
+          }
+        }
+      }
+    },
+    "Connect %@": {
+      "comment": "Welcome screen: connect a cloud provider; %@ is the provider brand name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect %@"
+          }
+        }
+      }
+    },
+    "Connect another device": {
+      "comment": "Device-pairing sheet: title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect another device"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device"
+          }
+        }
+      }
+    },
+    "Connect another device...": {
+      "comment": "Library settings: button to open the device-pairing sheet",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect another device..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connect another device..."
+          }
+        }
+      }
+    },
+    "Connected": {
+      "comment": "OAuth row / Discogs: provider connected state",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        }
+      }
+    },
+    "Connecting...": {
+      "comment": "Sync wizard: OAuth connect button while a connect is in flight",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting..."
+          }
+        }
+      }
+    },
+    "Copy Code": {
+      "comment": "Device-pairing sheet: copy the pairing code to clipboard",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Code"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Code"
+          }
+        }
+      }
+    },
+    "Copy Details": {
+      "comment": "Error alert: copy the diagnostic detail to the clipboard",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Details"
+          }
+        }
+      }
+    },
+    "Copy Library ID": {
+      "comment": "File menu: copy the library ID to the clipboard",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Library ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Library ID"
+          }
+        }
+      }
+    },
+    "Copy details": {
+      "comment": "Error disclosure: tooltip for the copy button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy details"
+          }
+        }
+      }
+    },
+    "Could not read %@: %@": {
+      "comment": "Import file pane: error opening a CUE/text file; args are the file name and the system error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read %1$@: %2$@"
+          }
+        }
+      }
+    },
+    "Could not read dropped item": {
+      "comment": "Main view: error when a dropped item can't be read",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not read dropped item"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Could not read dropped item"
+          }
+        }
+      }
+    },
+    "Couldn't add folder: %@": {
+      "comment": "Error when adding a watched folder fails; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't add folder: %@"
+          }
+        }
+      }
+    },
+    "Couldn't check for cloud-only releases: %@": {
+      "comment": "Library settings: error computing the disconnect warning; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't check for cloud-only releases: %@"
+          }
+        }
+      }
+    },
+    "Couldn't load image": {
+      "comment": "Lightbox: shown when an image fails to load",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load image"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't load image"
+          }
+        }
+      }
+    },
+    "Couldn't re-check the Discogs key: %@": {
+      "comment": "Discogs settings: error re-validating the key; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't re-check the Discogs key: %@"
+          }
+        }
+      }
+    },
+    "Couldn't read the stored Discogs key: %@": {
+      "comment": "Discogs settings: error reading the stored key; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't read the stored Discogs key: %@"
+          }
+        }
+      }
+    },
+    "Couldn't remove folder: %@": {
+      "comment": "Error shown when removing a watched folder fails; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove folder: %@"
+          }
+        }
+      }
+    },
+    "Couldn't remove the Discogs key: %@": {
+      "comment": "Discogs settings: error removing the key; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't remove the Discogs key: %@"
+          }
+        }
+      }
+    },
+    "Couldn't save the Discogs key: %@": {
+      "comment": "Discogs settings: error saving the key; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't save the Discogs key: %@"
+          }
+        }
+      }
+    },
+    "Couldn't update skip state: %@": {
+      "comment": "Error shown when skipping/unskipping an import candidate fails; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Couldn't update skip state: %@"
+          }
+        }
+      }
+    },
+    "Country": {
+      "comment": "Edit-metadata: pressing country field label & placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Country"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Country"
+          }
+        }
+      }
+    },
+    "Cover Change Failed": {
+      "comment": "Album detail: alert title when changing the cover art fails",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cover Change Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover Change Failed"
+          }
+        }
+      }
+    },
+    "Cover OCR": {
+      "comment": "Import signal badge popover: origin label for text read from cover art",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cover OCR"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cover OCR"
+          }
+        }
+      }
+    },
+    "Create new library": {
+      "comment": "Welcome screen: create a new library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create new library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Create new library"
+          }
+        }
+      }
+    },
+    "Cycle Repeat Mode": {
+      "comment": "Playback menu: cycle the repeat mode",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Cycle Repeat Mode"
+          }
+        }
+      }
+    },
+    "Date Added (Newest)": {
+      "comment": "Import candidate list: sort by date added, newest first",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Newest)"
+          }
+        }
+      }
+    },
+    "Date Added (Oldest)": {
+      "comment": "Import candidate list: sort by date added, oldest first",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Date Added (Oldest)"
+          }
+        }
+      }
+    },
+    "Delete": {
+      "comment": "Album detail: confirm-delete button in the delete-release alert",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete"
+          }
+        }
+      }
+    },
+    "Delete Release": {
+      "comment": "Album detail: confirmation alert title / destructive menu item to delete a release",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Release"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Release"
+          }
+        }
+      }
+    },
+    "Delete original files": {
+      "comment": "Manage-confirm sheet toggle: delete the source files after import",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete original files"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete original files"
+          }
+        }
+      }
+    },
+    "Details": {
+      "comment": "Error disclosure: label for the collapsible diagnostic detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Details"
+          }
+        }
+      }
+    },
+    "Devices": {
+      "comment": "Library settings: section header for device pairing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Devices"
+          }
+        }
+      }
+    },
+    "Disc": {
+      "comment": "Edit-metadata track table: disc column header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disc"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc"
+          }
+        }
+      }
+    },
+    "Disc ID": {
+      "comment": "Import pressing row / signal badge: disc-ID provenance label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disc ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc ID"
+          }
+        }
+      }
+    },
+    "Disc TOC": {
+      "comment": "Import signal badge popover: origin label for a disc table-of-contents signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disc TOC"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disc TOC"
+          }
+        }
+      }
+    },
+    "DiscID": {
+      "comment": "Import search conflict: section title for disc-ID results",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DiscID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DiscID"
+          }
+        }
+      }
+    },
+    "Discogs": {
+      "comment": "Discogs settings: row heading; brand name, translators keep as-is",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs"
+          }
+        }
+      }
+    },
+    "Discogs rejected this key — check it and save again.": {
+      "comment": "Discogs settings: 401 rejection of the typed key",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Discogs rejected this key — check it and save again."
+          }
+        }
+      }
+    },
+    "Disconnect": {
+      "comment": "Cloud sync: button/confirm action to disconnect the cloud provider",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect"
+          }
+        }
+      }
+    },
+    "Disconnect sync?": {
+      "comment": "Library settings: title of the disconnect-sync confirmation alert",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect sync?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnect sync?"
+          }
+        }
+      }
+    },
+    "Documents": {
+      "comment": "Import file pane: section header for document files",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documents"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Documents"
+          }
+        }
+      }
+    },
+    "Done": {
+      "comment": "Sheet dismiss button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Done"
+          }
+        }
+      }
+    },
+    "Downloading %lld%%": {
+      "comment": "Download row state badge: downloading at a percent; %lld is the percent",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloading %lld%%"
+          }
+        }
+      }
+    },
+    "Downloads": {
+      "comment": "Storage Manager: download (pin) queue header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Downloads"
+          }
+        }
+      }
+    },
+    "Drag to resize": {
+      "comment": "Import: help tooltip on the confirm pane drag handle",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drag to resize"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag to resize"
+          }
+        }
+      }
+    },
+    "Drag tracks here or play an album": {
+      "comment": "Queue panel: empty-state description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drag tracks here or play an album"
+          }
+        }
+      }
+    },
+    "Drive ID": {
+      "comment": "Restore form (OneDrive): drive ID field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drive ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drive ID"
+          }
+        }
+      }
+    },
+    "Drop a folder to import, not a file": {
+      "comment": "Main view: error when a file (not a folder) is dropped",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Drop a folder to import, not a file"
+          }
+        }
+      }
+    },
+    "Dropbox": {
+      "comment": "Sync wizard: Dropbox provider name; brand, translators keep as-is",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dropbox"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dropbox"
+          }
+        }
+      }
+    },
+    "Edit Metadata": {
+      "comment": "Edit-metadata sheet title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Metadata"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit Metadata"
+          }
+        }
+      }
+    },
+    "Edit metadata...": {
+      "comment": "Album detail menu: open the edit-metadata sheet",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit metadata..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Edit metadata..."
+          }
+        }
+      }
+    },
+    "Encryption Key": {
+      "comment": "Restore form: encryption key secure field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encryption Key"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption Key"
+          }
+        }
+      }
+    },
+    "Encryption key (64 hex characters)": {
+      "comment": "Unlock screen: encryption key secure field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Encryption key (64 hex characters)"
+          }
+        }
+      }
+    },
+    "Endpoint": {
+      "comment": "S3 sync: label for the endpoint row / placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endpoint"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint"
+          }
+        }
+      }
+    },
+    "Endpoint (optional)": {
+      "comment": "Restore form (S3): optional endpoint field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Endpoint (optional)"
+          }
+        }
+      }
+    },
+    "Enter details manually": {
+      "comment": "Restore screen: disclosure group to enter cloud details by hand",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter details manually"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter details manually"
+          }
+        }
+      }
+    },
+    "Error": {
+      "comment": "Global error alert title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Error"
+          }
+        }
+      }
+    },
+    "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys.": {
+      "comment": "Sync wizard: explanation of opaque storage mode",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Every object is encrypted before upload. Anyone with access to the storage sees only ciphertext under opaque keys."
+          }
+        }
+      }
+    },
+    "Exact pressing": {
+      "comment": "Import confirm: segment claiming the picked pressing exactly",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exact pressing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Exact pressing"
+          }
+        }
+      }
+    },
+    "Excluded from search": {
+      "comment": "Import signal badge popover: state when the signal is excluded",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluded from search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Excluded from search"
+          }
+        }
+      }
+    },
+    "Expand the sync queue": {
+      "comment": "Storage Manager: tooltip to expand the collapsed sync queue",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand the sync queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Expand the sync queue"
+          }
+        }
+      }
+    },
+    "Export Failed": {
+      "comment": "Album detail: alert title when exporting a track fails",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Failed"
+          }
+        }
+      }
+    },
+    "FLAC (Lossless)": {
+      "comment": "Export format choice: FLAC lossless audio",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "FLAC (Lossless)"
+          }
+        }
+      }
+    },
+    "Failed": {
+      "comment": "Download state badge: failed",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed"
+          }
+        }
+      }
+    },
+    "Failed to %@: %@": {
+      "comment": "Storage action runner: error template; first %@ is the action verb, second %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to %1$@: %2$@"
+          }
+        }
+      }
+    },
+    "Failed to cancel upload: %@": {
+      "comment": "Storage action runner: error cancelling an upload; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel upload: %@"
+          }
+        }
+      }
+    },
+    "Failed to cancel: %@": {
+      "comment": "Storage Manager: error when cancelling an outbox item fails; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to cancel: %@"
+          }
+        }
+      }
+    },
+    "Failed to disconnect: %@": {
+      "comment": "Library settings: error disconnecting sync; %@ is the system error",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to disconnect: %@"
+          }
+        }
+      }
+    },
+    "Failed to load covers: %@": {
+      "comment": "Cover sheet: error when fetching remote covers fails; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to load covers: %@"
+          }
+        }
+      }
+    },
+    "Failed to retry uploads: %@": {
+      "comment": "Storage Manager: error when retrying the outbox fails; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to retry uploads: %@"
+          }
+        }
+      }
+    },
+    "Failed to set primary release: %@": {
+      "comment": "Album detail: error shown when setting the primary release fails; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Failed to set primary release: %@"
+          }
+        }
+      }
+    },
+    "Fetching covers...": {
+      "comment": "Cover sheet: loading state",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetching covers..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Fetching covers..."
+          }
+        }
+      }
+    },
+    "Files": {
+      "comment": "Storage sheet / table header: file list section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Files"
+          }
+        }
+      }
+    },
+    "Filter": {
+      "comment": "Storage Manager: filter picker label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter"
+          }
+        }
+      }
+    },
+    "Filter...": {
+      "comment": "Import candidate list: filter text field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Filter..."
+          }
+        }
+      }
+    },
+    "Folder ID": {
+      "comment": "Restore form: cloud folder ID field placeholder (Google Drive / OneDrive)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folder ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder ID"
+          }
+        }
+      }
+    },
+    "Folder Path": {
+      "comment": "Restore form (Dropbox): folder path field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folder Path"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Folder Path"
+          }
+        }
+      }
+    },
+    "Format": {
+      "comment": "Column / field header: audio format",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Format"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format"
+          }
+        }
+      }
+    },
+    "Format:": {
+      "comment": "Export save panel: label for the audio format picker",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Format:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Format:"
+          }
+        }
+      }
+    },
+    "Found from a previous setup on this Mac.": {
+      "comment": "Welcome screen InfoTip: explains keychain-discovered restore entries",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Found from a previous setup on this Mac."
+          }
+        }
+      }
+    },
+    "General": {
+      "comment": "Import search: tab for general artist/album search",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "General"
+          }
+        }
+      }
+    },
+    "Get started with your music library.": {
+      "comment": "Welcome screen subtitle",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get started with your music library."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Get started with your music library."
+          }
+        }
+      }
+    },
+    "Go to Now Playing": {
+      "comment": "Menu: navigate to the now-playing album",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to Now Playing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Go to Now Playing"
+          }
+        }
+      }
+    },
+    "Google Drive": {
+      "comment": "Sync wizard: Google Drive provider name; brand, translators keep as-is",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Drive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Google Drive"
+          }
+        }
+      }
+    },
+    "Hello": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hello"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Hello"
+          }
+        }
+      }
+    },
+    "Identifies · finds releases": {
+      "comment": "Import signal badge popover: role label for an identity signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifies · finds releases"
+          }
+        }
+      }
+    },
+    "Identifying…": {
+      "comment": "Import search: placeholder title while auto-identification runs",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifying…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identifying…"
+          }
+        }
+      }
+    },
+    "Identity updated.": {
+      "comment": "Re-identify sheet: success heading after committing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identity updated."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Identity updated."
+          }
+        }
+      }
+    },
+    "Ignore Barcode": {
+      "comment": "Import search conflict: link to exclude the barcode signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore Barcode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Barcode"
+          }
+        }
+      }
+    },
+    "Ignore Catalog": {
+      "comment": "Import search conflict: link to exclude the catalog signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore Catalog"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore Catalog"
+          }
+        }
+      }
+    },
+    "Ignore DiscID": {
+      "comment": "Import search conflict: link to exclude the disc-ID signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore DiscID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ignore DiscID"
+          }
+        }
+      }
+    },
+    "Images": {
+      "comment": "Import file pane: section header for image files",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Images"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Images"
+          }
+        }
+      }
+    },
+    "Import": {
+      "comment": "Menu / title-bar segment / import confirm button: the import action",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import"
+          }
+        }
+      }
+    },
+    "Import Folder...": {
+      "comment": "File menu: add a folder to watch for import",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Folder..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Folder..."
+          }
+        }
+      }
+    },
+    "Import as": {
+      "comment": "Import confirm: label before the Exact pressing / Metadata only segmented choice",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import as"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import as"
+          }
+        }
+      }
+    },
+    "Import some music to get started": {
+      "comment": "Library: empty-state description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import some music to get started"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import some music to get started"
+          }
+        }
+      }
+    },
+    "Imported": {
+      "comment": "Import confirm: status label when the import is complete",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported"
+          }
+        }
+      }
+    },
+    "Imported — upload failed, retrying": {
+      "comment": "Import confirm: status when import succeeded but the cloud upload is retrying",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — upload failed, retrying"
+          }
+        }
+      }
+    },
+    "Imported — uploading to cloud": {
+      "comment": "Import confirm: status while the imported release's files are uploading",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Imported — uploading to cloud"
+          }
+        }
+      }
+    },
+    "In library": {
+      "comment": "Import pressing row: tag marking an already-imported pressing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "In library"
+          }
+        }
+      }
+    },
+    "Keep current metadata": {
+      "comment": "Re-identify sheet: decline refreshing metadata",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep current metadata"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep current metadata"
+          }
+        }
+      }
+    },
+    "Keep local copy": {
+      "comment": "Import confirm: toggle to keep a local copy of managed files",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep local copy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keep local copy"
+          }
+        }
+      }
+    },
+    "Key Prefix": {
+      "comment": "Sync wizard: S3 key-prefix text field title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key Prefix"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key Prefix"
+          }
+        }
+      }
+    },
+    "Key fingerprint: %@": {
+      "comment": "Unlock screen: shows the encryption key fingerprint; %@ is the fingerprint",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Key fingerprint: %@"
+          }
+        }
+      }
+    },
+    "Kind": {
+      "comment": "Storage sheet file table: content-type column header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kind"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Kind"
+          }
+        }
+      }
+    },
+    "Label": {
+      "comment": "Edit-metadata: pressing label field label & placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Label"
+          }
+        }
+      }
+    },
+    "Learn more": {
+      "comment": "InfoTip popover: link to documentation",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Learn more"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Learn more"
+          }
+        }
+      }
+    },
+    "Leave empty for standard AWS S3": {
+      "comment": "Restore form (S3): help text for the Endpoint field",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Leave empty for standard AWS S3"
+          }
+        }
+      }
+    },
+    "Library": {
+      "comment": "Restore screen labeled value / library section / library nav title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library"
+          }
+        }
+      }
+    },
+    "Library ID": {
+      "comment": "Restore form: library ID field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library ID"
+          }
+        }
+      }
+    },
+    "Library Locked": {
+      "comment": "Unlock screen title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library Locked"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Locked"
+          }
+        }
+      }
+    },
+    "Library Name (optional)": {
+      "comment": "Restore form: optional library name field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Library Name (optional)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Library Name (optional)"
+          }
+        }
+      }
+    },
+    "Likely imported": {
+      "comment": "Import candidate row: subtitle marking a folder that was probably already imported",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Likely imported"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Likely imported"
+          }
+        }
+      }
+    },
+    "Loading": {
+      "comment": "Play/pause control: tooltip and a11y label while a track loads",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading"
+          }
+        }
+      }
+    },
+    "Loading release details...": {
+      "comment": "Import: progress text while the picked release's detail loads",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading release details..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading release details..."
+          }
+        }
+      }
+    },
+    "Loading...": {
+      "comment": "Progress spinner label shown on startup before a library opens",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Loading..."
+          }
+        }
+      }
+    },
+    "Lock": {
+      "comment": "Destructive confirm button in the Lock Library alert",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lock"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock"
+          }
+        }
+      }
+    },
+    "Lock Library...": {
+      "comment": "File menu: lock the library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lock Library..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock Library..."
+          }
+        }
+      }
+    },
+    "Lock library?": {
+      "comment": "Title of the confirmation alert for locking the active library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lock library?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Lock library?"
+          }
+        }
+      }
+    },
+    "Looking up the signals above.": {
+      "comment": "Import search: placeholder description while auto-identifying",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Looking up the signals above."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up the signals above."
+          }
+        }
+      }
+    },
+    "Looking up…": {
+      "comment": "Import signal badge popover: state while an identity signal is looking up",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Looking up…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Looking up…"
+          }
+        }
+      }
+    },
+    "MP3 (320 kbps)": {
+      "comment": "Export format choice: MP3 at 320 kbps",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "MP3 (320 kbps)"
+          }
+        }
+      }
+    },
+    "Managed": {
+      "comment": "Storage Manager filter: managed releases",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Managed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Managed"
+          }
+        }
+      }
+    },
+    "Matches this pressing": {
+      "comment": "Import signal badge popover: state when a catalog filter confirms the pressing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matches this pressing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matches this pressing"
+          }
+        }
+      }
+    },
+    "Matching…": {
+      "comment": "Import signal badge popover: state while a filter signal is matching",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matching…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Matching…"
+          }
+        }
+      }
+    },
+    "Metadata only": {
+      "comment": "Import confirm: segment claiming just the album group, leaving pressing fields blank",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metadata only"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only"
+          }
+        }
+      }
+    },
+    "Metadata only — pressing fields stay blank; just the album group is recorded.": {
+      "comment": "Import confirm: note under the toggle when Metadata only is chosen",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Metadata only — pressing fields stay blank; just the album group is recorded."
+          }
+        }
+      }
+    },
+    "Move": {
+      "comment": "Manage-confirm sheet: confirm moving the release into the library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move"
+          }
+        }
+      }
+    },
+    "Move Here": {
+      "comment": "Open/save panel button: confirm moving release files to the chosen folder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Here"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move Here"
+          }
+        }
+      }
+    },
+    "Move into library": {
+      "comment": "Manage-confirm sheet title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move into library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move into library"
+          }
+        }
+      }
+    },
+    "Move to New": {
+      "comment": "Import candidate row: context-menu action to unskip a candidate",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to New"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Move to New"
+          }
+        }
+      }
+    },
+    "Mute": {
+      "comment": "Now-playing bar: mute button tooltip and a11y label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mute"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Mute"
+          }
+        }
+      }
+    },
+    "Name": {
+      "comment": "Storage sheet file table: filename column header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name"
+          }
+        }
+      }
+    },
+    "Name (A–Z)": {
+      "comment": "Import candidate list: sort by name ascending",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name (A–Z)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (A–Z)"
+          }
+        }
+      }
+    },
+    "Name (Z–A)": {
+      "comment": "Import candidate list: sort by name descending",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name (Z–A)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Name (Z–A)"
+          }
+        }
+      }
+    },
+    "New": {
+      "comment": "Import candidate list: tab for new (not-yet-imported) candidates",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New"
+          }
+        }
+      }
+    },
+    "New Library...": {
+      "comment": "File menu: create a new library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Library..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New Library..."
+          }
+        }
+      }
+    },
+    "New name": {
+      "comment": "Rename-library sheet: new name text field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "New name"
+          }
+        }
+      }
+    },
+    "Next Library": {
+      "comment": "File menu: switch to the next library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Library"
+          }
+        }
+      }
+    },
+    "Next Track": {
+      "comment": "Playback menu: skip to the next track",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next Track"
+          }
+        }
+      }
+    },
+    "Next track": {
+      "comment": "Now-playing bar: next-track button tooltip and a11y label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Next track"
+          }
+        }
+      }
+    },
+    "No Libraries": {
+      "comment": "Open Library submenu: disabled item when no libraries exist",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Libraries"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No Libraries"
+          }
+        }
+      }
+    },
+    "No albums": {
+      "comment": "Library: empty-state title when no albums exist",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No albums"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No albums"
+          }
+        }
+      }
+    },
+    "No automatic matches found": {
+      "comment": "Import search: banner when auto-identification found nothing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No automatic matches found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No automatic matches found"
+          }
+        }
+      }
+    },
+    "No cover art available": {
+      "comment": "Cover picker: empty state title when there is no remote or local artwork",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No cover art available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No cover art available"
+          }
+        }
+      }
+    },
+    "No disc layout": {
+      "comment": "Import signal badge popover: state when no disc layout was available for a disc-ID signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disc layout"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No disc layout"
+          }
+        }
+      }
+    },
+    "No identifying signals yet — search manually": {
+      "comment": "Import search: banner when there are no signals to identify with",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No identifying signals yet — search manually"
+          }
+        }
+      }
+    },
+    "No image": {
+      "comment": "Lightbox: shown when an image has no local path",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No image"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No image"
+          }
+        }
+      }
+    },
+    "No library loaded": {
+      "comment": "Placeholder title shown in the Storage Manager and Settings windows when no library is open",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No library loaded"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No library loaded"
+          }
+        }
+      }
+    },
+    "No matched pressing carries this catno": {
+      "comment": "Import signal badge popover: state when no matched pressing carries this catalog number",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matched pressing carries this catno"
+          }
+        }
+      }
+    },
+    "No matches": {
+      "comment": "Import candidate list: empty state when the filter matches nothing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matches"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches"
+          }
+        }
+      }
+    },
+    "No matches found": {
+      "comment": "Import search: empty state when a manual search returned nothing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matches found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No matches found"
+          }
+        }
+      }
+    },
+    "No releases matched": {
+      "comment": "Import signal badge popover: state when the signal found no releases",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No releases matched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No releases matched"
+          }
+        }
+      }
+    },
+    "No remote covers found": {
+      "comment": "Cover sheet: empty state for remote covers",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No remote covers found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote covers found"
+          }
+        }
+      }
+    },
+    "No remote or local artwork found": {
+      "comment": "Cover picker: empty state description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No remote or local artwork found"
+          }
+        }
+      }
+    },
+    "No results": {
+      "comment": "Import search: empty state before any manual search has run",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No results"
+          }
+        }
+      }
+    },
+    "No source to scan": {
+      "comment": "Import signal badge popover: state when there was no source to scan for the signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No source to scan"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No source to scan"
+          }
+        }
+      }
+    },
+    "No tracks": {
+      "comment": "Edit-metadata: shown when the release has no tracks",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tracks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No tracks"
+          }
+        }
+      }
+    },
+    "Nothing here yet": {
+      "comment": "Import candidate list: empty state when a tab has no items",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing here yet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Nothing here yet"
+          }
+        }
+      }
+    },
+    "Now Playing": {
+      "comment": "Queue panel: now-playing section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now Playing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Now Playing"
+          }
+        }
+      }
+    },
+    "OAuth token required for Dropbox": {
+      "comment": "Restore error: missing OAuth token for Dropbox",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Dropbox"
+          }
+        }
+      }
+    },
+    "OAuth token required for Google Drive": {
+      "comment": "Restore error: missing OAuth token for Google Drive",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for Google Drive"
+          }
+        }
+      }
+    },
+    "OAuth token required for OneDrive": {
+      "comment": "Restore error: missing OAuth token for OneDrive",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OAuth token required for OneDrive"
+          }
+        }
+      }
+    },
+    "OK": {
+      "comment": "Generic alert dismiss button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library.": {
+      "comment": "Sync wizard: explanation of browsable storage mode",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Objects are stored in the clear at readable paths, so anyone with access to the storage can read your files by name. Sharing is unavailable for a browsable library."
+          }
+        }
+      }
+    },
+    "OneDrive": {
+      "comment": "Sync wizard: OneDrive provider name; brand, translators keep as-is",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDrive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OneDrive"
+          }
+        }
+      }
+    },
+    "Opaque — end-to-end encrypted": {
+      "comment": "Sync wizard: opaque (encrypted) storage option",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opaque — end-to-end encrypted"
+          }
+        }
+      }
+    },
+    "Open Library": {
+      "comment": "File menu: submenu to open/switch libraries",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Library"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "comment": "Import search: button opening settings from the Discogs popover",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Settings"
+          }
+        }
+      }
+    },
+    "Open a library first": {
+      "comment": "Placeholder description in the Storage Manager window when no library is open",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open a library first"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first"
+          }
+        }
+      }
+    },
+    "Open a library first to access settings": {
+      "comment": "Placeholder description in the Settings window when no library is open",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open a library first to access settings"
+          }
+        }
+      }
+    },
+    "Open release group on %@": {
+      "comment": "Import release-group card: help tooltip on the source link; %@ is the source name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open release group on %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open release group on %@"
+          }
+        }
+      }
+    },
+    "Opens your browser to authorize bae with %@.": {
+      "comment": "Sync wizard: OAuth step explanation; %@ is the provider name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Opens your browser to authorize bae with %@."
+          }
+        }
+      }
+    },
+    "Paste restore code": {
+      "comment": "Restore screen: restore-code text field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste restore code"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste restore code"
+          }
+        }
+      }
+    },
+    "Paste your key here": {
+      "comment": "Discogs settings: API-key field placeholder prompt",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste your key here"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your key here"
+          }
+        }
+      }
+    },
+    "Paste your restore code, or enter details manually.": {
+      "comment": "Restore screen subtitle",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paste your restore code, or enter details manually."
+          }
+        }
+      }
+    },
+    "Path": {
+      "comment": "Library settings: label for the library folder path row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Path"
+          }
+        }
+      }
+    },
+    "Pause": {
+      "comment": "Queue control / play-pause: pause",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause"
+          }
+        }
+      }
+    },
+    "Paused": {
+      "comment": "Queue state badge: paused",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paused"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Paused"
+          }
+        }
+      }
+    },
+    "Pending delete": {
+      "comment": "Outbox delete row state badge",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pending delete"
+          }
+        }
+      }
+    },
+    "Pick the release you have, or dismiss the signal you trust less.": {
+      "comment": "Import search: conflict banner subtitle prompting a choice",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick the release you have, or dismiss the signal you trust less."
+          }
+        }
+      }
+    },
+    "Pin for offline": {
+      "comment": "Manage-confirm sheet toggle: keep a local copy",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin for offline"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pin for offline"
+          }
+        }
+      }
+    },
+    "Pinned": {
+      "comment": "Storage table storage badge: pinned for offline",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinned"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned"
+          }
+        }
+      }
+    },
+    "Pinned for offline": {
+      "comment": "Storage state: release kept available offline",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinned for offline"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pinned for offline"
+          }
+        }
+      }
+    },
+    "Play": {
+      "comment": "Play button / menu item",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play"
+          }
+        }
+      }
+    },
+    "Play / Pause": {
+      "comment": "Playback menu: toggle play/pause",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play / Pause"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play / Pause"
+          }
+        }
+      }
+    },
+    "Play Next": {
+      "comment": "Menu item: enqueue immediately after the current track",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play Next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Play Next"
+          }
+        }
+      }
+    },
+    "Playback": {
+      "comment": "Menu bar Playback menu / settings tab title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        }
+      }
+    },
+    "Playback position": {
+      "comment": "Now-playing bar: accessibility label for the progress bar",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback position"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback position"
+          }
+        }
+      }
+    },
+    "Previous Library": {
+      "comment": "File menu: switch to the previous library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Library"
+          }
+        }
+      }
+    },
+    "Previous Track": {
+      "comment": "Playback menu: skip to the previous track",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous Track"
+          }
+        }
+      }
+    },
+    "Previous track": {
+      "comment": "Now-playing bar: previous-track button tooltip and a11y label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Previous track"
+          }
+        }
+      }
+    },
+    "Provider": {
+      "comment": "Restore screen / cloud sync section: labeled value for the cloud provider",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Provider"
+          }
+        }
+      }
+    },
+    "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten.": {
+      "comment": "Re-identify sheet: refresh-prompt body",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten."
+          }
+        }
+      }
+    },
+    "Queue": {
+      "comment": "Queue panel title / queue button tooltip and a11y label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue"
+          }
+        }
+      }
+    },
+    "Queue is empty": {
+      "comment": "Queue panel: empty-state title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queue is empty"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queue is empty"
+          }
+        }
+      }
+    },
+    "Queued": {
+      "comment": "Download/upload state badge: queued",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queued"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Queued"
+          }
+        }
+      }
+    },
+    "Re-check": {
+      "comment": "Discogs settings: button to re-validate the stored API key",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-check"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-check"
+          }
+        }
+      }
+    },
+    "Re-identify": {
+      "comment": "Re-identify sheet title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-identify"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify"
+          }
+        }
+      }
+    },
+    "Re-identify failed.": {
+      "comment": "Re-identify sheet: error heading",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-identify failed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify failed."
+          }
+        }
+      }
+    },
+    "Re-identify...": {
+      "comment": "Album detail menu: open the re-identify sheet",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-identify..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-identify..."
+          }
+        }
+      }
+    },
+    "Re-run": {
+      "comment": "Import signals toolbar: link to re-run identification",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-run"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Re-run"
+          }
+        }
+      }
+    },
+    "Reconnect": {
+      "comment": "Library settings: sync-error banner reconnect button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reconnect"
+          }
+        }
+      }
+    },
+    "Refine": {
+      "comment": "Import signals toolbar: divider label before the filter badges",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refine"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refine"
+          }
+        }
+      }
+    },
+    "Refines · narrows the match": {
+      "comment": "Import signal badge popover: role label for a filter signal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refines · narrows the match"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "comment": "Cover sheet: refresh the remote covers",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh"
+          }
+        }
+      }
+    },
+    "Refresh from new source": {
+      "comment": "Re-identify sheet: accept refreshing metadata from the new source",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh from new source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refresh from new source"
+          }
+        }
+      }
+    },
+    "Refreshing metadata from new source...": {
+      "comment": "Re-identify sheet: refreshing progress label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Refreshing metadata from new source..."
+          }
+        }
+      }
+    },
+    "Region": {
+      "comment": "S3 sync: region field label / placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Region"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Region"
+          }
+        }
+      }
+    },
+    "Release %lld": {
+      "comment": "Album detail release picker: fallback segment label when a release has no display name; %lld is the release ordinal",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release %lld"
+          }
+        }
+      }
+    },
+    "Release Files": {
+      "comment": "Cover sheet: section header for images already in the release",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release Files"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release Files"
+          }
+        }
+      }
+    },
+    "Release pressing": {
+      "comment": "Edit-metadata: section header for pressing fields",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release pressing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Release pressing"
+          }
+        }
+      }
+    },
+    "Remote Sources": {
+      "comment": "Cover sheet: section header for remote cover candidates",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote Sources"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "comment": "Destructive action: remove an item",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove"
+          }
+        }
+      }
+    },
+    "Remove Folder": {
+      "comment": "Import: context-menu action to stop watching a folder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Folder"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove Folder"
+          }
+        }
+      }
+    },
+    "Remove from Queue": {
+      "comment": "Queue row context menu: remove the item",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from Queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from Queue"
+          }
+        }
+      }
+    },
+    "Remove from queue": {
+      "comment": "Queue row: tooltip for the remove button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from queue"
+          }
+        }
+      }
+    },
+    "Remove from the sync queue": {
+      "comment": "Outbox row: tooltip for the cancel/remove button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove from the sync queue"
+          }
+        }
+      }
+    },
+    "Remove this library from your keychain?": {
+      "comment": "Welcome screen: confirmation dialog title for removing a keychain restore entry",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remove this library from your keychain?"
+          }
+        }
+      }
+    },
+    "Rename": {
+      "comment": "Rename-library sheet: confirm rename button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename"
+          }
+        }
+      }
+    },
+    "Rename Library": {
+      "comment": "Rename-library sheet title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library"
+          }
+        }
+      }
+    },
+    "Rename Library...": {
+      "comment": "File menu: rename the library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Library..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Rename Library..."
+          }
+        }
+      }
+    },
+    "Repeat: album": {
+      "comment": "Now-playing bar: repeat button tooltip/a11y when repeating the album",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeat: album"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: album"
+          }
+        }
+      }
+    },
+    "Repeat: off": {
+      "comment": "Now-playing bar: repeat button tooltip/a11y when repeat is off",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeat: off"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: off"
+          }
+        }
+      }
+    },
+    "Repeat: track": {
+      "comment": "Now-playing bar: repeat button tooltip/a11y when repeating the track",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeat: track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Repeat: track"
+          }
+        }
+      }
+    },
+    "Reset failed: %@": {
+      "comment": "Edit-metadata sheet: reset error; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset failed: %@"
+          }
+        }
+      }
+    },
+    "Reset to Source": {
+      "comment": "Edit-metadata sheet: reset fields to the identified source",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reset to Source"
+          }
+        }
+      }
+    },
+    "Resetting...": {
+      "comment": "Edit-metadata sheet: resetting in-progress status",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resetting..."
+          }
+        }
+      }
+    },
+    "Restore": {
+      "comment": "Welcome screen: restore the selected library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
+          }
+        }
+      }
+    },
+    "Restore code": {
+      "comment": "Restore screen: section header for the restore-code field",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore code"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore code"
+          }
+        }
+      }
+    },
+    "Restore from Code...": {
+      "comment": "File menu: restore a library from a code",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore from Code..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Code..."
+          }
+        }
+      }
+    },
+    "Restore from cloud": {
+      "comment": "Welcome screen: button/title to restore a library from cloud",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore from cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from cloud"
+          }
+        }
+      }
+    },
+    "Restore on launch": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore on launch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore on launch"
+          }
+        }
+      }
+    },
+    "Restore your libraries": {
+      "comment": "Welcome screen: header above multiple restorable keychain libraries",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore your libraries"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your libraries"
+          }
+        }
+      }
+    },
+    "Restore your library": {
+      "comment": "Welcome screen: header above a single restorable keychain library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore your library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your library"
+          }
+        }
+      }
+    },
+    "Restoring library...": {
+      "comment": "Restore screen: in-progress status",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restoring library..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring library..."
+          }
+        }
+      }
+    },
+    "Resume": {
+      "comment": "Queue control: resume",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Resume"
+          }
+        }
+      }
+    },
+    "Retry Import": {
+      "comment": "Import confirm: button to retry a failed import",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry Import"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry Import"
+          }
+        }
+      }
+    },
+    "Retry now": {
+      "comment": "Queue control: retry failed items immediately",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retry now"
+          }
+        }
+      }
+    },
+    "Retrying (%lld)": {
+      "comment": "Outbox upload row state badge: retrying after failure; %lld is the attempt count",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Retrying (%lld)"
+          }
+        }
+      }
+    },
+    "Reveal Library in Finder": {
+      "comment": "File menu: reveal the library folder in Finder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal Library in Finder"
+          }
+        }
+      }
+    },
+    "Reveal in Finder": {
+      "comment": "Context-menu / tooltip: reveal a folder in Finder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Reveal in Finder"
+          }
+        }
+      }
+    },
+    "S3-compatible": {
+      "comment": "Sync wizard: S3 provider name (S3 is a brand; 'compatible' is descriptive)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S3-compatible"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "S3-compatible"
+          }
+        }
+      }
+    },
+    "Save": {
+      "comment": "Edit-metadata / Discogs: save button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save"
+          }
+        }
+      }
+    },
+    "Save As...": {
+      "comment": "Track context menu: export the track to a file",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save As..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save As..."
+          }
+        }
+      }
+    },
+    "Save failed: %@": {
+      "comment": "Edit-metadata sheet: save error; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Save failed: %@"
+          }
+        }
+      }
+    },
+    "Saved — couldn't validate yet (offline). Will retry.": {
+      "comment": "Discogs settings: unvalidated key status (offline)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saved — couldn't validate yet (offline). Will retry."
+          }
+        }
+      }
+    },
+    "Saves the current track, position, queue, and volume on quit and restores them on next launch.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saves the current track, position, queue, and volume on quit and restores them on next launch."
+          }
+        }
+      }
+    },
+    "Saving...": {
+      "comment": "Edit-metadata sheet: saving in-progress status",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saving..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Saving..."
+          }
+        }
+      }
+    },
+    "Scan failed: %@": {
+      "comment": "Error shown when scanning watched folders fails; %@ is the system error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan failed: %@"
+          }
+        }
+      }
+    },
+    "Scan this QR code or paste the code on another device to sync this library there.": {
+      "comment": "Device-pairing sheet: instructional caption",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan this QR code or paste the code on another device to sync this library there."
+          }
+        }
+      }
+    },
+    "Search": {
+      "comment": "Menu / import search: focus or submit search",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search"
+          }
+        }
+      }
+    },
+    "Search MusicBrainz or Discogs to find metadata": {
+      "comment": "Import search: empty state description before searching",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search MusicBrainz or Discogs to find metadata"
+          }
+        }
+      }
+    },
+    "Search failed: %@": {
+      "comment": "Title bar: error when a library search fails; %@ is the error description",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search failed: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search failed: %@"
+          }
+        }
+      }
+    },
+    "Search manually": {
+      "comment": "Import signals toolbar: escape to the manual search form",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search manually"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Search manually"
+          }
+        }
+      }
+    },
+    "Searching...": {
+      "comment": "Import search: progress text while a manual search runs",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Searching..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Searching..."
+          }
+        }
+      }
+    },
+    "Secret Key": {
+      "comment": "S3 sync: secret key secure field placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secret Key"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Secret Key"
+          }
+        }
+      }
+    },
+    "Section": {
+      "comment": "Title bar: accessibility label for the library/import section picker",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Section"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Section"
+          }
+        }
+      }
+    },
+    "Select a folder": {
+      "comment": "Import: placeholder title when no scanned folder is selected",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a folder"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder"
+          }
+        }
+      }
+    },
+    "Select a folder to watch for music to import": {
+      "comment": "Open panel message when adding a watched import folder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select a folder to watch for music to import"
+          }
+        }
+      }
+    },
+    "Set Up Sync": {
+      "comment": "Sync wizard: title on the provider-selection step",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Up Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set Up Sync"
+          }
+        }
+      }
+    },
+    "Set as Primary Release": {
+      "comment": "Album detail menu: make this release the album's primary",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set as Primary Release"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set as Primary Release"
+          }
+        }
+      }
+    },
+    "Set identity": {
+      "comment": "Re-identify sheet: commit the selected identity",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set identity"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity"
+          }
+        }
+      }
+    },
+    "Set identity to this pressing": {
+      "comment": "Re-identify sheet: footer label before the set-identity button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set identity to this pressing"
+          }
+        }
+      }
+    },
+    "Set up sync...": {
+      "comment": "Library settings: button to start the sync setup wizard",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set up sync..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set up sync..."
+          }
+        }
+      }
+    },
+    "Settings": {
+      "comment": "Title bar: settings button tooltip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Settings"
+          }
+        }
+      }
+    },
+    "Shuffle": {
+      "comment": "Album detail menu: shuffle-play the release",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shuffle"
+          }
+        }
+      }
+    },
+    "Signals": {
+      "comment": "Import signals toolbar: header label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signals"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals"
+          }
+        }
+      }
+    },
+    "Signals disagree on identity": {
+      "comment": "Import search: conflict banner title when signals point to different releases",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Signals disagree on identity"
+          }
+        }
+      }
+    },
+    "Size": {
+      "comment": "Column header: file size",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Size"
+          }
+        }
+      }
+    },
+    "Skip": {
+      "comment": "Import candidate row: context-menu action to skip a candidate",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip"
+          }
+        }
+      }
+    },
+    "Skip identifying": {
+      "comment": "Import signals toolbar: escape to add the candidate as Unknown",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip identifying"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skip identifying"
+          }
+        }
+      }
+    },
+    "Skipped": {
+      "comment": "Import candidate list: tab for manually-skipped candidates",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skipped"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Skipped"
+          }
+        }
+      }
+    },
+    "Sort": {
+      "comment": "Import candidate list: sort menu section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort"
+          }
+        }
+      }
+    },
+    "Sort Ascending": {
+      "comment": "Album grid sort chip: switch to ascending order",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort Ascending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Ascending"
+          }
+        }
+      }
+    },
+    "Sort Descending": {
+      "comment": "Album grid sort chip: switch to descending order",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort Descending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sort Descending"
+          }
+        }
+      }
+    },
+    "Starting re-identify...": {
+      "comment": "Re-identify sheet: initial progress label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starting re-identify..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Starting re-identify..."
+          }
+        }
+      }
+    },
+    "Storage": {
+      "comment": "Storage sheet / column header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage"
+          }
+        }
+      }
+    },
+    "Storage Manager": {
+      "comment": "Menu / window title: the Storage Manager",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage Manager"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage Manager"
+          }
+        }
+      }
+    },
+    "Storage...": {
+      "comment": "Album detail menu: open the storage management sheet",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Storage..."
+          }
+        }
+      }
+    },
+    "Switching libraries...": {
+      "comment": "Progress spinner label shown while swapping the active library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switching libraries..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Switching libraries..."
+          }
+        }
+      }
+    },
+    "Sync": {
+      "comment": "Library settings: section header for cloud sync",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync"
+          }
+        }
+      }
+    },
+    "Sync Now": {
+      "comment": "File menu: trigger a sync immediately",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync Now"
+          }
+        }
+      }
+    },
+    "Sync is failing": {
+      "comment": "Library settings: sync-error banner heading",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync is failing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync is failing"
+          }
+        }
+      }
+    },
+    "Sync queue": {
+      "comment": "Storage Manager: outbox/sync queue header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync queue"
+          }
+        }
+      }
+    },
+    "Sync via Dropbox": {
+      "comment": "Sync wizard: Dropbox provider blurb",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Dropbox"
+          }
+        }
+      }
+    },
+    "Sync via Google Drive": {
+      "comment": "Sync wizard: Google Drive provider blurb",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Google Drive"
+          }
+        }
+      }
+    },
+    "Sync via Microsoft OneDrive": {
+      "comment": "Sync wizard: OneDrive provider blurb",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via Microsoft OneDrive"
+          }
+        }
+      }
+    },
+    "Sync via your iCloud account": {
+      "comment": "Sync wizard: iCloud provider blurb",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Sync via your iCloud account"
+          }
+        }
+      }
+    },
+    "Text file": {
+      "comment": "Import signal badge popover: origin label for a signal from a text file",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text file"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Text file"
+          }
+        }
+      }
+    },
+    "The Google Drive folder ID containing your library": {
+      "comment": "Restore form: help text for the Google Drive folder ID field",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The Google Drive folder ID containing your library"
+          }
+        }
+      }
+    },
+    "The UUID from your other device's library": {
+      "comment": "Restore form: help text for the Library ID field",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The UUID from your other device's library"
+          }
+        }
+      }
+    },
+    "The cloud upload failed and retries automatically. See the Storage Manager for details.": {
+      "comment": "Import confirm: help tooltip on the upload-failed status",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The cloud upload failed and retries automatically. See the Storage Manager for details."
+          }
+        }
+      }
+    },
+    "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock.": {
+      "comment": "Unlock screen instructions",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "The encryption key for this library is not in the keyring. Enter the 64-character hex key to unlock."
+          }
+        }
+      }
+    },
+    "This library": {
+      "comment": "Fallback name for the active library in the lock-confirmation message when no library name is set",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This library"
+          }
+        }
+      }
+    },
+    "This release is already in your library": {
+      "comment": "Import confirm: warning banner when the exact release is already imported",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This release is already in your library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This release is already in your library"
+          }
+        }
+      }
+    },
+    "This will stop syncing and remove the cloud provider configuration.": {
+      "comment": "Library settings: disconnect confirmation body (a cloud-only data-loss warning from core may be appended)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "This will stop syncing and remove the cloud provider configuration."
+          }
+        }
+      }
+    },
+    "Title": {
+      "comment": "Edit-metadata: album/track title field label & placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Title"
+          }
+        }
+      }
+    },
+    "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above.": {
+      "comment": "Discogs settings: how to connect (markdown link)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To connect, [get your free API key](https://www.discogs.com/settings/developers) and paste it above."
+          }
+        }
+      }
+    },
+    "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings.": {
+      "comment": "Import search: popover instructing the user to add a Discogs API key (markdown link)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "To search Discogs, [get your free API key](https://www.discogs.com/settings/developers) and add it in settings."
+          }
+        }
+      }
+    },
+    "Toggle Queue": {
+      "comment": "Menu: show/hide the playback queue",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Queue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Queue"
+          }
+        }
+      }
+    },
+    "Total: %@": {
+      "comment": "Storage Manager footer: total size of loaded releases; %@ is a formatted byte count",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Total: %@"
+          }
+        }
+      }
+    },
+    "Track": {
+      "comment": "Edit-metadata track table: track-number column header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Track"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track"
+          }
+        }
+      }
+    },
+    "Track count mismatch: release has %lld tracks but local files don't match": {
+      "comment": "Import confirm: warning that the source release track count differs from local files; %lld is the release track count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "ar": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "he": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "uk": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "bg": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "cs": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        },
+        "hr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld track but local files don't match"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Track count mismatch: release has %lld tracks but local files don't match"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Track not found for export": {
+      "comment": "Album detail: error when the track to export can't be found",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Track not found for export"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Track not found for export"
+          }
+        }
+      }
+    },
+    "Tracks": {
+      "comment": "Search results / edit-metadata: tracks section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tracks"
+          }
+        }
+      }
+    },
+    "Transfer Failed": {
+      "comment": "Album detail: alert title when a storage transfer (pin/unpin/manage) fails",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Transfer Failed"
+          }
+        }
+      }
+    },
+    "Try different search terms or another source": {
+      "comment": "Import search: empty state description after a failed search",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Try different search terms or another source"
+          }
+        }
+      }
+    },
+    "Unlock": {
+      "comment": "Unlock screen: unlock button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unlock"
+          }
+        }
+      }
+    },
+    "Unmanaged": {
+      "comment": "Storage state: files live outside the managed library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmanaged"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmanaged"
+          }
+        }
+      }
+    },
+    "Unmute": {
+      "comment": "Now-playing bar: unmute button tooltip and a11y label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmute"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Unmute"
+          }
+        }
+      }
+    },
+    "Uploading": {
+      "comment": "Storage Manager filter / upload state badge",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploading"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading"
+          }
+        }
+      }
+    },
+    "Uploading (%lld remaining)…": {
+      "comment": "Album detail storage band: in-flight upload progress; %lld is remaining item count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "ar": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "he": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "uk": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "bg": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "cs": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        },
+        "hr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "Uploading (%lld remaining)…"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Uploading (%lld)": {
+      "comment": "Storage table/badge: uploading; %lld is pending item count",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uploading (%lld)"
+          }
+        }
+      }
+    },
+    "Use This Cover": {
+      "comment": "Cover picker: confirm the selected cover art",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use This Cover"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use This Cover"
+          }
+        }
+      }
+    },
+    "Use iCloud": {
+      "comment": "Sync wizard: button to connect via iCloud",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use iCloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use iCloud"
+          }
+        }
+      }
+    },
+    "Uses iCloud for sync. Requires iCloud to be enabled in System Settings.": {
+      "comment": "Sync wizard: iCloud step explanation",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses iCloud for sync. Requires iCloud to be enabled in System Settings."
+          }
+        }
+      }
+    },
+    "Uses track layout to find perfect matches on MusicBrainz.": {
+      "comment": "Import search: info tip explaining disc-ID identification",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Uses track layout to find perfect matches on MusicBrainz."
+          }
+        }
+      }
+    },
+    "Version %@": {
+      "comment": "About tab: app version label; %@ is the version string",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Version %@"
+          }
+        }
+      }
+    },
+    "View automatic matches (%lld)": {
+      "comment": "Import search: button returning from manual search to the auto-identified matches; %lld is the pressing count",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View automatic matches (%lld)"
+          }
+        }
+      }
+    },
+    "View in Library": {
+      "comment": "Import confirm: button linking to the matching album already in the library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View in Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View in Library"
+          }
+        }
+      }
+    },
+    "Volume": {
+      "comment": "Now-playing bar: accessibility label for the volume slider",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volume"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Volume"
+          }
+        }
+      }
+    },
+    "Year": {
+      "comment": "Edit-metadata: pressing year field label & placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Year"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year"
+          }
+        }
+      }
+    },
+    "Year unknown": {
+      "comment": "Import pressing row: shown when the pressing has no year",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Year unknown"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Year unknown"
+          }
+        }
+      }
+    },
+    "You will not be able to recover this library without a restore code.": {
+      "comment": "Welcome screen: confirmation dialog message for removing a keychain restore entry",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "You will not be able to recover this library without a restore code."
+          }
+        }
+      }
+    },
+    "Your libraries": {
+      "comment": "Welcome screen: header above multiple on-device libraries",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your libraries"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your libraries"
+          }
+        }
+      }
+    },
+    "Your library": {
+      "comment": "Welcome screen: header above a single on-device library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your library"
+          }
+        }
+      }
+    },
+    "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more.": {
+      "comment": "Import search: popover explaining the Discogs source (markdown link)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more."
+          }
+        }
+      }
+    },
+    "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums.": {
+      "comment": "Discogs settings: description of the Discogs service (markdown link)",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "[Discogs](https://www.discogs.com) is a music database with detailed release info — labels, catalog numbers, pressing variants, and more. bae can use it as a metadata source when importing albums."
+          }
+        }
+      }
+    },
+    "bae": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bae"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "bae"
+          }
+        }
+      }
+    },
+    "comma-separated": {
+      "comment": "Edit-metadata: hint that the artist field accepts comma-separated names",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "comma-separated"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "comma-separated"
+          }
+        }
+      }
+    },
+    "e.g. /Apps/bae/My Library": {
+      "comment": "Restore form (Dropbox): example folder path help text",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. /Apps/bae/My Library"
+          }
+        }
+      }
+    },
+    "e.g. 4943674251780": {
+      "comment": "Import search: barcode field placeholder example",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. 4943674251780"
+          }
+        }
+      }
+    },
+    "e.g. WPCR-80001": {
+      "comment": "Import search: catalog-number field placeholder example",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "e.g. WPCR-80001"
+          }
+        }
+      }
+    },
+    "file name": {
+      "comment": "Import signal badge popover: origin label for a signal from a file name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "file name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "file name"
+          }
+        }
+      }
+    },
+    "folder name": {
+      "comment": "Import signal badge popover: origin label for a signal from the folder name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "folder name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "folder name"
+          }
+        }
+      }
+    },
+    "iCloud": {
+      "comment": "Sync wizard: iCloud provider name; brand, translators keep as-is",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
+          }
+        }
+      }
+    },
+    "matched %lld releases": {
+      "comment": "Import search conflict: barcode section subtitle; %lld is the match count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "ar": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "he": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "uk": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "bg": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "cs": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        },
+        "hr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "new",
+                  "value": "matched %lld releases"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "matched %lld releases on %@": {
+      "comment": "Import search conflict: disc-ID section subtitle; args are the match count and the source label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "matched %1$lld releases on %2$@"
+          }
+        }
+      }
+    },
+    "move into library": {
+      "comment": "Storage action verb (manage), inserted into 'Failed to %@: ...'",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "move into library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move into library"
+          }
+        }
+      }
+    },
+    "move out of library": {
+      "comment": "Storage action verb (unmanage), inserted into 'Failed to %@: ...'",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "move out of library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "move out of library"
+          }
+        }
+      }
+    },
+    "remove local copy": {
+      "comment": "Storage action verb (unpin), inserted into 'Failed to %@: ...'",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remove local copy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "remove local copy"
+          }
+        }
+      }
+    },
+    "· blank = album artist": {
+      "comment": "Edit-metadata track table: hint that a blank track artist inherits the album artist",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· blank = album artist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "· blank = album artist"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -499,7 +499,7 @@ struct AlbumDetailView: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
-        panel.prompt = "Move Here"
+        panel.prompt = String(localized: "Move Here")
 
         guard panel.runModal() == .OK, let url = panel.url else {
             return
@@ -522,7 +522,10 @@ struct AlbumDetailView: View {
             catch {
                 await MainActor.run {
                     uiStore.showError(
-                        "Failed to set primary release: \(error.localizedDescription)"
+                        String(
+                            localized:
+                                "Failed to set primary release: \(error.localizedDescription)"
+                        )
                     )
                 }
             }
@@ -531,7 +534,7 @@ struct AlbumDetailView: View {
 
     private func exportTrack(trackId: String, tracks: [Track]) {
         guard let track = tracks.first(where: { $0.id == trackId }) else {
-            uiStore.showError("Track not found for export")
+            uiStore.showError(String(localized: "Track not found for export"))
             return
         }
         let trackTitle = track.title
@@ -557,7 +560,10 @@ struct AlbumDetailView: View {
             frame: NSRect(x: 0, y: 0, width: 200, height: 24),
             pullsDown: false
         )
-        formatPopup.addItems(withTitles: ["FLAC (Lossless)", "MP3 (320 kbps)"])
+        formatPopup.addItems(withTitles: [
+            String(localized: "FLAC (Lossless)"),
+            String(localized: "MP3 (320 kbps)"),
+        ])
         formatPopup.selectItem(
             at: UserDefaults.standard.integer(forKey: "exportFormat")
         )
@@ -567,7 +573,7 @@ struct AlbumDetailView: View {
         let accessoryContainer = NSView(
             frame: NSRect(x: 0, y: 0, width: 250, height: 34)
         )
-        let label = NSTextField(labelWithString: "Format:")
+        let label = NSTextField(labelWithString: String(localized: "Format:"))
         label.frame = NSRect(x: 0, y: 7, width: 50, height: 20)
         formatPopup.frame = NSRect(x: 54, y: 5, width: 190, height: 24)
         accessoryContainer.addSubview(label)
@@ -665,7 +671,7 @@ struct AlbumExpansionContent: View {
                         Text(summary.artistNames)
                             .foregroundStyle(.secondary)
                         if let year = summary.year {
-                            Text("\u{00B7}")
+                            Text(verbatim: "\u{00B7}")
                                 .foregroundStyle(.tertiary)
                             Text(String(year))
                                 .foregroundStyle(.tertiary)
@@ -789,7 +795,7 @@ struct AlbumExpansionContent: View {
                 .map { index, ref in
                     NativeSegmentedControl.Segment(
                         label: libraryStore.releaseDetails[ref.id]?.displayName
-                            ?? "Release \(index + 1)",
+                            ?? String(localized: "Release \(index + 1)"),
                         systemImage: releaseContainsCurrentTrack(id: ref.id)
                             ? "speaker.fill" : nil,
                     )
@@ -1025,7 +1031,7 @@ private struct TrackRowView: View {
 
     private var trackNumberLabel: some View {
         if track.positionText.isEmpty {
-            Text("-")
+            Text(verbatim: "-")
         }
         else {
             Text(track.positionText)
@@ -1143,7 +1149,10 @@ private struct StorageStatusBand: View {
             else if let progress = uploadProgress {
                 progressBar(
                     value: progress.fraction,
-                    label: "Uploading (\(progress.pending) remaining)…"
+                    label: String(
+                        localized:
+                            "Uploading (\(Int(progress.pending)) remaining)…"
+                    )
                 )
             }
             else {
@@ -1370,7 +1379,10 @@ extension View {
     /// Presents an OK-dismissible alert bound to an optional error message,
     /// clearing it on dismiss. Collapses the repeated "alert over a `String?`
     /// @State error" pattern.
-    fileprivate func errorAlert(_ title: String, message: Binding<String?>)
+    fileprivate func errorAlert(
+        _ title: LocalizedStringKey,
+        message: Binding<String?>
+    )
         -> some View
     {
         alert(

--- a/bae-macos/bae/bae/Views/AlbumGridView.swift
+++ b/bae-macos/bae/bae/Views/AlbumGridView.swift
@@ -413,12 +413,16 @@ private struct CardMenuButton: View {
     private func presentMenu() {
         showMenu = true
         let menu = NSMenu()
-        let playItem = MenuItem(title: "Play") { onPlay() }
+        let playItem = MenuItem(title: String(localized: "Play")) { onPlay() }
         menu.addItem(playItem)
         menu.addItem(NSMenuItem.separator())
-        let queueItem = MenuItem(title: "Add to Queue") { onAddToQueue() }
+        let queueItem = MenuItem(title: String(localized: "Add to Queue")) {
+            onAddToQueue()
+        }
         menu.addItem(queueItem)
-        let nextItem = MenuItem(title: "Add Next") { onAddNext() }
+        let nextItem = MenuItem(title: String(localized: "Add Next")) {
+            onAddNext()
+        }
         menu.addItem(nextItem)
 
         menu.popUp(

--- a/bae-macos/bae/bae/Views/CoverSheetView.swift
+++ b/bae-macos/bae/bae/Views/CoverSheetView.swift
@@ -136,8 +136,10 @@ struct CoverSheetView: View {
             // Sheet dismissed mid-fetch; teardown owns the next transition.
         }
         catch {
-            errorMessage =
-                "Failed to load covers: \(error.localizedDescription)"
+            errorMessage = String(
+                localized:
+                    "Failed to load covers: \(error.localizedDescription)"
+            )
             loading = false
         }
     }

--- a/bae-macos/bae/bae/Views/EditMetadataForm.swift
+++ b/bae-macos/bae/bae/Views/EditMetadataForm.swift
@@ -44,18 +44,18 @@ struct EditMetadataForm: View {
 
     private var albumGroup: some View {
         groupCard(
-            title: "Album",
+            title: String(localized: "Album"),
             rows: [
                 FieldRow(
-                    label: "Title",
-                    placeholder: "Album title",
+                    label: String(localized: "Title"),
+                    placeholder: String(localized: "Album title"),
                     text: $form.albumTitle,
                     width: .long,
                 ),
                 FieldRow(
-                    label: "Artist",
-                    hint: "comma-separated",
-                    placeholder: "Album artist",
+                    label: String(localized: "Artist"),
+                    hint: String(localized: "comma-separated"),
+                    placeholder: String(localized: "Album artist"),
                     text: $form.albumArtistText,
                     width: .long,
                 ),
@@ -67,42 +67,42 @@ struct EditMetadataForm: View {
 
     private var pressingGroup: some View {
         groupCard(
-            title: "Release pressing",
+            title: String(localized: "Release pressing"),
             rows: [
                 FieldRow(
-                    label: "Year",
-                    placeholder: "Year",
+                    label: String(localized: "Year"),
+                    placeholder: String(localized: "Year"),
                     text: $form.pressing.year,
                     width: .short,
                     monospaced: true,
                 ),
                 FieldRow(
-                    label: "Format",
-                    placeholder: "Format",
+                    label: String(localized: "Format"),
+                    placeholder: String(localized: "Format"),
                     text: $form.pressing.format,
                     width: .short,
                 ),
                 FieldRow(
-                    label: "Label",
-                    placeholder: "Label",
+                    label: String(localized: "Label"),
+                    placeholder: String(localized: "Label"),
                     text: $form.pressing.label,
                     width: .long,
                 ),
                 FieldRow(
-                    label: "Catalog number",
-                    placeholder: "Catalog number",
+                    label: String(localized: "Catalog number"),
+                    placeholder: String(localized: "Catalog number"),
                     text: $form.pressing.catalogNumber,
                     width: .medium,
                 ),
                 FieldRow(
-                    label: "Country",
-                    placeholder: "Country",
+                    label: String(localized: "Country"),
+                    placeholder: String(localized: "Country"),
                     text: $form.pressing.country,
                     width: .short,
                 ),
                 FieldRow(
-                    label: "Barcode",
-                    placeholder: "Barcode",
+                    label: String(localized: "Barcode"),
+                    placeholder: String(localized: "Barcode"),
                     text: $form.pressing.barcode,
                     width: .medium,
                     monospaced: true,
@@ -115,7 +115,10 @@ struct EditMetadataForm: View {
 
     private var tracksGroup: some View {
         VStack(alignment: .leading, spacing: 8) {
-            sectionHeader(title: "Tracks", trailing: trackCountLabel)
+            sectionHeader(
+                title: String(localized: "Tracks"),
+                trailing: trackCountLabel
+            )
             VStack(spacing: 0) {
                 trackHeaderRow
                 if form.tracks.isEmpty {
@@ -148,25 +151,25 @@ struct EditMetadataForm: View {
     }
 
     private var trackCountLabel: String {
-        form.tracks.count == 1 ? "1 track" : "\(form.tracks.count) tracks"
+        String(localized: "\(form.tracks.count) tracks")
     }
 
     private var trackHeaderRow: some View {
         HStack(spacing: 10) {
-            eyebrow("#")
+            eyebrow(Text(verbatim: "#"))
                 .frame(width: trackOrdinalWidth)
-            eyebrow("Title")
+            eyebrow(Text("Title"))
                 .frame(maxWidth: .infinity, alignment: .leading)
             HStack(spacing: 4) {
-                eyebrow("Artist")
+                eyebrow(Text("Artist"))
                 Text("· blank = album artist")
                     .font(.system(size: 10))
                     .foregroundStyle(.quaternary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            eyebrow("Disc")
+            eyebrow(Text("Disc"))
                 .frame(width: trackNumberWidth)
-            eyebrow("Track")
+            eyebrow(Text("Track"))
                 .frame(width: trackNumberWidth)
         }
         .padding(.horizontal, 14)
@@ -185,13 +188,13 @@ struct EditMetadataForm: View {
         isLast: Bool,
     ) -> some View {
         HStack(spacing: 10) {
-            Text("\(index + 1)")
+            Text(verbatim: (index + 1).formatted())
                 .font(.system(size: 12))
                 .monospacedDigit()
                 .foregroundStyle(.tertiary)
                 .frame(width: trackOrdinalWidth)
             MetadataField(
-                placeholder: "Title",
+                placeholder: String(localized: "Title"),
                 text: track.title,
                 boxed: false,
             )
@@ -226,7 +229,8 @@ struct EditMetadataForm: View {
     /// Empty track-artist fields inherit the album artist; surfacing it as
     /// the placeholder shows what a blank row will resolve to.
     private var trackArtistPlaceholder: String {
-        form.albumArtistText.isEmpty ? "Artist" : form.albumArtistText
+        form.albumArtistText.isEmpty
+            ? String(localized: "Artist") : form.albumArtistText
     }
 
     private let trackOrdinalWidth: CGFloat = 34
@@ -291,7 +295,7 @@ struct EditMetadataForm: View {
         trailing: String?
     ) -> some View {
         HStack(alignment: .firstTextBaseline) {
-            eyebrow(title, size: 11)
+            eyebrow(Text(verbatim: title), size: 11)
             Spacer()
             if let trailing {
                 Text(trailing)
@@ -305,8 +309,8 @@ struct EditMetadataForm: View {
 
     /// Section headers render at 11pt; the denser track-table column
     /// headers pass `size: 10`.
-    private func eyebrow(_ text: String, size: CGFloat = 10) -> some View {
-        Text(text)
+    private func eyebrow(_ text: Text, size: CGFloat = 10) -> some View {
+        text
             .font(.system(size: size, weight: .bold))
             .textCase(.uppercase)
             .tracking(1)

--- a/bae-macos/bae/bae/Views/EditMetadataSheet.swift
+++ b/bae-macos/bae/bae/Views/EditMetadataSheet.swift
@@ -160,7 +160,9 @@ struct EditMetadataSheet: View {
             }
             catch {
                 saving = false
-                errorMessage = "Save failed: \(error.localizedDescription)"
+                errorMessage = String(
+                    localized: "Save failed: \(error.localizedDescription)"
+                )
             }
         }
     }
@@ -183,7 +185,9 @@ struct EditMetadataSheet: View {
             }
             catch {
                 resetting = false
-                errorMessage = "Reset failed: \(error.localizedDescription)"
+                errorMessage = String(
+                    localized: "Reset failed: \(error.localizedDescription)"
+                )
             }
         }
     }

--- a/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
+++ b/bae-macos/bae/bae/Views/Import/FolderImportTab.swift
@@ -104,7 +104,9 @@ struct FolderImportTab: View {
             }
             catch {
                 uiStore.showError(
-                    "Scan failed: \(error.localizedDescription)"
+                    String(
+                        localized: "Scan failed: \(error.localizedDescription)"
+                    )
                 )
             }
         }
@@ -134,8 +136,10 @@ struct FolderImportTab: View {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
-        panel.message = "Select a folder to watch for music to import"
-        panel.prompt = "Add"
+        panel.message = String(
+            localized: "Select a folder to watch for music to import"
+        )
+        panel.prompt = String(localized: "Add")
         guard panel.runModal() == .OK, let url = panel.url else {
             return
         }
@@ -144,7 +148,10 @@ struct FolderImportTab: View {
         }
         catch {
             uiStore.showError(
-                "Couldn't add folder: \(error.localizedDescription)"
+                String(
+                    localized:
+                        "Couldn't add folder: \(error.localizedDescription)"
+                )
             )
         }
     }
@@ -212,7 +219,10 @@ struct FolderImportTab: View {
         }
         catch {
             uiStore.showError(
-                "Couldn't update skip state: \(error.localizedDescription)"
+                String(
+                    localized:
+                        "Couldn't update skip state: \(error.localizedDescription)"
+                )
             )
         }
     }
@@ -231,7 +241,10 @@ struct FolderImportTab: View {
         }
         catch {
             uiStore.showError(
-                "Couldn't remove folder: \(error.localizedDescription)"
+                String(
+                    localized:
+                        "Couldn't remove folder: \(error.localizedDescription)"
+                )
             )
         }
     }

--- a/bae-macos/bae/bae/Views/Import/ImportAsToggle.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportAsToggle.swift
@@ -42,7 +42,7 @@ struct ImportAsToggle: View {
     }
 
     private func segment(
-        _ title: String,
+        _ title: LocalizedStringKey,
         selected: Bool,
         action: @escaping () -> Void
     ) -> some View {

--- a/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
@@ -262,9 +262,10 @@ struct ImportCandidateListContent: View {
     }
 
     @ViewBuilder
-    private func sortButton(_ order: CandidateSortOrder, _ label: String)
-        -> some View
-    {
+    private func sortButton(
+        _ order: CandidateSortOrder,
+        _ label: LocalizedStringKey
+    ) -> some View {
         Button {
             sortOrder = order
         } label: {
@@ -298,9 +299,11 @@ private struct CandidateTabBar: View {
         }
     }
 
-    private func segment(_ tab: CandidateTab, _ label: String, _ count: Int)
-        -> some View
-    {
+    private func segment(
+        _ tab: CandidateTab,
+        _ label: LocalizedStringKey,
+        _ count: Int
+    ) -> some View {
         let isActive = activeTab == tab
         return Button {
             activeTab = tab
@@ -309,7 +312,7 @@ private struct CandidateTabBar: View {
                 Text(label)
                     .font(.caption)
                     .fontWeight(isActive ? .semibold : .regular)
-                Text("\(count)")
+                Text(verbatim: count.formatted())
                     .font(.caption2)
                     .monospacedDigit()
                     .padding(.horizontal, 5)
@@ -363,7 +366,7 @@ private struct FolderSectionHeader: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
             Spacer()
-            Text("\(count)")
+            Text(verbatim: count.formatted())
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundStyle(.tertiary)

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
@@ -194,7 +194,7 @@ struct ImportConfirmationView<
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                         Text(
-                            "Track count mismatch: release has \(expectedTrackCount) tracks but local files don't match"
+                            "Track count mismatch: release has \(Int(expectedTrackCount)) tracks but local files don't match"
                         )
                         .font(.callout)
                         .foregroundStyle(.orange)
@@ -272,7 +272,7 @@ struct ImportConfirmationView<
     /// rather than leaving stray separators.
     private var metaLine: String {
         let count = values.tracks.count
-        let trackText = count == 1 ? "1 track" : "\(count) tracks"
+        let trackText = String(localized: "\(count) tracks")
         return [values.pressing.format, values.pressing.year, trackText]
             .filter { !$0.isEmpty }
             .joined(separator: " · ")
@@ -291,8 +291,7 @@ struct ImportConfirmationView<
                         .foregroundStyle(.orange)
                         .font(.callout)
                         .help(
-                            "The cloud upload failed and retries automatically. "
-                                + "See the Storage Manager for details."
+                            "The cloud upload failed and retries automatically. See the Storage Manager for details."
                         )
                     }
                     else {

--- a/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportFilePane.swift
@@ -98,7 +98,7 @@ struct ImportFilePane: View {
     /// extending to the trailing edge. Replaces the chevron-collapsible
     /// section headers — the accent rules carry the hierarchy now.
     private func accentSection<Content: View>(
-        _ title: String,
+        _ title: LocalizedStringKey,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -210,7 +210,10 @@ struct ImportFilePane: View {
                             }
                             catch {
                                 onError(
-                                    "Could not read \(pair.cueName): \(error.localizedDescription)"
+                                    String(
+                                        localized:
+                                            "Could not read \(pair.cueName): \(error.localizedDescription)"
+                                    )
                                 )
                             }
                         } label: {
@@ -228,7 +231,7 @@ struct ImportFilePane: View {
                             .padding(.leading, 8)
                     }
                     if let trackCount = pair.trackCount {
-                        Text("\(trackCount) tracks")
+                        Text("\(Int(trackCount)) tracks")
                             .font(.caption2)
                             .fontWeight(.semibold)
                             .foregroundStyle(Theme.accent)
@@ -306,7 +309,10 @@ struct ImportFilePane: View {
             }
             catch {
                 onError(
-                    "Could not read \(file.name): \(error.localizedDescription)"
+                    String(
+                        localized:
+                            "Could not read \(file.name): \(error.localizedDescription)"
+                    )
                 )
             }
         }

--- a/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchPane.swift
@@ -73,14 +73,14 @@ struct ImportSearchFormView: View {
                 HStack {
                     AutocompleteTextField(
                         text: $searchArtist,
-                        placeholder: "Artist",
+                        placeholder: String(localized: "Artist"),
                         suggestions: generalSuggestions,
                         isLoading: isScanning,
                         onSubmit: { onSearch() },
                     )
                     AutocompleteTextField(
                         text: $searchAlbum,
-                        placeholder: "Album",
+                        placeholder: String(localized: "Album"),
                         suggestions: generalSuggestions,
                         isLoading: isScanning,
                         onSubmit: { onSearch() },
@@ -92,7 +92,7 @@ struct ImportSearchFormView: View {
                 HStack {
                     AutocompleteTextField(
                         text: $searchCatalog,
-                        placeholder: "e.g. WPCR-80001",
+                        placeholder: String(localized: "e.g. WPCR-80001"),
                         suggestions: catalogSuggestions,
                         isLoading: isScanning,
                         onSubmit: { onSearch() },
@@ -318,8 +318,7 @@ struct ImportSearchPane: View {
                         onViewMatches()
                     } label: {
                         Label(
-                            "View automatic matches "
-                                + "(\(found.group.pressings.count))",
+                            "View automatic matches (\(found.group.pressings.count))",
                             systemImage: "chevron.left",
                         )
                     }
@@ -544,7 +543,7 @@ struct ImportSearchPane: View {
     @ViewBuilder
     private func conflictSection(
         signal: ExcludedSignal,
-        title: String,
+        title: LocalizedStringKey,
         subtitle: AttributedString,
         results: [MetadataResult],
         libraryStatuses: [String: LibraryStatus],
@@ -594,9 +593,8 @@ struct ImportSearchPane: View {
     private func discidSectionSubtitle(count: Int, sourceLabel: String)
         -> AttributedString
     {
-        let releaseWord = count == 1 ? "release" : "releases"
-        return AttributedString(
-            "matched \(count) \(releaseWord) on \(sourceLabel)"
+        AttributedString(
+            String(localized: "matched \(count) releases on \(sourceLabel)")
         )
     }
 
@@ -608,8 +606,9 @@ struct ImportSearchPane: View {
         count: Int,
         matchedBarcode: String?
     ) -> AttributedString {
-        let releaseWord = count == 1 ? "release" : "releases"
-        var subtitle = AttributedString("matched \(count) \(releaseWord)")
+        var subtitle = AttributedString(
+            String(localized: "matched \(count) releases")
+        )
         if let barcode = matchedBarcode, !barcode.isEmpty {
             subtitle += AttributedString(" · ")
             var mono = AttributedString(barcode)
@@ -621,9 +620,9 @@ struct ImportSearchPane: View {
 
     private func ignoreButtonLabel(signal: ExcludedSignal) -> String {
         switch signal {
-        case .disc: "Ignore DiscID"
-        case .barcode: "Ignore Barcode"
-        case .catalog: "Ignore Catalog"
+        case .disc: String(localized: "Ignore DiscID")
+        case .barcode: String(localized: "Ignore Barcode")
+        case .catalog: String(localized: "Ignore Catalog")
         }
     }
 

--- a/bae-macos/bae/bae/Views/Import/ImportSearchResultRow.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchResultRow.swift
@@ -109,7 +109,7 @@ struct ImportSearchResultRow: View {
             if result.format != nil
                 && (result.catalogNumber != nil || result.country != nil)
             {
-                Text("·")
+                Text(verbatim: "·")
                     .font(.caption2)
                     .foregroundStyle(.quaternary)
             }
@@ -151,7 +151,11 @@ struct ImportSearchResultRow: View {
         }
     }
 
-    private func signalBadge(_ label: String, icon: String, on: Bool)
+    private func signalBadge(
+        _ label: LocalizedStringKey,
+        icon: String,
+        on: Bool
+    )
         -> some View
     {
         HStack(spacing: 3) {

--- a/bae-macos/bae/bae/Views/Import/ImportView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportView.swift
@@ -11,11 +11,11 @@ enum CandidateSortOrder: String, CaseIterable {
 }
 
 struct ImportCheckboxToggle: View {
-    let title: String
+    let title: LocalizedStringKey
     @Binding
     var isOn: Bool
 
-    init(_ title: String, isOn: Binding<Bool>) {
+    init(_ title: LocalizedStringKey, isOn: Binding<Bool>) {
         self.title = title
         _isOn = isOn
     }

--- a/bae-macos/bae/bae/Views/Import/SignalsToolbarView.swift
+++ b/bae-macos/bae/bae/Views/Import/SignalsToolbarView.swift
@@ -216,7 +216,7 @@ struct WrappingHStack: Layout {
 /// A transparent ghost pill button — the toolbar's escape actions.
 private struct GhostPill: View {
     let icon: String?
-    let label: String
+    let label: LocalizedStringKey
     let action: () -> Void
 
     @State
@@ -351,7 +351,7 @@ private struct SignalBadge: View {
                     .scaleEffect(0.6)
                     .frame(width: 16, height: 16)
             case .found(let count):
-                countCapsule("\(count)", tone: .green)
+                countCapsule(count.formatted(), tone: .green)
             case .confirms(let count):
                 if count > 0 {
                     Image(systemName: "checkmark")
@@ -364,10 +364,10 @@ private struct SignalBadge: View {
                         )
                 }
                 else {
-                    countCapsule("0", tone: .muted)
+                    countCapsule(0.formatted(), tone: .muted)
                 }
             case .noMatch:
-                countCapsule("0", tone: .muted)
+                countCapsule(0.formatted(), tone: .muted)
             case .skipped:
                 Image(systemName: "minus")
                     .font(.system(size: 10, weight: .semibold))
@@ -471,51 +471,53 @@ private enum SignalBadgeStyle {
 
     static func label(for kind: SignalKind) -> String {
         switch kind {
-        case .discId: "Disc ID"
-        case .barcode: "Barcode"
-        case .catalog: "Catalog"
+        case .discId: String(localized: "Disc ID")
+        case .barcode: String(localized: "Barcode")
+        case .catalog: String(localized: "Catalog")
         }
     }
 
     static func originLabel(for origin: SignalOrigin) -> String {
         switch origin {
-        case .discToc: "Disc TOC"
-        case .cueSheet: "CUE sheet"
-        case .artwork: "Cover OCR"
-        case .folderName: "folder name"
-        case .filename: "file name"
-        case .textFile: "Text file"
+        case .discToc: String(localized: "Disc TOC")
+        case .cueSheet: String(localized: "CUE sheet")
+        case .artwork: String(localized: "Cover OCR")
+        case .folderName: String(localized: "folder name")
+        case .filename: String(localized: "file name")
+        case .textFile: String(localized: "Text file")
         }
     }
 
     static func roleLabel(for role: SignalRole) -> String {
         switch role {
-        case .identity: "Identifies · finds releases"
-        case .filter: "Refines · narrows the match"
+        case .identity: String(localized: "Identifies · finds releases")
+        case .filter: String(localized: "Refines · narrows the match")
         }
     }
 
     static func stateLabel(for signal: ToolbarSignal) -> String {
         if signal.excluded {
-            return "Excluded from search"
+            return String(localized: "Excluded from search")
         }
         switch signal.state {
         case .lookingUp:
             return signal.role == .filter
-                ? "Matching\u{2026}" : "Looking up\u{2026}"
+                ? String(localized: "Matching\u{2026}")
+                : String(localized: "Looking up\u{2026}")
         case .found(let count):
-            return count == 1 ? "1 release" : "\(count) releases"
+            return String(localized: "\(Int(count)) releases")
         case .noMatch:
-            return "No releases matched"
+            return String(localized: "No releases matched")
         case .skipped:
             return signal.kind == .discId
-                ? "No disc layout" : "No source to scan"
+                ? String(localized: "No disc layout")
+                : String(localized: "No source to scan")
         case .failed(let failure):
             return failure.badgeLine
         case .confirms(let count):
             return count > 0
-                ? "Matches this pressing"
-                : "No matched pressing carries this catno"
+                ? String(localized: "Matches this pressing")
+                : String(localized: "No matched pressing carries this catno")
         }
     }
 

--- a/bae-macos/bae/bae/Views/InfoTip.swift
+++ b/bae-macos/bae/bae/Views/InfoTip.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// A "?" icon that shows an info popover on hover.
 /// The popover stays open while the cursor is over either the icon or the popover itself.
 struct InfoTip: View {
-    let text: String
+    let text: LocalizedStringKey
     var learnMoreURL: URL?
     var width: CGFloat = 260
     var arrowEdge: Edge = .top

--- a/bae-macos/bae/bae/Views/LibrarySearchField.swift
+++ b/bae-macos/bae/bae/Views/LibrarySearchField.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct LibrarySearchField: View {
     @Binding
     var text: String
-    var prompt: String
+    var prompt: LocalizedStringKey
     var focused: FocusState<Bool>.Binding
     var onEscape: () -> Void
 

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -44,7 +44,7 @@ struct LibraryView: View {
                         onAddNext: { releaseId in
                             queue.addReleaseNext(releaseId)
                         },
-                        headerTitle: "Library",
+                        headerTitle: String(localized: "Library"),
                     ) { albumId in
                         AlbumDetailView(albumId: albumId)
                     }

--- a/bae-macos/bae/bae/Views/MainAppMenuCommands.swift
+++ b/bae-macos/bae/bae/Views/MainAppMenuCommands.swift
@@ -12,8 +12,10 @@ struct ImportFolderButton: View {
             panel.canChooseDirectories = true
             panel.canChooseFiles = false
             panel.allowsMultipleSelection = false
-            panel.message = "Select a folder to watch for music to import"
-            panel.prompt = "Add"
+            panel.message = String(
+                localized: "Select a folder to watch for music to import"
+            )
+            panel.prompt = String(localized: "Add")
             guard panel.runModal() == .OK, let url = panel.url else {
                 return
             }
@@ -23,7 +25,10 @@ struct ImportFolderButton: View {
             }
             catch {
                 uiStore.showError(
-                    "Couldn't add folder: \(error.localizedDescription)"
+                    String(
+                        localized:
+                            "Couldn't add folder: \(error.localizedDescription)"
+                    )
                 )
             }
         }

--- a/bae-macos/bae/bae/Views/MainAppView.swift
+++ b/bae-macos/bae/bae/Views/MainAppView.swift
@@ -187,7 +187,9 @@ struct MainAppView: View {
                 let url = URL(dataRepresentation: data, relativeTo: nil)
             else {
                 DispatchQueue.main.async {
-                    uiStore.showError("Could not read dropped item")
+                    uiStore.showError(
+                        String(localized: "Could not read dropped item")
+                    )
                 }
                 return
             }
@@ -200,7 +202,9 @@ struct MainAppView: View {
                 isDir.boolValue
             else {
                 DispatchQueue.main.async {
-                    uiStore.showError("Drop a folder to import, not a file")
+                    uiStore.showError(
+                        String(localized: "Drop a folder to import, not a file")
+                    )
                 }
                 return
             }
@@ -210,7 +214,10 @@ struct MainAppView: View {
                 }
                 catch {
                     uiStore.showError(
-                        "Couldn't add folder: \(error.localizedDescription)"
+                        String(
+                            localized:
+                                "Couldn't add folder: \(error.localizedDescription)"
+                        )
                     )
                 }
                 uiStore.navigateToImport()

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -343,7 +343,7 @@ struct NowPlayingBar: View {
         .accessibilityLabel(repeatHelp)
     }
 
-    private var repeatHelp: String {
+    private var repeatHelp: LocalizedStringKey {
         switch repeatMode {
         case .none:
             "Repeat: off"

--- a/bae-macos/bae/bae/Views/QueueAddBadge.swift
+++ b/bae-macos/bae/bae/Views/QueueAddBadge.swift
@@ -9,7 +9,9 @@ struct QueueAddBadge: View {
 
     var body: some View {
         if let count = displayedCount {
-            Text("+\(count)")
+            // A bare count, not chrome: render with the locale's digits via
+            // `.formatted()` and `verbatim` so it doesn't become a catalog key.
+            Text(verbatim: "+\(count.formatted())")
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.white)
                 .padding(.horizontal, 5)

--- a/bae-macos/bae/bae/Views/Settings/AboutSettingsTab.swift
+++ b/bae-macos/bae/bae/Views/Settings/AboutSettingsTab.swift
@@ -7,7 +7,7 @@ struct AboutSettingsTab: View {
     var body: some View {
         VStack(spacing: 16) {
             Spacer()
-            Text("bae")
+            Text(verbatim: "bae")
                 .font(.largeTitle)
                 .fontWeight(.bold)
             if let version = Bundle.main.infoDictionary?[

--- a/bae-macos/bae/bae/Views/Settings/DiscogsSettingsTab.swift
+++ b/bae-macos/bae/bae/Views/Settings/DiscogsSettingsTab.swift
@@ -65,8 +65,10 @@ struct DiscogsSettingsTab: View {
             }
         }
         catch {
-            readError =
-                "Couldn't read the stored Discogs key: \(error.localizedDescription)"
+            readError = String(
+                localized:
+                    "Couldn't read the stored Discogs key: \(error.localizedDescription)"
+            )
         }
     }
 
@@ -81,8 +83,10 @@ struct DiscogsSettingsTab: View {
             do {
                 let outcome = try await discogs.saveDiscogsToken(token)
                 if case .rejected = outcome {
-                    saveError =
-                        "Discogs rejected this key — check it and save again."
+                    saveError = String(
+                        localized:
+                            "Discogs rejected this key — check it and save again."
+                    )
                 }
                 // `.valid` / `.unvalidated` update the persisted status
                 // reactively through the config event; nothing to set here.
@@ -91,8 +95,10 @@ struct DiscogsSettingsTab: View {
                 logger.debug("saveToken cancelled")
             }
             catch {
-                saveError =
-                    "Couldn't save the Discogs key: \(error.localizedDescription)"
+                saveError = String(
+                    localized:
+                        "Couldn't save the Discogs key: \(error.localizedDescription)"
+                )
             }
         }
     }
@@ -109,8 +115,10 @@ struct DiscogsSettingsTab: View {
                 logger.debug("revalidate cancelled")
             }
             catch {
-                saveError =
-                    "Couldn't re-check the Discogs key: \(error.localizedDescription)"
+                saveError = String(
+                    localized:
+                        "Couldn't re-check the Discogs key: \(error.localizedDescription)"
+                )
             }
         }
     }
@@ -123,8 +131,10 @@ struct DiscogsSettingsTab: View {
             draft = ""
         }
         catch {
-            saveError =
-                "Couldn't remove the Discogs key: \(error.localizedDescription)"
+            saveError = String(
+                localized:
+                    "Couldn't remove the Discogs key: \(error.localizedDescription)"
+            )
         }
     }
 }
@@ -213,7 +223,7 @@ struct DiscogsSettingsContent: View {
 
     @ViewBuilder
     private func connectedRow(
-        label: String,
+        label: LocalizedStringKey,
         systemImage: String,
         tint: Color
     ) -> some View {

--- a/bae-macos/bae/bae/Views/Settings/LibrarySettingsTab.swift
+++ b/bae-macos/bae/bae/Views/Settings/LibrarySettingsTab.swift
@@ -109,8 +109,10 @@ struct LibrarySettingsTab: View {
     /// data-loss warning when releases live only in the cloud; the view just
     /// stitches it onto the base sentence.
     private var disconnectMessage: String {
-        let base =
-            "This will stop syncing and remove the cloud provider configuration."
+        let base = String(
+            localized:
+                "This will stop syncing and remove the cloud provider configuration."
+        )
         guard let extra = disconnectExtraWarning else { return base }
         return "\(base) \(extra)"
     }
@@ -130,8 +132,10 @@ struct LibrarySettingsTab: View {
             logger.error(
                 "Failed to compute disconnect warning: \(error.localizedDescription)"
             )
-            self.error =
-                "Couldn't check for cloud-only releases: \(error.localizedDescription)"
+            self.error = String(
+                localized:
+                    "Couldn't check for cloud-only releases: \(error.localizedDescription)"
+            )
             disconnectExtraWarning = nil
         }
         showDisconnectConfirm = true
@@ -147,7 +151,10 @@ struct LibrarySettingsTab: View {
         }
         catch {
             logger.error("Failed to disconnect: \(error.localizedDescription)")
-            self.error = "Failed to disconnect: \(error.localizedDescription)"
+            self.error = String(
+                localized:
+                    "Failed to disconnect: \(error.localizedDescription)"
+            )
         }
     }
 

--- a/bae-macos/bae/bae/Views/Settings/SyncSetupWizard.swift
+++ b/bae-macos/bae/bae/Views/Settings/SyncSetupWizard.swift
@@ -18,6 +18,9 @@ private enum WizardStep: Equatable {
 
 private struct ProviderOption: Identifiable {
     let id: BridgeCloudProvider
+    // Resolved through the catalog at the access site (not stored as a
+    // `LocalizedStringKey`, which isn't `Sendable` and would break the
+    // concurrency-safe global `providerDisplay`/`providerOptions` tables).
     let name: String
     let description: String
     let icon: String
@@ -30,32 +33,34 @@ private struct ProviderOption: Identifiable {
 private let providerDisplay: [BridgeCloudProvider: ProviderOption] = [
     .cloudKit: ProviderOption(
         id: .cloudKit,
-        name: "iCloud",
-        description: "Sync via your iCloud account",
+        name: String(localized: "iCloud"),
+        description: String(localized: "Sync via your iCloud account"),
         icon: "icloud"
     ),
     .googleDrive: ProviderOption(
         id: .googleDrive,
-        name: "Google Drive",
-        description: "Sync via Google Drive",
+        name: String(localized: "Google Drive"),
+        description: String(localized: "Sync via Google Drive"),
         icon: "externaldrive"
     ),
     .dropbox: ProviderOption(
         id: .dropbox,
-        name: "Dropbox",
-        description: "Sync via Dropbox",
+        name: String(localized: "Dropbox"),
+        description: String(localized: "Sync via Dropbox"),
         icon: "externaldrive"
     ),
     .oneDrive: ProviderOption(
         id: .oneDrive,
-        name: "OneDrive",
-        description: "Sync via Microsoft OneDrive",
+        name: String(localized: "OneDrive"),
+        description: String(localized: "Sync via Microsoft OneDrive"),
         icon: "externaldrive"
     ),
     .s3: ProviderOption(
         id: .s3,
-        name: "S3-compatible",
-        description: "Any S3-compatible storage (AWS, Backblaze, Minio, ...)",
+        name: String(localized: "S3-compatible"),
+        description: String(
+            localized: "Any S3-compatible storage (AWS, Backblaze, Minio, ...)"
+        ),
         icon: "externaldrive.connected.to.line.below"
     ),
 ]
@@ -160,7 +165,7 @@ struct SyncSetupWizard: View {
     private var headerTitle: String {
         switch step {
         case .selectProvider:
-            "Set Up Sync"
+            String(localized: "Set Up Sync")
         case .configure(let provider):
             provider.displayName
         }
@@ -312,7 +317,11 @@ struct SyncSetupWizard: View {
 
     #if BAE_OAUTH_PROVIDERS
         private func oauthFields(provider: BridgeCloudProvider) -> some View {
-            Section {
+            let connectTitle: LocalizedStringKey =
+                isWorking
+                ? "Connecting..."
+                : "Connect \(provider.displayName)"
+            return Section {
                 VStack(spacing: 12) {
                     Text(
                         "Opens your browser to authorize bae with \(provider.displayName)."
@@ -323,11 +332,7 @@ struct SyncSetupWizard: View {
 
                     HStack {
                         Spacer()
-                        Button(
-                            isWorking
-                                ? "Connecting..."
-                                : "Connect \(provider.displayName)"
-                        ) {
+                        Button(connectTitle) {
                             connectOAuth(provider: provider)
                         }
                         .disabled(isWorking)
@@ -423,7 +428,8 @@ struct SyncSetupWizard: View {
         if case BridgeError.Diagnostic(let category, let detail) = error,
             category == .config
         {
-            return detail.contains("denied") ? "Access denied" : detail
+            return detail.contains("denied")
+                ? String(localized: "Access denied") : detail
         }
         #if BAE_CLOUDKIT
             if case CloudKitError.Storage(let msg) = error {

--- a/bae-macos/bae/bae/Views/StorageActionRunner.swift
+++ b/bae-macos/bae/bae/Views/StorageActionRunner.swift
@@ -56,7 +56,11 @@ final class StorageActionRunner {
             // and per-release transfer events — not an awaited per-release loop.
             downloads.queuePins(releaseIds)
         case .unpin:
-            runEach(releaseIds, "remove local copy", releaseEditor.unpinRelease)
+            runEach(
+                releaseIds,
+                String(localized: "remove local copy"),
+                releaseEditor.unpinRelease
+            )
         }
     }
 
@@ -65,7 +69,8 @@ final class StorageActionRunner {
     func confirmManage(pin: Bool, deleteSource: Bool) {
         let releaseIds = pendingManage ?? []
         pendingManage = nil
-        runEach(releaseIds, "move into library") { releaseId in
+        runEach(releaseIds, String(localized: "move into library")) {
+            releaseId in
             try await self.releaseEditor.manageRelease(
                 releaseId,
                 pin,
@@ -87,7 +92,10 @@ final class StorageActionRunner {
             }
             catch {
                 uiStore.showError(
-                    "Failed to cancel upload: \(error.localizedDescription)"
+                    String(
+                        localized:
+                            "Failed to cancel upload: \(error.localizedDescription)"
+                    )
                 )
                 return
             }
@@ -99,13 +107,14 @@ final class StorageActionRunner {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
-        panel.prompt = "Move Here"
+        panel.prompt = String(localized: "Move Here")
 
         guard panel.runModal() == .OK, let url = panel.url else {
             return
         }
         let newPath = url.path(percentEncoded: false)
-        runEach(releaseIds, "move out of library") { releaseId in
+        runEach(releaseIds, String(localized: "move out of library")) {
+            releaseId in
             try await self.releaseEditor.unmanageRelease(releaseId, newPath)
         }
     }
@@ -128,7 +137,10 @@ final class StorageActionRunner {
             }
             catch {
                 uiStore.showError(
-                    "Failed to \(verb): \(error.localizedDescription)"
+                    String(
+                        localized:
+                            "Failed to \(verb): \(error.localizedDescription)"
+                    )
                 )
             }
         }

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -290,7 +290,7 @@ private struct DownloadRow: View {
                 .foregroundStyle(.secondary)
         case .active:
             Label(
-                "Downloading \(op.percent)%",
+                "Downloading \(Int(op.percent))%",
                 systemImage: "arrow.down.circle.fill"
             )
             .foregroundStyle(.orange)
@@ -423,7 +423,10 @@ private struct OutboxSection: View {
                 do { try sync.retryOutbox() }
                 catch {
                     uiStore.showError(
-                        "Failed to retry uploads: \(error.localizedDescription)"
+                        String(
+                            localized:
+                                "Failed to retry uploads: \(error.localizedDescription)"
+                        )
                     )
                 }
             }
@@ -453,7 +456,9 @@ private struct OutboxSection: View {
         do { try sync.cancelOutboxItem(id) }
         catch {
             uiStore.showError(
-                "Failed to cancel: \(error.localizedDescription)"
+                String(
+                    localized: "Failed to cancel: \(error.localizedDescription)"
+                )
             )
         }
     }
@@ -478,14 +483,14 @@ private struct OutboxMasterProgress: View {
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
                 if !snapshot.throughputText.isEmpty {
-                    Text("·").foregroundStyle(.tertiary)
+                    Text(verbatim: "·").foregroundStyle(.tertiary)
                     Text(snapshot.throughputText)
                         .font(.caption)
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
                 if !snapshot.etaText.isEmpty {
-                    Text("·").foregroundStyle(.tertiary)
+                    Text(verbatim: "·").foregroundStyle(.tertiary)
                     Text(snapshot.etaText)
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -59,26 +59,46 @@ private enum StorageTableColumn: String, CaseIterable {
         switch self {
         case .album:
             Spec(
-                title: "Album",
+                title: String(localized: "Album"),
                 width: 280,
                 minWidth: 160,
                 sortField: .albumTitle
             )
         case .artist:
             Spec(
-                title: "Artist",
+                title: String(localized: "Artist"),
                 width: 200,
                 minWidth: 100,
                 sortField: .artistNames
             )
         case .format:
-            Spec(title: "Format", width: 80, minWidth: 60, sortField: .format)
+            Spec(
+                title: String(localized: "Format"),
+                width: 80,
+                minWidth: 60,
+                sortField: .format
+            )
         case .storage:
-            Spec(title: "Storage", width: 140, minWidth: 100, sortField: nil)
+            Spec(
+                title: String(localized: "Storage"),
+                width: 140,
+                minWidth: 100,
+                sortField: nil
+            )
         case .files:
-            Spec(title: "Files", width: 60, minWidth: 44, sortField: .fileCount)
+            Spec(
+                title: String(localized: "Files"),
+                width: 60,
+                minWidth: 44,
+                sortField: .fileCount
+            )
         case .size:
-            Spec(title: "Size", width: 100, minWidth: 70, sortField: .totalSize)
+            Spec(
+                title: String(localized: "Size"),
+                width: 100,
+                minWidth: 70,
+                sortField: .totalSize
+            )
         }
     }
 
@@ -727,7 +747,7 @@ extension StorageTableView.Coordinator: NSMenuDelegate {
                 .map(\.id)
             addMenuItem(
                 to: menu,
-                title: "Cancel Upload",
+                title: String(localized: "Cancel Upload"),
                 action: #selector(cancelUploadsAction(_:)),
                 symbol: "xmark.circle",
                 representedObject: opIds,
@@ -927,7 +947,7 @@ private struct StorageReleaseCell: View {
             case .storage:
                 StorageStateLabel(release: release)
             case .files:
-                Text("\(release.fileCount)")
+                Text(verbatim: release.fileCount.formatted())
                     .monospacedDigit()
                     .frame(maxWidth: .infinity, alignment: .trailing)
             case .size:
@@ -958,7 +978,7 @@ private struct StorageStateLabel: View {
             !progress.isIdle
         {
             Label(
-                "Uploading (\(progress.pending))",
+                "Uploading (\(Int(progress.pending)))",
                 systemImage: "arrow.up.circle"
             )
             .foregroundStyle(.orange)

--- a/bae-macos/bae/bae/Views/TitleBar.swift
+++ b/bae-macos/bae/bae/Views/TitleBar.swift
@@ -97,7 +97,10 @@ struct TitleBar: View {
             catch {
                 guard !Task.isCancelled else { return }
                 uiStore.showError(
-                    "Search failed: \(error.localizedDescription)"
+                    String(
+                        localized:
+                            "Search failed: \(error.localizedDescription)"
+                    )
                 )
             }
         }

--- a/bae-macos/bae/bae/Views/WelcomeView.swift
+++ b/bae-macos/bae/bae/Views/WelcomeView.swift
@@ -130,7 +130,7 @@ struct WelcomeView: View {
     private var chooseView: some View {
         VStack(spacing: 32) {
             Spacer()
-            Text("bae")
+            Text(verbatim: "bae")
                 .font(.system(size: 48, weight: .bold, design: .rounded))
             Text("Get started with your music library.")
                 .font(.title3)
@@ -773,7 +773,9 @@ struct WelcomeView: View {
             return .cloudKit
         case .googleDrive:
             guard let token = oauthTokenJson else {
-                error = "OAuth token required for Google Drive"
+                error = String(
+                    localized: "OAuth token required for Google Drive"
+                )
                 return nil
             }
             return .googleDrive(
@@ -782,7 +784,7 @@ struct WelcomeView: View {
             )
         case .dropbox:
             guard let token = oauthTokenJson else {
-                error = "OAuth token required for Dropbox"
+                error = String(localized: "OAuth token required for Dropbox")
                 return nil
             }
             return .dropbox(
@@ -791,7 +793,7 @@ struct WelcomeView: View {
             )
         case .oneDrive:
             guard let token = oauthTokenJson else {
-                error = "OAuth token required for OneDrive"
+                error = String(localized: "OAuth token required for OneDrive")
                 return nil
             }
             return .oneDrive(


### PR DESCRIPTION
The bridge inversion handled core-originated strings (errors, statuses, numeric/structured data) via the generated `Core` catalog. This is the other string population: the hand-authored native UI chrome — button/menu/section labels, window titles, alerts, accessibility text — which was bare English literals.

Adds the committed `Localizable.xcstrings` chrome catalog (~404 keys, six plural variations) and migrates the macOS SwiftUI/AppKit literals to it. Most were already `LocalizedStringKey`; the real edits were `String`-typed sinks (showError, NSOpenPanel prompts, NSTextField, computed titles) wrapped in `String(localized:)`. The catalog was authored from the compiler-emitted `.stringsdata` (`xcstringstool sync`), then given the 13 target-locale slots (English source values, untranslated — real translations land later). Proper nouns (brand/codec names, the `bae` wordmark), `Text(verbatim:)`, bridge-resolved values, and `core.*` keys are deliberately left alone.

## Test plan
- macOS build green (full pre-commit gate); all 14 `<loc>.lproj` compile into the .app
- Spot-check a few screens render unchanged in English; set system language to de/ja and confirm chrome picks up the catalog (English fallback until translations land)