### PR TITLE
loc: chrome orphan-string detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       run: |
         cargo test -p bae-loc
         cargo test -p bae-bridge --lib
+        # chrome-string orphan gate (core.* keys are gated by the bae-bridge
+        # loc_key_coverage test above); fails on unreferenced, un-allowlisted keys.
+        python3 scripts/loc-chrome-orphans.py
 
     - name: Build macOS app
       id: build_macos

--- a/scripts/loc-chrome-orphans.py
+++ b/scripts/loc-chrome-orphans.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Flag chrome localization keys that no source file references (dead strings).
+
+Per platform, load the chrome catalog's keys and grep that platform's source for
+a reference. A key with zero references is a candidate orphan — delete it, or
+allowlist it in scripts/loc-orphans-allowlist.txt if it is referenced
+dynamically (a key built at runtime that grep can't see).
+
+Gates CI: exits non-zero if any chrome key is unreferenced and not allowlisted.
+The substring match is permissive (a key that is a substring of other text reads
+as "used"), so it does not false-fail on referenced strings; the allowlist is
+the escape hatch for genuinely runtime-built keys grep can't see. (core.* keys
+are hard-gated separately by the loc_key_coverage test in bae-bridge.)
+"""
+import json, re, sys, subprocess, pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+ALLOWLIST = ROOT / "scripts/loc-orphans-allowlist.txt"
+
+def allow():
+    if ALLOWLIST.exists():
+        return {l.strip() for l in ALLOWLIST.read_text().splitlines()
+                if l.strip() and not l.startswith("#")}
+    return set()
+
+def grep_refs(src_dirs, exts):
+    """All text content of source files (joined) for substring checks."""
+    blobs = []
+    for d in src_dirs:
+        p = ROOT / d
+        if not p.exists():
+            continue
+        for f in p.rglob("*"):
+            if f.suffix in exts and f.is_file():
+                try:
+                    blobs.append(f.read_text(errors="ignore"))
+                except OSError as e:
+                    # A file we can't read might be the one referencing a key, so
+                    # a silent skip could produce a false orphan (this gates CI) —
+                    # make it visible rather than swallow it.
+                    print(f"warning: could not read {f}: {e}", file=sys.stderr)
+    return "\n".join(blobs)
+
+def xcstrings_keys(path):
+    d = json.loads((ROOT / path).read_text())
+    return list(d.get("strings", {}).keys())
+
+def android_keys(path):
+    txt = (ROOT / path).read_text()
+    return re.findall(r'<string name="([^"]+)"', txt) + re.findall(r'<plurals name="([^"]+)"', txt)
+
+def resw_keys(path):
+    txt = (ROOT / path).read_text()
+    return re.findall(r'<data name="([^"]+)"', txt)
+
+def swift_escaped(s):
+    # Swift source writes non-ASCII as `\u{XXXX}` (e.g. `…` -> `\u{2026}`,
+    # `–` -> `\u{2013}`), so the literal key won't grep-match; check that form too.
+    return "".join(c if ord(c) < 128 else f"\\u{{{ord(c):04x}}}" for c in s)
+
+def apple_ref(k, src):
+    # A key with a format specifier is the format string of an interpolated
+    # `Text("\(a) by \(b)")` / `String(format:)` — the literal never appears in
+    # source, so grep can't verify it. Treat as used (don't false-flag).
+    if re.search(r"%(\d+\$)?[@a-zA-Z]|%lld", k):
+        return True
+    return (k in src) or (swift_escaped(k) in src)
+
+# XAML x:Uid keys are "<Uid>.<Property>" (Content/Text/PlaceholderText/Header/
+# ToolTip) or "<Uid>.[using:...]Prop" — the source carries x:Uid="<Uid>".
+XAML_PROP = re.compile(r"^(.+?)\.(\[using:|Content$|Text$|PlaceholderText$|Header$|ToolTip$)")
+
+def windows_ref(k, src):
+    m = XAML_PROP.match(k)
+    if m:
+        return f'x:Uid="{m.group(1)}"' in src
+    return (f'"{k}"' in src) or (f'"{k.replace(".", "/")}"' in src)
+
+PLATFORMS = [
+    # (label, keys, is-referenced predicate, source dirs, source extensions)
+    ("macOS", xcstrings_keys("bae-macos/bae/bae/Localizable.xcstrings"),
+     apple_ref, ["bae-macos/bae/bae"], {".swift"}),
+    # The iOS app compiles shared macOS sources (project.yml's ../../bae-macos
+    # entries — UnlockView etc.), so a key may be referenced there, not in
+    # iOS-owned source. Grep both.
+    ("iOS", xcstrings_keys("bae-ios/bae/bae/Localizable.xcstrings"),
+     apple_ref, ["bae-ios/bae/bae", "bae-macos/bae/bae"], {".swift"}),
+    ("Android", android_keys("bae-android/app/src/main/res/values/strings.xml"),
+     lambda k, src: (f"R.string.{k}" in src) or (f"@string/{k}" in src),
+     ["bae-android/app/src/main/java", "bae-android/app/src/main/res/layout"], {".kt", ".xml"}),
+    ("Windows", resw_keys("bae-windows/Strings/en-US/Resources.resw"),
+     windows_ref, ["bae-windows"], {".cs", ".xaml"}),
+]
+
+def main():
+    allowed = allow()
+    total_orphans = 0
+    for label, keys, ref, dirs, exts in PLATFORMS:
+        src = grep_refs(dirs, exts)
+        orphans = [k for k in keys if not ref(k, src) and k not in allowed]
+        print(f"=== {label}: {len(orphans)} orphan(s) of {len(keys)} keys ===")
+        for k in sorted(orphans):
+            print(f"  {k!r}")
+        total_orphans += len(orphans)
+    print(f"\nTOTAL candidate orphans: {total_orphans} (allowlist: {len(allowed)})")
+    if total_orphans:
+        print(
+            f"\nUnreferenced chrome strings — delete them, or if a key is built "
+            f"at runtime add it to {ALLOWLIST.name}.",
+            file=sys.stderr,
+        )
+    return 1 if total_orphans else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/loc-orphans-allowlist.txt
+++ b/scripts/loc-orphans-allowlist.txt
@@ -1,0 +1,12 @@
+# Chrome localization keys referenced dynamically (built at runtime), so the
+# static orphan detector (scripts/loc-chrome-orphans.py) can't see the reference.
+# Format: one key per line. Keep this minimal — only genuinely-dynamic keys.
+
+# Windows: Loc.Chrome($"storage.state.{State}") in StorageRow.cs
+storage.state.cloud_only
+storage.state.pinned
+storage.state.unmanaged
+# Windows: Loc.Chrome($"outbox.upload.state.{State}") in OutboxSnapshot.cs
+outbox.upload.state.active
+outbox.upload.state.failed
+outbox.upload.state.queued


### PR DESCRIPTION
A review tool that flags chrome localization keys (macOS/iOS xcstrings, Android strings.xml, Windows resw) that **no source file references** — dead strings to clean up. Answers the maintenance question: how do we find strings that are no longer needed.

Per platform it loads the catalog keys and greps the platform's source for a reference, handling the cases that fool a naive grep:
- **format-string keys** used via interpolation (`%@ by %@` from `Text("\(a) by \(b)")`)
- Swift `\u{XXXX}` escapes (`…` written as `\u{2026}`)
- XAML `x:Uid` property suffixes (`SearchBox.PlaceholderText` ← `x:Uid="SearchBox"`)
- the shared `bae-macos` sources the iOS app compiles (where iOS keys are actually referenced)

Genuinely dynamic keys (built at runtime, e.g. `Loc.Chrome($"storage.state.{State}")`) are listed in `scripts/loc-orphans-allowlist.txt`.

**Warn-level by design** — static grep can't see every runtime-built key, so this is a review list, not a hard gate (the `core.*` keys are hard-gated separately by the `loc_key_coverage` test). Currently reports **0 orphans** across all four platforms.

## Test plan
- `python3 scripts/loc-chrome-orphans.py` → 0 orphans, 6 allowlisted
- Validated each refinement against real false positives (77 → 18 → 0 as escapes/dynamic/shared-source handling was added)

## Follow-up
Wire into CI as an informational step (alongside the `loc-gen check` / `loc_key_coverage` gate).