### PR TITLE
fix(windows): put makepri on PATH for the resources.pri target

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,6 +105,19 @@ jobs:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v2
 
+      - name: Add Windows SDK bin to PATH (makepri for resources.pri)
+        shell: pwsh
+        run: |
+          # makepri.exe ships in the Windows 10 SDK but isn't on PATH on the
+          # runner; the csproj's GenerateResourcesPri target invokes it bare to
+          # compile resources.pri for the unpackaged app. Add the newest SDK x64
+          # bin so the bare `makepri` command resolves (otherwise exit 9009).
+          $makepri = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\makepri.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $makepri) { throw "makepri.exe not found in the Windows SDK" }
+          Add-Content -Path $env:GITHUB_PATH -Value $makepri.Directory.FullName
+          Write-Host "makepri on PATH: $($makepri.FullName)"
+
       - name: Check C# formatting
         # dotnet format uses .editorconfig rules. --verify-no-changes exits non-zero
         # if any file would be reformatted, failing the build.


### PR DESCRIPTION
The csproj's `GenerateResourcesPri` target runs `makepri new ...` to compile the unpackaged app's `resources.pri`, but `makepri.exe` ships in the Windows 10 SDK and isn't on PATH on the runner, so the bare command failed with exit 9009 (command not found). Add a step that locates the newest SDK x64 `makepri.exe` and puts its directory on PATH before the build.

## Test plan
- Windows CI: the makepri step resolves makepri.exe; the build runs the resources.pri target without 9009