### PR TITLE
loc: adopt typed error events in the Android reducer

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/AppSession.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/AppSession.kt
@@ -62,13 +62,21 @@ class OpenLibrary(
      * before the first track plays).
      */
     fun wireUp(scope: CoroutineScope) {
-        appHandle.subscribeUiEvents(object : UiEventCallback {
-            override fun onEvent(event: BridgeUiEvent) {
-                scope.launch(Dispatchers.Main) {
-                    UiEventReducer.reduce(event, libraryStore, configStore, playback)
+        appHandle.subscribeUiEvents(
+            object : UiEventCallback {
+                override fun onEvent(event: BridgeUiEvent) {
+                    scope.launch(Dispatchers.Main) {
+                        UiEventReducer.reduce(
+                            event,
+                            libraryStore,
+                            configStore,
+                            playback,
+                            LocaleErrorLines(appContext),
+                        )
+                    }
                 }
-            }
-        })
+            },
+        )
         appHandle.triggerSync()
     }
 
@@ -103,9 +111,13 @@ sealed interface AppScreen {
         val fingerprint: String?,
     ) : AppScreen
 
-    data class LibraryOpen(val session: OpenLibrary) : AppScreen
+    data class LibraryOpen(
+        val session: OpenLibrary,
+    ) : AppScreen
 
-    data class Failed(val message: String) : AppScreen
+    data class Failed(
+        val message: String,
+    ) : AppScreen
 }
 
 /**
@@ -195,9 +207,10 @@ object AppSessionHolder {
         }
         onScreen(AppScreen.Loading)
         try {
-            val handle = withContext(Dispatchers.IO) {
-                initApp(libraryId, POSITION_UPDATE_INTERVAL_MS)
-            }
+            val handle =
+                withContext(Dispatchers.IO) {
+                    initApp(libraryId, POSITION_UPDATE_INTERVAL_MS)
+                }
             val config: BridgeConfig = withContext(Dispatchers.IO) { handle.getConfig() }
 
             if (config.encryptionKeyStored && !handle.hasEncryptionKey()) {
@@ -218,25 +231,29 @@ object AppSessionHolder {
 
             val appContext = context.applicationContext
             val library = Library(handle)
-            val session = OpenLibrary(
-                libraryId = libraryId,
-                appHandle = handle,
-                library = library,
-                libraryStore = LibraryStore(),
-                configStore = ConfigStore(config, handle.isSyncReady()),
-                playback = BaeCorePlayer(
-                    applicationLooper = Looper.getMainLooper(),
+            val session =
+                OpenLibrary(
+                    libraryId = libraryId,
                     appHandle = handle,
                     library = library,
-                    context = appContext,
-                    scope = appScope,
-                    isAppForeground = {
-                        ProcessLifecycleOwner.get().lifecycle.currentState
-                            .isAtLeast(Lifecycle.State.STARTED)
-                    },
-                ),
-                appContext = appContext,
-            )
+                    libraryStore = LibraryStore(),
+                    configStore = ConfigStore(config, handle.isSyncReady()),
+                    playback =
+                        BaeCorePlayer(
+                            applicationLooper = Looper.getMainLooper(),
+                            appHandle = handle,
+                            library = library,
+                            context = appContext,
+                            scope = appScope,
+                            isAppForeground = {
+                                ProcessLifecycleOwner
+                                    .get()
+                                    .lifecycle.currentState
+                                    .isAtLeast(Lifecycle.State.STARTED)
+                            },
+                        ),
+                    appContext = appContext,
+                )
             current = session
             session.wireUp(appScope)
             onScreen(AppScreen.LibraryOpen(session))

--- a/bae-android/app/src/main/java/fm/bae/app/ErrorLocalized.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ErrorLocalized.kt
@@ -1,0 +1,69 @@
+package fm.bae.app
+
+import android.content.Context
+import uniffi.bae_bridge.BridgeException
+import uniffi.bae_bridge.BridgePlaybackErrorReason
+import uniffi.bae_bridge.bridgeEntityNotFoundKey
+import uniffi.bae_bridge.bridgeErrorCategoryKey
+import uniffi.bae_bridge.bridgePlaybackErrorReasonKey
+
+// Renders bae's typed error events for the current locale. The locale never
+// crosses the bridge: core emits the typed reason plus a stable `core.*` catalog
+// key; this resolves the localized line. The opaque diagnostic `detail` (the
+// Rust error chain) is log-only and never translated, so it isn't surfaced as
+// primary copy. Mirrors macOS's `BridgeError+Localized` / iOS's `DisplayError`.
+//
+// `BridgeException` is uniffi's Kotlin name for the bridge `BridgeError`.
+
+/**
+ * The localized, user-facing line for a typed [BridgeException]. `Cancelled`
+ * shows nothing (the user dismissed it); `NotFound` and `Diagnostic` render the
+ * generic line core owns the key for.
+ */
+fun Context.localizedLine(error: BridgeException): String =
+    when (error) {
+        is BridgeException.Cancelled -> ""
+        is BridgeException.NotFound -> coreString(bridgeEntityNotFoundKey(error.entity))
+        is BridgeException.Diagnostic -> coreString(bridgeErrorCategoryKey(error.category))
+    }
+
+/**
+ * The localized, user-facing line for a [BridgePlaybackErrorReason]. The two
+ * actionable cloud cases resolve their own keyed line (core returns a key for
+ * exactly those); everything else renders through the shared [BridgeException]
+ * path.
+ */
+fun Context.localizedLine(reason: BridgePlaybackErrorReason): String =
+    when (reason) {
+        is BridgePlaybackErrorReason.SyncDisconnected,
+        is BridgePlaybackErrorReason.UploadPending,
+        -> {
+            // Core owns a key for exactly the actionable cases; non-null here.
+            coreString(bridgePlaybackErrorReasonKey(reason)!!)
+        }
+
+        is BridgePlaybackErrorReason.Diagnostic -> {
+            localizedLine(reason.error)
+        }
+    }
+
+/**
+ * Resolves a typed error event to its localized one-line message. Production
+ * binds a [Context] ([LocaleErrorLines]); unit tests pass a no-op so the reducer
+ * stays plain-JVM-testable — the same reason playback goes through a
+ * [fm.bae.app.playback.PlaybackEventSink] rather than a live player.
+ */
+interface ErrorLines {
+    fun line(reason: BridgePlaybackErrorReason): String
+
+    fun line(error: BridgeException): String
+}
+
+/** The production resolver: renders for the device locale via the Core catalog. */
+class LocaleErrorLines(
+    private val context: Context,
+) : ErrorLines {
+    override fun line(reason: BridgePlaybackErrorReason) = context.localizedLine(reason)
+
+    override fun line(error: BridgeException) = context.localizedLine(error)
+}

