### PR TITLE
fix(windows): add UTF-8 BOM to new C# source files

### DIFF
--- a/bae-windows/AlbumDetail.cs
+++ b/bae-windows/AlbumDetail.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Bae.Windows;

--- a/bae-windows/BaeEvent.cs
+++ b/bae-windows/BaeEvent.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Bae.Windows;
 

--- a/bae-windows/DiagnosticError.cs
+++ b/bae-windows/DiagnosticError.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Bae.Windows;

--- a/bae-windows/Loc.cs
+++ b/bae-windows/Loc.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Jeffijoe.MessageFormat;
 using Microsoft.Windows.ApplicationModel.Resources;
 

--- a/bae-windows/OutboxSnapshot.cs
+++ b/bae-windows/OutboxSnapshot.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Bae.Windows;

--- a/bae-windows/QueueItem.cs
+++ b/bae-windows/QueueItem.cs
@@ -1,4 +1,4 @@
-namespace Bae.Windows;
+﻿namespace Bae.Windows;
 
 /// <summary>One track in the play queue, from the <c>QueueUpdated</c> event JSON.</summary>
 public sealed class QueueItem

--- a/bae-windows/StorageRow.cs
+++ b/bae-windows/StorageRow.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Bae.Windows;


### PR DESCRIPTION
The Windows `Check C# formatting` step failed with `error CHARSET: Fix file encoding` on the seven C# files added for localization — written as UTF-8 without BOM, while the repo's existing C# (and the formatter) use UTF-8 with BOM. Prepend the BOM. Verified all `bae-windows/*.cs` now start with `EF BB BF`.