### PR TITLE
fix(windows): resw keys that are both resource and scope (PRI278)

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -2412,8 +2412,8 @@ public sealed partial class MainWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
         });
         var shuffleButton = new Button { Content = Loc.Chrome("album.shuffle") };
-        var editButton = new Button { Content = Loc.Chrome("album.edit") };
-        var reidentifyButton = new Button { Content = Loc.Chrome("album.reidentify") };
+        var editButton = new Button { Content = Loc.Chrome("album.edit.label") };
+        var reidentifyButton = new Button { Content = Loc.Chrome("album.reidentify.label") };
         header.Children.Add(shuffleButton);
         header.Children.Add(editButton);
         header.Children.Add(reidentifyButton);

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -20,14 +20,14 @@
   <data name="album.delete.body" xml:space="preserve"><value>This removes the release from the library.</value></data>
   <data name="album.delete.failed" xml:space="preserve"><value>couldn't delete</value></data>
   <data name="album.delete.title" xml:space="preserve"><value>delete release?</value></data>
-  <data name="album.edit" xml:space="preserve"><value>edit</value></data>
+  <data name="album.edit.label" xml:space="preserve"><value>edit</value></data>
   <data name="album.edit.load_failed" xml:space="preserve"><value>couldn't load the metadata editor</value></data>
   <data name="album.edit.reset" xml:space="preserve"><value>Reset to Source</value></data>
   <data name="album.edit.reset_failed" xml:space="preserve"><value>couldn't reset to source</value></data>
   <data name="album.edit.title" xml:space="preserve"><value>edit metadata</value></data>
   <data name="album.gallery" xml:space="preserve"><value>Gallery</value></data>
   <data name="album.open_failed" xml:space="preserve"><value>couldn't open this album</value></data>
-  <data name="album.reidentify" xml:space="preserve"><value>re-identify</value></data>
+  <data name="album.reidentify.label" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.reidentify.confirm" xml:space="preserve"><value>Re-identify</value></data>
   <data name="album.reidentify.title" xml:space="preserve"><value>re-identify</value></data>
   <data name="album.release_picker" xml:space="preserve"><value>Release</value></data>


### PR DESCRIPTION
makepri failed with PRI278 ("defined as both resource and scope"): the chrome keys `album.edit` and `album.reidentify` were leaf resources (the button labels) while also being the dotted parents of `album.edit.title`, `album.edit.load_failed`, `album.reidentify.confirm`, etc. PRI maps a dotted/slashed name to a scope tree, so a name can't be both a leaf and a scope.

Rename the two leaves to `album.edit.label` / `album.reidentify.label` across all 14 locales' `Resources.resw`, making the dotted prefixes pure scopes, and update the two `Loc.Chrome(...)` call sites.

## Test plan
- resw files parse as valid XML; no key is a prefix of another anymore
- Windows CI advances past PRI278 (makepri compiles resources.pri)