--- a/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
@@ -1,6 +1,7 @@
 package fm.bae.app.data
 
 import android.util.Log
+import fm.bae.app.ErrorLines
 import fm.bae.app.playback.PlaybackEventSink
 import uniffi.bae_bridge.BridgeUiEvent
 
@@ -25,22 +26,40 @@ object UiEventReducer {
         libraryStore: LibraryStore,
         configStore: ConfigStore,
         player: PlaybackEventSink,
+        errors: ErrorLines,
     ) {
         when (event) {
             // ── Library ────────────────────────────────────────────────────
-            is BridgeUiEvent.AlbumAdded -> libraryStore.handleAlbumAdded(event.album)
-            is BridgeUiEvent.AlbumUpdated -> libraryStore.handleAlbumUpdated(event.album)
-            is BridgeUiEvent.AlbumRemoved -> libraryStore.handleAlbumRemoved(event.albumId)
-            is BridgeUiEvent.ReleaseAdded ->
+            is BridgeUiEvent.AlbumAdded -> {
+                libraryStore.handleAlbumAdded(event.album)
+            }
+
+            is BridgeUiEvent.AlbumUpdated -> {
+                libraryStore.handleAlbumUpdated(event.album)
+            }
+
+            is BridgeUiEvent.AlbumRemoved -> {
+                libraryStore.handleAlbumRemoved(event.albumId)
+            }
+
+            is BridgeUiEvent.ReleaseAdded -> {
                 libraryStore.handleReleaseAdded(event.album, event.release)
-            is BridgeUiEvent.ReleaseUpdated ->
+            }
+
+            is BridgeUiEvent.ReleaseUpdated -> {
                 libraryStore.handleReleaseUpdated(event.albumId, event.release)
-            is BridgeUiEvent.ReleaseRemoved ->
+            }
+
+            is BridgeUiEvent.ReleaseRemoved -> {
                 libraryStore.handleReleaseRemoved(event.albumId, event.releaseId, event.album)
+            }
 
             // ── Playback (projected into the BaeCorePlayer) ─────────────────
-            is BridgeUiEvent.PlaybackLoading -> player.onLoading(event.trackId, event.track)
-            is BridgeUiEvent.PlaybackPlaying ->
+            is BridgeUiEvent.PlaybackLoading -> {
+                player.onLoading(event.trackId, event.track)
+            }
+
+            is BridgeUiEvent.PlaybackPlaying -> {
                 player.onPlaying(
                     trackId = event.trackId,
                     trackTitle = event.trackTitle,
@@ -49,7 +68,9 @@ object UiEventReducer {
                     coverImageId = event.coverImageId,
                     durationMs = event.durationMs.toLong(),
                 )
-            is BridgeUiEvent.PlaybackPaused ->
+            }
+
+            is BridgeUiEvent.PlaybackPaused -> {
                 player.onPaused(
                     trackId = event.trackId,
                     trackTitle = event.trackTitle,
@@ -58,42 +79,77 @@ object UiEventReducer {
                     coverImageId = event.coverImageId,
                     durationMs = event.durationMs.toLong(),
                 )
-            BridgeUiEvent.PlaybackStopped -> player.onStopped()
+            }
+
+            BridgeUiEvent.PlaybackStopped -> {
+                player.onStopped()
+            }
+
             // A track couldn't be played (cloud-only not downloaded, decode
             // failure); core has already fallen back to stopped. Surface why.
-            is BridgeUiEvent.PlaybackError -> configStore.showError(event.message)
-            is BridgeUiEvent.PlaybackProgress ->
+            is BridgeUiEvent.PlaybackError -> {
+                configStore.showError(errors.line(event.reason))
+            }
+
+            is BridgeUiEvent.PlaybackProgress -> {
                 player.onProgress(
                     positionMs = event.positionMs.toLong(),
                     durationMs = event.durationMs.toLong(),
                     progress = event.progress,
                 )
-            is BridgeUiEvent.RepeatModeChanged -> player.onRepeatModeChanged(event.mode)
-            is BridgeUiEvent.QueueUpdated ->
+            }
+
+            is BridgeUiEvent.RepeatModeChanged -> {
+                player.onRepeatModeChanged(event.mode)
+            }
+
+            is BridgeUiEvent.QueueUpdated -> {
                 player.onQueueUpdated(
                     items = event.items,
                     hasNext = event.hasNext,
                     hasPrevious = event.hasPrevious,
                 )
-            is BridgeUiEvent.VolumeChanged -> player.onVolumeChanged(event.volume)
-            is BridgeUiEvent.MuteChanged -> player.onMuteChanged(event.isMuted)
+            }
+
+            is BridgeUiEvent.VolumeChanged -> {
+                player.onVolumeChanged(event.volume)
+            }
+
+            is BridgeUiEvent.MuteChanged -> {
+                player.onMuteChanged(event.isMuted)
+            }
 
             // ── Config / sync ──────────────────────────────────────────────
             is BridgeUiEvent.ConfigChanged -> {
                 configStore.setConfig(event.config)
                 configStore.setSyncReady(event.syncReady)
             }
-            is BridgeUiEvent.SyncingChanged -> configStore.setSyncing(event.syncing)
-            is BridgeUiEvent.SyncError -> configStore.setSyncError(event.message)
+
+            is BridgeUiEvent.SyncingChanged -> {
+                configStore.setSyncing(event.syncing)
+            }
+
+            // A null error means sync recovered — it clears the banner (the
+            // bridge's `Option<BridgeError>`, the same as macOS/iOS `error.map`).
+            is BridgeUiEvent.SyncError -> {
+                configStore.setSyncError(event.error?.let { errors.line(it) })
+            }
 
             // ── Errors ─────────────────────────────────────────────────────
-            is BridgeUiEvent.Error -> configStore.showError(event.message)
-            BridgeUiEvent.ErrorCleared -> configStore.clearError()
+            is BridgeUiEvent.Error -> {
+                configStore.showError(errors.line(event.error))
+            }
+
+            BridgeUiEvent.ErrorCleared -> {
+                configStore.clearError()
+            }
 
             // Desktop-only events (import/scan/candidate/preview) never fire
             // on mobile; log if one ever does so a future mobile-firing event is
             // visible.
-            else -> Log.d(TAG, "ignoring ${event::class.simpleName}")
+            else -> {
+                Log.d(TAG, "ignoring ${event::class.simpleName}")
+            }
         }
     }
 }

--- a/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
@@ -1,52 +1,79 @@
 package fm.bae.app.data
 
 import fm.bae.app.BridgeFixtures
+import fm.bae.app.ErrorLines
 import fm.bae.app.playback.PlaybackEventSink
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
+import uniffi.bae_bridge.BridgeException
 import uniffi.bae_bridge.BridgeLoadingTrackInfo
+import uniffi.bae_bridge.BridgePlaybackErrorReason
 import uniffi.bae_bridge.BridgeQueueItem
 import uniffi.bae_bridge.BridgeRepeatMode
 import uniffi.bae_bridge.BridgeUiEvent
 
 class UiEventReducerTest {
-    private fun stores(): Pair<LibraryStore, ConfigStore> =
-        LibraryStore() to ConfigStore(BridgeFixtures.config(), initialSyncReady = false)
+    private fun stores(): Pair<LibraryStore, ConfigStore> = LibraryStore() to ConfigStore(BridgeFixtures.config(), initialSyncReady = false)
 
     // These tests exercise the library-routing arm; the playback sink is a no-op
     // (a real BaeCorePlayer needs a live AppHandle, which unit tests don't have —
     // that's why reduce() takes the PlaybackEventSink abstraction).
-    private val noopPlayer = object : PlaybackEventSink {
-        override fun onLoading(trackId: String, track: BridgeLoadingTrackInfo?) {}
-        override fun onPlaying(
-            trackId: String,
-            trackTitle: String,
-            artistNames: String,
-            albumTitle: String,
-            coverImageId: String?,
-            durationMs: Long,
-        ) {}
-        override fun onPaused(
-            trackId: String,
-            trackTitle: String,
-            artistNames: String,
-            albumTitle: String,
-            coverImageId: String?,
-            durationMs: Long,
-        ) {}
-        override fun onStopped() {}
-        override fun onProgress(
-            positionMs: Long,
-            durationMs: Long,
-            progress: Double,
-        ) {}
-        override fun onRepeatModeChanged(mode: BridgeRepeatMode) {}
-        override fun onQueueUpdated(items: List<BridgeQueueItem>, hasNext: Boolean, hasPrevious: Boolean) {}
-        override fun onVolumeChanged(volume: Float) {}
-        override fun onMuteChanged(isMuted: Boolean) {}
-    }
+    private val noopPlayer =
+        object : PlaybackEventSink {
+            override fun onLoading(
+                trackId: String,
+                track: BridgeLoadingTrackInfo?,
+            ) {}
+
+            override fun onPlaying(
+                trackId: String,
+                trackTitle: String,
+                artistNames: String,
+                albumTitle: String,
+                coverImageId: String?,
+                durationMs: Long,
+            ) {}
+
+            override fun onPaused(
+                trackId: String,
+                trackTitle: String,
+                artistNames: String,
+                albumTitle: String,
+                coverImageId: String?,
+                durationMs: Long,
+            ) {}
+
+            override fun onStopped() {}
+
+            override fun onProgress(
+                positionMs: Long,
+                durationMs: Long,
+                progress: Double,
+            ) {}
+
+            override fun onRepeatModeChanged(mode: BridgeRepeatMode) {}
+
+            override fun onQueueUpdated(
+                items: List<BridgeQueueItem>,
+                hasNext: Boolean,
+                hasPrevious: Boolean,
+            ) {}
+
+            override fun onVolumeChanged(volume: Float) {}
+
+            override fun onMuteChanged(isMuted: Boolean) {}
+        }
+
+    // No-op error resolver: these tests exercise the library/sync/playback arms,
+    // never the error events, so the localized line is never needed.
+    private val noopErrors =
+        object : ErrorLines {
+            override fun line(reason: BridgePlaybackErrorReason) = ""
+
+            override fun line(error: BridgeException) = ""
+        }
 
     @Test
     fun albumAddedRoutesIntoLibraryStoreAndBumpsGeneration() {
@@ -54,7 +81,7 @@ class UiEventReducerTest {
         val detail = BridgeFixtures.albumDetail(BridgeFixtures.album(id = "alb-1"))
         val generationBefore = library.generation.value
 
-        UiEventReducer.reduce(BridgeUiEvent.AlbumAdded(detail), library, config, noopPlayer)
+        UiEventReducer.reduce(BridgeUiEvent.AlbumAdded(detail), library, config, noopPlayer, noopErrors)
 
         assertNotNull("album should be interned", library.albumDetail("alb-1"))
         assertEquals(detail, library.albumDetail("alb-1"))
@@ -73,6 +100,7 @@ class UiEventReducerTest {
             library,
             config,
             noopPlayer,
+            noopErrors,
         )
 
         assertNull(library.albumDetail("alb-absent"))
@@ -87,10 +115,10 @@ class UiEventReducerTest {
         // config.syncing is the flow the library screen observes to show or hide
         // its sync indicator, so the reducer must mirror the SyncingChanged
         // signal onto it.
-        UiEventReducer.reduce(BridgeUiEvent.SyncingChanged(syncing = true), library, config, noopPlayer)
+        UiEventReducer.reduce(BridgeUiEvent.SyncingChanged(syncing = true), library, config, noopPlayer, noopErrors)
         assertEquals(true, config.syncing.value)
 
-        UiEventReducer.reduce(BridgeUiEvent.SyncingChanged(syncing = false), library, config, noopPlayer)
+        UiEventReducer.reduce(BridgeUiEvent.SyncingChanged(syncing = false), library, config, noopPlayer, noopErrors)
         assertEquals(false, config.syncing.value)
     }
 
@@ -98,23 +126,34 @@ class UiEventReducerTest {
     fun playbackLoadingForwardsResolvedTrackMetadataToThePlayer() {
         val (library, config) = stores()
         var received: BridgeLoadingTrackInfo? = null
-        val sink = object : PlaybackEventSink by noopPlayer {
-            override fun onLoading(trackId: String, track: BridgeLoadingTrackInfo?) {
-                received = track
+        val sink =
+            object : PlaybackEventSink by noopPlayer {
+                override fun onLoading(
+                    trackId: String,
+                    track: BridgeLoadingTrackInfo?,
+                ) {
+                    received = track
+                }
             }
-        }
-        val info = BridgeLoadingTrackInfo(
-            trackTitle = "Track Title",
-            artistNames = "Artist Name",
-            albumId = "alb-1",
-            albumTitle = "Album Title",
-            coverImageId = null,
-            durationMs = 1uL,
-        )
+        val info =
+            BridgeLoadingTrackInfo(
+                trackTitle = "Track Title",
+                artistNames = "Artist Name",
+                albumId = "alb-1",
+                albumTitle = "Album Title",
+                coverImageId = null,
+                durationMs = 1uL,
+            )
 
         // The player needs the resolved metadata to project a current track during
         // loading; the reducer must forward it rather than drop it.
-        UiEventReducer.reduce(BridgeUiEvent.PlaybackLoading(trackId = "t1", track = info), library, config, sink)
+        UiEventReducer.reduce(
+            BridgeUiEvent.PlaybackLoading(trackId = "t1", track = info),
+            library,
+            config,
+            sink,
+            noopErrors,
+        )
 
         assertEquals("Track Title", received?.trackTitle)
     }


### PR DESCRIPTION
The event-error-payloads conversion made `PlaybackError`/`SyncError`/`Error` carry typed reasons (`BridgePlaybackErrorReason`/`BridgeError`) instead of a prose `message` String. The macOS/iOS/Windows adoptions landed, but the Android reducer was built on a pre-conversion base and still read `event.message` — so **bae-android no longer compiled against main** (`crate::signals` was the first error, fixed by the iOS PR; this `event.message` mismatch was the next).

Resolve the typed reason to a localized line through the Core catalog keys (`bridgePlaybackErrorReasonKey` / `bridgeErrorCategoryKey` / `bridgeEntityNotFoundKey`), mirroring macOS's `BridgeError+Localized` and iOS's `DisplayError`. The resolver is injected as an `ErrorLines` interface (Context-backed in production, no-op in the JVM unit tests) so the reducer stays plain-JVM-testable — the same reason playback goes through `PlaybackEventSink` rather than a live player.

## Test plan
- `./bae-bridge/build-android.sh` (full + baeium) regenerates bindings + loc resources
- `./gradlew :app:compileFullDebugKotlin :app:testFullDebugUnitTest` and the baeium equivalents → **BUILD SUCCESSFUL**, unit tests pass (verified locally on both flavors)