### PR TITLE
fix(ios): green the periphery dead-code check

### DIFF
--- a/bae-ios/bae/.periphery.yml
+++ b/bae-ios/bae/.periphery.yml
@@ -4,5 +4,15 @@ schemes:
 targets:
   - bae
 index_exclude:
+  # The generated uniffi bindings.
   - bae/bae_bridge.swift
+  # Files shared from the macOS app (referenced via ../../bae-macos in
+  # project.yml). The macOS periphery run already checks those; the iOS target
+  # uses a subset of their members, so re-checking them here only surfaces
+  # macOS-only code as false iOS dead code.
+  - "**/bae-macos/**"
+# The web-auth presentation-context coordinator is held only to keep the auth
+# session's provider alive until its callback runs — assigned, never read.
+retain_assign_only_property_types:
+  - WebAuthCoordinator
 disable_update_check: true

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -13,8 +13,6 @@ struct LibraryView: View {
     private var libraryStore
     @Environment(Library.self)
     private var library
-    @Environment(MediaPaths.self)
-    private var mediaPaths
     @Environment(ConfigStore.self)
     private var configStore
     @Environment(Sync.self)
@@ -264,11 +262,6 @@ struct LibraryView: View {
 private struct AlbumGrid: View {
     let list: AlbumList
     let onSelect: (String) -> Void
-
-    @Environment(LibraryStore.self)
-    private var libraryStore
-    @Environment(MediaPaths.self)
-    private var mediaPaths
 
     private let columns = [GridItem(.adaptive(minimum: 150), spacing: 12)]
 


### PR DESCRIPTION
The iOS periphery step had never actually run — it failed earlier on `must supply --project` (no `.periphery.yml`), so the config that fixed that exposed real findings for the first time. Of 57: **53** were in the macOS files the iOS app shares via project.yml's `../../bae-macos` sources — the macOS periphery run already checks those, and the iOS target uses a subset of their members, so re-checking only surfaces macOS-only code as false iOS dead code → exclude `**/bae-macos/**`. Of the 4 iOS-owned: the web-auth coordinator is an intentional lifetime hold (assign-only) → retain by type; the other three were unused `@Environment` declarations → removed.

## Test plan
Verified locally: iOS simulator build succeeds, and `periphery scan --strict` reports **"No unused code detected"**.