### PR TITLE
fix(windows): invalid XML comment breaks csproj load

### DIFF
--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -73,7 +73,7 @@
   <!--
     Generate Strings/en-US/Core.resw from the master catalog before the build, so
     a catalog edit reaches the app without a manual step. Mirrors the macOS build
-    (bae-bridge/build-macos.sh runs `loc-gen emit --target apple`). loc-gen writes
+    (bae-bridge/build-macos.sh runs loc-gen's apple-target emit). loc-gen writes
     <out-dir>/en-US/Core.resw, so the out-dir is the Strings folder. Runs from the
     repo root (two levels up from this project) where the default catalog path
     (bae-bridge/loc/catalog.toml) resolves.


### PR DESCRIPTION
`bae-windows.csproj` had `loc-gen emit --target apple` inside an XML comment; `--` is illegal in XML comments, so MSBuild failed to load the project at all (`error MSB4025`) and the Windows build never reached the C# compile. Reword the comment to drop the `--`. Verified the csproj parses as well-formed XML.

## Test plan
- `python3 -c "import xml.etree.ElementTree as ET; ET.parse('bae-windows/bae-windows.csproj')"` → parses
- The Windows CI build will now load the project (the C# compile is the next gate)