### PR TITLE
Add core diagnostics pipeline

### DIFF
--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -1,22 +1,31 @@
 use std::sync::Arc;
 
 use bae_core::app::{bootstrap, BootstrapError, RunningApp};
-use bae_core::diagnostics::{DiagnosticLevel, Diagnostics, DiagnosticsConfig, DiagnosticsError};
+use bae_core::diagnostics::{
+    DatadogDiagnosticsConfig, DiagnosticLevel, Diagnostics, DiagnosticsConfig, DiagnosticsError,
+};
 
 use crate::handle::AppHandle;
 use crate::types::BridgeError;
 
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum BridgeDiagnosticsConfig {
+    Disabled,
+    Enabled {
+        config: BridgeDatadogDiagnosticsConfig,
+    },
+}
+
 #[derive(Debug, Clone, uniffi::Record)]
-pub struct BridgeDiagnosticsConfig {
-    pub enabled: bool,
-    pub datadog_site: Option<String>,
-    pub client_token: Option<String>,
-    pub source: Option<String>,
-    pub service: Option<String>,
-    pub environment: Option<String>,
-    pub app_version: Option<String>,
-    pub edition: Option<String>,
-    pub git_commit: Option<String>,
+pub struct BridgeDatadogDiagnosticsConfig {
+    pub datadog_site: String,
+    pub client_token: String,
+    pub source: String,
+    pub service: String,
+    pub environment: String,
+    pub app_version: String,
+    pub edition: String,
+    pub git_commit: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
@@ -34,12 +43,17 @@ pub struct BridgeDiagnosticField {
     pub value: String,
 }
 
+#[derive(uniffi::Object)]
+pub struct BridgeDiagnostics {
+    diagnostics: Diagnostics,
+}
+
 #[uniffi::export]
 pub fn init_app(
     library_id: String,
     position_update_interval_ms: u32,
 ) -> Result<Arc<AppHandle>, BridgeError> {
-    configure_logging();
+    configure_logging(Diagnostics::noop());
 
     let RunningApp {
         runtime,
@@ -55,81 +69,71 @@ pub fn init_app(
 }
 
 #[uniffi::export]
-pub fn configure_diagnostics(config: BridgeDiagnosticsConfig) -> Result<(), BridgeError> {
-    configure_logging();
-    Diagnostics::install_global(config.into_core()).map_err(diagnostics_error_to_bridge)?;
-    Ok(())
+pub fn configure_diagnostics(
+    config: BridgeDiagnosticsConfig,
+) -> Result<Arc<BridgeDiagnostics>, BridgeError> {
+    let diagnostics =
+        Diagnostics::configure(config.into_core()).map_err(diagnostics_error_to_bridge)?;
+    configure_logging(diagnostics.clone());
+    Ok(Arc::new(BridgeDiagnostics { diagnostics }))
 }
 
 #[uniffi::export]
-pub fn diagnostics_log(
-    level: BridgeDiagnosticLevel,
-    target: String,
-    message: String,
-    fields: Vec<BridgeDiagnosticField>,
-) {
-    Diagnostics::global().log(level.into_core(), target, message, bridge_fields(fields));
-}
+impl BridgeDiagnostics {
+    pub fn log(
+        &self,
+        level: BridgeDiagnosticLevel,
+        target: String,
+        message: String,
+        fields: Vec<BridgeDiagnosticField>,
+    ) -> Result<(), BridgeError> {
+        self.diagnostics
+            .log(level.into_core(), target, message, bridge_fields(fields))
+            .map_err(diagnostics_error_to_bridge)
+    }
 
-#[uniffi::export]
-pub fn diagnostics_event(name: String, fields: Vec<BridgeDiagnosticField>) {
-    Diagnostics::global().event(name, bridge_fields(fields));
-}
+    pub fn event(
+        &self,
+        name: String,
+        fields: Vec<BridgeDiagnosticField>,
+    ) -> Result<(), BridgeError> {
+        self.diagnostics
+            .event(name, bridge_fields(fields))
+            .map_err(diagnostics_error_to_bridge)
+    }
 
-#[uniffi::export]
-pub async fn flush_diagnostics() -> bool {
-    Diagnostics::global().flush().await
+    pub async fn flush(&self) -> Result<(), BridgeError> {
+        self.diagnostics
+            .flush()
+            .await
+            .map_err(diagnostics_error_to_bridge)
+    }
 }
 
 impl BridgeDiagnosticsConfig {
     fn into_core(self) -> DiagnosticsConfig {
-        let Some(datadog_site) = diagnostic_config_value(self.datadog_site) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(client_token) = diagnostic_config_value(self.client_token) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(source) = diagnostic_config_value(self.source) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(service) = diagnostic_config_value(self.service) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(environment) = diagnostic_config_value(self.environment) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(app_version) = diagnostic_config_value(self.app_version) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(edition) = diagnostic_config_value(self.edition) else {
-            return DiagnosticsConfig::disabled();
-        };
-        let Some(git_commit) = diagnostic_config_value(self.git_commit) else {
-            return DiagnosticsConfig::disabled();
-        };
-
-        if !self.enabled {
-            return DiagnosticsConfig::disabled();
-        }
-
-        DiagnosticsConfig {
-            enabled: true,
-            datadog_site,
-            client_token,
-            source,
-            service,
-            environment,
-            app_version,
-            edition,
-            git_commit,
+        match self {
+            Self::Disabled => DiagnosticsConfig::Disabled,
+            Self::Enabled { config } => config.into_core(),
         }
     }
 }
 
-fn diagnostic_config_value(value: Option<String>) -> Option<String> {
-    value
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+impl BridgeDatadogDiagnosticsConfig {
+    fn into_core(self) -> DiagnosticsConfig {
+        let config = DatadogDiagnosticsConfig {
+            datadog_site: self.datadog_site.trim().to_string(),
+            client_token: self.client_token.trim().to_string(),
+            source: self.source.trim().to_string(),
+            service: self.service.trim().to_string(),
+            environment: self.environment.trim().to_string(),
+            app_version: self.app_version.trim().to_string(),
+            edition: self.edition.trim().to_string(),
+            git_commit: self.git_commit.trim().to_string(),
+        };
+
+        DiagnosticsConfig::Enabled(config)
+    }
 }
 
 impl BridgeDiagnosticLevel {
@@ -179,11 +183,13 @@ fn env_filter() -> tracing_subscriber::EnvFilter {
 // Install the global subscriber. Ignores the "already initialized" error,
 // which is the documented use-case for `try_init`.
 fn install_subscriber(subscriber: impl tracing_subscriber::util::SubscriberInitExt) {
-    if let Err(_already_installed) = subscriber.try_init() {}
+    if subscriber.try_init().is_err() {
+        tracing::debug!("tracing subscriber already installed");
+    }
 }
 
 #[cfg(target_os = "macos")]
-fn configure_logging() {
+fn configure_logging(diagnostics: Diagnostics) {
     use tracing_subscriber::prelude::*;
 
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -196,14 +202,14 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer())
+            .with(bae_core::diagnostics::tracing_layer(diagnostics))
             .with(fmt_layer)
             .with(oslog_layer),
     );
 }
 
 #[cfg(target_os = "android")]
-fn configure_logging() {
+fn configure_logging(diagnostics: Diagnostics) {
     use tracing_subscriber::prelude::*;
 
     let android_layer = tracing_android::layer("bae").unwrap();
@@ -211,13 +217,13 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer())
+            .with(bae_core::diagnostics::tracing_layer(diagnostics))
             .with(android_layer),
     );
 }
 
 #[cfg(target_os = "ios")]
-fn configure_logging() {
+fn configure_logging(diagnostics: Diagnostics) {
     use tracing_subscriber::prelude::*;
 
     let oslog_layer = tracing_oslog::OsLogger::new("fm.bae.app", "default");
@@ -225,13 +231,13 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer())
+            .with(bae_core::diagnostics::tracing_layer(diagnostics))
             .with(oslog_layer),
     );
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "ios")))]
-fn configure_logging() {
+fn configure_logging(diagnostics: Diagnostics) {
     use tracing_subscriber::prelude::*;
 
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -242,7 +248,7 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer())
+            .with(bae_core::diagnostics::tracing_layer(diagnostics))
             .with(fmt_layer),
     );
 }
@@ -253,38 +259,31 @@ mod tests {
 
     #[test]
     fn missing_diagnostics_config_disables_sending() {
-        let config = BridgeDiagnosticsConfig {
-            enabled: true,
-            datadog_site: Some("datadoghq.com".to_string()),
-            client_token: None,
-            source: Some("ios".to_string()),
-            service: Some("bae".to_string()),
-            environment: Some("test".to_string()),
-            app_version: Some("1.2.3".to_string()),
-            edition: Some("bae".to_string()),
-            git_commit: Some("abc123".to_string()),
-        }
-        .into_core();
+        let config = BridgeDiagnosticsConfig::Disabled.into_core();
 
         assert!(!config.sends_events());
     }
 
     #[test]
     fn complete_diagnostics_config_sends_events() {
-        let config = BridgeDiagnosticsConfig {
-            enabled: true,
-            datadog_site: Some("datadoghq.com".to_string()),
-            client_token: Some("client-token".to_string()),
-            source: Some("ios".to_string()),
-            service: Some("bae".to_string()),
-            environment: Some("test".to_string()),
-            app_version: Some("1.2.3".to_string()),
-            edition: Some("bae".to_string()),
-            git_commit: Some("abc123".to_string()),
+        let config = BridgeDiagnosticsConfig::Enabled {
+            config: BridgeDatadogDiagnosticsConfig {
+                datadog_site: "datadoghq.com".to_string(),
+                client_token: "client-token".to_string(),
+                source: "ios".to_string(),
+                service: "bae".to_string(),
+                environment: "test".to_string(),
+                app_version: "1.2.3".to_string(),
+                edition: "bae".to_string(),
+                git_commit: "abc123".to_string(),
+            },
         }
         .into_core();
 
         assert!(config.sends_events());
+        let DiagnosticsConfig::Enabled(config) = config else {
+            panic!("complete bridge config must enable diagnostics");
+        };
         assert_eq!(config.source, "ios");
         assert_eq!(config.edition, "bae");
     }

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -182,8 +182,8 @@ fn env_filter() -> Result<tracing_subscriber::EnvFilter, BridgeError> {
 // Install the global subscriber. Ignores the "already initialized" error,
 // which is the documented use-case for `try_init`.
 fn install_subscriber(subscriber: impl tracing_subscriber::util::SubscriberInitExt) {
-    if subscriber.try_init().is_err() {
-        tracing::debug!("tracing subscriber already installed");
+    if let Err(error) = subscriber.try_init() {
+        tracing::debug!(%error, "tracing subscriber already installed");
     }
 }
 

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -188,69 +188,57 @@ fn install_subscriber(subscriber: impl tracing_subscriber::util::SubscriberInitE
     }
 }
 
-#[cfg(target_os = "macos")]
-fn configure_logging(diagnostics: Diagnostics) {
-    use tracing_subscriber::prelude::*;
+macro_rules! install_logging_subscriber {
+    ($diagnostics:expr $(, $layer:expr)+ $(,)?) => {{
+        use tracing_subscriber::prelude::*;
+        install_subscriber(
+            tracing_subscriber::registry()
+                .with(env_filter())
+                .with(bae_core::diagnostics::tracing_layer($diagnostics))
+                $(.with($layer))+,
+        );
+    }};
+}
 
-    let fmt_layer = tracing_subscriber::fmt::layer()
+fn fmt_log_layer<S>() -> impl tracing_subscriber::Layer<S>
+where
+    S: tracing::Subscriber,
+    for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracing_subscriber::fmt::layer()
         .with_line_number(true)
         .with_target(false)
-        .with_file(true);
+        .with_file(true)
+}
 
-    let oslog_layer = tracing_oslog::OsLogger::new("fm.bae.desktop", "default");
-
-    install_subscriber(
-        tracing_subscriber::registry()
-            .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer(diagnostics))
-            .with(fmt_layer)
-            .with(oslog_layer),
+#[cfg(target_os = "macos")]
+fn configure_logging(diagnostics: Diagnostics) {
+    install_logging_subscriber!(
+        diagnostics,
+        fmt_log_layer(),
+        tracing_oslog::OsLogger::new("fm.bae.desktop", "default"),
     );
 }
 
 #[cfg(target_os = "android")]
 fn configure_logging(diagnostics: Diagnostics) {
-    use tracing_subscriber::prelude::*;
-
-    let android_layer = tracing_android::layer("bae").unwrap();
-
-    install_subscriber(
-        tracing_subscriber::registry()
-            .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer(diagnostics))
-            .with(android_layer),
+    install_logging_subscriber!(
+        diagnostics,
+        tracing_android::layer("bae").expect("Android tracing layer initializes"),
     );
 }
 
 #[cfg(target_os = "ios")]
 fn configure_logging(diagnostics: Diagnostics) {
-    use tracing_subscriber::prelude::*;
-
-    let oslog_layer = tracing_oslog::OsLogger::new("fm.bae.app", "default");
-
-    install_subscriber(
-        tracing_subscriber::registry()
-            .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer(diagnostics))
-            .with(oslog_layer),
+    install_logging_subscriber!(
+        diagnostics,
+        tracing_oslog::OsLogger::new("fm.bae.app", "default"),
     );
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "ios")))]
 fn configure_logging(diagnostics: Diagnostics) {
-    use tracing_subscriber::prelude::*;
-
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_line_number(true)
-        .with_target(false)
-        .with_file(true);
-
-    install_subscriber(
-        tracing_subscriber::registry()
-            .with(env_filter())
-            .with(bae_core::diagnostics::tracing_layer(diagnostics))
-            .with(fmt_layer),
-    );
+    install_logging_subscriber!(diagnostics, fmt_log_layer());
 }
 
 #[cfg(test)]

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -1,9 +1,38 @@
 use std::sync::Arc;
 
 use bae_core::app::{bootstrap, BootstrapError, RunningApp};
+use bae_core::diagnostics::{DiagnosticLevel, Diagnostics, DiagnosticsConfig, DiagnosticsError};
 
 use crate::handle::AppHandle;
 use crate::types::BridgeError;
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeDiagnosticsConfig {
+    pub enabled: bool,
+    pub datadog_site: Option<String>,
+    pub client_token: Option<String>,
+    pub source: Option<String>,
+    pub service: Option<String>,
+    pub environment: Option<String>,
+    pub app_version: Option<String>,
+    pub edition: Option<String>,
+    pub git_commit: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeDiagnosticLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeDiagnosticField {
+    pub key: String,
+    pub value: String,
+}
 
 #[uniffi::export]
 pub fn init_app(
@@ -23,6 +52,104 @@ pub fn init_app(
         app_services: services,
         ui_event_bus,
     }))
+}
+
+#[uniffi::export]
+pub fn configure_diagnostics(config: BridgeDiagnosticsConfig) -> Result<(), BridgeError> {
+    configure_logging();
+    Diagnostics::install_global(config.into_core()).map_err(diagnostics_error_to_bridge)?;
+    Ok(())
+}
+
+#[uniffi::export]
+pub fn diagnostics_log(
+    level: BridgeDiagnosticLevel,
+    target: String,
+    message: String,
+    fields: Vec<BridgeDiagnosticField>,
+) {
+    Diagnostics::global().log(level.into_core(), target, message, bridge_fields(fields));
+}
+
+#[uniffi::export]
+pub fn diagnostics_event(name: String, fields: Vec<BridgeDiagnosticField>) {
+    Diagnostics::global().event(name, bridge_fields(fields));
+}
+
+#[uniffi::export]
+pub async fn flush_diagnostics() -> bool {
+    Diagnostics::global().flush().await
+}
+
+impl BridgeDiagnosticsConfig {
+    fn into_core(self) -> DiagnosticsConfig {
+        let Some(datadog_site) = diagnostic_config_value(self.datadog_site) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(client_token) = diagnostic_config_value(self.client_token) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(source) = diagnostic_config_value(self.source) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(service) = diagnostic_config_value(self.service) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(environment) = diagnostic_config_value(self.environment) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(app_version) = diagnostic_config_value(self.app_version) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(edition) = diagnostic_config_value(self.edition) else {
+            return DiagnosticsConfig::disabled();
+        };
+        let Some(git_commit) = diagnostic_config_value(self.git_commit) else {
+            return DiagnosticsConfig::disabled();
+        };
+
+        if !self.enabled {
+            return DiagnosticsConfig::disabled();
+        }
+
+        DiagnosticsConfig {
+            enabled: true,
+            datadog_site,
+            client_token,
+            source,
+            service,
+            environment,
+            app_version,
+            edition,
+            git_commit,
+        }
+    }
+}
+
+fn diagnostic_config_value(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+impl BridgeDiagnosticLevel {
+    fn into_core(self) -> DiagnosticLevel {
+        match self {
+            Self::Trace => DiagnosticLevel::Trace,
+            Self::Debug => DiagnosticLevel::Debug,
+            Self::Info => DiagnosticLevel::Info,
+            Self::Warn => DiagnosticLevel::Warn,
+            Self::Error => DiagnosticLevel::Error,
+        }
+    }
+}
+
+fn bridge_fields(fields: Vec<BridgeDiagnosticField>) -> impl Iterator<Item = (String, String)> {
+    fields.into_iter().map(|field| (field.key, field.value))
+}
+
+fn diagnostics_error_to_bridge(e: DiagnosticsError) -> BridgeError {
+    BridgeError::internal(format!("diagnostics setup failed: {e}"))
 }
 
 fn bootstrap_error_to_bridge(e: BootstrapError) -> BridgeError {
@@ -52,7 +179,7 @@ fn env_filter() -> tracing_subscriber::EnvFilter {
 // Install the global subscriber. Ignores the "already initialized" error,
 // which is the documented use-case for `try_init`.
 fn install_subscriber(subscriber: impl tracing_subscriber::util::SubscriberInitExt) {
-    let _ = subscriber.try_init();
+    if let Err(_already_installed) = subscriber.try_init() {}
 }
 
 #[cfg(target_os = "macos")]
@@ -69,6 +196,7 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
+            .with(bae_core::diagnostics::tracing_layer())
             .with(fmt_layer)
             .with(oslog_layer),
     );
@@ -83,6 +211,7 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
+            .with(bae_core::diagnostics::tracing_layer())
             .with(android_layer),
     );
 }
@@ -96,6 +225,7 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
+            .with(bae_core::diagnostics::tracing_layer())
             .with(oslog_layer),
     );
 }
