### PR TITLE
loc: adopt localization on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ name = "bae-windows-ffi"
 version = "0.1.0"
 dependencies = [
  "bae-core",
+ "bae-loc",
  "serde",
  "serde_json",
  "tokio",

--- a/bae-loc/src/bin/loc-gen.rs
+++ b/bae-loc/src/bin/loc-gen.rs
@@ -100,9 +100,8 @@ fn emit_target(args: &Args, catalog: &Catalog) -> Result<(), String> {
     let target = args.target.as_deref().ok_or("emit needs --target")?;
     let out_dir = args.out_dir.as_ref().ok_or("emit needs --out-dir")?;
 
-    // Each target emits one or more `(relative path, contents)` files. Apple
-    // and Windows carry every locale inside one file; Android needs a separate
-    // resource directory per locale, so it emits a file set.
+    // Apple packs every locale into one xcstrings; Android and Windows each
+    // emit a per-locale resource set (a directory per shipping locale).
     let files: Vec<(PathBuf, String)> = match target {
         "apple" => single_file(
             "Core.xcstrings",
@@ -112,10 +111,7 @@ fn emit_target(args: &Args, catalog: &Catalog) -> Result<(), String> {
             .into_iter()
             .map(|(rel, contents)| (PathBuf::from(rel), contents))
             .collect(),
-        "windows" => single_file(
-            format!("{SOURCE_LANGUAGE}-US/Core.resw"),
-            emit::windows_resw(catalog),
-        ),
+        "windows" => emit::windows_resw_all(catalog, SOURCE_LANGUAGE),
         other => {
             return Err(format!(
                 "unknown --target `{other}` (apple|android|windows)"

--- a/bae-loc/src/emit.rs
+++ b/bae-loc/src/emit.rs
@@ -275,6 +275,37 @@ pub fn windows_resw(cat: &Catalog) -> String {
     out
 }
 
+/// The shipping locales in build/BCP-47 form: the English source plus every
+/// `TARGET_LOCALES` entry. Windows resources are per-language directories (unlike
+/// Apple's single multi-locale `.xcstrings`), so the catalog fans out to one
+/// `Core.resw` per locale.
+fn windows_locales(src_lang: &str) -> Vec<String> {
+    let mut locales = vec![format!("{src_lang}-US")];
+    locales.extend(TARGET_LOCALES.iter().map(|l| (*l).to_string()));
+    locales
+}
+
+/// Emit one `<locale>/Core.resw` per shipping locale: `(relative path, contents)`
+/// pairs the caller writes under the project's `Strings` directory. Every locale
+/// carries the **English** value — the source locale because it's the source, the
+/// others as the untranslated starting point (English shows at runtime until a
+/// locale's `Core.resw` is actually translated). This declares locale support
+/// (the per-language directories are what make the app multilingual) without
+/// inventing translations. Mirrors the Apple emitter, which carries the same
+/// per-locale slots inside one file.
+pub fn windows_resw_all(cat: &Catalog, src_lang: &str) -> Vec<(std::path::PathBuf, String)> {
+    let contents = windows_resw(cat);
+    windows_locales(src_lang)
+        .into_iter()
+        .map(|locale| {
+            (
+                std::path::PathBuf::from(locale).join("Core.resw"),
+                contents.clone(),
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -372,6 +403,35 @@ value = "Looking up barcode {position} of {total}"
             resw.contains("Looking up barcode {position} of {total}"),
             "{resw}"
         );
+    }
+
+    #[test]
+    fn windows_fans_out_to_every_shipping_locale() {
+        let c = cat(r#"
+[messages."core.error.not_found.release"]
+value = "that release couldn't be found"
+"#);
+        let files = windows_resw_all(&c, "en");
+        // One Core.resw per shipping locale: en-US source + every TARGET_LOCALES.
+        assert_eq!(files.len(), TARGET_LOCALES.len() + 1);
+        let paths: Vec<String> = files
+            .iter()
+            .map(|(p, _)| p.to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert!(paths.contains(&"en-US/Core.resw".to_string()), "{paths:?}");
+        assert!(paths.contains(&"ar/Core.resw".to_string()), "{paths:?}");
+        assert!(
+            paths.contains(&"zh-Hans/Core.resw".to_string()),
+            "{paths:?}"
+        );
+        // Every locale carries the English source (others untranslated until a
+        // translator fills them) — no invented translations.
+        for (_, contents) in &files {
+            assert!(
+                contents.contains("that release couldn't be found"),
+                "{contents}"
+            );
+        }
     }
 
     #[test]

--- a/bae-windows-ffi/Cargo.toml
+++ b/bae-windows-ffi/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1"
 # one-off runtime that pre-init restore (no app handle yet) blocks on.
 tokio = { version = "1", features = ["sync", "rt-multi-thread"] }
 
+[dev-dependencies]
+# The catalog-key cross-check tests parse the master localization catalog
+# (`bae-bridge/loc/catalog.toml`) so a renamed/dropped `core.*` key fails this
+# crate's build, the way the bridge's own key tests do.
+bae-loc = { path = "../bae-loc" }
+
 [features]
 # Enables the OAuth cloud-provider C-ABI surface (bae_oauth_authorize,
 # bae_sign_in_cloud, bae_set_oauth_client_creds) via bae-core/coven. Off by

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -16,9 +16,131 @@ use bae_core::db::{AlbumSortCriterion, AlbumSortField, SortDirection};
 use bae_core::ui::UiBusEvent;
 use serde::{Deserialize, Serialize};
 
-fn format_minutes_seconds(ms: u64) -> String {
-    let total_seconds = ms / 1000;
-    format!("{}:{:02}", total_seconds / 60, total_seconds % 60)
+mod loc;
+
+/// Allocate an owned C string for a catalog key result, or null when the value
+/// has no key (the C# falls back to a passthrough / generic line). The result
+/// is freed with [`bae_string_free`], like every other string this library
+/// returns.
+fn key_cstring(key: Option<&str>) -> *mut c_char {
+    match key {
+        // Catalog keys are static `core.…` identifiers with no interior NUL, so
+        // `CString::new` can't fail here; `expect` surfaces a catalog bug rather
+        // than masking it as the null "no key" result the `None` arm returns.
+        Some(key) => CString::new(key)
+            .expect("catalog key has no interior NUL byte")
+            .into_raw(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Catalog key for a cloud provider's display name, or null for the brand-name
+/// providers the UI passes through verbatim. `provider` is the wire tag
+/// ("s3"/"google_drive"/…) or null for local-only. Mirrors macOS's uniffi
+/// `bridge_cloud_provider_label_key`. Free with [`bae_string_free`].
+///
+/// # Safety
+/// `provider` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_cloud_provider_label_key(provider: *const c_char) -> *mut c_char {
+    let provider = cstr(provider);
+    key_cstring(loc::cloud_provider_label_key(provider.as_deref()))
+}
+
+/// Catalog key for a channel count's word ("mono"/"stereo"), or null for counts
+/// the C# renders as "{n}ch". Mirrors `bridge_audio_channels_key`. Free with
+/// [`bae_string_free`].
+#[no_mangle]
+pub extern "C" fn bae_audio_channels_key(channels: i64) -> *mut c_char {
+    key_cstring(loc::audio_channels_key(channels))
+}
+
+/// Catalog key for a diagnostic error category's generic line, or null for an
+/// unknown tag. `category` is the wire tag carried by an `FfiError`
+/// (`{"kind":"diagnostic","category":…}`). Mirrors `bridge_error_category_key`.
+/// Free with [`bae_string_free`].
+///
+/// # Safety
+/// `category` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_error_category_key(category: *const c_char) -> *mut c_char {
+    let Some(category) = cstr(category) else {
+        return std::ptr::null_mut();
+    };
+    key_cstring(loc::error_category_key(&category))
+}
+
+/// Catalog key for a missing entity's "… not found" line, or null for an
+/// unknown tag. `entity` is the wire tag carried by an `FfiError`
+/// (`{"kind":"not_found","entity":…}`). Mirrors `bridge_entity_not_found_key`.
+/// Free with [`bae_string_free`].
+///
+/// # Safety
+/// `entity` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_entity_not_found_key(entity: *const c_char) -> *mut c_char {
+    let Some(entity) = cstr(entity) else {
+        return std::ptr::null_mut();
+    };
+    key_cstring(loc::entity_not_found_key(&entity))
+}
+
+/// Catalog key for an actionable playback-error reason, or null for the
+/// `diagnostic` reason (which renders through the error-category path) and
+/// unknown tags. `kind` is the wire tag carried by an `FfiPlaybackErrorReason`.
+/// Mirrors `bridge_playback_error_reason_key`. Free with [`bae_string_free`].
+///
+/// # Safety
+/// `kind` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_playback_error_reason_key(kind: *const c_char) -> *mut c_char {
+    let Some(kind) = cstr(kind) else {
+        return std::ptr::null_mut();
+    };
+    key_cstring(loc::playback_error_reason_key(&kind))
+}
+
+/// Catalog key for an import prepare-step wire tag (`FfiImportStep.Preparing`),
+/// or null for an unknown tag. Mirrors `bridge_prepare_step_key`. Free with
+/// [`bae_string_free`].
+///
+/// # Safety
+/// `step` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_prepare_step_key(step: *const c_char) -> *mut c_char {
+    let Some(step) = cstr(step) else {
+        return std::ptr::null_mut();
+    };
+    key_cstring(loc::prepare_step_key(&step))
+}
+
+/// Catalog key for an import-phase wire tag (`FfiImportStep.Running`), or null
+/// for an unknown tag. Mirrors `bridge_import_phase_key`. Free with
+/// [`bae_string_free`].
+///
+/// # Safety
+/// `phase` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_import_phase_key(phase: *const c_char) -> *mut c_char {
+    let Some(phase) = cstr(phase) else {
+        return std::ptr::null_mut();
+    };
+    key_cstring(loc::import_phase_key(&phase))
+}
+
+/// Catalog key for a transfer action's present-continuous progress verb, or
+/// null for an unknown tag. `action` is a wire tag from `FfiStorageRow.actions`
+/// ("pin"/"unpin"/"manage"/"unmanage"). Mirrors `bridge_transfer_action_key`.
+/// Free with [`bae_string_free`].
+///
+/// # Safety
+/// `action` must be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_transfer_action_key(action: *const c_char) -> *mut c_char {
+    let Some(action) = cstr(action) else {
+        return std::ptr::null_mut();
+    };
+    key_cstring(loc::transfer_action_key(&action))
 }
 
 /// Opaque app handle. Created by [`bae_init`], passed back to every call, freed
@@ -1039,19 +1161,6 @@ pub unsafe extern "C" fn bae_gallery(
 }
 
 /// The wire name for a storage action.
-fn format_bytes_ffi(bytes: i64) -> String {
-    let b = bytes.max(0) as f64;
-    if b < 1_000.0 {
-        format!("{} B", bytes.max(0))
-    } else if b < 1_000_000.0 {
-        format!("{:.1} KB", b / 1_000.0)
-    } else if b < 1_000_000_000.0 {
-        format!("{:.1} MB", b / 1_000_000.0)
-    } else {
-        format!("{:.1} GB", b / 1_000_000_000.0)
-    }
-}
-
 fn storage_action_name(action: &bae_core::album_detail::ReleaseStorageAction) -> &'static str {
     use bae_core::album_detail::ReleaseStorageAction;
     match action {
@@ -1069,16 +1178,26 @@ struct FfiStorageRow {
     album_title: String,
     artist: String,
     format: Option<String>,
-    /// Pre-formatted total size, e.g. "412 MB".
-    size: String,
+    /// Raw total size in bytes; the C# formats it for the locale.
+    total_size: i64,
     file_count: i64,
-    /// "Unmanaged", "Pinned", or "Cloud-only".
-    state: String,
+    /// Storage state wire tag: "unmanaged" / "pinned" / "cloud_only". The C#
+    /// resolves a localized label per tag.
+    state: &'static str,
     /// The storage transitions this release allows right now, gated on cloud
     /// home by the core. The in-flight-uploads gate lives in the UI: it reads
     /// `OutboxSnapshot.per_release[release_id]` and suppresses these actions
     /// when the release has uploads in flight.
     actions: Vec<String>,
+}
+
+/// Wire tag for a release's storage state. The C# resolves a localized label.
+fn storage_state_tag(state: ReleaseStorageState) -> &'static str {
+    match state {
+        ReleaseStorageState::Unmanaged => "unmanaged",
+        ReleaseStorageState::Pinned => "pinned",
+        ReleaseStorageState::CloudOnly => "cloud_only",
+    }
 }
 
 /// Every release's storage summary as a JSON array, or null on error. Free the
@@ -1119,14 +1238,9 @@ pub unsafe extern "C" fn bae_storage(handle: *const BaeHandle) -> *mut c_char {
                 album_title: summary.album_title,
                 artist: summary.artist_names,
                 format: summary.format,
-                size: format_bytes_ffi(summary.total_size),
+                total_size: summary.total_size,
                 file_count: summary.file_count,
-                state: match summary.storage_state {
-                    ReleaseStorageState::Unmanaged => "Unmanaged",
-                    ReleaseStorageState::Pinned => "Pinned",
-                    ReleaseStorageState::CloudOnly => "Cloud-only",
-                }
-                .to_string(),
+                state: storage_state_tag(summary.storage_state),
                 actions,
             }
         })
@@ -1262,13 +1376,16 @@ struct FfiUploadOp {
     /// Owning release id; null for an orphaned file.
     release_id: Option<String>,
     cloud_key: String,
+    /// Total bytes for this file; the C# formats it for the locale.
     bytes_total: u64,
     bytes_done: u64,
-    size_label: String,
     attempt_count: i64,
     /// "queued", "active", or "failed".
     state: String,
-    /// The last failure message when `state` is "failed".
+    /// The last failure message when `state` is "failed". This is an opaque,
+    /// log-only diagnostic string from the cloud layer (an exception's text),
+    /// not a localized line — the C# shows it verbatim in a copyable disclosure,
+    /// like macOS's `BridgeError::Diagnostic` detail.
     last_error: Option<String>,
 }
 
@@ -1290,7 +1407,8 @@ struct FfiUploadProgress {
 }
 
 /// The cloud outbox snapshot: per-item lists, per-release counts, overall
-/// totals, a pre-formatted summary band, throughput, and ETA.
+/// totals, raw throughput, and raw ETA. The C# composes the localized summary
+/// band and formats throughput/ETA/bytes for the locale.
 #[derive(Serialize)]
 struct FfiOutboxSnapshot {
     uploads: Vec<FfiUploadOp>,
@@ -1331,7 +1449,6 @@ fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOu
                 cloud_key: op.cloud_key.clone(),
                 bytes_total: op.bytes_total,
                 bytes_done,
-                size_label: format_bytes_ffi(op.bytes_total as i64),
                 attempt_count: op.attempt_count,
                 state: state.to_string(),
                 last_error,
@@ -1451,11 +1568,26 @@ struct FfiTrack {
     /// The track's id, used to play from this track or queue it individually.
     track_id: String,
     title: String,
-    /// Human-readable position, e.g. "A1", "1", "1-2".
-    position: String,
-    /// Pre-formatted duration, e.g. "3:07"; empty if unknown.
-    duration: String,
+    /// Structured position; the C# composes "A1"/"2-3"/"5" from the case and
+    /// formats nothing locale-specific.
+    position: loc::FfiTrackPosition,
+    /// Raw track length in milliseconds, or null when unknown. The C# formats
+    /// it for the locale (e.g. "3:07").
+    duration_ms: Option<i64>,
     artist: String,
+}
+
+/// One file in a release, mirroring `BridgeFile`. `audio_format` is `None` for
+/// non-audio files; for audio files the C# composes the one-line descriptor
+/// ("FLAC · 44.1 kHz · 16-bit · stereo") from its structured parts.
+#[derive(Serialize)]
+struct FfiFile {
+    id: String,
+    original_filename: String,
+    file_size: i64,
+    content_type: String,
+    is_image: bool,
+    audio_format: Option<loc::FfiAudioFormat>,
 }
 
 /// One release in an album's detail. The picker lists these by `display_name`;
@@ -1466,6 +1598,9 @@ struct FfiRelease {
     /// Human-readable picker label, e.g. "2009 · CD" or "Release 2".
     display_name: String,
     tracks: Vec<FfiTrack>,
+    /// The release's files (audio + images), each with its structured audio
+    /// format where applicable. Mirrors `BridgeRelease.files`.
+    files: Vec<FfiFile>,
 }
 
 /// An album's detail: header fields plus every release with its tracks. The UI
@@ -1525,12 +1660,24 @@ pub unsafe extern "C" fn bae_album_detail(
                 .map(|track| FfiTrack {
                     track_id: track.id.clone(),
                     title: track.title.clone(),
-                    position: track.position_label.clone(),
-                    duration: track
-                        .duration_ms
-                        .map(|ms| format_minutes_seconds(ms as u64))
-                        .unwrap_or_default(),
+                    position: loc::FfiTrackPosition::from_core(&track.position),
+                    duration_ms: track.duration_ms,
                     artist: track.artist_names.clone(),
+                })
+                .collect(),
+            files: release
+                .files
+                .iter()
+                .map(|file| FfiFile {
+                    id: file.id.clone(),
+                    original_filename: file.original_filename.clone(),
+                    file_size: file.file_size,
+                    content_type: file.content_type.clone(),
+                    is_image: file.is_image,
+                    audio_format: file
+                        .audio_format
+                        .as_ref()
+                        .map(loc::FfiAudioFormat::from_core),
                 })
                 .collect(),
         })
@@ -1552,7 +1699,8 @@ struct FfiQueueItem {
     track_id: String,
     title: String,
     artist: String,
-    duration: String,
+    /// Raw track length in milliseconds, or null when unknown. The C# formats it.
+    duration_ms: Option<i64>,
     album_title: String,
     cover_image_id: Option<String>,
 }
@@ -1579,13 +1727,15 @@ struct FfiSignal {
 
 /// A badge's live lookup/match state, flattened to a tag plus the one payload
 /// each variant carries. Mirrors `bae_core::identify::SignalState`: `count` is
-/// set for `found`/`confirms`, `message` for `failed`, both `None` otherwise.
+/// set for `found`/`confirms`, `failure` for `failed`, both `None` otherwise.
+/// `failure` is the structured lookup failure (no prose) — the C# resolves a
+/// localized line per variant and renders `provider`'s status as the argument.
 #[derive(Serialize)]
 struct FfiSignalState {
     /// `looking_up` / `found` / `no_match` / `skipped` / `failed` / `confirms`.
     kind: &'static str,
     count: Option<u32>,
-    message: Option<String>,
+    failure: Option<loc::FfiLookupFailure>,
 }
 
 /// A UI event pushed to the native app, as JSON `{type, ...}`. Only the events
@@ -1600,7 +1750,8 @@ enum FfiEvent {
         artist: String,
         album_title: String,
         cover_image_id: Option<String>,
-        duration_label: String,
+        /// Raw track length in milliseconds; the C# formats it.
+        duration_ms: u64,
     },
     PlaybackPaused {
         track_id: String,
@@ -1609,13 +1760,17 @@ enum FfiEvent {
         artist: String,
         album_title: String,
         cover_image_id: Option<String>,
-        duration_label: String,
+        /// Raw track length in milliseconds; the C# formats it.
+        duration_ms: u64,
     },
     PlaybackStopped,
     PlaybackProgress {
         progress: f64,
-        elapsed: String,
-        remaining: String,
+        /// Raw elapsed position in milliseconds; the C# formats it.
+        position_ms: u64,
+        /// Raw track length in milliseconds; the C# formats the remaining time
+        /// (`duration_ms - position_ms`) for the locale.
+        duration_ms: u64,
     },
     /// The library changed (album/release add/update/remove) — reload views.
     LibraryChanged,
@@ -1641,8 +1796,11 @@ enum FfiEvent {
         mode: String,
     },
     /// A sync-loop error, or `null` message when a prior error cleared.
+    /// Sync-loop error state, or `null` when a prior error cleared. When set,
+    /// the structured diagnostic the C# renders as a generic per-category line
+    /// plus the opaque, log-only `detail`.
     SyncError {
-        message: Option<String>,
+        error: Option<loc::FfiError>,
     },
     /// The sync pipeline started or stopped a pass — drives the toolbar indicator.
     SyncingChanged {
@@ -1653,27 +1811,29 @@ enum FfiEvent {
     SyncTimeChanged {
         sync_time: Option<i64>,
     },
-    /// Playback failed for the current track.
+    /// Playback failed for the current track. `reason` is the structured,
+    /// locale-free reason: the actionable cloud-only cases the C# keys, and a
+    /// `diagnostic` that renders through the error-category path.
     PlaybackError {
-        message: String,
+        reason: loc::FfiPlaybackErrorReason,
     },
     /// A general operation error (scan or library) with no event of its
-    /// own — surfaced in the error banner.
+    /// own — surfaced in the error banner. `error` is the structured diagnostic.
     Error {
-        message: String,
+        error: loc::FfiError,
     },
     /// A prior general error cleared — close the banner.
     ErrorCleared,
     /// The next track is loading (keep the prior now-playing visible).
     PlaybackLoading,
-    /// Import-preview playback position; `elapsed` is the formatted position label.
+    /// Import-preview playback position. Raw elapsed milliseconds; the C# formats it.
     PreviewProgress {
-        elapsed: String,
+        position_ms: u64,
     },
-    /// Import-preview playback started or resumed; `duration_label` is the
-    /// track's total length, shown next to the elapsed position.
+    /// Import-preview playback started or resumed. Raw track length in
+    /// milliseconds, shown (formatted) next to the elapsed position.
     PreviewPlaying {
-        duration_label: String,
+        duration_ms: u64,
     },
     /// Import-preview playback stopped/ended — clear its position display.
     PreviewIdle,
@@ -1711,11 +1871,13 @@ enum FfiEvent {
         /// transition; the app replaces the candidate's badge row wholesale.
         signals: Vec<FfiSignal>,
     },
-    /// Import progress for a candidate.
+    /// Import progress for a candidate. `step` is the structured, locale-free
+    /// step (or `null` before the first step is known); the C# resolves its
+    /// localized verb from the step's catalog key.
     CandidateImportProgress {
         key: String,
         progress_percent: u32,
-        status: Option<String>,
+        step: Option<loc::FfiImportStep>,
     },
     /// A candidate's import finished; the album is in the library.
     CandidateImportComplete {
@@ -1726,10 +1888,11 @@ enum FfiEvent {
         release_id: String,
         album_id: String,
     },
-    /// A candidate's import failed.
+    /// A candidate's import failed. `error` is the structured diagnostic the C#
+    /// renders as a generic per-category line plus the opaque, log-only detail.
     CandidateImportError {
         key: String,
-        message: String,
+        error: loc::FfiError,
     },
 }
 
@@ -1778,32 +1941,32 @@ fn toolbar_signal_to_ffi(signal: &bae_core::identify::ToolbarSignal) -> FfiSigna
         SignalState::LookingUp => FfiSignalState {
             kind: "looking_up",
             count: None,
-            message: None,
+            failure: None,
         },
         SignalState::Found { count } => FfiSignalState {
             kind: "found",
             count: Some(*count),
-            message: None,
+            failure: None,
         },
         SignalState::NoMatch => FfiSignalState {
             kind: "no_match",
             count: None,
-            message: None,
+            failure: None,
         },
         SignalState::Skipped => FfiSignalState {
             kind: "skipped",
             count: None,
-            message: None,
+            failure: None,
         },
-        SignalState::Failed { message } => FfiSignalState {
+        SignalState::Failed { failure } => FfiSignalState {
             kind: "failed",
             count: None,
-            message: Some(message.clone()),
+            failure: Some(loc::FfiLookupFailure::from_core(failure)),
         },
         SignalState::Confirms { count } => FfiSignalState {
             kind: "confirms",
             count: Some(*count),
-            message: None,
+            failure: None,
         },
     };
 
@@ -1863,7 +2026,7 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             artist: artist_names.clone(),
             album_title: album_title.clone(),
             cover_image_id: cover_image_id.clone(),
-            duration_label: format_minutes_seconds(*duration_ms),
+            duration_ms: *duration_ms,
         },
         UiBusEvent::PlaybackPaused {
             track_id,
@@ -1881,26 +2044,26 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             artist: artist_names.clone(),
             album_title: album_title.clone(),
             cover_image_id: cover_image_id.clone(),
-            duration_label: format_minutes_seconds(*duration_ms),
+            duration_ms: *duration_ms,
         },
         UiBusEvent::PlaybackStopped => FfiEvent::PlaybackStopped,
         UiBusEvent::PlaybackLoading { .. } => FfiEvent::PlaybackLoading,
         UiBusEvent::PreviewProgress { position_ms, .. } => FfiEvent::PreviewProgress {
-            elapsed: format_minutes_seconds(*position_ms),
+            position_ms: *position_ms,
         },
         UiBusEvent::PreviewPlaying { duration_ms, .. } => FfiEvent::PreviewPlaying {
-            duration_label: format_minutes_seconds(*duration_ms),
+            duration_ms: *duration_ms,
         },
         UiBusEvent::PreviewIdle => FfiEvent::PreviewIdle,
-        UiBusEvent::PlaybackError { message } => FfiEvent::PlaybackError {
-            message: message.clone(),
+        UiBusEvent::PlaybackError { reason } => FfiEvent::PlaybackError {
+            reason: loc::FfiPlaybackErrorReason::from_core(reason),
         },
-        UiBusEvent::Error { message } => FfiEvent::Error {
-            message: message.clone(),
+        UiBusEvent::Error { error } => FfiEvent::Error {
+            error: loc::FfiError::from_core(error),
         },
         UiBusEvent::ErrorCleared => FfiEvent::ErrorCleared,
-        UiBusEvent::SyncError { message } => FfiEvent::SyncError {
-            message: message.clone(),
+        UiBusEvent::SyncError { error } => FfiEvent::SyncError {
+            error: error.as_ref().map(loc::FfiError::from_core),
         },
         UiBusEvent::SyncingChanged { syncing } => FfiEvent::SyncingChanged { syncing: *syncing },
         UiBusEvent::SyncTimeChanged { time } => FfiEvent::SyncTimeChanged { sync_time: *time },
@@ -1911,8 +2074,8 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             ..
         } => FfiEvent::PlaybackProgress {
             progress: *progress,
-            elapsed: format_minutes_seconds(*position_ms),
-            remaining: format_minutes_seconds(duration_ms.saturating_sub(*position_ms)),
+            position_ms: *position_ms,
+            duration_ms: *duration_ms,
         },
         UiBusEvent::AlbumAdded { .. }
         | UiBusEvent::AlbumUpdated { .. }
@@ -1931,10 +2094,7 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
                     track_id: item.track_id.clone(),
                     title: item.title.clone(),
                     artist: item.artist_names.clone(),
-                    duration: item
-                        .duration_ms
-                        .map(|ms| format_minutes_seconds(ms as u64))
-                        .unwrap_or_default(),
+                    duration_ms: item.duration_ms,
                     album_title: item.album_title.clone(),
                     cover_image_id: item.cover_image_id.clone(),
                 })
@@ -1981,28 +2141,7 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
         } => FfiEvent::CandidateImportProgress {
             key: key.clone(),
             progress_percent: *progress_percent,
-            status: step.as_ref().map(|s| {
-                use bae_core::import::{ImportPhase, ImportStep, PrepareStep};
-                match s {
-                    ImportStep::Preparing(PrepareStep::ParsingMetadata) => {
-                        "Parsing metadata".to_string()
-                    }
-                    ImportStep::Preparing(PrepareStep::WritingCoverArt) => {
-                        "Writing cover art".to_string()
-                    }
-                    ImportStep::Preparing(PrepareStep::DiscoveringFiles) => {
-                        "Discovering files".to_string()
-                    }
-                    ImportStep::Preparing(PrepareStep::ValidatingTracks) => {
-                        "Validating tracks".to_string()
-                    }
-                    ImportStep::Preparing(PrepareStep::SavingToDatabase) => {
-                        "Saving to database".to_string()
-                    }
-                    ImportStep::Running(ImportPhase::Acquire) => "Acquiring".to_string(),
-                    ImportStep::Running(ImportPhase::Store) => "Storing".to_string(),
-                }
-            }),
+            step: step.as_ref().map(loc::FfiImportStep::from_core),
         },
         UiBusEvent::CandidateImportComplete {
             key,
@@ -2013,9 +2152,9 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             release_id: release_id.clone(),
             album_id: album_id.clone(),
         },
-        UiBusEvent::CandidateImportError { key, message } => FfiEvent::CandidateImportError {
+        UiBusEvent::CandidateImportError { key, error } => FfiEvent::CandidateImportError {
             key: key.clone(),
-            message: message.clone(),
+            error: loc::FfiError::from_core(error),
         },
         UiBusEvent::QueueItemsAdded { count } => FfiEvent::QueueItemsAdded { count: *count },
         _ => return None,

--- a/bae-windows-ffi/src/loc.rs
+++ b/bae-windows-ffi/src/loc.rs
@@ -1,0 +1,498 @@
+//! Locale-free wire mirrors and catalog-key selection for the Windows FFI.
+//!
+//! The locale never crosses the bridge: bae-core emits raw numbers, typed
+//! enums, and stable `core.*` catalog keys; the C# UI renders for its locale
+//! (numbers/bytes/durations via `Windows.Globalization`/`TimeSpan`, keys via
+//! `ResourceLoader.GetString` + the `MessageFormat` NuGet on the MF1 value).
+//!
+//! macOS binds the same core through uniffi, which generates `bridge_*_key()`
+//! functions from `bae-bridge/src/types.rs`. Windows has no uniffi, so the
+//! enum→key mapping is hand-mirrored here — this module is the single source of
+//! the `core.*` key strings on Windows (mirroring the strings in
+//! `bae-bridge/src/types.rs`). Each `*_key` returns exactly the same key macOS
+//! resolves, so a renamed catalog key is a one-line change in lockstep with the
+//! bridge, and the cross-check tests below fail the build if a key drops out of
+//! the catalog.
+//!
+//! These keys reach C# two ways, both single-sourced here:
+//!  - structured wire enums (below) serialize a `kind` tag the C# DTO switches
+//!    on, and the DTO calls `bae_*_key` (exported in `lib.rs`) for its key;
+//!  - the exported `bae_*_key` C-ABI functions return the key string directly
+//!    for the cases the C# can't reconstruct (cloud provider, audio channels).
+
+use bae_core::album_detail::TrackPosition;
+use serde::Serialize;
+
+// ── Track position ──────────────────────────────────────────────────────
+//
+// Structured position mirroring `BridgeTrackPosition`. The C# composes the
+// position string ("A1"/"2-3"/"5") mechanically from the fields and resolves
+// the side/disc header word from the `Side` group's catalog key. No prose
+// crosses the bridge — only the side letter, disc/track numbers, and the case.
+
+/// Wire mirror of `bae_core::album_detail::TrackPosition` (and the bridge's
+/// `BridgeTrackPosition`). `kind` tags the case; only that case's fields are
+/// set. The C# renders "A1" from `Sided`, "2-3" from `Disc`, "5" from `Flat`.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FfiTrackPosition {
+    /// Vinyl/cassette: position "{side_letter}{number}" (e.g. "A1").
+    Sided { side_letter: String, number: i32 },
+    /// Multi-disc digital: position "{disc}-{number}" (e.g. "2-3").
+    Disc { disc: i32, number: i32 },
+    /// Single-disc digital: position "{number}" (e.g. "5").
+    Flat { number: i32 },
+}
+
+impl FfiTrackPosition {
+    pub fn from_core(p: &TrackPosition) -> Self {
+        match p {
+            TrackPosition::Sided {
+                side_letter,
+                number,
+            } => Self::Sided {
+                side_letter: side_letter.clone(),
+                number: *number,
+            },
+            TrackPosition::Disc { disc, number } => Self::Disc {
+                disc: *disc,
+                number: *number,
+            },
+            TrackPosition::Flat { number } => Self::Flat { number: *number },
+        }
+    }
+}
+
+// ── Audio format ──────────────────────────────────────────────────────────
+//
+// Structured audio format mirroring `BridgeAudioFormat`. The C# composes the
+// one-line descriptor ("FLAC · 44.1 kHz · 16-bit · stereo") from the parts: the
+// codec is a proper noun, numbers format per locale, and the channel count maps
+// to a localized word via `bae_audio_channels_key`.
+
+/// Wire mirror of `bae_core::album_detail::AudioFormat` (and the bridge's
+/// `BridgeAudioFormat`). `bits_per_sample` present means lossless (show the bit
+/// depth); absent means lossy (show `bitrate_kbps`).
+#[derive(Serialize)]
+pub struct FfiAudioFormat {
+    pub codec: String,
+    pub sample_rate_hz: i64,
+    pub bits_per_sample: Option<i64>,
+    pub bitrate_kbps: Option<i64>,
+    pub channels: i64,
+}
+
+impl FfiAudioFormat {
+    pub fn from_core(f: &bae_core::album_detail::AudioFormat) -> Self {
+        Self {
+            codec: f.codec.clone(),
+            sample_rate_hz: f.sample_rate_hz,
+            bits_per_sample: f.bits_per_sample,
+            bitrate_kbps: f.bitrate_kbps,
+            channels: f.channels,
+        }
+    }
+}
+
+/// Catalog key for a channel count's word ("mono"/"stereo"), or `None` for
+/// counts the C# renders as "{n}ch". Mirrors `bridge_audio_channels_key`.
+pub fn audio_channels_key(channels: i64) -> Option<&'static str> {
+    match channels {
+        1 => Some("core.audio.channels.mono"),
+        2 => Some("core.audio.channels.stereo"),
+        _ => None,
+    }
+}
+
+// ── Cloud provider ──────────────────────────────────────────────────────────
+
+/// Catalog key for a cloud provider's display name, or `None` for the
+/// brand-name providers the UI passes through verbatim (iCloud, Google Drive,
+/// Dropbox, OneDrive). An empty/`None` wire tag means local-only. Mirrors
+/// `bridge_cloud_provider_label_key`. `provider` is the wire tag from
+/// `cloud_provider_name` ("s3"/"google_drive"/"dropbox"/"onedrive"/"cloudkit")
+/// or `None`/`""` for local-only.
+pub fn cloud_provider_label_key(provider: Option<&str>) -> Option<&'static str> {
+    match provider {
+        None | Some("") => Some("core.cloud.local_only"),
+        Some("s3") => Some("core.cloud.s3_compatible"),
+        // Brand names pass through (the UI hardcodes their display names).
+        Some(_) => None,
+    }
+}
+
+// ── Lookup failure ──────────────────────────────────────────────────────────
+//
+// Structured metadata-lookup failure mirroring `BridgeLookupFailure`. The C#
+// resolves a localized line per variant (`failure_key`) and renders
+// `Provider`'s status as the message argument. `Diagnostic` carries opaque,
+// log-only detail — never translated, never shown as primary copy.
+
+/// Wire mirror of `bae_core::signals::LookupFailure` (and the bridge's
+/// `BridgeLookupFailure`). `kind` tags the variant.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FfiLookupFailure {
+    /// Transport/connection failure — no HTTP response.
+    Network,
+    /// An HTTP error response, with its status code when one was observed.
+    Provider { status: Option<u16> },
+    /// The request timed out before a response arrived.
+    Timeout,
+    /// A local error. `detail` is the opaque error chain — log-only.
+    Diagnostic { detail: String },
+}
+
+impl FfiLookupFailure {
+    pub fn from_core(f: &bae_core::signals::LookupFailure) -> Self {
+        use bae_core::signals::LookupFailure;
+        match f {
+            LookupFailure::Network => Self::Network,
+            LookupFailure::Provider { status } => Self::Provider { status: *status },
+            LookupFailure::Timeout => Self::Timeout,
+            LookupFailure::Diagnostic { detail } => Self::Diagnostic {
+                detail: detail.clone(),
+            },
+        }
+    }
+}
+
+// ── Diagnostic error ──────────────────────────────────────────────────────────
+//
+// Structured user-facing error mirroring `BridgeError` (`bae_core::ui::UiError`).
+// The C# shows one generic localized line per category / per missing entity;
+// `detail` is the opaque Rust error chain — logged and offered in a copyable
+// disclosure, never translated.
+
+/// Wire mirror of `bae_core::ui::UiError` (and the bridge's `BridgeError`).
+/// `kind` tags the variant. `not_found` carries the entity wire tag the C#
+/// resolves via `bae_entity_not_found_key`; `diagnostic` carries the category
+/// wire tag the C# resolves via `bae_error_category_key` plus the opaque detail.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FfiError {
+    /// A specific entity was missing. `entity` is one of
+    /// "library"/"album"/"release"/"track"/"file".
+    NotFound { entity: &'static str, id: String },
+    /// A diagnostic failure. `category` is one of
+    /// "database"/"config"/"internal"/"import"/"export".
+    Diagnostic {
+        category: &'static str,
+        detail: String,
+    },
+}
+
+impl FfiError {
+    pub fn from_core(error: &bae_core::ui::UiError) -> Self {
+        use bae_core::ui::UiError;
+        match error {
+            UiError::NotFound { entity, id } => Self::NotFound {
+                entity: entity_kind_tag(*entity),
+                id: id.clone(),
+            },
+            UiError::Diagnostic { category, detail } => Self::Diagnostic {
+                category: error_category_tag(*category),
+                detail: detail.clone(),
+            },
+        }
+    }
+}
+
+/// Wire tag for a diagnostic error category. The C# maps it to its catalog key
+/// via `error_category_key` (single source below).
+fn error_category_tag(category: bae_core::ui::UiErrorCategory) -> &'static str {
+    use bae_core::ui::UiErrorCategory;
+    match category {
+        UiErrorCategory::Database => "database",
+        UiErrorCategory::Config => "config",
+        UiErrorCategory::Internal => "internal",
+        UiErrorCategory::Import => "import",
+        UiErrorCategory::Export => "export",
+    }
+}
+
+/// Wire tag for a missing-entity kind. The C# maps it to its catalog key via
+/// `entity_not_found_key` (single source below).
+fn entity_kind_tag(entity: bae_core::ui::UiEntityKind) -> &'static str {
+    use bae_core::ui::UiEntityKind;
+    match entity {
+        UiEntityKind::Library => "library",
+        UiEntityKind::Album => "album",
+        UiEntityKind::Release => "release",
+        UiEntityKind::Track => "track",
+        UiEntityKind::File => "file",
+    }
+}
+
+/// Catalog key for a diagnostic error category's generic line. Mirrors
+/// `bridge_error_category_key`. `category` is the wire tag `FfiError` carries.
+pub fn error_category_key(category: &str) -> Option<&'static str> {
+    match category {
+        "database" => Some("core.error.category.database"),
+        "config" => Some("core.error.category.config"),
+        "internal" => Some("core.error.category.internal"),
+        "import" => Some("core.error.category.import"),
+        "export" => Some("core.error.category.export"),
+        _ => None,
+    }
+}
+
+/// Catalog key for a missing-entity's "… not found" line. Mirrors
+/// `bridge_entity_not_found_key`. `entity` is the wire tag `FfiError` carries.
+pub fn entity_not_found_key(entity: &str) -> Option<&'static str> {
+    match entity {
+        "library" => Some("core.error.not_found.library"),
+        "album" => Some("core.error.not_found.album"),
+        "release" => Some("core.error.not_found.release"),
+        "track" => Some("core.error.not_found.track"),
+        "file" => Some("core.error.not_found.file"),
+        _ => None,
+    }
+}
+
+// ── Playback error ──────────────────────────────────────────────────────────
+//
+// Structured playback failure mirroring `BridgePlaybackErrorReason`. The two
+// actionable cloud-only cases are keyed; every in-core failure rides in
+// `Diagnostic` and renders through the same `FfiError` category path.
+
+/// Wire mirror of `bae_core::ui::PlaybackErrorReason` (and the bridge's
+/// `BridgePlaybackErrorReason`). `kind` tags the variant; `Diagnostic` carries
+/// the structured `FfiError`.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FfiPlaybackErrorReason {
+    SyncDisconnected,
+    UploadPending,
+    Diagnostic { error: FfiError },
+}
+
+impl FfiPlaybackErrorReason {
+    pub fn from_core(reason: &bae_core::ui::PlaybackErrorReason) -> Self {
+        use bae_core::ui::PlaybackErrorReason;
+        match reason {
+            PlaybackErrorReason::SyncDisconnected => Self::SyncDisconnected,
+            PlaybackErrorReason::UploadPending => Self::UploadPending,
+            PlaybackErrorReason::Diagnostic { error } => Self::Diagnostic {
+                error: FfiError::from_core(error),
+            },
+        }
+    }
+}
+
+/// Catalog key for an actionable playback reason, or `None` for `diagnostic`
+/// (the C# renders that through the `FfiError` category path). Mirrors
+/// `bridge_playback_error_reason_key`. `kind` is the wire tag.
+pub fn playback_error_reason_key(kind: &str) -> Option<&'static str> {
+    match kind {
+        "sync_disconnected" => Some("core.playback.error.sync_disconnected"),
+        "upload_pending" => Some("core.playback.error.upload_pending"),
+        _ => None,
+    }
+}
+
+// ── Import step ──────────────────────────────────────────────────────────────
+//
+// Structured import-progress step mirroring `BridgeImportStep`
+// (`BridgePrepareStep`/`BridgeImportPhase`). The C# resolves the localized verb
+// from the key; no English prose crosses the bridge.
+
+/// Wire mirror of `bae_core::import::ImportStep`. `kind` tags whether it's a
+/// prepare step or a running phase; `step`/`phase` is the inner wire tag the C#
+/// resolves via `import_step_key`.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FfiImportStep {
+    Preparing { step: &'static str },
+    Running { phase: &'static str },
+}
+
+impl FfiImportStep {
+    pub fn from_core(step: &bae_core::import::ImportStep) -> Self {
+        use bae_core::import::{ImportPhase, ImportStep, PrepareStep};
+        match step {
+            ImportStep::Preparing(p) => Self::Preparing {
+                step: match p {
+                    PrepareStep::ParsingMetadata => "parsing_metadata",
+                    PrepareStep::WritingCoverArt => "writing_cover_art",
+                    PrepareStep::DiscoveringFiles => "discovering_files",
+                    PrepareStep::ValidatingTracks => "validating_tracks",
+                    PrepareStep::SavingToDatabase => "saving_to_database",
+                },
+            },
+            ImportStep::Running(phase) => Self::Running {
+                phase: match phase {
+                    ImportPhase::Acquire => "acquire",
+                    ImportPhase::Store => "store",
+                },
+            },
+        }
+    }
+}
+
+/// Catalog key for an import prepare-step wire tag. Mirrors
+/// `bridge_prepare_step_key`.
+pub fn prepare_step_key(step: &str) -> Option<&'static str> {
+    match step {
+        "parsing_metadata" => Some("core.import.prepare.parsing_metadata"),
+        "writing_cover_art" => Some("core.import.prepare.writing_cover_art"),
+        "discovering_files" => Some("core.import.prepare.discovering_files"),
+        "validating_tracks" => Some("core.import.prepare.validating_tracks"),
+        "saving_to_database" => Some("core.import.prepare.saving_to_database"),
+        _ => None,
+    }
+}
+
+/// Catalog key for an import-phase wire tag. Mirrors `bridge_import_phase_key`.
+pub fn import_phase_key(phase: &str) -> Option<&'static str> {
+    match phase {
+        "acquire" => Some("core.import.phase.acquire"),
+        "store" => Some("core.import.phase.store"),
+        _ => None,
+    }
+}
+
+// ── Storage state + transfer action ─────────────────────────────────────────
+
+/// Catalog key for a transfer action's present-continuous progress verb. The
+/// `action` is the wire tag `FfiStorageRow.actions` carries. Mirrors
+/// `bridge_transfer_action_key`.
+pub fn transfer_action_key(action: &str) -> Option<&'static str> {
+    match action {
+        "pin" => Some("core.transfer.action.pin"),
+        "unpin" => Some("core.transfer.action.unpin"),
+        "manage" => Some("core.transfer.action.manage"),
+        "unmanage" => Some("core.transfer.action.unmanage"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Load the master catalog the macOS app and the Windows `Core.resw` are
+    /// generated from, so a renamed/dropped key fails this build instead of
+    /// rendering a raw key in the WinUI app.
+    fn catalog() -> bae_loc::Catalog {
+        bae_loc::Catalog::from_toml(include_str!("../../bae-bridge/loc/catalog.toml"))
+            .expect("catalog parses")
+    }
+
+    fn assert_key(cat: &bae_loc::Catalog, key: &str) {
+        assert!(cat.messages.contains_key(key), "catalog missing `{key}`");
+    }
+
+    #[test]
+    fn audio_channels_keys_exist() {
+        let cat = catalog();
+        assert_key(&cat, audio_channels_key(1).expect("mono"));
+        assert_key(&cat, audio_channels_key(2).expect("stereo"));
+        assert!(
+            audio_channels_key(6).is_none(),
+            "5.1 has no word, renders Nch"
+        );
+    }
+
+    #[test]
+    fn cloud_provider_keys_exist() {
+        let cat = catalog();
+        assert_key(&cat, cloud_provider_label_key(None).expect("local only"));
+        assert_key(
+            &cat,
+            cloud_provider_label_key(Some("")).expect("local only"),
+        );
+        assert_key(&cat, cloud_provider_label_key(Some("s3")).expect("s3"));
+        for brand in ["google_drive", "dropbox", "onedrive", "cloudkit"] {
+            assert!(
+                cloud_provider_label_key(Some(brand)).is_none(),
+                "brand names pass through: {brand}"
+            );
+        }
+    }
+
+    #[test]
+    fn error_keys_exist() {
+        let cat = catalog();
+        for category in ["database", "config", "internal", "import", "export"] {
+            assert_key(&cat, error_category_key(category).expect("category keyed"));
+        }
+        for entity in ["library", "album", "release", "track", "file"] {
+            assert_key(&cat, entity_not_found_key(entity).expect("entity keyed"));
+        }
+        assert!(error_category_key("nope").is_none());
+        assert!(entity_not_found_key("nope").is_none());
+    }
+
+    #[test]
+    fn playback_reason_keys_exist() {
+        let cat = catalog();
+        assert_key(
+            &cat,
+            playback_error_reason_key("sync_disconnected").expect("actionable"),
+        );
+        assert_key(
+            &cat,
+            playback_error_reason_key("upload_pending").expect("actionable"),
+        );
+        assert!(
+            playback_error_reason_key("diagnostic").is_none(),
+            "diagnostic renders through the FfiError category path"
+        );
+    }
+
+    #[test]
+    fn import_step_keys_exist() {
+        let cat = catalog();
+        for step in [
+            "parsing_metadata",
+            "writing_cover_art",
+            "discovering_files",
+            "validating_tracks",
+            "saving_to_database",
+        ] {
+            assert_key(&cat, prepare_step_key(step).expect("prepare step keyed"));
+        }
+        for phase in ["acquire", "store"] {
+            assert_key(&cat, import_phase_key(phase).expect("phase keyed"));
+        }
+    }
+
+    #[test]
+    fn transfer_action_keys_exist() {
+        let cat = catalog();
+        for action in ["pin", "unpin", "manage", "unmanage"] {
+            assert_key(&cat, transfer_action_key(action).expect("action keyed"));
+        }
+    }
+
+    /// The structured-composition keys the C# resolves (side/disc headers,
+    /// queue counts, outbox/transfer args, lookup failures, pressings plural)
+    /// must all exist — these have no `*_key` fn (the C# hardcodes the dotted
+    /// key for them), so this is their cross-check.
+    #[test]
+    fn composition_keys_exist() {
+        let cat = catalog();
+        for key in [
+            "core.track.side",
+            "core.track.disc",
+            "core.import.pressings",
+            "core.lookup.failure.network",
+            "core.lookup.failure.provider",
+            "core.lookup.failure.provider_unknown",
+            "core.lookup.failure.timeout",
+            "core.lookup.failure.diagnostic",
+            "core.queue.uploading",
+            "core.queue.downloading",
+            "core.queue.failed",
+            "core.queue.queued",
+            "core.outbox.bytes_progress",
+            "core.outbox.throughput",
+            "core.outbox.eta",
+            "core.outbox.pending_deletes",
+            "core.transfer.files",
+        ] {
+            assert_key(&cat, key);
+        }
+    }
+}

--- a/bae-windows/.gitignore
+++ b/bae-windows/.gitignore
@@ -5,3 +5,9 @@ obj/
 # Visual Studio
 .vs/
 *.user
+
+# Generated localization resources. loc-gen emits Strings/<lang>/Core.resw from
+# the master catalog (bae-bridge/loc/catalog.toml) on every build, the way the
+# macOS build regenerates Core.xcstrings. The committed Strings/<lang>/Resources.resw
+# (bare app chrome) are NOT generated and stay tracked.
+Strings/*/Core.resw

--- a/bae-windows/AlbumDetail.cs
+++ b/bae-windows/AlbumDetail.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Bae.Windows;
 
@@ -23,6 +24,10 @@ public sealed class Release
     public string DisplayName { get; set; } = string.Empty;
     public List<Track> Tracks { get; set; } = new();
 
+    /// <summary>The release's files (audio + images), each carrying its
+    /// structured audio format where applicable.</summary>
+    public List<ReleaseFile> Files { get; set; } = new();
+
     /// <summary>The picker label.</summary>
     public override string ToString() => DisplayName;
 }
@@ -32,10 +37,126 @@ public sealed class Track
 {
     public string TrackId { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
-    public string Position { get; set; } = string.Empty;
-    public string Duration { get; set; } = string.Empty;
+
+    /// <summary>Structured position; the locale never crosses the bridge, so the
+    /// position string ("A1"/"2-3"/"5") is composed here from the case.</summary>
+    public TrackPosition Position { get; set; } = new();
+
+    /// <summary>Raw track length in milliseconds, or null when unknown.</summary>
+    public long? DurationMs { get; set; }
+
     public string Artist { get; set; } = string.Empty;
 
+    /// <summary>The composed position string, e.g. "A1" / "2-3" / "5".</summary>
+    public string PositionLabel => Position.Label;
+
+    /// <summary>The track length formatted for the locale, e.g. "3:07"; empty if
+    /// unknown.</summary>
+    public string DurationLabel => Loc.Duration(DurationMs);
+
     /// <summary>The list row; used as the default item text.</summary>
-    public override string ToString() => $"{Position}  {Title}  {Duration}".Trim();
+    public override string ToString() => $"{PositionLabel}  {Title}  {DurationLabel}".Trim();
+}
+
+/// <summary>
+/// A track's structured display position, mirroring the FFI's
+/// <c>FfiTrackPosition</c> (and the bridge's <c>BridgeTrackPosition</c>).
+/// <see cref="Kind"/> tags the case; only that case's fields are set. The UI
+/// composes the position string mechanically — no prose crosses the bridge.
+/// </summary>
+public sealed class TrackPosition
+{
+    /// <summary>"sided" / "disc" / "flat".</summary>
+    public string Kind { get; set; } = "flat";
+
+    /// <summary>Side letter (A/B/C…) for the "sided" case.</summary>
+    public string? SideLetter { get; set; }
+
+    /// <summary>Disc number for the "disc" case.</summary>
+    public int Disc { get; set; }
+
+    /// <summary>Within-side / within-disc / flat track number.</summary>
+    public int Number { get; set; }
+
+    /// <summary>The composed position string: "{side_letter}{number}" (A1),
+    /// "{disc}-{number}" (2-3), or "{number}" (5).</summary>
+    [JsonIgnore]
+    public string Label => Kind switch
+    {
+        "sided" => $"{SideLetter}{Number}",
+        "disc" => $"{Disc}-{Number}",
+        _ => Number.ToString(System.Globalization.CultureInfo.CurrentCulture),
+    };
+}
+
+/// <summary>
+/// One file in a release, mirroring the FFI's <c>FfiFile</c> (and the bridge's
+/// <c>BridgeFile</c>). <see cref="AudioFormat"/> is null for non-audio files.
+/// </summary>
+public sealed class ReleaseFile
+{
+    public string Id { get; set; } = string.Empty;
+    public string OriginalFilename { get; set; } = string.Empty;
+    public long FileSize { get; set; }
+    public string ContentType { get; set; } = string.Empty;
+    public bool IsImage { get; set; }
+
+    /// <summary>Structured audio format for an audio file; null otherwise.</summary>
+    public AudioFormat? AudioFormat { get; set; }
+
+    /// <summary>File size formatted for the locale, e.g. "12.4 MB".</summary>
+    public string SizeLabel => Loc.Bytes(FileSize);
+}
+
+/// <summary>
+/// A file's structured audio format, mirroring the FFI's <c>FfiAudioFormat</c>
+/// (and the bridge's <c>BridgeAudioFormat</c>). The one-line descriptor is
+/// composed here from the parts: the codec is a proper noun, numbers format per
+/// locale, and the channel count maps to a localized word.
+/// <see cref="BitsPerSample"/> present means lossless (show the bit depth);
+/// absent means lossy (show <see cref="BitrateKbps"/>).
+/// </summary>
+public sealed class AudioFormat
+{
+    public string Codec { get; set; } = string.Empty;
+    public long SampleRateHz { get; set; }
+    public long? BitsPerSample { get; set; }
+    public long? BitrateKbps { get; set; }
+    public long Channels { get; set; }
+
+    /// <summary>The one-line descriptor, e.g. "FLAC · 44.1 kHz · 16-bit · stereo"
+    /// (lossless) or "MP3 · 320 kbps · 44.1 kHz · stereo" (lossy).</summary>
+    [JsonIgnore]
+    public string Text
+    {
+        get
+        {
+            var culture = System.Globalization.CultureInfo.CurrentCulture;
+            var parts = new List<string> { Codec };
+            if (BitsPerSample is null && BitrateKbps is { } kbps)
+            {
+                parts.Add($"{Loc.Number(kbps)} kbps");
+            }
+            var khz = SampleRateHz / 1000.0;
+            parts.Add($"{khz.ToString("0.#", culture)} kHz");
+            if (BitsPerSample is { } bits)
+            {
+                parts.Add($"{Loc.Number(bits)}-bit");
+            }
+            parts.Add(ChannelsText);
+            return string.Join(" · ", parts);
+        }
+    }
+
+    /// <summary>The localized channel word ("mono"/"stereo") or "{n}ch" for
+    /// counts with no word. The key comes from the FFI (one source for the
+    /// mapping), resolved through the Core catalog.</summary>
+    private string ChannelsText
+    {
+        get
+        {
+            var key = NativeBae.AudioChannelsKey(Channels);
+            return key is null ? $"{Loc.Number(Channels)}ch" : Loc.Core(key);
+        }
+    }
 }

--- a/bae-windows/BaeEvent.cs
+++ b/bae-windows/BaeEvent.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Bae.Windows;
 
@@ -6,6 +6,10 @@ namespace Bae.Windows;
 /// A UI event from the core, deserialized from the FFI's tagged JSON. A single
 /// flat shape covers every event: <see cref="Type"/> names the FfiEvent variant
 /// and only that variant's fields are set; the handler switches on it.
+///
+/// The locale never crosses the bridge: progress/duration are raw milliseconds
+/// formatted here, and failures are structured (<see cref="Reason"/>,
+/// <see cref="Error"/>, <see cref="Step"/>) so the UI resolves a localized line.
 /// </summary>
 public sealed class BaeEvent
 {
@@ -18,10 +22,25 @@ public sealed class BaeEvent
     public string? TrackTitle { get; set; }
     public string? Artist { get; set; }
     public string? CoverImageId { get; set; }
-    public string? DurationLabel { get; set; }
+
+    // Raw track length / playback position in milliseconds; formatted for the
+    // locale by the handler. DurationMs is carried by PlaybackPlaying /
+    // PlaybackPaused / PlaybackProgress / PreviewPlaying; PositionMs by
+    // PlaybackProgress / PreviewProgress.
+    public ulong DurationMs { get; set; }
+    public ulong PositionMs { get; set; }
     public double Progress { get; set; }
-    public string? Elapsed { get; set; }
-    public string? Remaining { get; set; }
+
+    /// <summary>Now-playing track length formatted for the locale, e.g. "3:07".</summary>
+    public string DurationLabel => Loc.Duration((long)DurationMs);
+
+    /// <summary>Elapsed playback position formatted for the locale.</summary>
+    public string ElapsedLabel => Loc.Duration((long)PositionMs);
+
+    /// <summary>Remaining playback time (duration − position) formatted for the
+    /// locale; the now-playing bar shows it on the trailing side.</summary>
+    public string RemainingLabel =>
+        Loc.Duration((long)(DurationMs > PositionMs ? DurationMs - PositionMs : 0));
 
     // Volume / mute / repeat.
     public float Volume { get; set; }
@@ -44,17 +63,64 @@ public sealed class BaeEvent
     // Auto-identify events (CandidateIdentifyState).
     public string? Status { get; set; }
     public List<Candidate>? Matches { get; set; }
-    public string? Message { get; set; }
 
     // Per-signal badge list, carried by CandidateIdentifyState.
     public List<SignalBadge>? Signals { get; set; }
 
-    // Import events (CandidateImportProgress / Complete / Error).
+    // Import progress (CandidateImportProgress): percent + the structured step.
     public int ProgressPercent { get; set; }
+
+    /// <summary>The structured import step (CandidateImportProgress); null before
+    /// the first step is known. The handler resolves its localized verb.</summary>
+    public ImportStep? Step { get; set; }
+
+    /// <summary>The structured diagnostic for Error / SyncError /
+    /// CandidateImportError; null when SyncError clears a prior failure.</summary>
+    public DiagnosticError? Error { get; set; }
+
+    /// <summary>The structured playback-failure reason (PlaybackError).</summary>
+    public PlaybackErrorReason? Reason { get; set; }
 
     // Sync status (SyncingChanged / SyncTimeChanged) for the toolbar indicator.
     // SyncTime is Unix epoch milliseconds of the last successful sync, or null
     // when never synced.
     public bool Syncing { get; set; }
     public long? SyncTime { get; set; }
+}
+
+/// <summary>
+/// A structured import-progress step, mirroring the FFI's <c>FfiImportStep</c>.
+/// <see cref="Kind"/> tags whether it's a prepare step ("preparing") or a
+/// running phase ("running"); <see cref="StepTag"/> / <see cref="Phase"/> is the
+/// inner wire tag whose catalog key the FFI maps. The locale never crosses the
+/// bridge — the verb is resolved here.
+/// </summary>
+public sealed class ImportStep
+{
+    /// <summary>"preparing" / "running".</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Prepare-step wire tag for the "preparing" case
+    /// (e.g. "parsing_metadata").</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("step")]
+    public string? StepTag { get; set; }
+
+    /// <summary>Import-phase wire tag for the "running" case ("acquire"/"store").</summary>
+    public string? Phase { get; set; }
+
+    /// <summary>The localized progress verb for this step, or empty for an
+    /// unknown tag. The key comes from the FFI (one source for the mapping).</summary>
+    public string LocalizedLabel
+    {
+        get
+        {
+            var key = Kind switch
+            {
+                "preparing" when StepTag is not null => NativeBae.PrepareStepKey(StepTag),
+                "running" when Phase is not null => NativeBae.ImportPhaseKey(Phase),
+                _ => null,
+            };
+            return key is null ? string.Empty : Loc.Core(key);
+        }
+    }
 }

--- a/bae-windows/DiagnosticError.cs
+++ b/bae-windows/DiagnosticError.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// A user-facing error from the core, mirroring the FFI's <c>FfiError</c> (and
+/// the bridge's <c>BridgeError</c> / macOS's <c>BridgeError+Localized</c>). The
+/// locale never crosses the bridge: this is a typed reason plus, for
+/// diagnostics, the opaque Rust error chain (<see cref="Detail"/>) the UI logs
+/// and offers in a copyable disclosure but never translates. The
+/// <see cref="LocalizedLine"/> resolves the generic per-category / per-entity
+/// line for the current locale.
+/// </summary>
+public sealed class DiagnosticError
+{
+    /// <summary>"not_found" / "diagnostic".</summary>
+    public string Kind { get; set; } = "diagnostic";
+
+    /// <summary>The missing entity's wire tag for the "not_found" case
+    /// ("library"/"album"/"release"/"track"/"file").</summary>
+    public string? Entity { get; set; }
+
+    /// <summary>The missing entity's id for the "not_found" case (log/detail
+    /// only — never shown as primary copy).</summary>
+    public string? Id { get; set; }
+
+    /// <summary>The diagnostic category wire tag for the "diagnostic" case
+    /// ("database"/"config"/"internal"/"import"/"export").</summary>
+    public string? Category { get; set; }
+
+    /// <summary>The opaque Rust error chain for the "diagnostic" case — logged
+    /// and offered in a copyable disclosure, never translated.</summary>
+    public string? Detail { get; set; }
+
+    /// <summary>
+    /// The generic localized line for this error. For "not_found" it's the
+    /// entity's "… not found" line; for "diagnostic" it's the category's generic
+    /// line. The key comes from the FFI (one source for the mapping); a missing
+    /// mapping falls back to the internal-error line.
+    /// </summary>
+    [JsonIgnore]
+    public string LocalizedLine
+    {
+        get
+        {
+            var key = Kind switch
+            {
+                "not_found" when Entity is not null => NativeBae.EntityNotFoundKey(Entity),
+                "diagnostic" when Category is not null => NativeBae.ErrorCategoryKey(Category),
+                _ => null,
+            };
+            return key is null ? Loc.Core("core.error.category.internal") : Loc.Core(key);
+        }
+    }
+}
+
+/// <summary>
+/// Why playback couldn't start or continue, mirroring the FFI's
+/// <c>FfiPlaybackErrorReason</c> (and the bridge's
+/// <c>BridgePlaybackErrorReason</c>). The two actionable cloud-only cases are
+/// keyed; every in-core failure rides in <see cref="Error"/> and renders
+/// through the diagnostic-error path.
+/// </summary>
+public sealed class PlaybackErrorReason
+{
+    /// <summary>"sync_disconnected" / "upload_pending" / "diagnostic".</summary>
+    public string Kind { get; set; } = "diagnostic";
+
+    /// <summary>The structured diagnostic for the "diagnostic" case.</summary>
+    public DiagnosticError? Error { get; set; }
+
+    /// <summary>The localized line for this reason: the actionable line for the
+    /// keyed cases, else the diagnostic error's generic line.</summary>
+    [JsonIgnore]
+    public string LocalizedLine
+    {
+        get
+        {
+            var key = NativeBae.PlaybackErrorReasonKey(Kind);
+            if (key is not null)
+            {
+                return Loc.Core(key);
+            }
+            return Error?.LocalizedLine ?? Loc.Core("core.error.category.internal");
+        }
+    }
+}
+
+/// <summary>
+/// A metadata-lookup failure, mirroring the FFI's <c>FfiLookupFailure</c> (and
+/// the bridge's <c>BridgeLookupFailure</c>). The UI resolves a localized line
+/// per variant and renders <c>provider</c>'s status as the message argument;
+/// <see cref="Detail"/> for the diagnostic case is opaque, log-only.
+/// </summary>
+public sealed class LookupFailure
+{
+    /// <summary>"network" / "provider" / "timeout" / "diagnostic".</summary>
+    public string Kind { get; set; } = "diagnostic";
+
+    /// <summary>The HTTP status code for the "provider" case, when one was
+    /// observed; null otherwise.</summary>
+    public int? Status { get; set; }
+
+    /// <summary>The opaque error chain for the "diagnostic" case — log-only.</summary>
+    public string? Detail { get; set; }
+
+    /// <summary>The localized failure line for the current locale.</summary>
+    [JsonIgnore]
+    public string LocalizedLine => Kind switch
+    {
+        "network" => Loc.Core("core.lookup.failure.network"),
+        "timeout" => Loc.Core("core.lookup.failure.timeout"),
+        "provider" => Status is { } status
+            ? Loc.Core("core.lookup.failure.provider", "status", status)
+            : Loc.Core("core.lookup.failure.provider_unknown"),
+        // Diagnostic carries no translated copy — show the generic line; Detail
+        // is surfaced separately (log / copyable disclosure).
+        _ => Loc.Core("core.lookup.failure.diagnostic"),
+    };
+}

--- a/bae-windows/Loc.cs
+++ b/bae-windows/Loc.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using Jeffijoe.MessageFormat;
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// Localized-string resolution and locale-aware value formatting — the one
+/// computation the UI is required to do because the locale never crosses the
+/// bridge. bae-core and bae-windows-ffi emit raw numbers, typed enums, and
+/// stable <c>core.*</c> / <c>ui.*</c> catalog keys; this class turns a key (and
+/// its MessageFormat arguments) into a string for the current locale, and
+/// formats raw byte counts / durations / numbers the way macOS does with
+/// <c>ByteCountFormatter</c> / <c>DateComponentsFormatter</c>.
+///
+/// The <c>core.*</c> keys live in the <c>Core</c> resource table generated from
+/// the master catalog (<c>bae-bridge/loc/catalog.toml</c>) by
+/// <c>loc-gen --target windows</c>; the <c>ui.*</c> chrome keys live in the same
+/// table (also generated) and bare app chrome lives in <c>Resources</c>. Each
+/// message value is an ICU MessageFormat 1 string; the
+/// <see href="https://github.com/jeffijoe/messageformat.net">MessageFormat</see>
+/// NuGet parses it at runtime (plural / select / named args), matching the
+/// verbatim MF1 macOS/Android consume.
+/// </summary>
+internal static class Loc
+{
+    // The Core table holds bridge-originated keys (core.*) and shared chrome
+    // (ui.*); both are generated from the master catalog. Bare app chrome lives
+    // in the default Resources table. ResourceLoader maps a table name to its
+    // compiled .resw subtree.
+    private static readonly ResourceLoader CoreLoader = new("Core");
+    private static readonly ResourceLoader ChromeLoader = new();
+
+    // One formatter per culture name. The MessageFormat instance compiles and
+    // caches each pattern; its locale drives plural-category selection ("one" vs
+    // "other"), so it must track the UI culture, not the invariant one.
+    private static readonly Dictionary<string, MessageFormatter> Formatters = new();
+    private static readonly object FormattersLock = new();
+
+    /// <summary>
+    /// The resolved string for a <c>core.*</c> / <c>ui.*</c> catalog key, with
+    /// no arguments. Use <see cref="Core(string, IReadOnlyDictionary{string, object?})"/>
+    /// for a message that takes MessageFormat arguments.
+    /// </summary>
+    internal static string Core(string key) => Lookup(CoreLoader, key);
+
+    /// <summary>
+    /// The resolved string for a <c>core.*</c> / <c>ui.*</c> catalog key, with
+    /// its MessageFormat arguments substituted (named args, plural/select).
+    /// </summary>
+    internal static string Core(string key, IReadOnlyDictionary<string, object?> args) =>
+        Format(Lookup(CoreLoader, key), args);
+
+    /// <summary>One-argument convenience overload.</summary>
+    internal static string Core(string key, string name, object? value) =>
+        Core(key, new Dictionary<string, object?> { [name] = value });
+
+    /// <summary>The resolved string for a bare app-chrome key in the default
+    /// <c>Resources</c> table.</summary>
+    internal static string Chrome(string key) => Lookup(ChromeLoader, key);
+
+    /// <summary>The resolved string for an app-chrome key in the default
+    /// <c>Resources</c> table, with its MessageFormat arguments substituted.</summary>
+    internal static string Chrome(string key, IReadOnlyDictionary<string, object?> args) =>
+        Format(Lookup(ChromeLoader, key), args);
+
+    /// <summary>One-argument convenience overload for app chrome.</summary>
+    internal static string Chrome(string key, string name, object? value) =>
+        Chrome(key, new Dictionary<string, object?> { [name] = value });
+
+    /// <summary>
+    /// Resolve a key, returning the key itself when it isn't found so a missing
+    /// catalog entry is visible in the UI rather than silently empty. The
+    /// resource name is the dotted id with <c>.</c>/<c>-</c> mapped to <c>/</c>
+    /// because <c>ResourceLoader.GetString</c> treats <c>/</c> and <c>.</c> as
+    /// the resource-map path separator; resw <c>name</c>s keep the dotted id, so
+    /// the path form addresses the same entry.
+    /// </summary>
+    private static string Lookup(ResourceLoader loader, string key)
+    {
+        var resolved = loader.GetString(key.Replace('.', '/'));
+        return string.IsNullOrEmpty(resolved) ? key : resolved;
+    }
+
+    /// <summary>
+    /// Substitute MessageFormat arguments into a resolved pattern for the
+    /// current UI culture. The MF1 pattern is the verbatim catalog value.
+    /// </summary>
+    private static string Format(string pattern, IReadOnlyDictionary<string, object?> args)
+    {
+        var culture = CultureInfo.CurrentUICulture.Name;
+        MessageFormatter formatter;
+        lock (FormattersLock)
+        {
+            if (!Formatters.TryGetValue(culture, out formatter!))
+            {
+                // useCache: the formatter memoizes each compiled pattern; locale
+                // is the BCP-47 name so plural categories resolve per locale.
+                formatter = new MessageFormatter(useCache: true, locale: culture);
+                Formatters[culture] = formatter;
+            }
+        }
+
+        // MessageFormat.NET takes IReadOnlyDictionary<string, object?>; pass the
+        // args through with non-null values (a null arg renders as empty, which
+        // is the right behavior for an optional substitution).
+        var data = new Dictionary<string, object?>(args.Count);
+        foreach (var (name, value) in args)
+        {
+            data[name] = value ?? string.Empty;
+        }
+        return formatter.FormatMessage(pattern, data);
+    }
+
+    // ── Value formatters (locale-aware) ──────────────────────────────────────
+
+    /// <summary>
+    /// A raw byte count formatted for the current locale, e.g. "412 MB" — the
+    /// analog of macOS's <c>ByteCountFormatter(.file)</c>. Decimal (SI) units to
+    /// match the byte counts the storage UI shows elsewhere.
+    /// </summary>
+    internal static string Bytes(long bytes)
+    {
+        var b = bytes < 0 ? 0 : bytes;
+        string[] units = { "B", "KB", "MB", "GB", "TB" };
+        double value = b;
+        var unit = 0;
+        while (value >= 1000 && unit < units.Length - 1)
+        {
+            value /= 1000;
+            unit++;
+        }
+        // Whole bytes show no decimal; larger units show one. NumberFormatInfo
+        // from the current culture localizes the decimal separator.
+        var culture = CultureInfo.CurrentCulture;
+        return unit == 0
+            ? string.Format(culture, "{0:0} {1}", value, units[unit])
+            : string.Format(culture, "{0:0.0} {1}", value, units[unit]);
+    }
+
+    /// <summary>
+    /// A raw millisecond duration formatted as minutes:seconds for the current
+    /// locale (e.g. "3:07") — the analog of macOS's
+    /// <c>DateComponentsFormatter</c> in the now-playing / track-list context.
+    /// Hours roll into the leading field when present. Returns an empty string
+    /// for a null duration (unknown track length).
+    /// </summary>
+    internal static string Duration(long? milliseconds)
+    {
+        if (milliseconds is not { } ms)
+        {
+            return string.Empty;
+        }
+        var span = TimeSpan.FromMilliseconds(ms < 0 ? 0 : ms);
+        var culture = CultureInfo.CurrentCulture;
+        // "m:ss", or "h:mm:ss" once an hour accrues — the conventional
+        // track/elapsed form. TimeSpan's own formatting can't drop the leading
+        // zero on minutes, so compose the fields explicitly.
+        return span.TotalHours >= 1
+            ? string.Format(
+                culture, "{0}:{1:00}:{2:00}",
+                (int)span.TotalHours, span.Minutes, span.Seconds)
+            : string.Format(culture, "{0}:{1:00}", span.Minutes, span.Seconds);
+    }
+
+    /// <summary>
+    /// A raw whole number formatted for the current locale (grouping separators),
+    /// e.g. a sample-rate or track number. macOS uses <c>.formatted()</c>; this
+    /// is the .NET equivalent.
+    /// </summary>
+    internal static string Number(long value) =>
+        value.ToString("N0", CultureInfo.CurrentCulture);
+}

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -8,7 +8,7 @@
     <!-- Background="Transparent" makes the whole window a hit-testable drop target,
          so a folder can be dropped over empty areas (e.g. the empty-library state),
          not just over the grid. -->
-    <Grid KeyDown="OnGlobalKeyDown" AllowDrop="True" DragOver="OnWindowDragOver" Drop="OnWindowDrop" Background="Transparent">
+    <Grid x:Name="RootGrid" KeyDown="OnGlobalKeyDown" AllowDrop="True" DragOver="OnWindowDragOver" Drop="OnWindowDrop" Background="Transparent">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Modifiers="Control" Key="F" Invoked="OnFocusSearchAccelerator" />
             <KeyboardAccelerator Modifiers="Control" Key="L" Invoked="OnGoToNowPlaying" />
@@ -25,6 +25,7 @@
             </Grid.ColumnDefinitions>
             <AutoSuggestBox
                 x:Name="SearchBox"
+                x:Uid="SearchBox"
                 Grid.Column="0"
                 PlaceholderText="search"
                 QueryIcon="Find"
@@ -33,8 +34,8 @@
                 <TextBlock x:Name="SyncIndicator" VerticalAlignment="Center"
                            Foreground="Gray" TextWrapping="NoWrap" />
                 <ComboBox x:Name="SortBox" SelectionChanged="OnSortChanged" VerticalAlignment="Center" />
-                <Button Content="libraries" Click="OnLibrariesClick" />
-                <Button Content="close" Click="OnCloseLibraryClick" ToolTipService.ToolTip="close library">
+                <Button x:Uid="LibrariesButton" Content="libraries" Click="OnLibrariesClick" />
+                <Button x:Uid="CloseLibraryButton" Content="close" Click="OnCloseLibraryClick" ToolTipService.ToolTip="close library">
                     <Button.KeyboardAccelerators>
                         <!-- Ctrl+Shift+W, not bare Ctrl+W: closing the library is destructive
                              (tears down to the welcome chooser), and bare Ctrl+W is the reflex
@@ -42,17 +43,17 @@
                         <KeyboardAccelerator Modifiers="Control,Shift" Key="W" />
                     </Button.KeyboardAccelerators>
                 </Button>
-                <Button Content="import" Click="OnImportClick">
+                <Button x:Uid="ImportButton" Content="import" Click="OnImportClick">
                     <Button.KeyboardAccelerators>
                         <KeyboardAccelerator Modifiers="Control" Key="I" />
                     </Button.KeyboardAccelerators>
                 </Button>
-                <Button Content="storage" Click="OnStorageClick">
+                <Button x:Uid="StorageButton" Content="storage" Click="OnStorageClick">
                     <Button.KeyboardAccelerators>
                         <KeyboardAccelerator Modifiers="Control" Key="Number0" />
                     </Button.KeyboardAccelerators>
                 </Button>
-                <Button Content="settings" Click="OnSettingsClick" />
+                <Button x:Uid="SettingsButton" Content="settings" Click="OnSettingsClick" />
             </StackPanel>
         </Grid>
         <GridView

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
@@ -31,14 +32,17 @@ public sealed partial class MainWindow : Window
     private const uint PositionUpdateIntervalMs = 250;
     private const ulong FirstPageSize = 500;
 
-    private sealed record SortOption(string Label, string Field, bool Ascending);
+    // LabelKey is a chrome key resolved to the localized menu label at display
+    // time; Field is the locale-free sort identifier the FFI expects (never
+    // localized).
+    private sealed record SortOption(string LabelKey, string Field, bool Ascending);
 
     private static readonly SortOption[] SortOptions =
     {
-        new("newest", "date_added", false),
-        new("title", "title", true),
-        new("artist", "artist", true),
-        new("year", "year", true),
+        new("sort.newest", "date_added", false),
+        new("sort.title", "title", true),
+        new("sort.artist", "artist", true),
+        new("sort.year", "year", true),
     };
 
     private SortOption _sort = SortOptions[0];
@@ -124,9 +128,17 @@ public sealed partial class MainWindow : Window
         InitializeComponent();
         Closed += OnClosed;
 
+        // Bind layout direction to the UI locale: ar/he (and any other RTL
+        // culture) lay out right-to-left. The whole tree inherits from the root
+        // grid, so this is the single place the app decides direction. macOS gets
+        // this from the system; on Windows the app sets it from the culture.
+        RootGrid.FlowDirection = CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft
+            ? FlowDirection.RightToLeft
+            : FlowDirection.LeftToRight;
+
         foreach (var option in SortOptions)
         {
-            SortBox.Items.Add(option.Label);
+            SortBox.Items.Add(Loc.Chrome(option.LabelKey));
         }
         SortBox.SelectedIndex = 0;
 
@@ -160,7 +172,7 @@ public sealed partial class MainWindow : Window
         // order. Reload only when no search is active and the library is open.
         if (_handle != IntPtr.Zero && string.IsNullOrEmpty(SearchBox.Text))
         {
-            SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), "library is empty");
+            SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
         }
     }
 
@@ -172,7 +184,7 @@ public sealed partial class MainWindow : Window
         var id = NativeBae.CreateLibrary();
         if (id is null)
         {
-            reportError("couldn't create a library");
+            reportError(Loc.Chrome("library.create_failed"));
         }
 
         return id;
@@ -207,7 +219,7 @@ public sealed partial class MainWindow : Window
         _handle = NativeBae.Init(libraryId, PositionUpdateIntervalMs);
         if (_handle == IntPtr.Zero)
         {
-            StatusText.Text = "couldn't open the library";
+            StatusText.Text = Loc.Chrome("library.open_failed");
             return;
         }
 
@@ -227,7 +239,7 @@ public sealed partial class MainWindow : Window
         // above leaves the welcome in place rather than stranding the user.
         DismissWelcome();
 
-        SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), "library is empty");
+        SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
 
         _suppressVolume = true;
         NpVolume.Value = NativeBae.GetVolume(_handle);
@@ -258,7 +270,7 @@ public sealed partial class MainWindow : Window
     // open on a bad key; cancelling leaves the library locked.
     private async System.Threading.Tasks.Task ShowUnlock(string libraryId)
     {
-        var keyBox = new TextBox { PlaceholderText = "64-character hex key", Width = 360 };
+        var keyBox = new TextBox { PlaceholderText = Loc.Chrome("library.unlock.key_placeholder"), Width = 360 };
         var status = new TextBlock
         {
             Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
@@ -268,8 +280,7 @@ public sealed partial class MainWindow : Window
         var content = new StackPanel { Spacing = 8 };
         content.Children.Add(new TextBlock
         {
-            Text = "This library is encrypted and its key isn't on this device. "
-                + "Enter the 64-character hex key to unlock it.",
+            Text = Loc.Chrome("library.unlock.body"),
             TextWrapping = TextWrapping.Wrap,
         });
         content.Children.Add(keyBox);
@@ -277,10 +288,10 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "unlock library",
+            Title = Loc.Chrome("library.unlock.title"),
             Content = content,
-            PrimaryButtonText = "Unlock",
-            CloseButtonText = "Cancel",
+            PrimaryButtonText = Loc.Chrome("library.unlock.confirm"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
         };
         dialog.PrimaryButtonClick += async (_, args) =>
@@ -305,7 +316,7 @@ public sealed partial class MainWindow : Window
         }
         else
         {
-            StatusText.Text = "library is locked";
+            StatusText.Text = Loc.Chrome("library.locked");
         }
     }
 
@@ -386,9 +397,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "libraries",
+            Title = Loc.Chrome("libraries.title"),
             Content = new ScrollViewer { Content = list, MaxHeight = 420 },
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -405,7 +416,9 @@ public sealed partial class MainWindow : Window
             // to itself but can still be renamed.
             var switchButton = new Button
             {
-                Content = isActive ? $"{library.Name}  ·  active" : library.Name,
+                Content = isActive
+                    ? Loc.Chrome("libraries.active", "name", library.Name)
+                    : library.Name,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 IsEnabled = !isActive,
             };
@@ -426,7 +439,7 @@ public sealed partial class MainWindow : Window
                 TextWrapping = TextWrapping.Wrap,
                 Visibility = Visibility.Collapsed,
             };
-            var saveName = new Button { Content = "save" };
+            var saveName = new Button { Content = Loc.Chrome("action.save") };
             var renameContent = new StackPanel { Spacing = 6 };
             renameContent.Children.Add(nameBox);
             renameContent.Children.Add(saveName);
@@ -448,13 +461,15 @@ public sealed partial class MainWindow : Window
                     return;
                 }
 
-                switchButton.Content = isActive ? $"{newName}  ·  active" : newName;
+                switchButton.Content = isActive
+                    ? Loc.Chrome("libraries.active", "name", newName)
+                    : newName;
                 // Keep the editor's value in sync so reopening it shows the saved
                 // name, not the stale snapshot it was seeded with.
                 nameBox.Text = newName;
                 renameFlyout.Hide();
             };
-            var renameButton = new Button { Content = "rename", Flyout = renameFlyout };
+            var renameButton = new Button { Content = Loc.Chrome("libraries.rename"), Flyout = renameFlyout };
             Grid.SetColumn(renameButton, 1);
             row.Children.Add(renameButton);
 
@@ -463,7 +478,7 @@ public sealed partial class MainWindow : Window
 
         var newButton = new Button
         {
-            Content = "new library",
+            Content = Loc.Chrome("libraries.new"),
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
         newButton.Click += (_, _) =>
@@ -499,7 +514,9 @@ public sealed partial class MainWindow : Window
         DismissWelcome();
 
         var libraries = LoadLibraries();
-        StatusText.Text = libraries.Count > 0 ? "choose a library" : "no library yet";
+        StatusText.Text = libraries.Count > 0
+            ? Loc.Chrome("welcome.choose_library")
+            : Loc.Chrome("welcome.no_library");
 
         _welcome = new StackPanel { Spacing = 8, HorizontalAlignment = HorizontalAlignment.Center };
 
@@ -507,7 +524,7 @@ public sealed partial class MainWindow : Window
         {
             _welcome.Children.Add(new TextBlock
             {
-                Text = "your libraries",
+                Text = Loc.Chrome("welcome.your_libraries"),
                 HorizontalAlignment = HorizontalAlignment.Center,
             });
             foreach (var library in libraries)
@@ -525,7 +542,7 @@ public sealed partial class MainWindow : Window
 
         var createButton = new Button
         {
-            Content = "create library",
+            Content = Loc.Chrome("welcome.create_library"),
             HorizontalAlignment = HorizontalAlignment.Center,
         };
         createButton.Click += (_, _) =>
@@ -539,10 +556,10 @@ public sealed partial class MainWindow : Window
             OpenLibrary(libraryId);
         };
 
-        var codeBox = new TextBox { PlaceholderText = "restore code", Width = 320 };
+        var codeBox = new TextBox { PlaceholderText = Loc.Chrome("restore.code_placeholder"), Width = 320 };
         var restoreButton = new Button
         {
-            Content = "restore from code",
+            Content = Loc.Chrome("restore.from_code"),
             HorizontalAlignment = HorizontalAlignment.Center,
         };
         restoreButton.Click += async (_, _) => await RestoreFromCode(codeBox.Text ?? string.Empty);
@@ -551,7 +568,7 @@ public sealed partial class MainWindow : Window
         // there's no restore code (the code can't carry secrets like S3 keys).
         var restoreCloudButton = new Button
         {
-            Content = "restore from cloud",
+            Content = Loc.Chrome("restore.from_cloud"),
             HorizontalAlignment = HorizontalAlignment.Center,
         };
         restoreCloudButton.Click += async (_, _) => await ShowRestoreFromCloud();
@@ -583,7 +600,7 @@ public sealed partial class MainWindow : Window
         var info = infoJson is null ? null : JsonSerializer.Deserialize<RestoreCodeInfo>(infoJson, JsonOptions);
         if (info is null)
         {
-            StatusText.Text = "invalid restore code";
+            StatusText.Text = Loc.Chrome("restore.invalid_code");
             return;
         }
 
@@ -599,32 +616,32 @@ public sealed partial class MainWindow : Window
             // supported set before reaching the (absent) sign-in call.
             if (!NativeBae.AvailableCloudProviders().Contains(info.Provider))
             {
-                StatusText.Text = $"this build doesn't support {ProviderDisplayName(info.Provider)} sync";
+                StatusText.Text = Loc.Chrome("cloud.unsupported_provider", "provider", ProviderDisplayName(info.Provider));
                 return;
             }
             if (!OAuthCreds.Available)
             {
                 StatusText.Text = OAuthCreds.RegistrationError
-                    ?? "cloud sign-in isn't configured on this build (no oauth-creds.json)";
+                    ?? Loc.Chrome("cloud.signin.not_configured");
                 return;
             }
-            StatusText.Text = $"signing in to {ProviderDisplayName(info.Provider)}…";
+            StatusText.Text = Loc.Chrome("cloud.signin.in_progress", "provider", ProviderDisplayName(info.Provider));
             var oauthJson = await System.Threading.Tasks.Task.Run(() => NativeBae.OAuthAuthorize(info.Provider));
             var oauth = oauthJson is null ? null : JsonSerializer.Deserialize<OAuthResult>(oauthJson, JsonOptions);
             if (oauth?.Token is null)
             {
-                StatusText.Text = oauth?.Error ?? "cloud sign-in failed";
+                StatusText.Text = oauth?.Error ?? Loc.Chrome("cloud.signin.failed");
                 return;
             }
             oauthTokenJson = oauth.Token;
         }
 
-        StatusText.Text = $"restoring {info.LibraryName}…";
+        StatusText.Text = Loc.Chrome("restore.in_progress_named", "name", info.LibraryName);
         var resultJson = await System.Threading.Tasks.Task.Run(() => NativeBae.RestoreFromCode(code, oauthTokenJson));
         var result = resultJson is null ? null : JsonSerializer.Deserialize<RestoreResult>(resultJson, JsonOptions);
         if (result?.LibraryId is null)
         {
-            StatusText.Text = result?.Error ?? "restore failed";
+            StatusText.Text = result?.Error ?? Loc.Chrome("restore.failed");
             return;
         }
 
@@ -640,17 +657,17 @@ public sealed partial class MainWindow : Window
     {
         var content = new StackPanel { Spacing = 8, MinWidth = 360 };
 
-        var libraryIdBox = new TextBox { Header = "library id" };
+        var libraryIdBox = new TextBox { Header = Loc.Chrome("restore.field.library_id") };
         // The encryption key unlocks the whole library — mask it, as macOS does.
-        var keyBox = new PasswordBox { Header = "encryption key (hex)" };
-        var nameBox = new TextBox { Header = "library name (optional)" };
+        var keyBox = new PasswordBox { Header = Loc.Chrome("restore.field.encryption_key") };
+        var nameBox = new TextBox { Header = Loc.Chrome("restore.field.library_name") };
         content.Children.Add(libraryIdBox);
         content.Children.Add(keyBox);
         content.Children.Add(nameBox);
 
         var providerPicker = new ComboBox
         {
-            Header = "cloud storage",
+            Header = Loc.Chrome("restore.field.cloud_storage"),
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
         foreach (var wire in new[] { "s3" })
@@ -660,11 +677,11 @@ public sealed partial class MainWindow : Window
         content.Children.Add(providerPicker);
 
         // S3 fields, shown when S3 is selected.
-        var s3Bucket = new TextBox { Header = "S3 bucket", Visibility = Visibility.Collapsed };
-        var s3Region = new TextBox { Header = "region", Visibility = Visibility.Collapsed };
-        var s3Endpoint = new TextBox { Header = "endpoint (optional)", Visibility = Visibility.Collapsed };
-        var s3AccessKey = new PasswordBox { Header = "access key", Visibility = Visibility.Collapsed };
-        var s3SecretKey = new PasswordBox { Header = "secret key", Visibility = Visibility.Collapsed };
+        var s3Bucket = new TextBox { Header = Loc.Chrome("s3.field.bucket"), Visibility = Visibility.Collapsed };
+        var s3Region = new TextBox { Header = Loc.Chrome("s3.field.region"), Visibility = Visibility.Collapsed };
+        var s3Endpoint = new TextBox { Header = Loc.Chrome("s3.field.endpoint"), Visibility = Visibility.Collapsed };
+        var s3AccessKey = new PasswordBox { Header = Loc.Chrome("s3.field.access_key"), Visibility = Visibility.Collapsed };
+        var s3SecretKey = new PasswordBox { Header = Loc.Chrome("s3.field.secret_key"), Visibility = Visibility.Collapsed };
         content.Children.Add(s3Bucket);
         content.Children.Add(s3Region);
         content.Children.Add(s3Endpoint);
@@ -681,7 +698,7 @@ public sealed partial class MainWindow : Window
 
         var restoreButton = new Button
         {
-            Content = "restore",
+            Content = Loc.Chrome("restore.confirm"),
             HorizontalAlignment = HorizontalAlignment.Stretch,
             IsEnabled = false,
         };
@@ -689,9 +706,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "restore from cloud",
+            Title = Loc.Chrome("restore.from_cloud_title"),
             Content = new ScrollViewer { Content = content, MaxHeight = 520 },
-            CloseButtonText = "Cancel",
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -750,7 +767,7 @@ public sealed partial class MainWindow : Window
 
             restoreButton.IsEnabled = false;
             status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
-            status.Text = "restoring…";
+            status.Text = Loc.Chrome("restore.in_progress");
             status.Visibility = Visibility.Visible;
 
             var libraryId = libraryIdBox.Text?.Trim() ?? string.Empty;
@@ -764,7 +781,7 @@ public sealed partial class MainWindow : Window
             if (result?.LibraryId is null)
             {
                 status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon);
-                status.Text = result?.Error ?? "restore failed";
+                status.Text = result?.Error ?? Loc.Chrome("restore.failed");
                 restoreButton.IsEnabled = true;
                 return;
             }
@@ -781,10 +798,10 @@ public sealed partial class MainWindow : Window
     // show the user. Unknown tags pass through unchanged.
     private static string ProviderDisplayName(string provider) => provider switch
     {
-        "google_drive" => "Google Drive",
-        "dropbox" => "Dropbox",
-        "onedrive" => "OneDrive",
-        "s3" => "S3",
+        "google_drive" => Loc.Chrome("cloud.provider.google_drive"),
+        "dropbox" => Loc.Chrome("cloud.provider.dropbox"),
+        "onedrive" => Loc.Chrome("cloud.provider.onedrive"),
+        "s3" => Loc.Chrome("cloud.provider.s3"),
         _ => provider,
     };
 
@@ -807,17 +824,17 @@ public sealed partial class MainWindow : Window
     {
         if (_syncErrorText is not null)
         {
-            SyncIndicator.Text = "sync error";
+            SyncIndicator.Text = Loc.Chrome("sync.error_title");
             SyncIndicator.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon);
         }
         else if (_syncing)
         {
-            SyncIndicator.Text = "syncing…";
+            SyncIndicator.Text = Loc.Chrome("sync.syncing");
             SyncIndicator.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
         }
         else if (_lastSyncTime is not null)
         {
-            SyncIndicator.Text = $"synced {_lastSyncTime}";
+            SyncIndicator.Text = Loc.Chrome("sync.synced", "time", _lastSyncTime);
             SyncIndicator.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
         }
         else
@@ -876,8 +893,8 @@ public sealed partial class MainWindow : Window
                 {
                     NpProgress.Value = evt.Progress;
                 }
-                NpElapsed.Text = evt.Elapsed ?? "0:00";
-                NpRemaining.Text = evt.Remaining ?? "0:00";
+                NpElapsed.Text = evt.ElapsedLabel;
+                NpRemaining.Text = evt.RemainingLabel;
                 break;
             case "VolumeChanged":
                 _suppressVolume = true;
@@ -898,27 +915,30 @@ public sealed partial class MainWindow : Window
             case "SyncError":
                 // Sync uses its own banner so a general ErrorCleared can't dismiss a
                 // still-broken sync (and vice versa), matching the macOS slot split.
-                if (evt.Message is null)
+                // evt.Error is null when a prior failure cleared; otherwise it's the
+                // structured diagnostic whose generic line we render for the locale.
+                var syncLine = evt.Error?.LocalizedLine;
+                if (syncLine is null)
                 {
                     SyncBanner.IsOpen = false;
                 }
                 else
                 {
-                    var reconnect = new Button { Content = "Reconnect" };
+                    var reconnect = new Button { Content = Loc.Chrome("sync.reconnect") };
                     reconnect.Click += (_, _) => NativeBae.TriggerSync(_handle);
                     SyncBanner.Severity = InfoBarSeverity.Error;
-                    SyncBanner.Title = "sync error";
-                    SyncBanner.Message = evt.Message;
+                    SyncBanner.Title = Loc.Chrome("sync.error_title");
+                    SyncBanner.Message = syncLine;
                     SyncBanner.ActionButton = reconnect;
                     SyncBanner.IsOpen = true;
                 }
-                _syncErrorText = evt.Message;
+                _syncErrorText = syncLine;
                 UpdateSyncIndicator();
                 break;
             case "PreviewProgress":
                 if (_previewElapsed is not null)
                 {
-                    var elapsed = evt.Elapsed ?? string.Empty;
+                    var elapsed = evt.ElapsedLabel;
                     _previewElapsed.Text = _previewDurationLabel is null
                         ? elapsed
                         : $"{elapsed} / {_previewDurationLabel}";
@@ -946,15 +966,17 @@ public sealed partial class MainWindow : Window
                 break;
             case "PlaybackError":
                 Banner.Severity = InfoBarSeverity.Error;
-                Banner.Title = "playback error";
-                Banner.Message = evt.Message ?? "playback failed";
+                Banner.Title = Loc.Chrome("error.playback_title");
+                // The structured reason resolves its own localized line (the
+                // actionable cloud-only cases, or a diagnostic's generic line).
+                Banner.Message = evt.Reason?.LocalizedLine ?? Loc.Core("core.error.category.internal");
                 Banner.ActionButton = null;
                 Banner.IsOpen = true;
                 break;
             case "Error":
                 Banner.Severity = InfoBarSeverity.Error;
-                Banner.Title = "error";
-                Banner.Message = evt.Message ?? "something went wrong";
+                Banner.Title = Loc.Chrome("error.title");
+                Banner.Message = evt.Error?.LocalizedLine ?? Loc.Core("core.error.category.internal");
                 Banner.ActionButton = null;
                 Banner.IsOpen = true;
                 break;
@@ -974,7 +996,7 @@ public sealed partial class MainWindow : Window
             case "LibraryChanged":
                 if (string.IsNullOrEmpty(SearchBox.Text))
                 {
-                    SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), "library is empty");
+                    SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
                 }
                 _refreshStorageRows?.Invoke();
                 break;
@@ -1016,7 +1038,7 @@ public sealed partial class MainWindow : Window
             case "ScanFinished":
                 if (_scanStatus is not null)
                 {
-                    _scanStatus.Text = _candidates.Count == 0 ? "no releases found" : string.Empty;
+                    _scanStatus.Text = _candidates.Count == 0 ? Loc.Chrome("import.no_releases") : string.Empty;
                 }
                 break;
             case "CandidateIdentifyState":
@@ -1027,14 +1049,24 @@ public sealed partial class MainWindow : Window
                 }, DescribeIdentify(evt));
                 break;
             case "CandidateImportProgress":
+                // The percent is localized as a chrome message; the step (when
+                // known) resolves its localized verb from the catalog.
+                var stepLabel = evt.Step?.LocalizedLabel;
+                var importing = Loc.Chrome("import.progress.percent", "percent", evt.ProgressPercent);
                 UpdateCandidate(evt.Key, null,
-                    $"importing {evt.ProgressPercent}%{(string.IsNullOrEmpty(evt.Status) ? string.Empty : $" — {evt.Status}")}");
+                    string.IsNullOrEmpty(stepLabel) ? importing : $"{importing} — {stepLabel}");
                 break;
             case "CandidateImportComplete":
-                UpdateCandidate(evt.Key, null, "imported");
+                UpdateCandidate(evt.Key, null, Loc.Chrome("import.complete"));
                 break;
             case "CandidateImportError":
-                UpdateCandidate(evt.Key, null, evt.Message is null ? "import failed" : $"import failed: {evt.Message}");
+                // The structured diagnostic resolves its generic localized line;
+                // the failure word is chrome.
+                var failLine = evt.Error?.LocalizedLine;
+                UpdateCandidate(evt.Key, null,
+                    failLine is null
+                        ? Loc.Chrome("import.failed")
+                        : $"{Loc.Chrome("import.failed")}: {failLine}");
                 break;
         }
     }
@@ -1082,12 +1114,12 @@ public sealed partial class MainWindow : Window
 
     private static string DescribeIdentify(BaeEvent evt) => evt.Status switch
     {
-        "identifying" => "identifying…",
-        "found" => $"found ({evt.Matches?.Count ?? 0})",
-        "conflict" => "conflict",
-        "not_found" => "not found",
-        "manual" => "manual search only",
-        "error" => evt.Message ?? "error",
+        "identifying" => Loc.Chrome("identify.identifying"),
+        "found" => Loc.Chrome("identify.found", "count", evt.Matches?.Count ?? 0),
+        "conflict" => Loc.Chrome("identify.conflict"),
+        "not_found" => Loc.Chrome("identify.not_found"),
+        "manual" => Loc.Chrome("identify.manual"),
+        "error" => Loc.Chrome("identify.error"),
         _ => string.Empty,
     };
 
@@ -1106,7 +1138,7 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        var scanButton = new Button { Content = "choose folder & scan" };
+        var scanButton = new Button { Content = Loc.Chrome("import.choose_folder") };
         var status = new TextBlock
         {
             Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
@@ -1172,7 +1204,7 @@ public sealed partial class MainWindow : Window
                 return;
             }
 
-            status.Text = "scanning…";
+            status.Text = Loc.Chrome("import.scanning");
             status.Visibility = Visibility.Visible;
             var path = folder.Path;
             var error = await System.Threading.Tasks.Task.Run(() => NativeBae.ScanFolder(_handle, path, true));
@@ -1189,9 +1221,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "import",
+            Title = Loc.Chrome("import.title"),
             Content = content,
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -1211,7 +1243,7 @@ public sealed partial class MainWindow : Window
             // Null for some shell drags; the caption is just a cursor hint.
             if (e.DragUIOverride is not null)
             {
-                e.DragUIOverride.Caption = "scan & import";
+                e.DragUIOverride.Caption = Loc.Chrome("import.drop_caption");
             }
         }
         else
@@ -1245,7 +1277,7 @@ public sealed partial class MainWindow : Window
         }
         catch (Exception)
         {
-            readError = "could not read the dropped item";
+            readError = Loc.Chrome("import.drop_read_failed");
         }
         finally
         {
@@ -1262,7 +1294,7 @@ public sealed partial class MainWindow : Window
 
         if (folderPath is null)
         {
-            ShowImportBanner("drop a folder to import");
+            ShowImportBanner(Loc.Chrome("import.drop_folder_only"));
             return;
         }
 
@@ -1284,7 +1316,7 @@ public sealed partial class MainWindow : Window
     private void ShowImportBanner(string message)
     {
         Banner.Severity = InfoBarSeverity.Error;
-        Banner.Title = "import error";
+        Banner.Title = Loc.Chrome("import.error_title");
         Banner.Message = message;
         Banner.ActionButton = null;
         Banner.IsOpen = true;
@@ -1332,7 +1364,7 @@ public sealed partial class MainWindow : Window
             Padding = new Thickness(8, 3, 8, 3),
             VerticalAlignment = VerticalAlignment.Center,
         };
-        ToolTipService.SetToolTip(button, "re-run identification");
+        ToolTipService.SetToolTip(button, Loc.Chrome("import.rerun_identify"));
         button.Click += (_, _) =>
         {
             if (_handle != IntPtr.Zero)
@@ -1437,7 +1469,9 @@ public sealed partial class MainWindow : Window
         // Clicking toggles this signal's exclusion. Excluded badges stay clickable
         // (to re-include). The catalog kind names a specific candidate by its value;
         // disc_id / barcode are singletons (value ignored core-side).
-        ToolTipService.SetToolTip(badge, signal.Excluded ? "include signal" : "exclude signal");
+        ToolTipService.SetToolTip(
+            badge,
+            signal.Excluded ? Loc.Chrome("signal.include") : Loc.Chrome("signal.exclude"));
         badge.Click += (_, _) =>
         {
             if (_handle != IntPtr.Zero)
@@ -1494,25 +1528,33 @@ public sealed partial class MainWindow : Window
                     VerticalAlignment = VerticalAlignment.Center,
                 };
             case "failed":
-                return new TextBlock
+                var warning = new TextBlock
                 {
                     Text = "⚠",
                     FontSize = 12,
                     Foreground = new SolidColorBrush(Microsoft.UI.Colors.Orange),
                     VerticalAlignment = VerticalAlignment.Center,
                 };
+                // The structured lookup failure resolves its localized line for
+                // the hover tooltip; no prose crosses the bridge.
+                if (signal.State.Failure is { } failure)
+                {
+                    ToolTipService.SetToolTip(warning, failure.LocalizedLine);
+                }
+                return warning;
             default:
                 return new TextBlock { Text = string.Empty };
         }
     }
 
     // The badge's kind label. Mirrors the macOS SignalBadgeStyle.label(for:);
-    // the wire kind names come from the FFI's snake_case mapping.
+    // the wire kind names come from the FFI's snake_case mapping, resolved to a
+    // localized chrome label.
     private static string SignalKindLabel(string kind) => kind switch
     {
-        "disc_id" => "Disc ID",
-        "barcode" => "Barcode",
-        "catalog" => "Catalog",
+        "disc_id" => Loc.Chrome("signal.kind.disc_id"),
+        "barcode" => Loc.Chrome("signal.kind.barcode"),
+        "catalog" => Loc.Chrome("signal.kind.catalog"),
         _ => kind,
     };
 
@@ -1548,13 +1590,13 @@ public sealed partial class MainWindow : Window
         void RenderResults() => resultsList.ItemsSource = results.Select(result => result.Summary).ToList();
         RenderResults();
 
-        var artistBox = new TextBox { Header = "artist (manual search)" };
-        var albumBox = new TextBox { Header = "album", Text = candidate.Name };
-        var sourceBox = new ComboBox { Header = "source" };
+        var artistBox = new TextBox { Header = Loc.Chrome("import.field.artist_manual") };
+        var albumBox = new TextBox { Header = Loc.Chrome("search.field.album"), Text = candidate.Name };
+        var sourceBox = new ComboBox { Header = Loc.Chrome("search.field.source") };
         sourceBox.Items.Add("discogs");
         sourceBox.Items.Add("musicbrainz");
         sourceBox.SelectedIndex = 0;
-        var searchButton = new Button { Content = "search" };
+        var searchButton = new Button { Content = Loc.Chrome("action.search") };
 
         var status = new TextBlock
         {
@@ -1569,7 +1611,7 @@ public sealed partial class MainWindow : Window
         // Preview the candidate's audio before committing to an identity.
         if (candidate.AudioPaths.Count > 0)
         {
-            var preview = new Button { Content = "▶ preview" };
+            var preview = new Button { Content = "▶ " + Loc.Chrome("import.preview") };
             preview.Click += (_, _) => NativeBae.PreviewPlay(_handle, candidate.AudioPaths[0]);
             var pause = new Button { Content = "⏸" };
             pause.Click += (_, _) => NativeBae.PreviewTogglePause(_handle);
@@ -1595,10 +1637,10 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "import release",
+            Title = Loc.Chrome("import.release_title"),
             Content = new ScrollViewer { Content = content },
-            PrimaryButtonText = "Import",
-            CloseButtonText = "Cancel",
+            PrimaryButtonText = Loc.Chrome("action.import"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
             IsPrimaryButtonEnabled = false,
         };
@@ -1615,7 +1657,7 @@ public sealed partial class MainWindow : Window
             var parsed = json is null ? null : JsonSerializer.Deserialize<List<Candidate>>(json, JsonOptions);
             if (parsed is null)
             {
-                status.Text = "search failed";
+                status.Text = Loc.Chrome("search.failed");
                 status.Visibility = Visibility.Visible;
                 return;
             }
@@ -1676,7 +1718,7 @@ public sealed partial class MainWindow : Window
         var dialog = new ContentDialog
         {
             Title = title,
-            CloseButtonText = "OK",
+            CloseButtonText = Loc.Chrome("action.ok"),
             XamlRoot = Content.XamlRoot,
         };
         if (message is not null)
@@ -1704,14 +1746,14 @@ public sealed partial class MainWindow : Window
         var prefetched = json is null ? null : JsonSerializer.Deserialize<PrefetchedEdit>(json, JsonOptions);
         if (prefetched is null)
         {
-            await ShowError("couldn't load the release to import");
+            await ShowError(Loc.Chrome("import.error.load_release"));
             return false;
         }
 
         var settingsJson = await System.Threading.Tasks.Task.Run(() => NativeBae.SettingsJson(_handle));
         if (settingsJson is null)
         {
-            await ShowError("couldn't load storage settings");
+            await ShowError(Loc.Chrome("import.error.load_storage_settings"));
             return false;
         }
         Settings settings;
@@ -1722,7 +1764,7 @@ public sealed partial class MainWindow : Window
         }
         catch (JsonException ex)
         {
-            await ShowError("couldn't read storage settings", ex.Message);
+            await ShowError(Loc.Chrome("import.error.read_storage_settings"), ex.Message);
             return false;
         }
         var form = new ReleaseEditForm(prefetched.Edit, 520);
@@ -1732,13 +1774,13 @@ public sealed partial class MainWindow : Window
         var selectedCoverJson = string.Empty;
         var storageManaged = new CheckBox
         {
-            Content = "Managed",
+            Content = Loc.Chrome("import.storage.managed"),
             IsChecked = true,
             VerticalAlignment = VerticalAlignment.Center,
         };
         var storagePinned = new CheckBox
         {
-            Content = "Keep local copy",
+            Content = Loc.Chrome("import.storage.keep_local"),
             IsChecked = true,
             VerticalAlignment = VerticalAlignment.Center,
         };
@@ -1780,11 +1822,11 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "confirm import",
+            Title = Loc.Chrome("import.confirm_title"),
             Content = new ScrollViewer { Content = panel },
-            PrimaryButtonText = "Import",
-            SecondaryButtonText = "Back to Search",
-            CloseButtonText = "Cancel",
+            PrimaryButtonText = Loc.Chrome("action.import"),
+            SecondaryButtonText = Loc.Chrome("import.back_to_search"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -1864,12 +1906,12 @@ public sealed partial class MainWindow : Window
             Severity = InfoBarSeverity.Warning,
             IsOpen = true,
             IsClosable = false,
-            Message = "this release is already in your library",
+            Message = Loc.Chrome("import.already_in_library"),
         };
 
         if (!string.IsNullOrEmpty(status.AlbumId))
         {
-            var viewButton = new Button { Content = "view in library" };
+            var viewButton = new Button { Content = Loc.Chrome("import.view_in_library") };
             viewButton.Click += (_, _) => onViewInLibrary();
             banner.ActionButton = viewButton;
         }
@@ -1890,13 +1932,13 @@ public sealed partial class MainWindow : Window
         List<RemoteCover> remoteCovers, List<LocalArtwork> localArtwork, Action<string> onPick)
     {
         var section = new StackPanel { Spacing = 4 };
-        section.Children.Add(new TextBlock { Text = "Cover" });
+        section.Children.Add(new TextBlock { Text = Loc.Chrome("cover.section_title") });
 
         if (remoteCovers.Count == 0 && localArtwork.Count == 0)
         {
             section.Children.Add(new TextBlock
             {
-                Text = "No cover art available — the import uses its default cover.",
+                Text = Loc.Chrome("cover.none_available"),
                 Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
                 TextWrapping = TextWrapping.Wrap,
             });
@@ -1905,7 +1947,7 @@ public sealed partial class MainWindow : Window
 
         section.Children.Add(new TextBlock
         {
-            Text = "Pick a cover, or leave unselected to use the default.",
+            Text = Loc.Chrome("cover.pick_hint"),
             Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
             TextWrapping = TextWrapping.Wrap,
         });
@@ -2091,7 +2133,7 @@ public sealed partial class MainWindow : Window
             }
 
             var menu = new MenuFlyout();
-            var remove = new MenuFlyoutItem { Text = "Remove from queue" };
+            var remove = new MenuFlyoutItem { Text = Loc.Chrome("queue.remove_item") };
             remove.Click += (_, _) =>
             {
                 // Recompute: a reorder between the right-tap and the click could have
@@ -2108,7 +2150,7 @@ public sealed partial class MainWindow : Window
             menu.ShowAt(element, new FlyoutShowOptions { Position = args.GetPosition(element) });
         };
 
-        var clear = new Button { Content = "clear queue" };
+        var clear = new Button { Content = Loc.Chrome("queue.clear") };
         clear.Click += (_, _) => NativeBae.QueueClear(_handle);
 
         var content = new StackPanel { Spacing = 8 };
@@ -2117,9 +2159,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "queue",
+            Title = Loc.Chrome("queue.title"),
             Content = content,
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
         await dialog.ShowAsync();
@@ -2279,11 +2321,11 @@ public sealed partial class MainWindow : Window
         var query = args.QueryText?.Trim() ?? string.Empty;
         if (query.Length == 0)
         {
-            SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), "library is empty");
+            SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
         }
         else
         {
-            SetAlbums(NativeBae.SearchJson(_handle, query), "no matches");
+            SetAlbums(NativeBae.SearchJson(_handle, query), Loc.Chrome("search.no_matches"));
         }
     }
 
@@ -2293,7 +2335,7 @@ public sealed partial class MainWindow : Window
         Albums.Clear();
         if (json is null)
         {
-            StatusText.Text = "couldn't load the library";
+            StatusText.Text = Loc.Chrome("library.load_failed");
             return;
         }
 
@@ -2329,20 +2371,20 @@ public sealed partial class MainWindow : Window
         var json = NativeBae.AlbumDetailJson(_handle, albumId);
         if (json is null)
         {
-            StatusText.Text = "couldn't open this album";
+            StatusText.Text = Loc.Chrome("album.open_failed");
             return;
         }
 
         var detail = JsonSerializer.Deserialize<AlbumDetail>(json, JsonOptions);
         if (detail is null)
         {
-            StatusText.Text = "couldn't open this album";
+            StatusText.Text = Loc.Chrome("album.open_failed");
             return;
         }
 
         if (detail.Releases.Count == 0)
         {
-            StatusText.Text = "couldn't open this album";
+            StatusText.Text = Loc.Chrome("album.open_failed");
             return;
         }
 
@@ -2369,9 +2411,9 @@ public sealed partial class MainWindow : Window
             Text = detail.Artist,
             VerticalAlignment = VerticalAlignment.Center,
         });
-        var shuffleButton = new Button { Content = "shuffle" };
-        var editButton = new Button { Content = "edit" };
-        var reidentifyButton = new Button { Content = "re-identify" };
+        var shuffleButton = new Button { Content = Loc.Chrome("album.shuffle") };
+        var editButton = new Button { Content = Loc.Chrome("album.edit") };
+        var reidentifyButton = new Button { Content = Loc.Chrome("album.reidentify") };
         header.Children.Add(shuffleButton);
         header.Children.Add(editButton);
         header.Children.Add(reidentifyButton);
@@ -2380,7 +2422,7 @@ public sealed partial class MainWindow : Window
         var deleteRequested = false;
         var moreButton = new Button { Content = "⋯" };
         var moreMenu = new MenuFlyout();
-        var playNextItem = new MenuFlyoutItem { Text = "Play Next" };
+        var playNextItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.play_next") };
         playNextItem.Click += (_, _) =>
         {
             if (!string.IsNullOrEmpty(selectedRelease.ReleaseId))
@@ -2388,7 +2430,7 @@ public sealed partial class MainWindow : Window
                 NativeBae.AddReleaseNext(_handle, selectedRelease.ReleaseId);
             }
         };
-        var addQueueItem = new MenuFlyoutItem { Text = "Add to Queue" };
+        var addQueueItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.add_to_queue") };
         addQueueItem.Click += (_, _) =>
         {
             if (!string.IsNullOrEmpty(selectedRelease.ReleaseId))
@@ -2398,14 +2440,14 @@ public sealed partial class MainWindow : Window
         };
         // Set the selected release as the album's primary (canonical) one — only
         // meaningful when the album has more than one release.
-        var setPrimaryItem = new MenuFlyoutItem { Text = "Set as primary release" };
+        var setPrimaryItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.set_primary") };
         setPrimaryItem.Click += (_, _) =>
         {
             var error = NativeBae.SetPrimaryRelease(_handle, detail.Id, selectedRelease.ReleaseId);
-            StatusText.Text = error ?? "set as primary release";
+            StatusText.Text = error ?? Loc.Chrome("menu.set_primary_done");
         };
-        var changeCoverItem = new MenuFlyoutItem { Text = "Change cover…" };
-        var deleteItem = new MenuFlyoutItem { Text = "Delete…" };
+        var changeCoverItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.change_cover") };
+        var deleteItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.delete") };
         moreMenu.Items.Add(playNextItem);
         moreMenu.Items.Add(addQueueItem);
         if (detail.Releases.Count > 1)
@@ -2478,13 +2520,13 @@ public sealed partial class MainWindow : Window
             }
 
             var menu = new MenuFlyout();
-            var play = new MenuFlyoutItem { Text = "Play" };
+            var play = new MenuFlyoutItem { Text = Loc.Chrome("menu.play") };
             play.Click += (_, _) => PlayFromTrack(track);
-            var playNextTrack = new MenuFlyoutItem { Text = "Play Next" };
+            var playNextTrack = new MenuFlyoutItem { Text = Loc.Chrome("menu.play_next") };
             playNextTrack.Click += (_, _) => QueueTrack(track, next: true);
-            var addQueueTrack = new MenuFlyoutItem { Text = "Add to Queue" };
+            var addQueueTrack = new MenuFlyoutItem { Text = Loc.Chrome("menu.add_to_queue") };
             addQueueTrack.Click += (_, _) => QueueTrack(track, next: false);
-            var exportTrack = new MenuFlyoutItem { Text = "Export…" };
+            var exportTrack = new MenuFlyoutItem { Text = Loc.Chrome("menu.export") };
             exportTrack.Click += async (_, _) =>
             {
                 exportStatus.Visibility = Visibility.Collapsed;
@@ -2493,8 +2535,8 @@ public sealed partial class MainWindow : Window
                     picker, WinRT.Interop.WindowNative.GetWindowHandle(this));
                 // The chosen file type decides the export format; its extension
                 // round-trips back to the format string the FFI expects.
-                picker.FileTypeChoices.Add("FLAC (lossless)", new List<string> { ".flac" });
-                picker.FileTypeChoices.Add("MP3 (320 kbps)", new List<string> { ".mp3" });
+                picker.FileTypeChoices.Add(Loc.Chrome("track.export.flac"), new List<string> { ".flac" });
+                picker.FileTypeChoices.Add(Loc.Chrome("track.export.mp3"), new List<string> { ".mp3" });
                 var invalid = System.IO.Path.GetInvalidFileNameChars();
                 var suggested = new string(track.Title.Select(c => invalid.Contains(c) ? '-' : c).ToArray());
                 picker.SuggestedFileName = string.IsNullOrWhiteSpace(suggested) ? "track" : suggested;
@@ -2529,7 +2571,7 @@ public sealed partial class MainWindow : Window
         {
             var releasePicker = new ComboBox
             {
-                Header = "Release",
+                Header = Loc.Chrome("album.release_picker"),
                 ItemsSource = detail.Releases,
                 SelectedItem = selectedRelease,
             };
@@ -2550,9 +2592,9 @@ public sealed partial class MainWindow : Window
         {
             Title = detail.Title,
             Content = content,
-            PrimaryButtonText = "Play",
-            SecondaryButtonText = "Gallery",
-            CloseButtonText = "Close",
+            PrimaryButtonText = Loc.Chrome("action.play"),
+            SecondaryButtonText = Loc.Chrome("album.gallery"),
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -2677,10 +2719,10 @@ public sealed partial class MainWindow : Window
 
         var confirm = new ContentDialog
         {
-            Title = "delete release?",
-            Content = "This removes the release from the library.",
-            PrimaryButtonText = "Delete",
-            CloseButtonText = "Cancel",
+            Title = Loc.Chrome("album.delete.title"),
+            Content = Loc.Chrome("album.delete.body"),
+            PrimaryButtonText = Loc.Chrome("action.delete"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
         };
         if (await confirm.ShowAsync() != ContentDialogResult.Primary)
@@ -2692,7 +2734,7 @@ public sealed partial class MainWindow : Window
         var error = await System.Threading.Tasks.Task.Run(() => NativeBae.DeleteRelease(_handle, releaseId));
         if (error is not null)
         {
-            await ShowError("couldn't delete", error);
+            await ShowError(Loc.Chrome("album.delete.failed"), error);
         }
     }
 
@@ -2707,7 +2749,7 @@ public sealed partial class MainWindow : Window
         var seeded = json is null ? null : JsonSerializer.Deserialize<ReleaseEdit>(json, JsonOptions);
         if (seeded is null)
         {
-            await ShowError("couldn't load the metadata editor");
+            await ShowError(Loc.Chrome("album.edit.load_failed"));
             return;
         }
 
@@ -2715,11 +2757,11 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "edit metadata",
+            Title = Loc.Chrome("album.edit.title"),
             Content = new ScrollViewer { Content = form.Panel },
-            PrimaryButtonText = "Save",
-            SecondaryButtonText = "Reset to Source",
-            CloseButtonText = "Cancel",
+            PrimaryButtonText = Loc.Chrome("action.save"),
+            SecondaryButtonText = Loc.Chrome("album.edit.reset"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -2754,7 +2796,7 @@ public sealed partial class MainWindow : Window
                     : JsonSerializer.Deserialize<ReleaseEdit>(resetJson, JsonOptions);
                 if (fresh is null)
                 {
-                    form.ErrorText.Text = "couldn't reset to source";
+                    form.ErrorText.Text = Loc.Chrome("album.edit.reset_failed");
                     form.ErrorText.Visibility = Visibility.Visible;
                     return;
                 }
@@ -2778,13 +2820,13 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        var artistBox = new TextBox { Header = "artist", Text = seedArtist };
-        var albumBox = new TextBox { Header = "album", Text = seedAlbum };
-        var sourceBox = new ComboBox { Header = "source" };
+        var artistBox = new TextBox { Header = Loc.Chrome("search.field.artist"), Text = seedArtist };
+        var albumBox = new TextBox { Header = Loc.Chrome("search.field.album"), Text = seedAlbum };
+        var sourceBox = new ComboBox { Header = Loc.Chrome("search.field.source") };
         sourceBox.Items.Add("discogs");
         sourceBox.Items.Add("musicbrainz");
         sourceBox.SelectedIndex = 0;
-        var searchButton = new Button { Content = "search" };
+        var searchButton = new Button { Content = Loc.Chrome("action.search") };
 
         var resultsList = new ListView
         {
@@ -2808,10 +2850,10 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "re-identify",
+            Title = Loc.Chrome("album.reidentify.title"),
             Content = new ScrollViewer { Content = form },
-            PrimaryButtonText = "Re-identify",
-            CloseButtonText = "Cancel",
+            PrimaryButtonText = Loc.Chrome("album.reidentify.confirm"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = Content.XamlRoot,
             IsPrimaryButtonEnabled = false,
         };
@@ -2833,14 +2875,14 @@ public sealed partial class MainWindow : Window
             var parsed = json is null ? null : JsonSerializer.Deserialize<List<Candidate>>(json, JsonOptions);
             if (parsed is null)
             {
-                status.Text = "search failed";
+                status.Text = Loc.Chrome("search.failed");
                 status.Visibility = Visibility.Visible;
                 return;
             }
 
             candidates = parsed;
             resultsList.ItemsSource = candidates.Select(candidate => candidate.Summary).ToList();
-            status.Text = "no matches";
+            status.Text = Loc.Chrome("search.no_matches");
             status.Visibility = candidates.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             dialog.IsPrimaryButtonEnabled = false;
         };
@@ -2881,14 +2923,14 @@ public sealed partial class MainWindow : Window
         var json = NativeBae.GalleryJson(_handle, releaseId);
         if (json is null)
         {
-            StatusText.Text = "couldn't load the gallery";
+            StatusText.Text = Loc.Chrome("gallery.load_failed");
             return;
         }
 
         var images = JsonSerializer.Deserialize<List<GalleryImage>>(json, JsonOptions);
         if (images is null)
         {
-            StatusText.Text = "couldn't read the gallery";
+            StatusText.Text = Loc.Chrome("gallery.read_failed");
             return;
         }
 
@@ -2928,9 +2970,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "gallery",
+            Title = Loc.Chrome("gallery.title"),
             Content = content,
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
         await dialog.ShowAsync();
@@ -2953,7 +2995,7 @@ public sealed partial class MainWindow : Window
         var imagesJson = NativeBae.GetReleaseImagesJson(_handle, releaseId);
         if (imagesJson is null)
         {
-            StatusText.Text = "couldn't load this release's images";
+            StatusText.Text = Loc.Chrome("cover.images_load_failed");
             return;
         }
 
@@ -2974,9 +3016,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "change cover",
+            Title = Loc.Chrome("cover.change_title"),
             Content = new ScrollViewer { Content = content, MaxHeight = 520 },
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
 
@@ -3008,7 +3050,7 @@ public sealed partial class MainWindow : Window
 
         if (releaseImages.Count > 0)
         {
-            content.Children.Add(new TextBlock { Text = "Release files" });
+            content.Children.Add(new TextBlock { Text = Loc.Chrome("cover.release_files") });
             var fileGrid = new VariableSizedWrapGrid
             {
                 Orientation = Orientation.Horizontal,
@@ -3026,14 +3068,14 @@ public sealed partial class MainWindow : Window
             content.Children.Add(fileGrid);
         }
 
-        content.Children.Add(new TextBlock { Text = "Remote sources" });
+        content.Children.Add(new TextBlock { Text = Loc.Chrome("cover.remote_sources") });
         var loading = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 8,
         };
         loading.Children.Add(new ProgressRing { IsActive = true, Width = 20, Height = 20 });
-        loading.Children.Add(new TextBlock { Text = "fetching covers…" });
+        loading.Children.Add(new TextBlock { Text = Loc.Chrome("cover.fetching") });
         content.Children.Add(loading);
 
         var remoteGrid = new VariableSizedWrapGrid
@@ -3054,7 +3096,7 @@ public sealed partial class MainWindow : Window
             loading.Visibility = Visibility.Collapsed;
             if (coversJson is null)
             {
-                statusText.Text = "couldn't fetch remote covers";
+                statusText.Text = Loc.Chrome("cover.fetch_failed");
                 statusText.Visibility = Visibility.Visible;
                 return;
             }
@@ -3065,7 +3107,7 @@ public sealed partial class MainWindow : Window
                     ?? new List<RemoteCover>();
                 if (covers.Count == 0)
                 {
-                    remoteGrid.Children.Add(new TextBlock { Text = "No remote covers found" });
+                    remoteGrid.Children.Add(new TextBlock { Text = Loc.Chrome("cover.none_remote") });
                     return;
                 }
 
@@ -3081,7 +3123,7 @@ public sealed partial class MainWindow : Window
             {
                 // Fire-and-forget: a malformed cover URL or unexpected payload must
                 // surface here, not as an unobserved task exception.
-                statusText.Text = $"couldn't show remote covers: {ex.Message}";
+                statusText.Text = Loc.Chrome("cover.show_failed", "detail", ex.Message);
                 statusText.Visibility = Visibility.Visible;
             }
         }
@@ -3124,7 +3166,7 @@ public sealed partial class MainWindow : Window
             var json = NativeBae.StorageJson(_handle);
             if (json is null)
             {
-                storageStatus.Text = "couldn't load storage";
+                storageStatus.Text = Loc.Chrome("storage.load_failed");
                 storageStatus.Visibility = Visibility.Visible;
                 return;
             }
@@ -3132,7 +3174,7 @@ public sealed partial class MainWindow : Window
             var rows = JsonSerializer.Deserialize<List<StorageRow>>(json, JsonOptions);
             if (rows is null)
             {
-                storageStatus.Text = "couldn't read storage";
+                storageStatus.Text = Loc.Chrome("storage.read_failed");
                 storageStatus.Visibility = Visibility.Visible;
                 return;
             }
@@ -3229,7 +3271,7 @@ public sealed partial class MainWindow : Window
             var json = await System.Threading.Tasks.Task.Run(() => NativeBae.OutboxSnapshotJson(_handle));
             if (json is null)
             {
-                storageStatus.Text = "couldn't load the outbox";
+                storageStatus.Text = Loc.Chrome("outbox.load_failed");
                 storageStatus.Visibility = Visibility.Visible;
                 return;
             }
@@ -3237,7 +3279,7 @@ public sealed partial class MainWindow : Window
             var snapshot = JsonSerializer.Deserialize<OutboxSnapshot>(json, JsonOptions);
             if (snapshot is null)
             {
-                storageStatus.Text = "couldn't read the outbox";
+                storageStatus.Text = Loc.Chrome("outbox.read_failed");
                 storageStatus.Visibility = Visibility.Visible;
                 return;
             }
@@ -3255,7 +3297,7 @@ public sealed partial class MainWindow : Window
                 Text = snapshot.Summary,
                 VerticalAlignment = VerticalAlignment.Center,
             });
-            var retry = new Button { Content = "retry now" };
+            var retry = new Button { Content = Loc.Chrome("outbox.retry_now") };
             retry.Click += async (_, _) =>
             {
                 storageStatus.Visibility = Visibility.Collapsed;
@@ -3275,7 +3317,7 @@ public sealed partial class MainWindow : Window
             // Pause/resume the upload pipeline. Paused leaves items queued but stops
             // the sync cycle from draining them.
             var paused = snapshot.Paused;
-            var pause = new Button { Content = paused ? "resume" : "pause" };
+            var pause = new Button { Content = paused ? Loc.Chrome("outbox.resume") : Loc.Chrome("outbox.pause") };
             pause.Click += async (_, _) =>
             {
                 pause.IsEnabled = false;
@@ -3348,7 +3390,7 @@ public sealed partial class MainWindow : Window
                 Grid.SetColumn(labelColumn, 0);
                 itemGrid.Children.Add(labelColumn);
 
-                var cancel = new Button { Content = "cancel" };
+                var cancel = new Button { Content = Loc.Chrome("outbox.cancel_item") };
                 cancel.Click += async (_, _) =>
                 {
                     storageStatus.Visibility = Visibility.Collapsed;
@@ -3388,9 +3430,9 @@ public sealed partial class MainWindow : Window
 
         var dialog = new ContentDialog
         {
-            Title = "storage",
+            Title = Loc.Chrome("storage.title"),
             Content = new ScrollViewer { Content = content, MaxHeight = 480 },
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
         // Refresh both the outbox panel and the storage rows live while the dialog
@@ -3426,10 +3468,10 @@ public sealed partial class MainWindow : Window
     // "Storage…" sheet / context menu wording.
     private static string StorageActionLabel(string action) => action switch
     {
-        "manage" => "Move into library",
-        "unmanage" => "Move out of library…",
-        "pin" => "Pin for offline",
-        "unpin" => "Remove local copy",
+        "manage" => Loc.Chrome("storage.action.manage"),
+        "unmanage" => Loc.Chrome("storage.action.unmanage"),
+        "pin" => Loc.Chrome("storage.action.pin"),
+        "unpin" => Loc.Chrome("storage.action.unpin"),
         _ => action,
     };
 
@@ -3508,7 +3550,7 @@ public sealed partial class MainWindow : Window
         var cancelIds = await UploadOpIdsForReleases(releaseIds);
         if (cancelIds.Count > 0)
         {
-            var cancel = new MenuFlyoutItem { Text = "Cancel upload" };
+            var cancel = new MenuFlyoutItem { Text = Loc.Chrome("storage.cancel_upload") };
             cancel.Click += async (_, _) =>
             {
                 foreach (var id in cancelIds)
@@ -3654,10 +3696,10 @@ public sealed partial class MainWindow : Window
             Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
             Visibility = Visibility.Collapsed,
         };
-        var tokenBox = new TextBox { PlaceholderText = "Discogs API token" };
-        var save = new Button { Content = "save token" };
-        var recheck = new Button { Content = "re-check" };
-        var remove = new Button { Content = "remove token" };
+        var tokenBox = new TextBox { PlaceholderText = Loc.Chrome("settings.discogs.token_placeholder") };
+        var save = new Button { Content = Loc.Chrome("settings.discogs.save") };
+        var recheck = new Button { Content = Loc.Chrome("settings.discogs.recheck") };
+        var remove = new Button { Content = Loc.Chrome("settings.discogs.remove") };
         var discogsBusy = false;
 
         void ShowDiscogsError(string message)
@@ -3700,7 +3742,7 @@ public sealed partial class MainWindow : Window
 
             discogsBusy = true;
             ClearDiscogsError();
-            status.Text = "Validating…";
+            status.Text = Loc.Chrome("settings.discogs.validating");
             var outcome = await System.Threading.Tasks.Task.Run(
                 () => NativeBae.SaveDiscogsToken(_handle, token));
             discogsBusy = false;
@@ -3715,11 +3757,11 @@ public sealed partial class MainWindow : Window
                     // Nothing stored, so no ConfigChanged fires — keep the draft and
                     // surface the rejection.
                     status.Text = string.Empty;
-                    ShowDiscogsError("Discogs rejected this key — check it and save again.");
+                    ShowDiscogsError(Loc.Chrome("settings.discogs.rejected"));
                     break;
                 default:
                     status.Text = string.Empty;
-                    ShowDiscogsError("couldn't save the key — something went wrong.");
+                    ShowDiscogsError(Loc.Chrome("settings.discogs.save_failed"));
                     break;
             }
         };
@@ -3732,7 +3774,7 @@ public sealed partial class MainWindow : Window
 
             discogsBusy = true;
             ClearDiscogsError();
-            status.Text = "Validating…";
+            status.Text = Loc.Chrome("settings.discogs.validating");
             var error = await System.Threading.Tasks.Task.Run(
                 () => NativeBae.RevalidateDiscogsToken(_handle));
             discogsBusy = false;
@@ -3769,7 +3811,7 @@ public sealed partial class MainWindow : Window
         // Two-step disconnect: the first click surfaces the data-loss warning (when
         // releases live only in the cloud) inline and arms; the second confirms.
         // A nested ContentDialog can't open over the settings dialog.
-        var disconnect = new Button { Content = "disconnect" };
+        var disconnect = new Button { Content = Loc.Chrome("settings.sync.disconnect") };
         var disconnectArmed = false;
         disconnect.Click += async (_, _) =>
         {
@@ -3778,7 +3820,7 @@ public sealed partial class MainWindow : Window
                 var warning = await System.Threading.Tasks.Task.Run(() => NativeBae.DisconnectWarning(_handle));
                 if (warning is not null)
                 {
-                    syncStatus.Text = $"{warning} click disconnect again to confirm.";
+                    syncStatus.Text = Loc.Chrome("settings.sync.disconnect_confirm", "warning", warning);
                     disconnectArmed = true;
                     return;
                 }
@@ -3795,7 +3837,7 @@ public sealed partial class MainWindow : Window
                 _refreshSettings?.Invoke();
             }
         };
-        var syncNow = new Button { Content = "sync now" };
+        var syncNow = new Button { Content = Loc.Chrome("settings.sync.now") };
         syncNow.Click += (_, _) => NativeBae.TriggerSync(_handle);
         var syncButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
         syncButtons.Children.Add(disconnect);
@@ -3804,9 +3846,9 @@ public sealed partial class MainWindow : Window
         // Opaque (encrypted) vs browsable (stored in the clear), applied to
         // whichever provider is connected below. Defaults to the secure choice.
         // Not access control — the bucket's own credentials gate it either way.
-        var storagePicker = new ComboBox { Header = "storage", SelectedIndex = 0 };
-        storagePicker.Items.Add(new ComboBoxItem { Content = "opaque — end-to-end encrypted", Tag = "opaque" });
-        storagePicker.Items.Add(new ComboBoxItem { Content = "browsable — stored unencrypted", Tag = "browsable" });
+        var storagePicker = new ComboBox { Header = Loc.Chrome("settings.storage.mode"), SelectedIndex = 0 };
+        storagePicker.Items.Add(new ComboBoxItem { Content = Loc.Chrome("settings.storage.opaque"), Tag = "opaque" });
+        storagePicker.Items.Add(new ComboBoxItem { Content = Loc.Chrome("settings.storage.browsable"), Tag = "browsable" });
         string SelectedStorage() =>
             (storagePicker.SelectedItem as ComboBoxItem)?.Tag as string ?? "opaque";
 
@@ -3820,10 +3862,10 @@ public sealed partial class MainWindow : Window
                 if (!OAuthCreds.Available)
                 {
                     syncStatus.Text = OAuthCreds.RegistrationError
-                        ?? "cloud sign-in isn't configured on this build (no oauth-creds.json)";
+                        ?? Loc.Chrome("cloud.signin.not_configured");
                     return;
                 }
-                syncStatus.Text = $"signing in to {label}…";
+                syncStatus.Text = Loc.Chrome("cloud.signin.in_progress", "provider", label);
                 var storage = SelectedStorage();
                 var error = await System.Threading.Tasks.Task.Run(() => NativeBae.SignInCloud(_handle, provider, storage));
                 if (error is not null)
@@ -3844,22 +3886,17 @@ public sealed partial class MainWindow : Window
         // missing symbol, independent of whether oauth-creds.json is present.
         var available = NativeBae.AvailableCloudProviders();
         var oauthButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-        foreach (var (label, wire) in new[]
-                 {
-                     ("google drive", "google_drive"),
-                     ("dropbox", "dropbox"),
-                     ("onedrive", "onedrive"),
-                 })
+        foreach (var wire in new[] { "google_drive", "dropbox", "onedrive" })
         {
             if (available.Contains(wire))
             {
-                oauthButtons.Children.Add(CloudButton(label, wire));
+                oauthButtons.Children.Add(CloudButton(ProviderDisplayName(wire), wire));
             }
         }
 
         var content = new StackPanel { Spacing = 8, MinWidth = 360 };
-        var libraryLabel = new TextBlock { Text = $"Library: {s.LibraryName}" };
-        var discogsLabel = new TextBlock { Text = "Discogs token" };
+        var libraryLabel = new TextBlock { Text = Loc.Chrome("settings.library_label", "name", s.LibraryName) };
+        var discogsLabel = new TextBlock { Text = Loc.Chrome("settings.discogs.label") };
         content.Children.Add(libraryLabel);
         content.Children.Add(discogsLabel);
         content.Children.Add(tokenBox);
@@ -3868,16 +3905,16 @@ public sealed partial class MainWindow : Window
         content.Children.Add(errorText);
         RenderDiscogs(s);
         // S3-compatible provider form. The core probes the bucket before saving.
-        var s3Bucket = new TextBox { Header = "S3 bucket" };
-        var s3Region = new TextBox { Header = "region" };
-        var s3Endpoint = new TextBox { Header = "endpoint (optional)" };
-        var s3KeyPrefix = new TextBox { Header = "key prefix (optional)" };
-        var s3AccessKey = new TextBox { Header = "access key" };
-        var s3SecretKey = new PasswordBox { Header = "secret key" };
-        var connectS3 = new Button { Content = "connect S3" };
+        var s3Bucket = new TextBox { Header = Loc.Chrome("s3.field.bucket") };
+        var s3Region = new TextBox { Header = Loc.Chrome("s3.field.region") };
+        var s3Endpoint = new TextBox { Header = Loc.Chrome("s3.field.endpoint") };
+        var s3KeyPrefix = new TextBox { Header = Loc.Chrome("s3.field.key_prefix") };
+        var s3AccessKey = new TextBox { Header = Loc.Chrome("s3.field.access_key") };
+        var s3SecretKey = new PasswordBox { Header = Loc.Chrome("s3.field.secret_key") };
+        var connectS3 = new Button { Content = Loc.Chrome("settings.s3.connect") };
         connectS3.Click += async (_, _) =>
         {
-            syncStatus.Text = "connecting to S3…";
+            syncStatus.Text = Loc.Chrome("settings.s3.connecting");
             var storage = SelectedStorage();
             var error = await System.Threading.Tasks.Task.Run(() => NativeBae.SaveSyncConfig(
                 _handle,
@@ -3915,15 +3952,15 @@ public sealed partial class MainWindow : Window
         // Restore code: enter it on another device to restore this library.
         var restoreCode = new TextBox
         {
-            Header = "restore code (enter on another device)",
+            Header = Loc.Chrome("settings.restore_code.label"),
             IsReadOnly = true,
             TextWrapping = TextWrapping.Wrap,
             Visibility = Visibility.Collapsed,
         };
-        var showRestoreCode = new Button { Content = "show restore code" };
+        var showRestoreCode = new Button { Content = Loc.Chrome("settings.restore_code.show") };
         showRestoreCode.Click += (_, _) =>
         {
-            restoreCode.Text = NativeBae.GenerateRestoreCode(_handle) ?? "(unavailable — is sync connected?)";
+            restoreCode.Text = NativeBae.GenerateRestoreCode(_handle) ?? Loc.Chrome("settings.restore_code.unavailable");
             restoreCode.Visibility = Visibility.Visible;
         };
         content.Children.Add(showRestoreCode);
@@ -3932,14 +3969,14 @@ public sealed partial class MainWindow : Window
         // Lock this library: forget its encryption key on this device. Sync stops
         // and the library reopens to the unlock prompt; local files stay.
         var lockRequested = false;
-        var lockButton = new Button { Content = "lock library" };
+        var lockButton = new Button { Content = Loc.Chrome("settings.lock_library") };
         content.Children.Add(lockButton);
 
         var dialog = new ContentDialog
         {
-            Title = "settings",
+            Title = Loc.Chrome("settings.title"),
             Content = new ScrollViewer { Content = content },
-            CloseButtonText = "Close",
+            CloseButtonText = Loc.Chrome("action.close"),
             XamlRoot = Content.XamlRoot,
         };
         lockButton.Click += (_, _) =>
@@ -3966,7 +4003,7 @@ public sealed partial class MainWindow : Window
             }
 
             syncStatus.Text = fresh.SyncStatusText;
-            libraryLabel.Text = $"Library: {fresh.LibraryName}";
+            libraryLabel.Text = Loc.Chrome("settings.library_label", "name", fresh.LibraryName);
             RenderDiscogs(fresh);
         };
 

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -60,6 +60,81 @@ internal static class NativeBae
     internal static bool SupportsOAuthProviders() =>
         AvailableCloudProviders().Any(provider => provider is not "s3");
 
+    // ── Catalog-key selection ────────────────────────────────────────────────
+    //
+    // The enum→key mapping macOS gets free from uniffi's bridge_*_key() functions
+    // is hand-mirrored in bae-windows-ffi (src/loc.rs) and exported as these
+    // entry points, so the key strings have one source (Rust), not a duplicate in
+    // C#. Each returns the core.* catalog key for the value, or null when the
+    // value has no key (the caller falls back to a passthrough / generic line).
+    // The C# resolves the returned key through Loc.Core.
+
+    [DllImport(Dll, EntryPoint = "bae_cloud_provider_label_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr CloudProviderLabelKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string? provider);
+
+    /// <summary>The catalog key for a cloud provider's display name, or null for
+    /// the brand-name providers the UI passes through verbatim. <paramref name="provider"/>
+    /// is the wire tag ("s3"/"google_drive"/…) or null/"" for local-only.</summary>
+    internal static string? CloudProviderLabelKey(string? provider) =>
+        CopyAndFree(CloudProviderLabelKeyPtr(provider));
+
+    [DllImport(Dll, EntryPoint = "bae_audio_channels_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr AudioChannelsKeyPtr(long channels);
+
+    /// <summary>The catalog key for a channel count's word ("mono"/"stereo"), or
+    /// null for counts the UI renders as "{n}ch".</summary>
+    internal static string? AudioChannelsKey(long channels) =>
+        CopyAndFree(AudioChannelsKeyPtr(channels));
+
+    [DllImport(Dll, EntryPoint = "bae_error_category_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ErrorCategoryKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string category);
+
+    /// <summary>The catalog key for a diagnostic error category's generic line
+    /// (the wire tag an FfiError carries), or null for an unknown tag.</summary>
+    internal static string? ErrorCategoryKey(string category) =>
+        CopyAndFree(ErrorCategoryKeyPtr(category));
+
+    [DllImport(Dll, EntryPoint = "bae_entity_not_found_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr EntityNotFoundKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string entity);
+
+    /// <summary>The catalog key for a missing entity's "… not found" line (the
+    /// wire tag an FfiError carries), or null for an unknown tag.</summary>
+    internal static string? EntityNotFoundKey(string entity) =>
+        CopyAndFree(EntityNotFoundKeyPtr(entity));
+
+    [DllImport(Dll, EntryPoint = "bae_playback_error_reason_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr PlaybackErrorReasonKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string kind);
+
+    /// <summary>The catalog key for an actionable playback-error reason (the wire
+    /// tag the reason carries), or null for the "diagnostic" reason (rendered
+    /// through the error-category path) and unknown tags.</summary>
+    internal static string? PlaybackErrorReasonKey(string kind) =>
+        CopyAndFree(PlaybackErrorReasonKeyPtr(kind));
+
+    [DllImport(Dll, EntryPoint = "bae_prepare_step_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr PrepareStepKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string step);
+
+    /// <summary>The catalog key for an import prepare-step wire tag, or null for
+    /// an unknown tag.</summary>
+    internal static string? PrepareStepKey(string step) =>
+        CopyAndFree(PrepareStepKeyPtr(step));
+
+    [DllImport(Dll, EntryPoint = "bae_import_phase_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ImportPhaseKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string phase);
+
+    /// <summary>The catalog key for an import-phase wire tag, or null for an
+    /// unknown tag.</summary>
+    internal static string? ImportPhaseKey(string phase) =>
+        CopyAndFree(ImportPhaseKeyPtr(phase));
+
+    [DllImport(Dll, EntryPoint = "bae_transfer_action_key", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr TransferActionKeyPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string action);
+
+    /// <summary>The catalog key for a transfer action's progress verb (a wire tag
+    /// from a storage row's actions), or null for an unknown tag.</summary>
+    internal static string? TransferActionKey(string action) =>
+        CopyAndFree(TransferActionKeyPtr(action));
+
     /// <summary>Discovered libraries as JSON, or null. Copies and frees.</summary>
     [DllImport(Dll, EntryPoint = "bae_libraries", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr LibrariesPtr();

--- a/bae-windows/OutboxSnapshot.cs
+++ b/bae-windows/OutboxSnapshot.cs
@@ -1,28 +1,15 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Bae.Windows;
 
 /// <summary>
 /// The cloud outbox snapshot, deserialized from the FFI's
-/// <c>bae_outbox_snapshot</c> JSON: a one-line summary band plus the queued upload
-/// and delete operations.
+/// <c>bae_outbox_snapshot</c> JSON. The locale never crosses the bridge: counts,
+/// throughput, ETA, and byte totals are raw, composed into localized lines here.
 /// </summary>
 public sealed class OutboxSnapshot
 {
-    /// <summary>One-line queue summary, e.g. "2 uploading · 1 failed · 3 queued";
-    /// empty when the queue is idle so the UI can hide it.</summary>
-    public string Summary
-    {
-        get
-        {
-            var parts = new System.Collections.Generic.List<string>();
-            if (Total.Active > 0) parts.Add($"{Total.Active} uploading");
-            if (Total.Failed > 0) parts.Add($"{Total.Failed} failed");
-            if (Total.Queued > 0) parts.Add($"{Total.Queued} queued");
-            if (Deletes.Count > 0) parts.Add($"{Deletes.Count} pending delete{(Deletes.Count == 1 ? "" : "s")}");
-            return string.Join(" · ", parts);
-        }
-    }
     public List<UploadOp> Uploads { get; set; } = new();
     public List<DeleteOp> Deletes { get; set; } = new();
 
@@ -39,37 +26,55 @@ public sealed class OutboxSnapshot
     /// <summary>Aggregate byte progress; the master bar reads its done/total.</summary>
     public UploadProgress Total { get; set; } = new();
 
-    /// <summary>Formatted throughput, e.g. "5.2 MB/s"; empty when idle.</summary>
-    public string ThroughputLabel =>
-        ThroughputBps > 0 ? FormatBytes(ThroughputBps) + "/s" : string.Empty;
-
-    /// <summary>Formatted ETA, e.g. "2m 14s remaining"; empty when not computable.</summary>
-    public string EtaLabel
+    /// <summary>One-line queue summary, e.g. "2 uploading · 1 failed · 3 queued";
+    /// empty when the queue is idle so the UI can hide it. Each part is a
+    /// localized count message from the shared catalog.</summary>
+    [JsonIgnore]
+    public string Summary
     {
         get
         {
-            if (!EtaSeconds.HasValue) return string.Empty;
-            var secs = EtaSeconds.Value;
-            if (secs < 60) return $"{secs}s remaining";
-            var mins = secs / 60;
-            var rem = secs % 60;
-            return rem > 0 ? $"{mins}m {rem}s remaining" : $"{mins}m remaining";
+            var parts = new List<string>();
+            if (Total.Active > 0) parts.Add(Loc.Core("core.queue.uploading", "count", Total.Active));
+            if (Total.Failed > 0) parts.Add(Loc.Core("core.queue.failed", "count", Total.Failed));
+            if (Total.Queued > 0) parts.Add(Loc.Core("core.queue.queued", "count", Total.Queued));
+            if (Deletes.Count > 0)
+                parts.Add(Loc.Core("core.outbox.pending_deletes", "count", Deletes.Count));
+            return string.Join(" · ", parts);
         }
     }
 
-    /// <summary>Formatted aggregate progress, e.g. "1.2 GB of 14.4 GB"; empty when
-    /// there is nothing to upload.</summary>
-    public string BytesLabel =>
-        Total.BytesTotal > 0
-            ? $"{FormatBytes(Total.BytesDone)} of {FormatBytes(Total.BytesTotal)}"
+    /// <summary>Formatted throughput, e.g. "5.2 MB/s"; empty when idle. The rate
+    /// is a locale-formatted byte count substituted into the shared message.</summary>
+    [JsonIgnore]
+    public string ThroughputLabel =>
+        ThroughputBps > 0 ? Loc.Core("core.outbox.throughput", "rate", Loc.Bytes(ThroughputBps)) : string.Empty;
+
+    /// <summary>Formatted ETA, e.g. "2m 14s remaining"; empty when not computable.
+    /// The duration is locale-formatted and substituted into the shared message.</summary>
+    [JsonIgnore]
+    public string EtaLabel =>
+        EtaSeconds is { } secs
+            ? Loc.Core("core.outbox.eta", "duration", Loc.Duration(secs * 1000))
             : string.Empty;
 
-    private static string FormatBytes(long bytes)
+    /// <summary>Formatted aggregate progress, e.g. "1.2 GB of 14.4 GB"; empty when
+    /// there is nothing to upload. Both byte counts are locale-formatted and
+    /// substituted into the shared message.</summary>
+    [JsonIgnore]
+    public string BytesLabel
     {
-        if (bytes < 1_000) return $"{bytes} B";
-        if (bytes < 1_000_000) return $"{bytes / 1_000.0:F1} KB";
-        if (bytes < 1_000_000_000) return $"{bytes / 1_000_000.0:F1} MB";
-        return $"{bytes / 1_000_000_000.0:F1} GB";
+        get
+        {
+            if (Total.BytesTotal <= 0) return string.Empty;
+            return Loc.Core(
+                "core.outbox.bytes_progress",
+                new Dictionary<string, object?>
+                {
+                    ["done"] = Loc.Bytes(Total.BytesDone),
+                    ["total"] = Loc.Bytes(Total.BytesTotal),
+                });
+        }
     }
 }
 
@@ -96,34 +101,41 @@ public sealed class UploadOp
     /// orphaned file.</summary>
     public string? Title { get; set; }
     public string CloudKey { get; set; } = string.Empty;
-
-    /// <summary>Pre-formatted size, e.g. "12.4 MB".</summary>
-    public string SizeLabel { get; set; } = string.Empty;
     public long AttemptCount { get; set; }
 
     /// <summary>Bytes of this file that have reached the cloud so far; advances
     /// mid-upload while <see cref="State"/> is "active".</summary>
     public long BytesDone { get; set; }
 
-    /// <summary>Total bytes for this file (the encrypted payload size).</summary>
+    /// <summary>Total bytes for this file (the encrypted payload size); formatted
+    /// for the locale by <see cref="SizeLabel"/>.</summary>
     public long BytesTotal { get; set; }
 
     /// <summary>"queued", "active", or "failed".</summary>
     public string State { get; set; } = string.Empty;
 
-    /// <summary>The last failure message when <see cref="State"/> is "failed".</summary>
+    /// <summary>The last failure message when <see cref="State"/> is "failed".
+    /// This is an opaque, log-only diagnostic string from the cloud layer (an
+    /// exception's text), shown verbatim in a copyable disclosure — never
+    /// translated, like a diagnostic error's detail.</summary>
     public string? LastError { get; set; }
+
+    /// <summary>The total size formatted for the locale, e.g. "12.4 MB".</summary>
+    [JsonIgnore]
+    public string SizeLabel => Loc.Bytes(BytesTotal);
 
     /// <summary>True while this upload is in flight — drives the per-file mini
     /// progress bar.</summary>
+    [JsonIgnore]
     public bool IsActive => State == "active";
 
     /// <summary>Byte progress as a 0...1 fraction for the active-row mini bar.</summary>
+    [JsonIgnore]
     public double Fraction => BytesTotal > 0 ? (double)BytesDone / BytesTotal : 0;
 
-    /// <summary>The list row: title-or-key, state, size, and attempt count. An
-    /// active upload shows its live byte fraction (e.g. "45% · 31.5 of 70 MB")
-    /// instead of the bare "active".</summary>
+    /// <summary>The list row: title-or-key, localized state, size, and attempt
+    /// count. An active upload shows its live byte fraction.</summary>
+    [JsonIgnore]
     public string Label
     {
         get
@@ -132,21 +144,24 @@ public sealed class UploadOp
             string detail;
             if (State == "failed" && !string.IsNullOrEmpty(LastError))
             {
-                detail = $"failed: {LastError}";
+                // The failure word is chrome; LastError is the opaque detail.
+                detail = $"{Loc.Chrome("outbox.upload.failed")}: {LastError}";
             }
             else if (IsActive && BytesTotal > 0)
             {
-                detail = $"uploading · {(int)(Fraction * 100)}%";
+                detail = Loc.Chrome(
+                    "outbox.upload.active_percent",
+                    "percent", (int)(Fraction * 100));
             }
             else
             {
-                detail = State;
+                detail = Loc.Chrome($"outbox.upload.state.{State}");
             }
-            var size = string.IsNullOrEmpty(SizeLabel) ? string.Empty : $" · {SizeLabel}";
+            var size = BytesTotal > 0 ? $" · {SizeLabel}" : string.Empty;
             var attempts = AttemptCount > 0
-                ? $" · {AttemptCount} attempt{(AttemptCount == 1 ? "" : "s")}"
+                ? $" · {Loc.Chrome("outbox.upload.attempts", "count", AttemptCount)}"
                 : string.Empty;
-            return $"{name} — upload · {detail}{size}{attempts}";
+            return $"{name} — {Loc.Chrome("outbox.upload.kind")} · {detail}{size}{attempts}";
         }
     }
 }
@@ -157,6 +172,7 @@ public sealed class DeleteOp
     public long Id { get; set; }
     public string CloudKey { get; set; } = string.Empty;
 
-    /// <summary>The list row: the cloud key being deleted.</summary>
-    public string Label => $"{CloudKey} — delete";
+    /// <summary>The list row: the cloud key being deleted, with a localized kind.</summary>
+    [JsonIgnore]
+    public string Label => $"{CloudKey} — {Loc.Chrome("outbox.delete.kind")}";
 }

--- a/bae-windows/QueueItem.cs
+++ b/bae-windows/QueueItem.cs
@@ -1,4 +1,4 @@
-﻿namespace Bae.Windows;
+namespace Bae.Windows;
 
 /// <summary>One track in the play queue, from the <c>QueueUpdated</c> event JSON.</summary>
 public sealed class QueueItem
@@ -6,8 +6,13 @@ public sealed class QueueItem
     public string TrackId { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string Artist { get; set; } = string.Empty;
-    public string Duration { get; set; } = string.Empty;
+
+    /// <summary>Raw track length in milliseconds, or null when unknown.</summary>
+    public long? DurationMs { get; set; }
+
+    /// <summary>The track length formatted for the locale, e.g. "3:07".</summary>
+    public string DurationLabel => Loc.Duration(DurationMs);
 
     /// <summary>The list row; used as the default item text.</summary>
-    public override string ToString() => $"{Title} — {Artist} · {Duration}".Trim();
+    public override string ToString() => $"{Title} — {Artist} · {DurationLabel}".Trim();
 }

--- a/bae-windows/Settings.cs
+++ b/bae-windows/Settings.cs
@@ -1,4 +1,6 @@
-﻿namespace Bae.Windows;
+﻿using System.Text.Json.Serialization;
+
+namespace Bae.Windows;
 
 /// <summary>App settings from the FFI's <c>bae_settings</c> JSON.</summary>
 public sealed class Settings
@@ -21,10 +23,60 @@ public sealed class Settings
     public bool SyncReady { get; set; }
     public bool HasCloudHome => SyncProvider is not null;
 
+    /// <summary>
+    /// The connected provider's display name. The locale never crosses the
+    /// bridge: the FFI maps the wire tag to a catalog key (S3 → "S3-compatible",
+    /// local-only → "Local only") or null for the brand-name providers the UI
+    /// passes through verbatim (Google Drive, Dropbox, OneDrive, iCloud). Mirrors
+    /// macOS's <c>localizedCloudProviderName</c>.
+    /// </summary>
+    [JsonIgnore]
+    public string ProviderLabel
+    {
+        get
+        {
+            var key = NativeBae.CloudProviderLabelKey(SyncProvider);
+            if (key is not null)
+            {
+                return Loc.Core(key);
+            }
+            // No key → a brand name the UI shows verbatim; map the wire tag to
+            // its proper-noun chrome label.
+            return SyncProvider switch
+            {
+                "google_drive" => Loc.Chrome("cloud.provider.google_drive"),
+                "dropbox" => Loc.Chrome("cloud.provider.dropbox"),
+                "onedrive" => Loc.Chrome("cloud.provider.onedrive"),
+                "cloudkit" => Loc.Chrome("cloud.provider.icloud"),
+                _ => SyncProvider ?? string.Empty,
+            };
+        }
+    }
+
     /// <summary>One-line sync state for the settings header.</summary>
-    public string SyncStatusText => SyncProvider is null
-        ? "Sync: not connected"
-        : $"Sync: {SyncProvider}{(string.IsNullOrEmpty(SyncAccount) ? string.Empty : $" ({SyncAccount})")} — {(SyncReady ? "ready" : "initializing")}";
+    [JsonIgnore]
+    public string SyncStatusText
+    {
+        get
+        {
+            if (SyncProvider is null)
+            {
+                return Loc.Chrome("settings.sync.not_connected");
+            }
+            var account = string.IsNullOrEmpty(SyncAccount) ? string.Empty : $" ({SyncAccount})";
+            var state = SyncReady
+                ? Loc.Chrome("settings.sync.ready")
+                : Loc.Chrome("settings.sync.initializing");
+            return Loc.Chrome(
+                "settings.sync.status",
+                new System.Collections.Generic.Dictionary<string, object?>
+                {
+                    ["provider"] = ProviderLabel,
+                    ["account"] = account,
+                    ["state"] = state,
+                });
+        }
+    }
 
     /// <summary>
     /// The persisted Discogs key is usable (stored and not rejected) — the
@@ -45,10 +97,11 @@ public sealed class Settings
     /// A rejected key stores nothing (so it isn't configured) and a missing key
     /// shows the editable input, so neither needs a label here.
     /// </summary>
+    [JsonIgnore]
     public string DiscogsStatusText => DiscogsStatus switch
     {
-        "valid" => "connected",
-        "unvalidated" => "saved — couldn't validate yet (offline). will retry.",
+        "valid" => Loc.Chrome("settings.discogs.connected"),
+        "unvalidated" => Loc.Chrome("settings.discogs.unvalidated"),
         _ => string.Empty,
     };
 }

--- a/bae-windows/SignalBadge.cs
+++ b/bae-windows/SignalBadge.cs
@@ -26,11 +26,17 @@ public sealed class SignalBadge
 /// <summary>
 /// A badge's live lookup/match state — a tag plus the one payload each variant
 /// carries. Mirrors the FFI's <c>FfiSignalState</c>: <see cref="Count"/> is set
-/// for "found"/"confirms", null otherwise.
+/// for "found"/"confirms", <see cref="Failure"/> for "failed", both null
+/// otherwise. The locale never crosses the bridge, so the failed state carries
+/// the structured <see cref="LookupFailure"/>, not a prose message.
 /// </summary>
 public sealed class SignalBadgeState
 {
     /// <summary>"looking_up" / "found" / "no_match" / "skipped" / "failed" / "confirms".</summary>
     public string Kind { get; set; } = string.Empty;
     public uint? Count { get; set; }
+
+    /// <summary>The structured lookup failure for the "failed" state; null
+    /// otherwise. The badge resolves its localized line from this.</summary>
+    public LookupFailure? Failure { get; set; }
 }

--- a/bae-windows/StorageRow.cs
+++ b/bae-windows/StorageRow.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Bae.Windows;
 
 /// <summary>
 /// One release row in the storage manager, deserialized from the FFI's
-/// <c>bae_storage</c> JSON.
+/// <c>bae_storage</c> JSON. The locale never crosses the bridge: the size is a
+/// raw byte count and the state is a wire tag, both rendered for the locale here.
 /// </summary>
 public sealed class StorageRow
 {
@@ -12,23 +14,49 @@ public sealed class StorageRow
     public string AlbumTitle { get; set; } = string.Empty;
     public string Artist { get; set; } = string.Empty;
     public string? Format { get; set; }
-    public string Size { get; set; } = string.Empty;
+
+    /// <summary>Raw total size in bytes; formatted for the locale by
+    /// <see cref="SizeLabel"/>.</summary>
+    public long TotalSize { get; set; }
+
     public long FileCount { get; set; }
+
+    /// <summary>Storage-state wire tag: "unmanaged" / "pinned" / "cloud_only".</summary>
     public string State { get; set; } = string.Empty;
+
     public long PendingUploads { get; set; }
 
     /// <summary>The transitions this release allows now (pin/unpin/manage/unmanage),
     /// computed by the core (gated on cloud-home + pending uploads).</summary>
     public List<string> Actions { get; set; } = new();
 
+    /// <summary>The total size formatted for the locale, e.g. "412 MB".</summary>
+    [JsonIgnore]
+    public string SizeLabel => Loc.Bytes(TotalSize);
+
+    /// <summary>
+    /// The localized storage-state label. macOS does not yet route this typed
+    /// state through the shared catalog (it hardcodes the words in Swift), so
+    /// it's app chrome here — keyed by the wire tag in the app's own Resources
+    /// table — rather than an invented <c>core.*</c> key macOS doesn't have.
+    /// </summary>
+    [JsonIgnore]
+    public string StateLabel => Loc.Chrome($"storage.state.{State}");
+
     /// <summary>The list row, omitting absent fields.</summary>
+    [JsonIgnore]
     public string Summary
     {
         get
         {
             var format = string.IsNullOrEmpty(Format) ? string.Empty : $" · {Format}";
-            var pending = PendingUploads > 0 ? $" · {PendingUploads} pending" : string.Empty;
-            return $"{AlbumTitle} — {Artist}{format} · {FileCount} files · {Size} · {State}{pending}";
+            // File count is app chrome (pluralized via the MF1 value in Resources);
+            // pending uploads reuses the shared core.queue.uploading message.
+            var files = Loc.Chrome("storage.files", "count", FileCount);
+            var pending = PendingUploads > 0
+                ? $" · {Loc.Core("core.queue.uploading", "count", PendingUploads)}"
+                : string.Empty;
+            return $"{AlbumTitle} — {Artist}{format} · {files} · {SizeLabel} · {StateLabel}{pending}";
         }
     }
 }

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
+  <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
+  <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
+  <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
+  <data name="StorageButton.Content" xml:space="preserve"><value>storage</value></data>
+  <data name="SettingsButton.Content" xml:space="preserve"><value>settings</value></data>
+  <data name="action.cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="action.close" xml:space="preserve"><value>Close</value></data>
+  <data name="action.delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="action.import" xml:space="preserve"><value>Import</value></data>
+  <data name="action.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="action.play" xml:space="preserve"><value>Play</value></data>
+  <data name="action.save" xml:space="preserve"><value>Save</value></data>
+  <data name="action.search" xml:space="preserve"><value>search</value></data>
+  <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
+  <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
+  <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
+  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
+  <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
+  <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
+  <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
+  <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
+  <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
+  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
+  <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>
+  <data name="album.shuffle" xml:space="preserve"><value>shuffle</value></data>
+  <data name="cloud.provider.dropbox" xml:space="preserve"><value>Dropbox</value></data>
+  <data name="cloud.provider.google_drive" xml:space="preserve"><value>Google Drive</value></data>
+  <data name="cloud.provider.onedrive" xml:space="preserve"><value>OneDrive</value></data>
+  <data name="cloud.provider.s3" xml:space="preserve"><value>S3</value></data>
+  <data name="cloud.signin.failed" xml:space="preserve"><value>cloud sign-in failed</value></data>
+  <data name="cloud.signin.in_progress" xml:space="preserve"><value>signing in to {provider}…</value></data>
+  <data name="cloud.signin.not_configured" xml:space="preserve"><value>cloud sign-in isn't configured on this build (no oauth-creds.json)</value></data>
+  <data name="cloud.unsupported_provider" xml:space="preserve"><value>this build doesn't support {provider} sync</value></data>
+  <data name="cover.change_title" xml:space="preserve"><value>change cover</value></data>
+  <data name="cover.fetch_failed" xml:space="preserve"><value>couldn't fetch remote covers</value></data>
+  <data name="cover.fetching" xml:space="preserve"><value>fetching covers…</value></data>
+  <data name="cover.images_load_failed" xml:space="preserve"><value>couldn't load this release's images</value></data>
+  <data name="cover.none_available" xml:space="preserve"><value>No cover art available — the import uses its default cover.</value></data>
+  <data name="cover.none_remote" xml:space="preserve"><value>No remote covers found</value></data>
+  <data name="cover.pick_hint" xml:space="preserve"><value>Pick a cover, or leave unselected to use the default.</value></data>
+  <data name="cover.release_files" xml:space="preserve"><value>Release files</value></data>
+  <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
+  <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
+  <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
+  <data name="error.title" xml:space="preserve"><value>error</value></data>
+  <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
+  <data name="gallery.read_failed" xml:space="preserve"><value>couldn't read the gallery</value></data>
+  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
+  <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
+  <data name="identify.error" xml:space="preserve"><value>error</value></data>
+  <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
+  <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
+  <data name="identify.manual" xml:space="preserve"><value>manual search only</value></data>
+  <data name="identify.not_found" xml:space="preserve"><value>not found</value></data>
+  <data name="import.already_in_library" xml:space="preserve"><value>this release is already in your library</value></data>
+  <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
+  <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
+  <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
+  <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
+  <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>
+  <data name="import.drop_read_failed" xml:space="preserve"><value>could not read the dropped item</value></data>
+  <data name="import.error_title" xml:space="preserve"><value>import error</value></data>
+  <data name="import.error.load_release" xml:space="preserve"><value>couldn't load the release to import</value></data>
+  <data name="import.error.load_storage_settings" xml:space="preserve"><value>couldn't load storage settings</value></data>
+  <data name="import.error.read_storage_settings" xml:space="preserve"><value>couldn't read storage settings</value></data>
+  <data name="import.failed" xml:space="preserve"><value>import failed</value></data>
+  <data name="import.field.artist_manual" xml:space="preserve"><value>artist (manual search)</value></data>
+  <data name="import.no_releases" xml:space="preserve"><value>no releases found</value></data>
+  <data name="import.preview" xml:space="preserve"><value>preview</value></data>
+  <data name="import.progress.percent" xml:space="preserve"><value>importing {percent}%</value></data>
+  <data name="import.release_title" xml:space="preserve"><value>import release</value></data>
+  <data name="import.rerun_identify" xml:space="preserve"><value>re-run identification</value></data>
+  <data name="import.scanning" xml:space="preserve"><value>scanning…</value></data>
+  <data name="import.storage.keep_local" xml:space="preserve"><value>Keep local copy</value></data>
+  <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="import.title" xml:space="preserve"><value>import</value></data>
+  <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
+  <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
+  <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
+  <data name="libraries.title" xml:space="preserve"><value>libraries</value></data>
+  <data name="library.create_failed" xml:space="preserve"><value>couldn't create a library</value></data>
+  <data name="library.empty" xml:space="preserve"><value>library is empty</value></data>
+  <data name="library.load_failed" xml:space="preserve"><value>couldn't load the library</value></data>
+  <data name="library.locked" xml:space="preserve"><value>library is locked</value></data>
+  <data name="library.open_failed" xml:space="preserve"><value>couldn't open the library</value></data>
+  <data name="library.unlock.body" xml:space="preserve"><value>This library is encrypted and its key isn't on this device. Enter the 64-character hex key to unlock it.</value></data>
+  <data name="library.unlock.confirm" xml:space="preserve"><value>Unlock</value></data>
+  <data name="library.unlock.key_placeholder" xml:space="preserve"><value>64-character hex key</value></data>
+  <data name="library.unlock.title" xml:space="preserve"><value>unlock library</value></data>
+  <data name="menu.add_to_queue" xml:space="preserve"><value>Add to Queue</value></data>
+  <data name="menu.change_cover" xml:space="preserve"><value>Change cover…</value></data>
+  <data name="menu.delete" xml:space="preserve"><value>Delete…</value></data>
+  <data name="menu.export" xml:space="preserve"><value>Export…</value></data>
+  <data name="menu.play" xml:space="preserve"><value>Play</value></data>
+  <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
+  <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
+  <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
+  <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
+  <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
+  <data name="outbox.pause" xml:space="preserve"><value>pause</value></data>
+  <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
+  <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
+  <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
+  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
+  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
+  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
+  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
+  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
+  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
+  <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
+  <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
+  <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>
+  <data name="restore.field.cloud_storage" xml:space="preserve"><value>cloud storage</value></data>
+  <data name="restore.field.encryption_key" xml:space="preserve"><value>encryption key (hex)</value></data>
+  <data name="restore.field.library_id" xml:space="preserve"><value>library id</value></data>
+  <data name="restore.field.library_name" xml:space="preserve"><value>library name (optional)</value></data>
+  <data name="restore.from_cloud" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_cloud_title" xml:space="preserve"><value>restore from cloud</value></data>
+  <data name="restore.from_code" xml:space="preserve"><value>restore from code</value></data>
+  <data name="restore.in_progress" xml:space="preserve"><value>restoring…</value></data>
+  <data name="restore.in_progress_named" xml:space="preserve"><value>restoring {name}…</value></data>
+  <data name="restore.invalid_code" xml:space="preserve"><value>invalid restore code</value></data>
+  <data name="s3.field.access_key" xml:space="preserve"><value>access key</value></data>
+  <data name="s3.field.bucket" xml:space="preserve"><value>S3 bucket</value></data>
+  <data name="s3.field.endpoint" xml:space="preserve"><value>endpoint (optional)</value></data>
+  <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
+  <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
+  <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
+  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.field.album" xml:space="preserve"><value>album</value></data>
+  <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="search.field.source" xml:space="preserve"><value>source</value></data>
+  <data name="search.no_matches" xml:space="preserve"><value>no matches</value></data>
+  <data name="settings.discogs.label" xml:space="preserve"><value>Discogs token</value></data>
+  <data name="settings.discogs.recheck" xml:space="preserve"><value>re-check</value></data>
+  <data name="settings.discogs.rejected" xml:space="preserve"><value>Discogs rejected this key — check it and save again.</value></data>
+  <data name="settings.discogs.remove" xml:space="preserve"><value>remove token</value></data>
+  <data name="settings.discogs.save" xml:space="preserve"><value>save token</value></data>
+  <data name="settings.discogs.save_failed" xml:space="preserve"><value>couldn't save the key — something went wrong.</value></data>
+  <data name="settings.discogs.token_placeholder" xml:space="preserve"><value>Discogs API token</value></data>
+  <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
+  <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
+  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
+  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
+  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
+  <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
+  <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
+  <data name="settings.storage.mode" xml:space="preserve"><value>storage</value></data>
+  <data name="settings.storage.opaque" xml:space="preserve"><value>opaque — end-to-end encrypted</value></data>
+  <data name="settings.sync.disconnect" xml:space="preserve"><value>disconnect</value></data>
+  <data name="settings.sync.disconnect_confirm" xml:space="preserve"><value>{warning} click disconnect again to confirm.</value></data>
+  <data name="settings.sync.now" xml:space="preserve"><value>sync now</value></data>
+  <data name="settings.title" xml:space="preserve"><value>settings</value></data>
+  <data name="signal.exclude" xml:space="preserve"><value>exclude signal</value></data>
+  <data name="signal.include" xml:space="preserve"><value>include signal</value></data>
+  <data name="signal.kind.barcode" xml:space="preserve"><value>Barcode</value></data>
+  <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
+  <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
+  <data name="sort.title" xml:space="preserve"><value>title</value></data>
+  <data name="sort.year" xml:space="preserve"><value>year</value></data>
+  <data name="storage.action.manage" xml:space="preserve"><value>Move into library</value></data>
+  <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
+  <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
+  <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
+  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
+  <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
+  <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
+  <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>
+  <data name="storage.state.cloud_only" xml:space="preserve"><value>Cloud-only</value></data>
+  <data name="storage.state.pinned" xml:space="preserve"><value>Pinned</value></data>
+  <data name="storage.state.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.title" xml:space="preserve"><value>storage</value></data>
+  <data name="sync.error_title" xml:space="preserve"><value>sync error</value></data>
+  <data name="sync.reconnect" xml:space="preserve"><value>Reconnect</value></data>
+  <data name="sync.synced" xml:space="preserve"><value>synced {time}</value></data>
+  <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
+  <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
+  <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
+  <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
+  <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>
+  <data name="cloud.provider.icloud" xml:space="preserve"><value>iCloud</value></data>
+  <data name="settings.discogs.connected" xml:space="preserve"><value>connected</value></data>
+  <data name="settings.discogs.unvalidated" xml:space="preserve"><value>saved — couldn't validate yet (offline). will retry.</value></data>
+  <data name="settings.sync.initializing" xml:space="preserve"><value>initializing</value></data>
+  <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
+  <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
+  <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+</root>

--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -42,6 +42,65 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260508005" />
+    <!--
+      ICU MessageFormat 1 runtime. The localization catalog stores each message
+      as a verbatim MF1 string (plural / select / named args); this parses it at
+      runtime for the current locale — the analog of macOS's String Catalog
+      variations. Loc.cs wraps it.
+    -->
+    <PackageReference Include="MessageFormat" Version="7.0.0" />
+  </ItemGroup>
+
+  <!--
+    Generated localization resources.
+
+    The bridge-originated strings (core.*) and shared chrome (ui.*) live in the
+    master catalog (bae-bridge/loc/catalog.toml); loc-gen emits them as
+    Strings/en-US/Core.resw. The 13 non-source locales each get a Strings/<lang>/
+    directory with the English source marked for translation (untranslated until
+    a translator fills them); English shows at runtime until then. Bare app chrome
+    (titles, buttons) lives in the committed Strings/<lang>/Resources.resw.
+
+    Every Strings/<lang>/*.resw compiles into the per-language resource map. The
+    PRIResource item is how the WinUI/MSBuild resource pipeline picks them up; the
+    GenerateResourcesPri target below then compiles the lot into resources.pri for
+    the unpackaged app.
+  -->
+  <ItemGroup>
+    <PRIResource Include="Strings\**\*.resw" />
+  </ItemGroup>
+
+  <!--
+    Generate Strings/en-US/Core.resw from the master catalog before the build, so
+    a catalog edit reaches the app without a manual step. Mirrors the macOS build
+    (bae-bridge/build-macos.sh runs `loc-gen emit --target apple`). loc-gen writes
+    <out-dir>/en-US/Core.resw, so the out-dir is the Strings folder. Runs from the
+    repo root (two levels up from this project) where the default catalog path
+    (bae-bridge/loc/catalog.toml) resolves.
+  -->
+  <Target Name="GenerateCoreResw" BeforeTargets="BeforeBuild">
+    <Exec
+      Command="cargo run -q -p bae-loc --bin loc-gen -- emit --target windows --out-dir &quot;$(MSBuildProjectDirectory)\Strings&quot;"
+      WorkingDirectory="$(MSBuildProjectDirectory)\.." />
+  </Target>
+
+  <!--
+    Unpackaged apps don't get a resources.pri built automatically. Compile every
+    Strings/<lang>/*.resw into one resources.pri next to the exe so ResourceLoader
+    resolves keys at runtime. makepri ships in the Windows SDK; priconfig.xml is
+    the committed config (stock makepri default with the MSIX <packaging> section
+    removed). Runs after build so the generated Core.resw is present.
+  -->
+  <Target Name="GenerateResourcesPri" AfterTargets="Build">
+    <Exec
+      Command="makepri new /pr &quot;$(MSBuildProjectDirectory)&quot; /cf &quot;$(MSBuildProjectDirectory)\priconfig.xml&quot; /of &quot;$(OutDir)resources.pri&quot; /o"
+      ContinueOnError="false" />
+  </Target>
+
+  <!-- The committed resw + priconfig participate in the build but aren't compiled
+       as C#; mark them so they don't fall into the default C# globs. -->
+  <ItemGroup>
+    <None Include="priconfig.xml" />
   </ItemGroup>
 
   <!--

--- a/bae-windows/priconfig.xml
+++ b/bae-windows/priconfig.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  PRI (Package Resource Index) config for the unpackaged bae-windows app.
+
+  An MSIX-packaged app gets its resources.pri built automatically by the
+  packaging tooling. This app is unpackaged (WindowsPackageType=None), so the
+  build runs `makepri` itself (see the GenerateResourcesPri target in
+  bae-windows.csproj) to compile every Strings/<lang>/*.resw into a single
+  resources.pri next to the exe, which ResourceLoader reads at runtime.
+
+  This is the default makepri config with the <packaging> section removed:
+  packaging splits the index into per-language bundles for an MSIX, which an
+  unpackaged app neither produces nor loads. Everything else (the default qualifiers
+  — language, scale, contrast, … — and the index that walks the project for .resw
+  files) is the stock makepri default.
+-->
+<resources targetOsVersion="10.0.0" majorVersion="1">
+  <index root="\" startIndexAt="\">
+    <default>
+      <qualifier name="Language" value="en-US" />
+      <qualifier name="Contrast" value="standard" />
+      <qualifier name="Scale" value="200" />
+      <qualifier name="HomeRegion" value="001" />
+      <qualifier name="TargetSize" value="256" />
+      <qualifier name="LayoutDirection" value="LTR" />
+      <qualifier name="Theme" value="dark" />
+      <qualifier name="AlternateForm" value="" />
+      <qualifier name="DXFeatureLevel" value="DX9" />
+      <qualifier name="Configuration" value="" />
+      <qualifier name="DeviceFamily" value="Universal" />
+      <qualifier name="Custom" value="" />
+    </default>
+    <indexer-config type="folder" foldernameAsQualifier="true" filenameAsQualifier="true" qualifierDelimiter="." />
+    <indexer-config type="resw" convertDotsToSlashes="true" initialPath="" />
+    <indexer-config type="resjson" initialPath="" />
+    <indexer-config type="PRI" />
+  </index>
+</resources>


### PR DESCRIPTION
Windows has no uniffi — bridge data reaches C# through the hand-written `bae-windows-ffi` C ABI + serde JSON + C# DTOs. The macOS loc series structured bae-core's `UiBusEvent`/`SignalState`/`TrackDetail` out from under it, so the Windows FFI no longer compiled (it still emitted pre-formatted English prose). This both fixes that and brings Windows to localization parity.

- **FFI inversion** (`bae-windows-ffi/src/lib.rs` + new `loc.rs`): structured `FfiTrackPosition`/`FfiAudioFormat`/`FfiLookupFailure`/`FfiError`/`FfiPlaybackErrorReason` and raw `duration_ms`/`position_ms`/byte counts replace the pre-formatted prose; deleted `format_minutes_seconds`/`format_bytes_ffi`.
- **Key-selection (one source)**: `loc.rs` holds the `core.*` key strings (mirroring `bae-bridge/src/types.rs`), cross-checked against the catalog by tests, exported as `bae_*_key` C-ABI fns.
- **C#**: structured DTOs; `Loc.cs` resolves keys via `ResourceLoader` + the `MessageFormat` NuGet (MF1) + `Windows.Globalization.NumberFormatting` byte/duration/number formatters.
- **Build/locales**: loc-gen fans the Windows target to one `Core.resw` per shipping locale; `.csproj` wires generation + `makepri` (the app is unpackaged, so `priconfig.xml` is committed). Chrome: 14-locale `Strings/<lang>/Resources.resw` (206 keys) + `x:Uid`/`Loc.Chrome` migration. `FlowDirection` binds to the locale for ar/he. 14 locales, English source, untranslated.

## Test plan
- `cargo build/clippy/test -p bae-windows-ffi` (10 pass incl. catalog cross-check) + `bae-loc` (26 pass) — the verifiable anchor on macOS
- The C#/XAML/MSBuild side builds on Windows (CI): `MainWindow.xaml.cs` (structured-error call sites + ~130 `Loc.Chrome` migrations), `Loc.cs` (MessageFormat/ResourceLoader APIs), the DTOs' JSON binding, the `loc-gen`/`makepri` MSBuild targets, and `x:Uid` resolution