### PR TITLE
fix(windows): disable default PRIResource items (NETSDK1022)

### DIFF
--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -32,6 +32,15 @@
     <WindowsPackageType>None</WindowsPackageType>
 
     <!--
+      The localization .resw are included explicitly (the Strings/**/*.resw
+      PRIResource group below). Turn off the SDK's default PRIResource
+      auto-include so the same files aren't added twice (NETSDK1022). The
+      unpackaged app's resources.pri is compiled by the makepri target below,
+      not the SDK's packaged-app PRI pipeline.
+    -->
+    <EnableDefaultPriItems>false</EnableDefaultPriItems>
+
+    <!--
       x64 only. Platforms drives the MSBuild configuration; RuntimeIdentifiers uses
       the portable RID form (win-x64, not win10-x64) required by .NET 8 to avoid
       NETSDK1083 "version-specific runtime identifier" errors.


### PR DESCRIPTION
With the project's explicit `<PRIResource Include="Strings\**\*.resw" />`, the .NET SDK's default PRIResource auto-include pulled the same files a second time, failing the build with NETSDK1022 (duplicate items) for every `Strings/<lang>/Resources.resw`. Set `EnableDefaultPriItems=false` so the explicit group is the only source. The unpackaged app's `resources.pri` is built by the `makepri` target (which scans the Strings dir directly), not the SDK's packaged-app PRI pipeline, so dropping the default auto-include loses nothing.

## Test plan
- csproj parses as well-formed XML
- Windows CI build advances past the PRIResource duplicate (next gate is the WinUI compile)