@@ -112,6 +242,74 @@ fn configure_logging() {
     install_subscriber(
         tracing_subscriber::registry()
             .with(env_filter())
+            .with(bae_core::diagnostics::tracing_layer())
             .with(fmt_layer),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_diagnostics_config_disables_sending() {
+        let config = BridgeDiagnosticsConfig {
+            enabled: true,
+            datadog_site: Some("datadoghq.com".to_string()),
+            client_token: None,
+            source: Some("ios".to_string()),
+            service: Some("bae".to_string()),
+            environment: Some("test".to_string()),
+            app_version: Some("1.2.3".to_string()),
+            edition: Some("bae".to_string()),
+            git_commit: Some("abc123".to_string()),
+        }
+        .into_core();
+
+        assert!(!config.sends_events());
+    }
+
+    #[test]
+    fn complete_diagnostics_config_sends_events() {
+        let config = BridgeDiagnosticsConfig {
+            enabled: true,
+            datadog_site: Some("datadoghq.com".to_string()),
+            client_token: Some("client-token".to_string()),
+            source: Some("ios".to_string()),
+            service: Some("bae".to_string()),
+            environment: Some("test".to_string()),
+            app_version: Some("1.2.3".to_string()),
+            edition: Some("bae".to_string()),
+            git_commit: Some("abc123".to_string()),
+        }
+        .into_core();
+
+        assert!(config.sends_events());
+        assert_eq!(config.source, "ios");
+        assert_eq!(config.edition, "bae");
+    }
+
+    #[test]
+    fn bridge_diagnostic_level_maps_to_core() {
+        assert_eq!(
+            BridgeDiagnosticLevel::Trace.into_core(),
+            DiagnosticLevel::Trace
+        );
+        assert_eq!(
+            BridgeDiagnosticLevel::Debug.into_core(),
+            DiagnosticLevel::Debug
+        );
+        assert_eq!(
+            BridgeDiagnosticLevel::Info.into_core(),
+            DiagnosticLevel::Info
+        );
+        assert_eq!(
+            BridgeDiagnosticLevel::Warn.into_core(),
+            DiagnosticLevel::Warn
+        );
+        assert_eq!(
+            BridgeDiagnosticLevel::Error.into_core(),
+            DiagnosticLevel::Error
+        );
+    }
 }

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use bae_core::app::{bootstrap, BootstrapError, RunningApp};
 use bae_core::diagnostics::{
-    DatadogDiagnosticsConfig, DiagnosticLevel, Diagnostics, DiagnosticsConfig, DiagnosticsError,
+    AppDiagnosticMetadata, DatadogDiagnosticsConfig, DiagnosticLevel, Diagnostics,
+    DiagnosticsConfig, DiagnosticsError,
 };
 
 use crate::handle::AppHandle;
@@ -21,6 +22,11 @@ pub struct BridgeDatadogDiagnosticsConfig {
     pub datadog_site: String,
     pub client_token: String,
     pub source: String,
+    pub app: BridgeAppDiagnosticMetadata,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeAppDiagnosticMetadata {
     pub service: String,
     pub environment: String,
     pub app_version: String,
@@ -125,11 +131,13 @@ impl BridgeDatadogDiagnosticsConfig {
             datadog_site: self.datadog_site.trim().to_string(),
             client_token: self.client_token.trim().to_string(),
             source: self.source.trim().to_string(),
-            service: self.service.trim().to_string(),
-            environment: self.environment.trim().to_string(),
-            app_version: self.app_version.trim().to_string(),
-            edition: self.edition.trim().to_string(),
-            git_commit: self.git_commit.trim().to_string(),
+            app: AppDiagnosticMetadata {
+                service: self.app.service.trim().to_string(),
+                environment: self.app.environment.trim().to_string(),
+                app_version: self.app.app_version.trim().to_string(),
+                edition: self.app.edition.trim().to_string(),
+                git_commit: self.app.git_commit.trim().to_string(),
+            },
         };
 
         DiagnosticsConfig::Enabled(config)
@@ -260,11 +268,13 @@ mod tests {
                 datadog_site: "datadoghq.com".to_string(),
                 client_token: "client-token".to_string(),
                 source: "ios".to_string(),
-                service: "bae".to_string(),
-                environment: "test".to_string(),
-                app_version: "1.2.3".to_string(),
-                edition: "bae".to_string(),
-                git_commit: "abc123".to_string(),
+                app: BridgeAppDiagnosticMetadata {
+                    service: "bae".to_string(),
+                    environment: "test".to_string(),
+                    app_version: "1.2.3".to_string(),
+                    edition: "bae".to_string(),
+                    git_commit: "abc123".to_string(),
+                },
             },
         }
         .into_core();
@@ -274,7 +284,7 @@ mod tests {
             panic!("complete bridge config must enable diagnostics");
         };
         assert_eq!(config.source, "ios");
-        assert_eq!(config.edition, "bae");
+        assert_eq!(config.app.edition, "bae");
     }
 
     #[test]

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -128,15 +128,15 @@ impl BridgeDiagnosticsConfig {
 impl BridgeDatadogDiagnosticsConfig {
     fn into_core(self) -> DiagnosticsConfig {
         let config = DatadogDiagnosticsConfig {
-            datadog_site: self.datadog_site.trim().to_string(),
-            client_token: self.client_token.trim().to_string(),
-            source: self.source.trim().to_string(),
+            datadog_site: self.datadog_site,
+            client_token: self.client_token,
+            source: self.source,
             app: AppDiagnosticMetadata {
-                service: self.app.service.trim().to_string(),
-                environment: self.app.environment.trim().to_string(),
-                app_version: self.app.app_version.trim().to_string(),
-                edition: self.app.edition.trim().to_string(),
-                git_commit: self.app.git_commit.trim().to_string(),
+                service: self.app.service,
+                environment: self.app.environment,
+                app_version: self.app.app_version,
+                edition: self.app.edition,
+                git_commit: self.app.git_commit,
             },
         };
 

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -209,6 +209,10 @@ macro_rules! install_logging_subscriber {
     }};
 }
 
+#[cfg(any(
+    target_os = "macos",
+    not(any(target_os = "macos", target_os = "android", target_os = "ios"))
+))]
 fn fmt_log_layer<S>() -> impl tracing_subscriber::Layer<S>
 where
     S: tracing::Subscriber,

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -53,7 +53,7 @@ pub fn init_app(
     library_id: String,
     position_update_interval_ms: u32,
 ) -> Result<Arc<AppHandle>, BridgeError> {
-    configure_logging(Diagnostics::noop());
+    configure_logging(Diagnostics::noop())?;
 
     let RunningApp {
         runtime,
@@ -74,7 +74,7 @@ pub fn configure_diagnostics(
 ) -> Result<Arc<BridgeDiagnostics>, BridgeError> {
     let diagnostics =
         Diagnostics::configure(config.into_core()).map_err(diagnostics_error_to_bridge)?;
-    configure_logging(diagnostics.clone());
+    configure_logging(diagnostics.clone())?;
     Ok(Arc::new(BridgeDiagnostics { diagnostics }))
 }
 
@@ -168,15 +168,14 @@ fn bootstrap_error_to_bridge(e: BootstrapError) -> BridgeError {
     }
 }
 
-/// Build an `EnvFilter` from `RUST_LOG`. If the variable is unset, defaults to "info".
-/// If set but malformed, warns on stderr and falls back to "info".
-fn env_filter() -> tracing_subscriber::EnvFilter {
+fn env_filter() -> Result<tracing_subscriber::EnvFilter, BridgeError> {
     match std::env::var("RUST_LOG") {
-        Err(_) => tracing_subscriber::EnvFilter::new("info"),
-        Ok(val) => tracing_subscriber::EnvFilter::try_new(&val).unwrap_or_else(|e| {
-            eprintln!("warning: RUST_LOG={val:?} is malformed ({e}), falling back to \"info\"");
-            tracing_subscriber::EnvFilter::new("info")
-        }),
+        Err(std::env::VarError::NotPresent) => Ok(tracing_subscriber::EnvFilter::new("info")),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(BridgeError::config("RUST_LOG is not valid Unicode"))
+        }
+        Ok(value) => tracing_subscriber::EnvFilter::try_new(&value)
+            .map_err(|e| BridgeError::config(format!("RUST_LOG={value:?} is malformed: {e}"))),
     }
 }
 
@@ -191,12 +190,14 @@ fn install_subscriber(subscriber: impl tracing_subscriber::util::SubscriberInitE
 macro_rules! install_logging_subscriber {
     ($diagnostics:expr $(, $layer:expr)+ $(,)?) => {{
         use tracing_subscriber::prelude::*;
+        let filter = env_filter()?;
         install_subscriber(
             tracing_subscriber::registry()
-                .with(env_filter())
+                .with(filter)
                 .with(bae_core::diagnostics::tracing_layer($diagnostics))
                 $(.with($layer))+,
         );
+        Ok(())
     }};
 }
 
@@ -212,33 +213,33 @@ where
 }
 
 #[cfg(target_os = "macos")]
-fn configure_logging(diagnostics: Diagnostics) {
+fn configure_logging(diagnostics: Diagnostics) -> Result<(), BridgeError> {
     install_logging_subscriber!(
         diagnostics,
         fmt_log_layer(),
         tracing_oslog::OsLogger::new("fm.bae.desktop", "default"),
-    );
+    )
 }
 
 #[cfg(target_os = "android")]
-fn configure_logging(diagnostics: Diagnostics) {
+fn configure_logging(diagnostics: Diagnostics) -> Result<(), BridgeError> {
     install_logging_subscriber!(
         diagnostics,
         tracing_android::layer("bae").expect("Android tracing layer initializes"),
-    );
+    )
 }
 
 #[cfg(target_os = "ios")]
-fn configure_logging(diagnostics: Diagnostics) {
+fn configure_logging(diagnostics: Diagnostics) -> Result<(), BridgeError> {
     install_logging_subscriber!(
         diagnostics,
         tracing_oslog::OsLogger::new("fm.bae.app", "default"),
-    );
+    )
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "ios")))]
-fn configure_logging(diagnostics: Diagnostics) {
-    install_logging_subscriber!(diagnostics, fmt_log_layer());
+fn configure_logging(diagnostics: Diagnostics) -> Result<(), BridgeError> {
+    install_logging_subscriber!(diagnostics, fmt_log_layer())
 }
 
 #[cfg(test)]

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -44,6 +44,7 @@ tokio-util = { version = "0.7", features = ["io", "rt"] }
 rand = "0.9"
 lru = "0.17"
 tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 notify = "8.2.0"
 notify-debouncer-full = "0.7.0"
 
@@ -73,7 +74,6 @@ lofty = "0.23"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
 rayon = "1.10"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 dotenvy = "0.15"
 discid = "0.5"
 lofty = "0.23"

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -218,7 +218,7 @@ impl Diagnostics {
             return Ok(Self::noop());
         };
         if !config.is_complete() {
-            return Ok(Self::noop());
+            return Err(DiagnosticsError::IncompleteConfig);
         }
         Self::with_transport(config, dependencies, Arc::new(DatadogTransport::new()))
     }
@@ -488,6 +488,8 @@ pub enum DiagnosticsError {
     SpawnWorker(#[source] std::io::Error),
     #[error("diagnostics runtime failed to start")]
     BuildRuntime(#[source] std::io::Error),
+    #[error("diagnostics config is missing required Datadog fields")]
+    IncompleteConfig,
     #[error("diagnostics worker stopped")]
     WorkerStopped,
     #[error("diagnostics Datadog site is invalid: {0}")]
@@ -579,6 +581,7 @@ pub fn should_retry(error: &DiagnosticsError) -> bool {
         }
         DiagnosticsError::SpawnWorker(_)
         | DiagnosticsError::BuildRuntime(_)
+        | DiagnosticsError::IncompleteConfig
         | DiagnosticsError::WorkerStopped
         | DiagnosticsError::InvalidSite(_)
         | DiagnosticsError::InvalidUrl { .. }
@@ -819,7 +822,14 @@ mod tests {
 
         let mut incomplete = config();
         incomplete.client_token = String::new();
-        assert!(!DiagnosticsConfig::Enabled(incomplete).sends_events());
+        assert!(!DiagnosticsConfig::Enabled(incomplete.clone()).sends_events());
+        assert!(matches!(
+            Diagnostics::configure_with_dependencies(
+                DiagnosticsConfig::Enabled(incomplete),
+                dependencies()
+            ),
+            Err(DiagnosticsError::IncompleteConfig)
+        ));
     }
 
     #[test]

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -1,0 +1,985 @@
+//! Crash reporting stays in the platform apps because crash handlers, native
+//! crash capture, and symbol upload are platform-specific. Logs and telemetry
+//! live here so Rust and host-originated events share schema, redaction,
+//! batching, retry, and transport.
+//!
+//! The Datadog logs transport sends directly to the client intake endpoint used
+//! by Datadog's browser, iOS, and Android SDKs: `browser-intake-.../api/v2/logs`
+//! with a client token. Client tokens are public intake credentials for
+//! end-user apps; `DD_API_KEY` is never shipped in bae. baeium configures
+//! no-op crash reporting and no-op diagnostics.
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    fmt,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, OnceLock, RwLock},
+    time::Duration,
+};
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use reqwest::{
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    StatusCode, Url,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{field::Visit, Event, Subscriber};
+use tracing_subscriber::{layer::Context, Layer};
+use uuid::Uuid;
+
+const BATCH_SIZE: usize = 50;
+const MAX_BUFFERED_EVENTS: usize = 1_000;
+const FLUSH_INTERVAL: Duration = Duration::from_secs(2);
+const RETRY_ATTEMPTS: usize = 3;
+const RETRY_DELAY: Duration = Duration::from_millis(250);
+const DATADOG_ORIGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+static GLOBAL_DIAGNOSTICS: OnceLock<RwLock<Diagnostics>> = OnceLock::new();
+
+type DiagnosticFields = BTreeMap<String, String>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiagnosticsConfig {
+    pub enabled: bool,
+    pub datadog_site: String,
+    pub client_token: String,
+    pub source: String,
+    pub service: String,
+    pub environment: String,
+    pub app_version: String,
+    pub edition: String,
+    pub git_commit: String,
+}
+
+impl DiagnosticsConfig {
+    pub fn sends_events(&self) -> bool {
+        self.enabled
+            && !self.datadog_site.trim().is_empty()
+            && !self.client_token.trim().is_empty()
+            && !self.source.trim().is_empty()
+            && !self.service.trim().is_empty()
+            && !self.environment.trim().is_empty()
+            && !self.app_version.trim().is_empty()
+            && !self.edition.trim().is_empty()
+            && !self.git_commit.trim().is_empty()
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            datadog_site: String::new(),
+            client_token: String::new(),
+            source: String::new(),
+            service: String::new(),
+            environment: String::new(),
+            app_version: String::new(),
+            edition: String::new(),
+            git_commit: String::new(),
+        }
+    }
+
+    fn metadata(&self) -> AppDiagnosticMetadata {
+        AppDiagnosticMetadata {
+            service: self.service.clone(),
+            environment: self.environment.clone(),
+            app_version: self.app_version.clone(),
+            edition: self.edition.clone(),
+            git_commit: self.git_commit.clone(),
+        }
+    }
+
+    fn intake_url(&self) -> Result<Url, DiagnosticsError> {
+        validate_datadog_site(&self.datadog_site)?;
+        let mut url = Url::parse(&format!(
+            "https://browser-intake-{}/api/v2/logs",
+            self.datadog_site
+        ))
+        .map_err(|source| DiagnosticsError::InvalidUrl {
+            site: self.datadog_site.clone(),
+            detail: source.to_string(),
+        })?;
+        url.query_pairs_mut().append_pair("ddsource", &self.source);
+        Ok(url)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticEvent {
+    pub kind: DiagnosticKind,
+    pub name: String,
+    pub level: DiagnosticLevel,
+    pub target: String,
+    pub message: String,
+    pub timestamp: DateTime<Utc>,
+    pub fields: DiagnosticFields,
+    #[serde(flatten)]
+    pub app: AppDiagnosticMetadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppDiagnosticMetadata {
+    pub service: String,
+    #[serde(rename = "env")]
+    pub environment: String,
+    #[serde(rename = "version")]
+    pub app_version: String,
+    pub edition: String,
+    pub git_commit: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticKind {
+    Log,
+    Telemetry,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Clone)]
+pub struct Diagnostics {
+    inner: Arc<DiagnosticsInner>,
+}
+
+impl fmt::Debug for Diagnostics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Diagnostics").finish_non_exhaustive()
+    }
+}
+
+enum DiagnosticsInner {
+    Noop,
+    Worker {
+        tx: mpsc::UnboundedSender<WorkerMessage>,
+        app: AppDiagnosticMetadata,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct NoopDiagnostics;
+
+impl NoopDiagnostics {
+    pub fn log(
+        self,
+        level: DiagnosticLevel,
+        target: impl Into<String>,
+        message: impl Into<String>,
+        fields: impl IntoIterator<Item = (String, String)>,
+    ) {
+        let _ = (
+            level,
+            target.into(),
+            message.into(),
+            fields.into_iter().count(),
+        );
+    }
+
+    pub fn event(
+        self,
+        name: impl Into<String>,
+        fields: impl IntoIterator<Item = (String, String)>,
+    ) {
+        let _ = (name.into(), fields.into_iter().count());
+    }
+}
+
+impl Diagnostics {
+    pub fn noop() -> Self {
+        Self {
+            inner: Arc::new(DiagnosticsInner::Noop),
+        }
+    }
+
+    pub fn configure(config: DiagnosticsConfig) -> Result<Self, DiagnosticsError> {
+        if !config.sends_events() {
+            return Ok(Self::noop());
+        }
+        Self::with_transport(config, Arc::new(DatadogTransport::new()))
+    }
+
+    pub fn install_global(config: DiagnosticsConfig) -> Result<Self, DiagnosticsError> {
+        let diagnostics = Self::configure(config)?;
+        let lock = GLOBAL_DIAGNOSTICS.get_or_init(|| RwLock::new(Self::noop()));
+        let mut guard = lock.write().map_err(|_| DiagnosticsError::GlobalPoisoned)?;
+        *guard = diagnostics.clone();
+        Ok(diagnostics)
+    }
+
+    pub fn global() -> Self {
+        let lock = GLOBAL_DIAGNOSTICS.get_or_init(|| RwLock::new(Self::noop()));
+        match lock.read() {
+            Ok(guard) => guard.clone(),
+            Err(_) => Self::noop(),
+        }
+    }
+
+    fn with_transport(
+        config: DiagnosticsConfig,
+        transport: Arc<dyn DiagnosticsTransport>,
+    ) -> Result<Self, DiagnosticsError> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let app = config.metadata();
+        let worker = DiagnosticsWorker::new(config, transport, rx);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(DiagnosticsError::BuildRuntime)?;
+        std::thread::Builder::new()
+            .name("bae-diagnostics".to_string())
+            .spawn(move || runtime.block_on(worker.run()))
+            .map_err(DiagnosticsError::SpawnWorker)?;
+
+        Ok(Self {
+            inner: Arc::new(DiagnosticsInner::Worker { tx, app }),
+        })
+    }
+
+    pub fn log(
+        &self,
+        level: DiagnosticLevel,
+        target: impl Into<String>,
+        message: impl Into<String>,
+        fields: impl IntoIterator<Item = (String, String)>,
+    ) {
+        let app = match self.app_metadata() {
+            Some(app) => app,
+            None => return,
+        };
+        self.emit(DiagnosticEvent {
+            kind: DiagnosticKind::Log,
+            name: "log".to_string(),
+            level,
+            target: target.into(),
+            message: redact_text(&message.into()),
+            timestamp: Utc::now(),
+            fields: sanitize_fields(fields),
+            app,
+        });
+    }
+
+    pub fn event(
+        &self,
+        name: impl Into<String>,
+        fields: impl IntoIterator<Item = (String, String)>,
+    ) {
+        let name = name.into();
+        let app = match self.app_metadata() {
+            Some(app) => app,
+            None => return,
+        };
+        self.emit(DiagnosticEvent {
+            kind: DiagnosticKind::Telemetry,
+            name: redact_text(&name),
+            level: DiagnosticLevel::Info,
+            target: "telemetry".to_string(),
+            message: redact_text(&name),
+            timestamp: Utc::now(),
+            fields: sanitize_fields(fields),
+            app,
+        });
+    }
+
+    pub async fn flush(&self) -> bool {
+        let DiagnosticsInner::Worker { tx, .. } = self.inner.as_ref() else {
+            return true;
+        };
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if tx.send(WorkerMessage::Flush(reply_tx)).is_err() {
+            return false;
+        }
+        reply_rx.await.unwrap_or(false)
+    }
+
+    fn emit(&self, event: DiagnosticEvent) {
+        let DiagnosticsInner::Worker { tx, .. } = self.inner.as_ref() else {
+            return;
+        };
+        let _ = tx.send(WorkerMessage::Event(event));
+    }
+
+    fn app_metadata(&self) -> Option<AppDiagnosticMetadata> {
+        match self.inner.as_ref() {
+            DiagnosticsInner::Noop => None,
+            DiagnosticsInner::Worker { app, .. } => Some(app.clone()),
+        }
+    }
+}
+
+enum WorkerMessage {
+    Event(DiagnosticEvent),
+    Flush(oneshot::Sender<bool>),
+}
+
+struct DiagnosticsWorker {
+    config: DiagnosticsConfig,
+    transport: Arc<dyn DiagnosticsTransport>,
+    rx: mpsc::UnboundedReceiver<WorkerMessage>,
+    buffered: VecDeque<DiagnosticEvent>,
+}
+
+impl DiagnosticsWorker {
+    fn new(
+        config: DiagnosticsConfig,
+        transport: Arc<dyn DiagnosticsTransport>,
+        rx: mpsc::UnboundedReceiver<WorkerMessage>,
+    ) -> Self {
+        Self {
+            config,
+            transport,
+            rx,
+            buffered: VecDeque::new(),
+        }
+    }
+
+    async fn run(mut self) {
+        let mut flush_interval = tokio::time::interval(FLUSH_INTERVAL);
+        loop {
+            tokio::select! {
+                Some(message) = self.rx.recv() => {
+                    match message {
+                        WorkerMessage::Event(event) => {
+                            self.push(event);
+                            if self.buffered.len() >= BATCH_SIZE {
+                                let _sent = self.flush_buffer().await;
+                            }
+                        }
+                        WorkerMessage::Flush(reply) => {
+                            let sent = self.flush_buffer().await;
+                            let _ = reply.send(sent);
+                        }
+                    }
+                }
+                _ = flush_interval.tick() => {
+                    let _sent = self.flush_buffer().await;
+                }
+                else => break,
+            }
+        }
+    }
+
+    fn push(&mut self, event: DiagnosticEvent) {
+        if self.buffered.len() == MAX_BUFFERED_EVENTS {
+            self.buffered.pop_front();
+        }
+        self.buffered.push_back(event);
+    }
+
+    async fn flush_buffer(&mut self) -> bool {
+        if self.buffered.is_empty() {
+            return true;
+        }
+
+        let batch_len = self.buffered.len().min(BATCH_SIZE);
+        let batch: Vec<_> = self.buffered.drain(..batch_len).collect();
+        let request = match DatadogRequest::build(&self.config, &batch) {
+            Ok(request) => request,
+            Err(_) => {
+                self.restore_front(batch);
+                return false;
+            }
+        };
+
+        match send_with_retry(self.transport.as_ref(), request).await {
+            Ok(()) => true,
+            Err(_) => {
+                self.restore_front(batch);
+                false
+            }
+        }
+    }
+
+    fn restore_front(&mut self, mut batch: Vec<DiagnosticEvent>) {
+        while let Some(event) = batch.pop() {
+            self.buffered.push_front(event);
+        }
+        while self.buffered.len() > MAX_BUFFERED_EVENTS {
+            self.buffered.pop_front();
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatadogRequest {
+    pub url: Url,
+    pub headers: HeaderMap,
+    pub body: Vec<u8>,
+}
+
+impl DatadogRequest {
+    pub fn build(
+        config: &DiagnosticsConfig,
+        events: &[DiagnosticEvent],
+    ) -> Result<Self, DiagnosticsError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(
+            "DD-API-KEY",
+            HeaderValue::from_str(&config.client_token).map_err(DiagnosticsError::InvalidHeader)?,
+        );
+        headers.insert(
+            "DD-EVP-ORIGIN",
+            HeaderValue::from_str(&config.source).map_err(DiagnosticsError::InvalidHeader)?,
+        );
+        headers.insert(
+            "DD-EVP-ORIGIN-VERSION",
+            HeaderValue::from_static(DATADOG_ORIGIN_VERSION),
+        );
+        headers.insert(
+            "DD-REQUEST-ID",
+            HeaderValue::from_str(&Uuid::new_v4().to_string())
+                .map_err(DiagnosticsError::InvalidHeader)?,
+        );
+
+        Ok(Self {
+            url: config.intake_url()?,
+            headers,
+            body: serde_json::to_vec(events).map_err(DiagnosticsError::Serialize)?,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DiagnosticsError {
+    #[error("diagnostics worker failed to start")]
+    SpawnWorker(#[source] std::io::Error),
+    #[error("diagnostics runtime failed to start")]
+    BuildRuntime(#[source] std::io::Error),
+    #[error("diagnostics global state is poisoned")]
+    GlobalPoisoned,
+    #[error("diagnostics Datadog site is invalid: {0}")]
+    InvalidSite(String),
+    #[error("diagnostics Datadog URL is invalid for site {site}: {detail}")]
+    InvalidUrl { site: String, detail: String },
+    #[error("diagnostics HTTP header is invalid")]
+    InvalidHeader(#[source] reqwest::header::InvalidHeaderValue),
+    #[error("diagnostic event serialization failed")]
+    Serialize(#[source] serde_json::Error),
+    #[error("diagnostics transport failed")]
+    Transport(#[source] reqwest::Error),
+    #[error("diagnostics intake rejected the batch with HTTP {0}")]
+    Status(StatusCode),
+}
+
+pub trait DiagnosticsTransport: Send + Sync {
+    fn send<'a>(
+        &'a self,
+        request: DatadogRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<(), DiagnosticsError>> + Send + 'a>>;
+}
+
+#[derive(Debug)]
+pub struct DatadogTransport {
+    client: reqwest::Client,
+}
+
+impl DatadogTransport {
+    fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl DiagnosticsTransport for DatadogTransport {
+    fn send<'a>(
+        &'a self,
+        request: DatadogRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<(), DiagnosticsError>> + Send + 'a>> {
+        Box::pin(async move {
+            let response = self
+                .client
+                .post(request.url)
+                .headers(request.headers)
+                .body(request.body)
+                .send()
+                .await
+                .map_err(DiagnosticsError::Transport)?;
+
+            if response.status().is_success() {
+                Ok(())
+            } else {
+                Err(DiagnosticsError::Status(response.status()))
+            }
+        })
+    }
+}
+
+async fn send_with_retry(
+    transport: &dyn DiagnosticsTransport,
+    request: DatadogRequest,
+) -> Result<(), DiagnosticsError> {
+    let mut last_error = None;
+    for attempt in 0..RETRY_ATTEMPTS {
+        match transport.send(request.clone()).await {
+            Ok(()) => return Ok(()),
+            Err(e) if should_retry(&e) => {
+                last_error = Some(e);
+                if attempt + 1 < RETRY_ATTEMPTS {
+                    tokio::time::sleep(RETRY_DELAY).await;
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    match last_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+pub fn should_retry(error: &DiagnosticsError) -> bool {
+    match error {
+        DiagnosticsError::Transport(_) => true,
+        DiagnosticsError::Status(status) => {
+            status.is_server_error() || *status == StatusCode::TOO_MANY_REQUESTS
+        }
+        DiagnosticsError::SpawnWorker(_)
+        | DiagnosticsError::BuildRuntime(_)
+        | DiagnosticsError::GlobalPoisoned
+        | DiagnosticsError::InvalidSite(_)
+        | DiagnosticsError::InvalidUrl { .. }
+        | DiagnosticsError::InvalidHeader(_)
+        | DiagnosticsError::Serialize(_) => false,
+    }
+}
+
+pub fn tracing_layer() -> DiagnosticsTracingLayer {
+    DiagnosticsTracingLayer
+}
+
+#[derive(Clone, Debug)]
+pub struct DiagnosticsTracingLayer;
+
+impl<S> Layer<S> for DiagnosticsTracingLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = EventVisitor::new();
+        event.record(&mut visitor);
+        let metadata = event.metadata();
+        let message = visitor
+            .message
+            .unwrap_or_else(|| metadata.name().to_string());
+        Diagnostics::global().log(
+            DiagnosticLevel::from_tracing(metadata.level()),
+            metadata.target(),
+            message,
+            visitor.fields,
+        );
+    }
+}
+
+impl DiagnosticLevel {
+    fn from_tracing(level: &tracing::Level) -> Self {
+        match *level {
+            tracing::Level::TRACE => Self::Trace,
+            tracing::Level::DEBUG => Self::Debug,
+            tracing::Level::INFO => Self::Info,
+            tracing::Level::WARN => Self::Warn,
+            tracing::Level::ERROR => Self::Error,
+        }
+    }
+}
+
+struct EventVisitor {
+    message: Option<String>,
+    fields: Vec<(String, String)>,
+}
+
+impl EventVisitor {
+    fn new() -> Self {
+        Self {
+            message: None,
+            fields: Vec::new(),
+        }
+    }
+}
+
+impl Visit for EventVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        } else {
+            self.fields
+                .push((field.name().to_string(), format!("{value:?}")));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        } else {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
+    }
+}
+
+fn sanitize_fields(fields: impl IntoIterator<Item = (String, String)>) -> DiagnosticFields {
+    fields
+        .into_iter()
+        .filter_map(|(key, value)| {
+            let key = key.trim();
+            if field_allowed(key) {
+                Some((key.to_string(), redact_text(&value)))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn field_allowed(key: &str) -> bool {
+    matches!(
+        key,
+        "action"
+            | "album_count"
+            | "cloud_provider"
+            | "count"
+            | "duration_ms"
+            | "error_code"
+            | "error_kind"
+            | "library_state"
+            | "operation"
+            | "position_ms"
+            | "provider"
+            | "release_id_kind"
+            | "screen"
+            | "source"
+            | "status"
+            | "track_count"
+    )
+}
+
+fn redact_text(value: &str) -> String {
+    let value = path_regex().replace_all(value, "[redacted-path]");
+    let value = uuid_regex().replace_all(&value, "[redacted-id]");
+    secret_regex()
+        .replace_all(&value, "[redacted-secret]")
+        .into_owned()
+}
+
+fn path_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(/[A-Za-z0-9._ -]+(?:/[A-Za-z0-9._ -]+)+|[A-Za-z]:\\[^\s]+)")
+            .expect("path redaction regex compiles")
+    })
+}
+
+fn uuid_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+            .expect("UUID redaction regex compiles")
+    })
+}
+
+fn secret_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\b[A-Za-z0-9_-]{32,}\b").expect("secret redaction regex compiles")
+    })
+}
+
+fn validate_datadog_site(site: &str) -> Result<(), DiagnosticsError> {
+    let valid = !site.is_empty()
+        && site
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-')
+        && site.contains('.');
+    if valid {
+        Ok(())
+    } else {
+        Err(DiagnosticsError::InvalidSite(site.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::{Mutex, MutexGuard};
+    use tracing_subscriber::prelude::*;
+
+    fn config() -> DiagnosticsConfig {
+        DiagnosticsConfig {
+            enabled: true,
+            datadog_site: "datadoghq.com".to_string(),
+            client_token: "client-token".to_string(),
+            source: "ios".to_string(),
+            service: "bae".to_string(),
+            environment: "test".to_string(),
+            app_version: "1.2.3".to_string(),
+            edition: "bae".to_string(),
+            git_commit: "abc123".to_string(),
+        }
+    }
+
+    fn event() -> DiagnosticEvent {
+        DiagnosticEvent {
+            kind: DiagnosticKind::Log,
+            name: "log".to_string(),
+            level: DiagnosticLevel::Warn,
+            target: "target".to_string(),
+            message: "message".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2026-06-20T00:00:00Z")
+                .expect("test timestamp parses")
+                .with_timezone(&Utc),
+            fields: BTreeMap::from([("operation".to_string(), "scan".to_string())]),
+            app: config().metadata(),
+        }
+    }
+
+    #[test]
+    fn event_serialization_contains_schema_and_app_metadata() {
+        let json = serde_json::to_value(event()).expect("event serializes");
+
+        assert_eq!(json["kind"], "log");
+        assert_eq!(json["name"], "log");
+        assert_eq!(json["level"], "warn");
+        assert_eq!(json["target"], "target");
+        assert_eq!(json["message"], "message");
+        assert_eq!(json["service"], "bae");
+        assert_eq!(json["env"], "test");
+        assert_eq!(json["version"], "1.2.3");
+        assert_eq!(json["edition"], "bae");
+        assert_eq!(json["git_commit"], "abc123");
+        assert_eq!(json["fields"]["operation"], "scan");
+    }
+
+    #[test]
+    fn redaction_drops_unapproved_fields_and_redacts_sensitive_values() {
+        let fields = sanitize_fields([
+            ("operation".to_string(), "scan".to_string()),
+            (
+                "path".to_string(),
+                "/Users/person/Music/file.flac".to_string(),
+            ),
+            (
+                "status".to_string(),
+                "stored at /Users/person/Music/file.flac".to_string(),
+            ),
+            (
+                "error_code".to_string(),
+                "abcd1234abcd1234abcd1234abcd1234".to_string(),
+            ),
+        ]);
+
+        assert_eq!(fields.get("operation").map(String::as_str), Some("scan"));
+        assert!(!fields.contains_key("path"));
+        assert_eq!(
+            fields.get("status").map(String::as_str),
+            Some("stored at [redacted-path]")
+        );
+        assert_eq!(
+            fields.get("error_code").map(String::as_str),
+            Some("[redacted-secret]")
+        );
+    }
+
+    #[test]
+    fn no_op_diagnostics_drops_events() {
+        let diagnostics = Diagnostics::noop();
+        diagnostics.log(
+            DiagnosticLevel::Info,
+            "target",
+            "message",
+            [("operation".to_string(), "scan".to_string())],
+        );
+        diagnostics.event("opened", [("screen".to_string(), "library".to_string())]);
+    }
+
+    #[test]
+    fn datadog_request_uses_client_intake_shape() {
+        let request = DatadogRequest::build(&config(), &[event()]).expect("request builds");
+
+        assert_eq!(
+            request.url.as_str(),
+            "https://browser-intake-datadoghq.com/api/v2/logs?ddsource=ios"
+        );
+        assert_eq!(
+            request
+                .headers
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("DD-API-KEY")
+                .and_then(|v| v.to_str().ok()),
+            Some("client-token")
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("DD-EVP-ORIGIN")
+                .and_then(|v| v.to_str().ok()),
+            Some("ios")
+        );
+        assert!(request.headers.contains_key("DD-EVP-ORIGIN-VERSION"));
+        assert!(request.headers.contains_key("DD-REQUEST-ID"));
+        let body: serde_json::Value =
+            serde_json::from_slice(&request.body).expect("request body is JSON");
+        assert_eq!(body.as_array().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn retry_decision_retries_transient_failures_only() {
+        assert!(should_retry(&DiagnosticsError::Status(
+            StatusCode::INTERNAL_SERVER_ERROR
+        )));
+        assert!(should_retry(&DiagnosticsError::Status(
+            StatusCode::TOO_MANY_REQUESTS
+        )));
+        assert!(!should_retry(&DiagnosticsError::Status(
+            StatusCode::BAD_REQUEST
+        )));
+        assert!(!should_retry(&DiagnosticsError::InvalidSite(
+            "bad/site".to_string()
+        )));
+    }
+
+    #[tokio::test]
+    async fn batching_flushes_events_through_transport() {
+        let transport = Arc::new(RecordingTransport::new(vec![Ok(())]));
+        let diagnostics =
+            Diagnostics::with_transport(config(), transport.clone()).expect("diagnostics starts");
+        diagnostics.log(
+            DiagnosticLevel::Info,
+            "target",
+            "message",
+            [("operation".to_string(), "scan".to_string())],
+        );
+
+        assert!(diagnostics.flush().await);
+        let requests = transport.requests();
+        assert_eq!(requests.len(), 1);
+        let body: serde_json::Value =
+            serde_json::from_slice(&requests[0].body).expect("request body is JSON");
+        assert_eq!(body.as_array().map(Vec::len), Some(1));
+    }
+
+    #[tokio::test]
+    async fn failed_flush_keeps_events_buffered_for_later_retry() {
+        let transport = Arc::new(RecordingTransport::new(vec![
+            Err(DiagnosticsError::Status(StatusCode::BAD_REQUEST)),
+            Ok(()),
+        ]));
+        let diagnostics =
+            Diagnostics::with_transport(config(), transport.clone()).expect("diagnostics starts");
+        diagnostics.event("opened", [("screen".to_string(), "library".to_string())]);
+
+        assert!(!diagnostics.flush().await);
+        assert!(diagnostics.flush().await);
+        assert_eq!(transport.requests().len(), 2);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn tracing_layer_maps_events_to_diagnostics() {
+        let transport = Arc::new(RecordingTransport::new(vec![Ok(())]));
+        let diagnostics =
+            Diagnostics::with_transport(config(), transport.clone()).expect("diagnostics starts");
+        install_global_for_test(diagnostics.clone());
+
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(tracing_layer()),
+            || {
+                tracing::warn!(
+                    target: "scan",
+                    operation = "import",
+                    path = "/Users/person/Music/file.flac",
+                    "release {} failed",
+                    "123e4567-e89b-12d3-a456-426614174000"
+                );
+            },
+        );
+
+        assert!(diagnostics.flush().await);
+        let requests = transport.requests();
+        let body: serde_json::Value =
+            serde_json::from_slice(&requests[0].body).expect("request body is JSON");
+        let event = &body[0];
+        assert_eq!(event["level"], "warn");
+        assert_eq!(event["target"], "scan");
+        assert_eq!(event["fields"]["operation"], "import");
+        assert!(event["fields"].get("path").is_none());
+        assert_eq!(event["message"], "release [redacted-id] failed");
+    }
+
+    fn install_global_for_test(diagnostics: Diagnostics) {
+        let lock = GLOBAL_DIAGNOSTICS.get_or_init(|| RwLock::new(Diagnostics::noop()));
+        let mut guard = lock.write().expect("global diagnostics lock is available");
+        *guard = diagnostics;
+    }
+
+    struct RecordingTransport {
+        requests: Mutex<Vec<DatadogRequest>>,
+        outcomes: Mutex<VecDeque<Result<(), DiagnosticsError>>>,
+    }
+
+    impl RecordingTransport {
+        fn new(outcomes: Vec<Result<(), DiagnosticsError>>) -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+                outcomes: Mutex::new(outcomes.into()),
+            }
+        }
+
+        fn requests(&self) -> Vec<DatadogRequest> {
+            self.requests_guard().clone()
+        }
+
+        fn requests_guard(&self) -> MutexGuard<'_, Vec<DatadogRequest>> {
+            self.requests.lock().expect("requests mutex is available")
+        }
+
+        fn outcomes_guard(&self) -> MutexGuard<'_, VecDeque<Result<(), DiagnosticsError>>> {
+            self.outcomes.lock().expect("outcomes mutex is available")
+        }
+    }
+
+    impl DiagnosticsTransport for RecordingTransport {
+        fn send<'a>(
+            &'a self,
+            request: DatadogRequest,
+        ) -> Pin<Box<dyn Future<Output = Result<(), DiagnosticsError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.requests_guard().push(request);
+                self.outcomes_guard()
+                    .pop_front()
+                    .expect("test provides a transport outcome")
+            })
+        }
+    }
+}

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -461,22 +461,13 @@ impl DatadogRequest {
     ) -> Result<Self, DiagnosticsError> {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        headers.insert(
-            "DD-API-KEY",
-            HeaderValue::from_str(&config.client_token).map_err(DiagnosticsError::InvalidHeader)?,
-        );
-        headers.insert(
-            "DD-EVP-ORIGIN",
-            HeaderValue::from_str(&config.source).map_err(DiagnosticsError::InvalidHeader)?,
-        );
+        insert_str_header(&mut headers, "DD-API-KEY", &config.client_token)?;
+        insert_str_header(&mut headers, "DD-EVP-ORIGIN", &config.source)?;
         headers.insert(
             "DD-EVP-ORIGIN-VERSION",
             HeaderValue::from_static(DATADOG_ORIGIN_VERSION),
         );
-        headers.insert(
-            "DD-REQUEST-ID",
-            HeaderValue::from_str(&request_id).map_err(DiagnosticsError::InvalidHeader)?,
-        );
+        insert_str_header(&mut headers, "DD-REQUEST-ID", &request_id)?;
 
         Ok(Self {
             url: config.intake_url()?,
@@ -484,6 +475,18 @@ impl DatadogRequest {
             body: serde_json::to_vec(events).map_err(DiagnosticsError::Serialize)?,
         })
     }
+}
+
+fn insert_str_header(
+    headers: &mut HeaderMap,
+    name: &'static str,
+    value: &str,
+) -> Result<(), DiagnosticsError> {
+    headers.insert(
+        name,
+        HeaderValue::from_str(value).map_err(DiagnosticsError::InvalidHeader)?,
+    );
+    Ok(())
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -348,7 +348,6 @@ struct DiagnosticsWorker {
     transport: Arc<dyn DiagnosticsTransport>,
     rx: mpsc::UnboundedReceiver<WorkerMessage>,
     buffered: VecDeque<DiagnosticEvent>,
-    last_failure: Option<String>,
 }
 
 impl DiagnosticsWorker {
@@ -364,7 +363,6 @@ impl DiagnosticsWorker {
             transport,
             rx,
             buffered: VecDeque::new(),
-            last_failure: None,
         }
     }
 
@@ -383,7 +381,7 @@ impl DiagnosticsWorker {
                         WorkerMessage::Flush(reply) => {
                             let result = self.flush_buffer().await;
                             if reply.send(result).is_err() {
-                                self.last_failure = Some("diagnostics flush receiver dropped".to_string());
+                                tracing::debug!("diagnostics flush receiver dropped");
                             }
                         }
                     }
@@ -404,9 +402,8 @@ impl DiagnosticsWorker {
     }
 
     async fn record_flush_result(&mut self) {
-        match self.flush_buffer().await {
-            Ok(()) => self.last_failure = None,
-            Err(e) => self.last_failure = Some(e.to_string()),
+        if let Err(error) = self.flush_buffer().await {
+            tracing::debug!(%error, "diagnostics flush failed");
         }
     }
 
@@ -604,12 +601,16 @@ where
     S: Subscriber,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        if metadata.target().starts_with("bae_core::diagnostics") {
+            return;
+        }
         let mut visitor = EventVisitor::new();
         event.record(&mut visitor);
-        let metadata = event.metadata();
-        let message = visitor
-            .message
-            .unwrap_or_else(|| metadata.name().to_string());
+        let message = match visitor.message {
+            Some(message) => message,
+            None => metadata.name().to_string(),
+        };
         match self.diagnostics.log(
             DiagnosticLevel::from_tracing(metadata.level()),
             metadata.target(),
@@ -798,6 +799,15 @@ mod tests {
         }
     }
 
+    fn header_value<'a>(request: &'a DatadogRequest, name: &str) -> &'a str {
+        request
+            .headers
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} header is present"))
+            .to_str()
+            .unwrap_or_else(|e| panic!("{name} header is valid UTF-8: {e}"))
+    }
+
     #[test]
     fn disabled_config_does_not_send_events() {
         assert!(!DiagnosticsConfig::Disabled.sends_events());
@@ -885,33 +895,12 @@ mod tests {
             "https://browser-intake-datadoghq.com/api/v2/logs?ddsource=ios"
         );
         assert_eq!(
-            request
-                .headers
-                .get(CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok()),
-            Some("application/json")
+            header_value(&request, CONTENT_TYPE.as_str()),
+            "application/json"
         );
-        assert_eq!(
-            request
-                .headers
-                .get("DD-API-KEY")
-                .and_then(|v| v.to_str().ok()),
-            Some("client-token")
-        );
-        assert_eq!(
-            request
-                .headers
-                .get("DD-EVP-ORIGIN")
-                .and_then(|v| v.to_str().ok()),
-            Some("ios")
-        );
-        assert_eq!(
-            request
-                .headers
-                .get("DD-REQUEST-ID")
-                .and_then(|v| v.to_str().ok()),
-            Some("request-id")
-        );
+        assert_eq!(header_value(&request, "DD-API-KEY"), "client-token");
+        assert_eq!(header_value(&request, "DD-EVP-ORIGIN"), "ios");
+        assert_eq!(header_value(&request, "DD-REQUEST-ID"), "request-id");
         assert!(request.headers.contains_key("DD-EVP-ORIGIN-VERSION"));
         let body: serde_json::Value =
             serde_json::from_slice(&request.body).expect("request body is JSON");

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -14,7 +14,7 @@ use std::{
     fmt,
     future::Future,
     pin::Pin,
-    sync::{Arc, OnceLock, RwLock},
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
@@ -37,13 +37,22 @@ const RETRY_ATTEMPTS: usize = 3;
 const RETRY_DELAY: Duration = Duration::from_millis(250);
 const DATADOG_ORIGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-static GLOBAL_DIAGNOSTICS: OnceLock<RwLock<Diagnostics>> = OnceLock::new();
-
 type DiagnosticFields = BTreeMap<String, String>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DiagnosticsConfig {
-    pub enabled: bool,
+pub enum DiagnosticsConfig {
+    Disabled,
+    Enabled(DatadogDiagnosticsConfig),
+}
+
+impl DiagnosticsConfig {
+    pub fn sends_events(&self) -> bool {
+        matches!(self, Self::Enabled(config) if config.is_complete())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatadogDiagnosticsConfig {
     pub datadog_site: String,
     pub client_token: String,
     pub source: String,
@@ -54,31 +63,22 @@ pub struct DiagnosticsConfig {
     pub git_commit: String,
 }
 
-impl DiagnosticsConfig {
-    pub fn sends_events(&self) -> bool {
-        self.enabled
-            && !self.datadog_site.trim().is_empty()
-            && !self.client_token.trim().is_empty()
-            && !self.source.trim().is_empty()
-            && !self.service.trim().is_empty()
-            && !self.environment.trim().is_empty()
-            && !self.app_version.trim().is_empty()
-            && !self.edition.trim().is_empty()
-            && !self.git_commit.trim().is_empty()
+impl DatadogDiagnosticsConfig {
+    fn is_complete(&self) -> bool {
+        self.required_values().iter().all(|value| !value.is_empty())
     }
 
-    pub fn disabled() -> Self {
-        Self {
-            enabled: false,
-            datadog_site: String::new(),
-            client_token: String::new(),
-            source: String::new(),
-            service: String::new(),
-            environment: String::new(),
-            app_version: String::new(),
-            edition: String::new(),
-            git_commit: String::new(),
-        }
+    fn required_values(&self) -> [&str; 8] {
+        [
+            &self.datadog_site,
+            &self.client_token,
+            &self.source,
+            &self.service,
+            &self.environment,
+            &self.app_version,
+            &self.edition,
+            &self.git_commit,
+        ]
     }
 
     fn metadata(&self) -> AppDiagnosticMetadata {
@@ -103,6 +103,38 @@ impl DiagnosticsConfig {
         })?;
         url.query_pairs_mut().append_pair("ddsource", &self.source);
         Ok(url)
+    }
+}
+
+#[derive(Clone)]
+pub struct DiagnosticsDependencies {
+    now: Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>,
+    request_id: Arc<dyn Fn() -> String + Send + Sync>,
+}
+
+impl DiagnosticsDependencies {
+    pub fn new(
+        now: impl Fn() -> DateTime<Utc> + Send + Sync + 'static,
+        request_id: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            now: Arc::new(now),
+            request_id: Arc::new(request_id),
+        }
+    }
+
+    fn now(&self) -> DateTime<Utc> {
+        (self.now)()
+    }
+
+    fn request_id(&self) -> String {
+        (self.request_id)()
+    }
+}
+
+impl Default for DiagnosticsDependencies {
+    fn default() -> Self {
+        Self::new(Utc::now, || Uuid::new_v4().to_string())
     }
 }
 
@@ -163,35 +195,8 @@ enum DiagnosticsInner {
     Worker {
         tx: mpsc::UnboundedSender<WorkerMessage>,
         app: AppDiagnosticMetadata,
+        dependencies: DiagnosticsDependencies,
     },
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct NoopDiagnostics;
-
-impl NoopDiagnostics {
-    pub fn log(
-        self,
-        level: DiagnosticLevel,
-        target: impl Into<String>,
-        message: impl Into<String>,
-        fields: impl IntoIterator<Item = (String, String)>,
-    ) {
-        let _ = (
-            level,
-            target.into(),
-            message.into(),
-            fields.into_iter().count(),
-        );
-    }
-
-    pub fn event(
-        self,
-        name: impl Into<String>,
-        fields: impl IntoIterator<Item = (String, String)>,
-    ) {
-        let _ = (name.into(), fields.into_iter().count());
-    }
 }
 
 impl Diagnostics {
@@ -202,35 +207,30 @@ impl Diagnostics {
     }
 
     pub fn configure(config: DiagnosticsConfig) -> Result<Self, DiagnosticsError> {
-        if !config.sends_events() {
+        Self::configure_with_dependencies(config, DiagnosticsDependencies::default())
+    }
+
+    pub fn configure_with_dependencies(
+        config: DiagnosticsConfig,
+        dependencies: DiagnosticsDependencies,
+    ) -> Result<Self, DiagnosticsError> {
+        let DiagnosticsConfig::Enabled(config) = config else {
+            return Ok(Self::noop());
+        };
+        if !config.is_complete() {
             return Ok(Self::noop());
         }
-        Self::with_transport(config, Arc::new(DatadogTransport::new()))
-    }
-
-    pub fn install_global(config: DiagnosticsConfig) -> Result<Self, DiagnosticsError> {
-        let diagnostics = Self::configure(config)?;
-        let lock = GLOBAL_DIAGNOSTICS.get_or_init(|| RwLock::new(Self::noop()));
-        let mut guard = lock.write().map_err(|_| DiagnosticsError::GlobalPoisoned)?;
-        *guard = diagnostics.clone();
-        Ok(diagnostics)
-    }
-
-    pub fn global() -> Self {
-        let lock = GLOBAL_DIAGNOSTICS.get_or_init(|| RwLock::new(Self::noop()));
-        match lock.read() {
-            Ok(guard) => guard.clone(),
-            Err(_) => Self::noop(),
-        }
+        Self::with_transport(config, dependencies, Arc::new(DatadogTransport::new()))
     }
 
     fn with_transport(
-        config: DiagnosticsConfig,
+        config: DatadogDiagnosticsConfig,
+        dependencies: DiagnosticsDependencies,
         transport: Arc<dyn DiagnosticsTransport>,
     ) -> Result<Self, DiagnosticsError> {
         let (tx, rx) = mpsc::unbounded_channel();
         let app = config.metadata();
-        let worker = DiagnosticsWorker::new(config, transport, rx);
+        let worker = DiagnosticsWorker::new(config, dependencies.clone(), transport, rx);
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -241,7 +241,11 @@ impl Diagnostics {
             .map_err(DiagnosticsError::SpawnWorker)?;
 
         Ok(Self {
-            inner: Arc::new(DiagnosticsInner::Worker { tx, app }),
+            inner: Arc::new(DiagnosticsInner::Worker {
+                tx,
+                app,
+                dependencies,
+            }),
         })
     }
 
@@ -251,94 +255,116 @@ impl Diagnostics {
         target: impl Into<String>,
         message: impl Into<String>,
         fields: impl IntoIterator<Item = (String, String)>,
-    ) {
-        let app = match self.app_metadata() {
-            Some(app) => app,
-            None => return,
-        };
-        self.emit(DiagnosticEvent {
+    ) -> Result<(), DiagnosticsError> {
+        self.emit_event(DiagnosticEventInput {
             kind: DiagnosticKind::Log,
             name: "log".to_string(),
             level,
             target: target.into(),
-            message: redact_text(&message.into()),
-            timestamp: Utc::now(),
-            fields: sanitize_fields(fields),
-            app,
-        });
+            message: message.into(),
+            fields: fields.into_iter().collect(),
+        })
     }
 
     pub fn event(
         &self,
         name: impl Into<String>,
         fields: impl IntoIterator<Item = (String, String)>,
-    ) {
+    ) -> Result<(), DiagnosticsError> {
         let name = name.into();
-        let app = match self.app_metadata() {
-            Some(app) => app,
-            None => return,
-        };
-        self.emit(DiagnosticEvent {
+        self.emit_event(DiagnosticEventInput {
             kind: DiagnosticKind::Telemetry,
-            name: redact_text(&name),
+            name: name.clone(),
             level: DiagnosticLevel::Info,
             target: "telemetry".to_string(),
-            message: redact_text(&name),
-            timestamp: Utc::now(),
-            fields: sanitize_fields(fields),
-            app,
-        });
+            message: name,
+            fields: fields.into_iter().collect(),
+        })
     }
 
-    pub async fn flush(&self) -> bool {
+    pub async fn flush(&self) -> Result<(), DiagnosticsError> {
         let DiagnosticsInner::Worker { tx, .. } = self.inner.as_ref() else {
-            return true;
+            return Ok(());
         };
         let (reply_tx, reply_rx) = oneshot::channel();
-        if tx.send(WorkerMessage::Flush(reply_tx)).is_err() {
-            return false;
-        }
-        reply_rx.await.unwrap_or(false)
+        tx.send(WorkerMessage::Flush(reply_tx))
+            .map_err(|_| DiagnosticsError::WorkerStopped)?;
+        reply_rx
+            .await
+            .map_err(|_| DiagnosticsError::WorkerStopped)?
     }
 
-    fn emit(&self, event: DiagnosticEvent) {
-        let DiagnosticsInner::Worker { tx, .. } = self.inner.as_ref() else {
-            return;
+    fn emit_event(&self, input: DiagnosticEventInput) -> Result<(), DiagnosticsError> {
+        let Some((app, dependencies)) = self.app_context() else {
+            return Ok(());
         };
-        let _ = tx.send(WorkerMessage::Event(event));
+        self.emit(DiagnosticEvent {
+            kind: input.kind,
+            name: redact_text(&input.name),
+            level: input.level,
+            target: input.target,
+            message: redact_text(&input.message),
+            timestamp: dependencies.now(),
+            fields: sanitize_fields(input.fields),
+            app,
+        })
     }
 
-    fn app_metadata(&self) -> Option<AppDiagnosticMetadata> {
+    fn emit(&self, event: DiagnosticEvent) -> Result<(), DiagnosticsError> {
+        let DiagnosticsInner::Worker { tx, .. } = self.inner.as_ref() else {
+            return Ok(());
+        };
+        tx.send(WorkerMessage::Event(event))
+            .map_err(|_| DiagnosticsError::WorkerStopped)
+    }
+
+    fn app_context(&self) -> Option<(AppDiagnosticMetadata, DiagnosticsDependencies)> {
         match self.inner.as_ref() {
             DiagnosticsInner::Noop => None,
-            DiagnosticsInner::Worker { app, .. } => Some(app.clone()),
+            DiagnosticsInner::Worker {
+                app, dependencies, ..
+            } => Some((app.clone(), dependencies.clone())),
         }
     }
+}
+
+struct DiagnosticEventInput {
+    kind: DiagnosticKind,
+    name: String,
+    level: DiagnosticLevel,
+    target: String,
+    message: String,
+    fields: Vec<(String, String)>,
 }
 
 enum WorkerMessage {
     Event(DiagnosticEvent),
-    Flush(oneshot::Sender<bool>),
+    Flush(oneshot::Sender<Result<(), DiagnosticsError>>),
 }
 
 struct DiagnosticsWorker {
-    config: DiagnosticsConfig,
+    config: DatadogDiagnosticsConfig,
+    dependencies: DiagnosticsDependencies,
     transport: Arc<dyn DiagnosticsTransport>,
     rx: mpsc::UnboundedReceiver<WorkerMessage>,
     buffered: VecDeque<DiagnosticEvent>,
+    last_failure: Option<String>,
 }
 
 impl DiagnosticsWorker {
     fn new(
-        config: DiagnosticsConfig,
+        config: DatadogDiagnosticsConfig,
+        dependencies: DiagnosticsDependencies,
         transport: Arc<dyn DiagnosticsTransport>,
         rx: mpsc::UnboundedReceiver<WorkerMessage>,
     ) -> Self {
         Self {
             config,
+            dependencies,
             transport,
             rx,
             buffered: VecDeque::new(),
+            last_failure: None,
         }
     }
 
@@ -351,17 +377,19 @@ impl DiagnosticsWorker {
                         WorkerMessage::Event(event) => {
                             self.push(event);
                             if self.buffered.len() >= BATCH_SIZE {
-                                let _sent = self.flush_buffer().await;
+                                self.record_flush_result().await;
                             }
                         }
                         WorkerMessage::Flush(reply) => {
-                            let sent = self.flush_buffer().await;
-                            let _ = reply.send(sent);
+                            let result = self.flush_buffer().await;
+                            if reply.send(result).is_err() {
+                                self.last_failure = Some("diagnostics flush receiver dropped".to_string());
+                            }
                         }
                     }
                 }
                 _ = flush_interval.tick() => {
-                    let _sent = self.flush_buffer().await;
+                    self.record_flush_result().await;
                 }
                 else => break,
             }
@@ -375,26 +403,34 @@ impl DiagnosticsWorker {
         self.buffered.push_back(event);
     }
 
-    async fn flush_buffer(&mut self) -> bool {
+    async fn record_flush_result(&mut self) {
+        match self.flush_buffer().await {
+            Ok(()) => self.last_failure = None,
+            Err(e) => self.last_failure = Some(e.to_string()),
+        }
+    }
+
+    async fn flush_buffer(&mut self) -> Result<(), DiagnosticsError> {
         if self.buffered.is_empty() {
-            return true;
+            return Ok(());
         }
 
         let batch_len = self.buffered.len().min(BATCH_SIZE);
         let batch: Vec<_> = self.buffered.drain(..batch_len).collect();
-        let request = match DatadogRequest::build(&self.config, &batch) {
-            Ok(request) => request,
-            Err(_) => {
-                self.restore_front(batch);
-                return false;
-            }
-        };
+        let request =
+            match DatadogRequest::build(&self.config, &batch, self.dependencies.request_id()) {
+                Ok(request) => request,
+                Err(e) => {
+                    self.restore_front(batch);
+                    return Err(e);
+                }
+            };
 
         match send_with_retry(self.transport.as_ref(), request).await {
-            Ok(()) => true,
-            Err(_) => {
+            Ok(()) => Ok(()),
+            Err(e) => {
                 self.restore_front(batch);
-                false
+                Err(e)
             }
         }
     }
@@ -418,8 +454,9 @@ pub struct DatadogRequest {
 
 impl DatadogRequest {
     pub fn build(
-        config: &DiagnosticsConfig,
+        config: &DatadogDiagnosticsConfig,
         events: &[DiagnosticEvent],
+        request_id: String,
     ) -> Result<Self, DiagnosticsError> {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -437,8 +474,7 @@ impl DatadogRequest {
         );
         headers.insert(
             "DD-REQUEST-ID",
-            HeaderValue::from_str(&Uuid::new_v4().to_string())
-                .map_err(DiagnosticsError::InvalidHeader)?,
+            HeaderValue::from_str(&request_id).map_err(DiagnosticsError::InvalidHeader)?,
         );
 
         Ok(Self {
@@ -455,8 +491,8 @@ pub enum DiagnosticsError {
     SpawnWorker(#[source] std::io::Error),
     #[error("diagnostics runtime failed to start")]
     BuildRuntime(#[source] std::io::Error),
-    #[error("diagnostics global state is poisoned")]
-    GlobalPoisoned,
+    #[error("diagnostics worker stopped")]
+    WorkerStopped,
     #[error("diagnostics Datadog site is invalid: {0}")]
     InvalidSite(String),
     #[error("diagnostics Datadog URL is invalid for site {site}: {detail}")]
@@ -546,7 +582,7 @@ pub fn should_retry(error: &DiagnosticsError) -> bool {
         }
         DiagnosticsError::SpawnWorker(_)
         | DiagnosticsError::BuildRuntime(_)
-        | DiagnosticsError::GlobalPoisoned
+        | DiagnosticsError::WorkerStopped
         | DiagnosticsError::InvalidSite(_)
         | DiagnosticsError::InvalidUrl { .. }
         | DiagnosticsError::InvalidHeader(_)
@@ -554,12 +590,14 @@ pub fn should_retry(error: &DiagnosticsError) -> bool {
     }
 }
 
-pub fn tracing_layer() -> DiagnosticsTracingLayer {
-    DiagnosticsTracingLayer
+pub fn tracing_layer(diagnostics: Diagnostics) -> DiagnosticsTracingLayer {
+    DiagnosticsTracingLayer { diagnostics }
 }
 
 #[derive(Clone, Debug)]
-pub struct DiagnosticsTracingLayer;
+pub struct DiagnosticsTracingLayer {
+    diagnostics: Diagnostics,
+}
 
 impl<S> Layer<S> for DiagnosticsTracingLayer
 where
@@ -572,12 +610,15 @@ where
         let message = visitor
             .message
             .unwrap_or_else(|| metadata.name().to_string());
-        Diagnostics::global().log(
+        match self.diagnostics.log(
             DiagnosticLevel::from_tracing(metadata.level()),
             metadata.target(),
             message,
             visitor.fields,
-        );
+        ) {
+            Ok(()) | Err(DiagnosticsError::WorkerStopped) => {}
+            Err(e) => tracing::debug!("diagnostics tracing layer dropped event: {e}"),
+        }
     }
 }
 
@@ -605,40 +646,35 @@ impl EventVisitor {
             fields: Vec::new(),
         }
     }
+
+    fn push_field(&mut self, field: &tracing::field::Field, value: String) {
+        if field.name() == "message" {
+            self.message = Some(value);
+        } else {
+            self.fields.push((field.name().to_string(), value));
+        }
+    }
 }
 
 impl Visit for EventVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
-        if field.name() == "message" {
-            self.message = Some(format!("{value:?}"));
-        } else {
-            self.fields
-                .push((field.name().to_string(), format!("{value:?}")));
-        }
+        self.push_field(field, format!("{value:?}"));
     }
 
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        if field.name() == "message" {
-            self.message = Some(value.to_string());
-        } else {
-            self.fields
-                .push((field.name().to_string(), value.to_string()));
-        }
+        self.push_field(field, value.to_string());
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.fields
-            .push((field.name().to_string(), value.to_string()));
+        self.push_field(field, value.to_string());
     }
 
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.fields
-            .push((field.name().to_string(), value.to_string()));
+        self.push_field(field, value.to_string());
     }
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.fields
-            .push((field.name().to_string(), value.to_string()));
+        self.push_field(field, value.to_string());
     }
 }
 
@@ -679,33 +715,29 @@ fn field_allowed(key: &str) -> bool {
 }
 
 fn redact_text(value: &str) -> String {
-    let value = path_regex().replace_all(value, "[redacted-path]");
-    let value = uuid_regex().replace_all(&value, "[redacted-id]");
-    secret_regex()
+    let regexes = redaction_regexes();
+    let value = regexes.path.replace_all(value, "[redacted-path]");
+    let value = regexes.uuid.replace_all(&value, "[redacted-id]");
+    regexes
+        .secret
         .replace_all(&value, "[redacted-secret]")
         .into_owned()
 }
 
-fn path_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"(?i)(/[A-Za-z0-9._ -]+(?:/[A-Za-z0-9._ -]+)+|[A-Za-z]:\\[^\s]+)")
-            .expect("path redaction regex compiles")
-    })
+struct RedactionRegexes {
+    path: Regex,
+    uuid: Regex,
+    secret: Regex,
 }
 
-fn uuid_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
-            .expect("UUID redaction regex compiles")
-    })
-}
-
-fn secret_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"\b[A-Za-z0-9_-]{32,}\b").expect("secret redaction regex compiles")
+fn redaction_regexes() -> &'static RedactionRegexes {
+    static REGEXES: OnceLock<RedactionRegexes> = OnceLock::new();
+    REGEXES.get_or_init(|| RedactionRegexes {
+        path: Regex::new(r"(?i)(/[A-Za-z0-9._ -]+(?:/[A-Za-z0-9._ -]+)+|[A-Za-z]:\\[^\s]+)")
+            .expect("path redaction regex compiles"),
+        uuid: Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+            .expect("UUID redaction regex compiles"),
+        secret: Regex::new(r"\b[A-Za-z0-9_-]{32,}\b").expect("secret redaction regex compiles"),
     })
 }
 
@@ -729,9 +761,8 @@ mod tests {
     use std::sync::{Mutex, MutexGuard};
     use tracing_subscriber::prelude::*;
 
-    fn config() -> DiagnosticsConfig {
-        DiagnosticsConfig {
-            enabled: true,
+    fn config() -> DatadogDiagnosticsConfig {
+        DatadogDiagnosticsConfig {
             datadog_site: "datadoghq.com".to_string(),
             client_token: "client-token".to_string(),
             source: "ios".to_string(),
@@ -743,6 +774,17 @@ mod tests {
         }
     }
 
+    fn dependencies() -> DiagnosticsDependencies {
+        DiagnosticsDependencies::new(
+            || {
+                DateTime::parse_from_rfc3339("2026-06-20T00:00:00Z")
+                    .expect("test timestamp parses")
+                    .with_timezone(&Utc)
+            },
+            || "request-id".to_string(),
+        )
+    }
+
     fn event() -> DiagnosticEvent {
         DiagnosticEvent {
             kind: DiagnosticKind::Log,
@@ -750,12 +792,24 @@ mod tests {
             level: DiagnosticLevel::Warn,
             target: "target".to_string(),
             message: "message".to_string(),
-            timestamp: DateTime::parse_from_rfc3339("2026-06-20T00:00:00Z")
-                .expect("test timestamp parses")
-                .with_timezone(&Utc),
+            timestamp: dependencies().now(),
             fields: BTreeMap::from([("operation".to_string(), "scan".to_string())]),
             app: config().metadata(),
         }
+    }
+
+    #[test]
+    fn disabled_config_does_not_send_events() {
+        assert!(!DiagnosticsConfig::Disabled.sends_events());
+    }
+
+    #[test]
+    fn enabled_config_requires_every_value() {
+        assert!(DiagnosticsConfig::Enabled(config()).sends_events());
+
+        let mut incomplete = config();
+        incomplete.client_token = String::new();
+        assert!(!DiagnosticsConfig::Enabled(incomplete).sends_events());
     }
 
     #[test]
@@ -808,18 +862,23 @@ mod tests {
     #[test]
     fn no_op_diagnostics_drops_events() {
         let diagnostics = Diagnostics::noop();
-        diagnostics.log(
-            DiagnosticLevel::Info,
-            "target",
-            "message",
-            [("operation".to_string(), "scan".to_string())],
-        );
-        diagnostics.event("opened", [("screen".to_string(), "library".to_string())]);
+        assert!(diagnostics
+            .log(
+                DiagnosticLevel::Info,
+                "target",
+                "message",
+                [("operation".to_string(), "scan".to_string())],
+            )
+            .is_ok());
+        assert!(diagnostics
+            .event("opened", [("screen".to_string(), "library".to_string())])
+            .is_ok());
     }
 
     #[test]
     fn datadog_request_uses_client_intake_shape() {
-        let request = DatadogRequest::build(&config(), &[event()]).expect("request builds");
+        let request = DatadogRequest::build(&config(), &[event()], "request-id".to_string())
+            .expect("request builds");
 
         assert_eq!(
             request.url.as_str(),
@@ -846,8 +905,14 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("ios")
         );
+        assert_eq!(
+            request
+                .headers
+                .get("DD-REQUEST-ID")
+                .and_then(|v| v.to_str().ok()),
+            Some("request-id")
+        );
         assert!(request.headers.contains_key("DD-EVP-ORIGIN-VERSION"));
-        assert!(request.headers.contains_key("DD-REQUEST-ID"));
         let body: serde_json::Value =
             serde_json::from_slice(&request.body).expect("request body is JSON");
         assert_eq!(body.as_array().map(Vec::len), Some(1));
@@ -872,16 +937,18 @@ mod tests {
     #[tokio::test]
     async fn batching_flushes_events_through_transport() {
         let transport = Arc::new(RecordingTransport::new(vec![Ok(())]));
-        let diagnostics =
-            Diagnostics::with_transport(config(), transport.clone()).expect("diagnostics starts");
-        diagnostics.log(
-            DiagnosticLevel::Info,
-            "target",
-            "message",
-            [("operation".to_string(), "scan".to_string())],
-        );
+        let diagnostics = Diagnostics::with_transport(config(), dependencies(), transport.clone())
+            .expect("diagnostics starts");
+        diagnostics
+            .log(
+                DiagnosticLevel::Info,
+                "target",
+                "message",
+                [("operation".to_string(), "scan".to_string())],
+            )
+            .expect("event queues");
 
-        assert!(diagnostics.flush().await);
+        diagnostics.flush().await.expect("flush succeeds");
         let requests = transport.requests();
         assert_eq!(requests.len(), 1);
         let body: serde_json::Value =
@@ -895,12 +962,17 @@ mod tests {
             Err(DiagnosticsError::Status(StatusCode::BAD_REQUEST)),
             Ok(()),
         ]));
-        let diagnostics =
-            Diagnostics::with_transport(config(), transport.clone()).expect("diagnostics starts");
-        diagnostics.event("opened", [("screen".to_string(), "library".to_string())]);
+        let diagnostics = Diagnostics::with_transport(config(), dependencies(), transport.clone())
+            .expect("diagnostics starts");
+        diagnostics
+            .event("opened", [("screen".to_string(), "library".to_string())])
+            .expect("event queues");
 
-        assert!(!diagnostics.flush().await);
-        assert!(diagnostics.flush().await);
+        assert!(matches!(
+            diagnostics.flush().await,
+            Err(DiagnosticsError::Status(StatusCode::BAD_REQUEST))
+        ));
+        diagnostics.flush().await.expect("second flush succeeds");
         assert_eq!(transport.requests().len(), 2);
     }
 
@@ -908,12 +980,11 @@ mod tests {
     #[serial]
     async fn tracing_layer_maps_events_to_diagnostics() {
         let transport = Arc::new(RecordingTransport::new(vec![Ok(())]));
-        let diagnostics =
-            Diagnostics::with_transport(config(), transport.clone()).expect("diagnostics starts");
-        install_global_for_test(diagnostics.clone());
+        let diagnostics = Diagnostics::with_transport(config(), dependencies(), transport.clone())
+            .expect("diagnostics starts");
 
         tracing::subscriber::with_default(
-            tracing_subscriber::registry().with(tracing_layer()),
+            tracing_subscriber::registry().with(tracing_layer(diagnostics.clone())),
             || {
                 tracing::warn!(
                     target: "scan",
@@ -925,7 +996,7 @@ mod tests {
             },
         );
 
-        assert!(diagnostics.flush().await);
+        diagnostics.flush().await.expect("flush succeeds");
         let requests = transport.requests();
         let body: serde_json::Value =
             serde_json::from_slice(&requests[0].body).expect("request body is JSON");
@@ -935,12 +1006,6 @@ mod tests {
         assert_eq!(event["fields"]["operation"], "import");
         assert!(event["fields"].get("path").is_none());
         assert_eq!(event["message"], "release [redacted-id] failed");
-    }
-
-    fn install_global_for_test(diagnostics: Diagnostics) {
-        let lock = GLOBAL_DIAGNOSTICS.get_or_init(|| RwLock::new(Diagnostics::noop()));
-        let mut guard = lock.write().expect("global diagnostics lock is available");
-        *guard = diagnostics;
     }
 
     struct RecordingTransport {

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -56,11 +56,7 @@ pub struct DatadogDiagnosticsConfig {
     pub datadog_site: String,
     pub client_token: String,
     pub source: String,
-    pub service: String,
-    pub environment: String,
-    pub app_version: String,
-    pub edition: String,
-    pub git_commit: String,
+    pub app: AppDiagnosticMetadata,
 }
 
 impl DatadogDiagnosticsConfig {
@@ -73,22 +69,12 @@ impl DatadogDiagnosticsConfig {
             &self.datadog_site,
             &self.client_token,
             &self.source,
-            &self.service,
-            &self.environment,
-            &self.app_version,
-            &self.edition,
-            &self.git_commit,
+            &self.app.service,
+            &self.app.environment,
+            &self.app.app_version,
+            &self.app.edition,
+            &self.app.git_commit,
         ]
-    }
-
-    fn metadata(&self) -> AppDiagnosticMetadata {
-        AppDiagnosticMetadata {
-            service: self.service.clone(),
-            environment: self.environment.clone(),
-            app_version: self.app_version.clone(),
-            edition: self.edition.clone(),
-            git_commit: self.git_commit.clone(),
-        }
     }
 
     fn intake_url(&self) -> Result<Url, DiagnosticsError> {
@@ -229,7 +215,7 @@ impl Diagnostics {
         transport: Arc<dyn DiagnosticsTransport>,
     ) -> Result<Self, DiagnosticsError> {
         let (tx, rx) = mpsc::unbounded_channel();
-        let app = config.metadata();
+        let app = config.app.clone();
         let worker = DiagnosticsWorker::new(config, dependencies.clone(), transport, rx);
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -770,11 +756,13 @@ mod tests {
             datadog_site: "datadoghq.com".to_string(),
             client_token: "client-token".to_string(),
             source: "ios".to_string(),
-            service: "bae".to_string(),
-            environment: "test".to_string(),
-            app_version: "1.2.3".to_string(),
-            edition: "bae".to_string(),
-            git_commit: "abc123".to_string(),
+            app: AppDiagnosticMetadata {
+                service: "bae".to_string(),
+                environment: "test".to_string(),
+                app_version: "1.2.3".to_string(),
+                edition: "bae".to_string(),
+                git_commit: "abc123".to_string(),
+            },
         }
     }
 
@@ -798,7 +786,7 @@ mod tests {
             message: "message".to_string(),
             timestamp: dependencies().now(),
             fields: BTreeMap::from([("operation".to_string(), "scan".to_string())]),
-            app: config().metadata(),
+            app: config().app,
         }
     }
 

--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -61,7 +61,24 @@ pub struct DatadogDiagnosticsConfig {
 
 impl DatadogDiagnosticsConfig {
     fn is_complete(&self) -> bool {
-        self.required_values().iter().all(|value| !value.is_empty())
+        self.required_values()
+            .iter()
+            .all(|value| !value.trim().is_empty())
+    }
+
+    fn normalized(self) -> Self {
+        Self {
+            datadog_site: self.datadog_site.trim().to_string(),
+            client_token: self.client_token.trim().to_string(),
+            source: self.source.trim().to_string(),
+            app: AppDiagnosticMetadata {
+                service: self.app.service.trim().to_string(),
+                environment: self.app.environment.trim().to_string(),
+                app_version: self.app.app_version.trim().to_string(),
+                edition: self.app.edition.trim().to_string(),
+                git_commit: self.app.git_commit.trim().to_string(),
+            },
+        }
     }
 
     fn required_values(&self) -> [&str; 8] {
@@ -206,6 +223,7 @@ impl Diagnostics {
         if !config.is_complete() {
             return Err(DiagnosticsError::IncompleteConfig);
         }
+        let config = config.normalized();
         Self::with_transport(config, dependencies, Arc::new(DatadogTransport::new()))
     }
 
@@ -606,7 +624,10 @@ where
             message,
             visitor.fields,
         ) {
-            Ok(()) | Err(DiagnosticsError::WorkerStopped) => {}
+            Ok(()) => {}
+            Err(DiagnosticsError::WorkerStopped) => {
+                tracing::debug!("diagnostics tracing layer dropped event: worker stopped");
+            }
             Err(e) => tracing::debug!("diagnostics tracing layer dropped event: {e}"),
         }
     }
@@ -644,6 +665,10 @@ impl EventVisitor {
             self.fields.push((field.name().to_string(), value));
         }
     }
+
+    fn record_display(&mut self, field: &tracing::field::Field, value: impl fmt::Display) {
+        self.push_field(field, value.to_string());
+    }
 }
 
 impl Visit for EventVisitor {
@@ -652,19 +677,19 @@ impl Visit for EventVisitor {
     }
 
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.push_field(field, value.to_string());
+        self.record_display(field, value);
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.push_field(field, value.to_string());
+        self.record_display(field, value);
     }
 
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.push_field(field, value.to_string());
+        self.record_display(field, value);
     }
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.push_field(field, value.to_string());
+        self.record_display(field, value);
     }
 }
 
@@ -818,6 +843,24 @@ mod tests {
             ),
             Err(DiagnosticsError::IncompleteConfig)
         ));
+
+        let mut whitespace = config();
+        whitespace.client_token = "   ".to_string();
+        assert!(!DiagnosticsConfig::Enabled(whitespace).sends_events());
+    }
+
+    #[test]
+    fn enabled_config_normalizes_values_before_sending() {
+        let mut config = config();
+        config.datadog_site = " datadoghq.com ".to_string();
+        config.source = " ios ".to_string();
+        config.app.service = " bae ".to_string();
+
+        let normalized = config.normalized();
+
+        assert_eq!(normalized.datadog_site, "datadoghq.com");
+        assert_eq!(normalized.source, "ios");
+        assert_eq!(normalized.app.service, "bae");
     }
 
     #[test]

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod clock;
 pub mod config;
 pub mod cue_flac;
 pub mod db;
+pub mod diagnostics;
 pub mod discogs;
 pub mod encryption;
 pub mod id_provider;


### PR DESCRIPTION
This adds the Rust-owned diagnostics pipeline for logs and telemetry. Crash reporting remains platform-owned; non-crash events flow through bae-core so Rust and host-originated diagnostics share event schema, redaction, batching, retry, and Datadog client intake transport.\n\nTests:\n- cargo test -p bae-core --features test-utils diagnostics\n- cargo test -p bae-bridge\n- env CARGO_BUILD_RUSTC_WRAPPER= PATH=/private/tmp/bae-no-sccache-bin:/usr/bin:/bin:/usr/sbin:/sbin ./bae-bridge/build-macos.sh