### PR TITLE
Route host diagnostics through core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bae-android/app/build.gradle.kts
+++ b/bae-android/app/build.gradle.kts
@@ -13,7 +13,13 @@ val baeVersionName = System.getenv("BAE_VERSION") ?: "0.0-dev"
 val baeVersionCode = (System.getenv("BAE_VERSION_CODE") ?: "1").toInt()
 val baeGitCommit = System.getenv("BAE_GIT_COMMIT") ?: "dev"
 val baeCovenRev = System.getenv("BAE_COVEN_REV") ?: "dev"
+val baeEnvironment = System.getenv("BAE_ENVIRONMENT") ?: ""
+val baeDatadogSite = System.getenv("BAE_DATADOG_SITE") ?: ""
+val baeDatadogClientToken = System.getenv("BAE_DATADOG_CLIENT_TOKEN") ?: ""
 val releaseKeystore = System.getenv("ANDROID_KEYSTORE_FILE")
+
+fun buildConfigString(value: String): String =
+    "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
 
 android {
     namespace = "fm.bae.app"
@@ -28,6 +34,9 @@ android {
 
         buildConfigField("String", "BAE_GIT_COMMIT", "\"$baeGitCommit\"")
         buildConfigField("String", "BAE_COVEN_REV", "\"$baeCovenRev\"")
+        buildConfigField("String", "BAE_ENVIRONMENT", buildConfigString(baeEnvironment))
+        buildConfigField("String", "BAE_DATADOG_SITE", buildConfigString(baeDatadogSite))
+        buildConfigField("String", "BAE_DATADOG_CLIENT_TOKEN", buildConfigString(baeDatadogClientToken))
 
         // The launcher label. The baeium flavor overrides it to "baeium" so the two
         // editions are distinguishable once both are installed.
@@ -54,6 +63,7 @@ android {
         // without credentials. OAuthRedirectActivity binds it in the manifest.
         create("full") {
             dimension = "edition"
+            buildConfigField("String", "BAE_EDITION", "\"bae\"")
             val oauthCreds = file("src/full/assets/oauth-creds.json")
             val redirectScheme =
                 if (oauthCreds.exists()) {
@@ -75,6 +85,7 @@ android {
         // the build never depends on an oauth-creds.json.
         create("baeium") {
             dimension = "edition"
+            buildConfigField("String", "BAE_EDITION", "\"baeium\"")
             manifestPlaceholders["oauthRedirectScheme"] = "fm.bae.oauth.unconfigured"
             // baeium installs alongside the full bae build as a distinct app:
             // applicationId fm.bae.app.baeium (the namespace / R package stays

--- a/bae-android/app/src/full/java/fm/bae/app/OAuthLinking.kt
+++ b/bae-android/app/src/full/java/fm/bae/app/OAuthLinking.kt
@@ -2,7 +2,6 @@ package fm.bae.app
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import androidx.browser.customtabs.CustomTabsIntent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +16,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 
 private const val TAG = "bae.OAuthLinking"
+private val logger = BaeLogger(TAG)
 
 /**
  * Load the host's OAuth client creds (full edition); null when no
@@ -112,7 +112,7 @@ class OAuthLinking private constructor(
                         .bufferedReader()
                         .use { it.readText() }
                 } catch (e: FileNotFoundException) {
-                    Log.d(TAG, "assets/oauth-creds.json not bundled; OAuth linking unavailable")
+                    logger.debug("assets/oauth-creds.json not bundled; OAuth linking unavailable")
                     return null
                 } catch (e: IOException) {
                     throw IllegalStateException("Couldn't read oauth-creds.json: ${e.message}", e)

--- a/bae-android/app/src/main/java/fm/bae/app/AppSession.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/AppSession.kt
@@ -3,7 +3,6 @@ package fm.bae.app
 import android.content.Context
 import android.content.Intent
 import android.os.Looper
-import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import fm.bae.app.data.ConfigStore
@@ -27,6 +26,7 @@ import uniffi.bae_bridge.discoverLibraries
 import uniffi.bae_bridge.initApp
 
 private const val TAG = "bae.AppSession"
+private val logger = BaeLogger(TAG)
 
 /**
  * Position-update tick interval handed to the bridge, in milliseconds. bae-core
@@ -146,7 +146,7 @@ object AppSessionHolder {
             try {
                 discoverLibraries().firstOrNull()
             } catch (e: Exception) {
-                Log.e(TAG, "discoverLibraries failed", e)
+                logger.error("discoverLibraries failed", e)
                 null
             }
         }
@@ -171,7 +171,7 @@ object AppSessionHolder {
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Log.e(TAG, "forgetLibrary failed", e)
+            logger.error("forgetLibrary failed", e)
             onScreen(AppScreen.Failed(e.message ?: "Failed to remove library"))
             return
         }
@@ -242,7 +242,7 @@ object AppSessionHolder {
             // spurious Failed over the open that superseded us.
             throw e
         } catch (e: Exception) {
-            Log.e(TAG, "openLibrary failed for $libraryId", e)
+            logger.error("openLibrary failed for $libraryId", e)
             onScreen(AppScreen.Failed(e.message ?: "Failed to open library"))
         }
     }

--- a/bae-android/app/src/main/java/fm/bae/app/BaeApp.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/BaeApp.kt
@@ -1,13 +1,13 @@
 package fm.bae.app
 
 import android.app.Application
-import android.util.Log
 import io.crates.keyring.Keyring
 import uniffi.bae_bridge.initKeyring
 import uniffi.bae_bridge.setCaCertDir
 import uniffi.bae_bridge.setDataDir
 
 private const val TAG = "bae.BaeApp"
+private val logger = BaeLogger(TAG)
 
 class BaeApp : Application() {
     var oauthLinking: OAuthLinker? = null
@@ -18,6 +18,8 @@ class BaeApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        BaeDiagnostics.configure()
+        logger.info("application launched")
         // Android app processes have no $HOME, which bae-core needs to locate
         // its data root (`~/.bae`). Point it at our private files dir before any
         // library access (discover/restore/initApp) so those don't fail with
@@ -43,7 +45,7 @@ class BaeApp : Application() {
             oauthLinking?.register()
         } catch (e: Exception) {
             oauthLinkingError = e.toString()
-            Log.e(TAG, "Failed to register OAuth client creds", e)
+            logger.error("Failed to register OAuth client creds", e)
         }
     }
 }

--- a/bae-android/app/src/main/java/fm/bae/app/BaeLogger.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/BaeLogger.kt
@@ -1,0 +1,137 @@
+package fm.bae.app
+
+import android.util.Log
+import uniffi.bae_bridge.BridgeAppDiagnosticMetadata
+import uniffi.bae_bridge.BridgeDatadogDiagnosticsConfig
+import uniffi.bae_bridge.BridgeDiagnosticField
+import uniffi.bae_bridge.BridgeDiagnosticLevel
+import uniffi.bae_bridge.BridgeDiagnostics
+import uniffi.bae_bridge.BridgeDiagnosticsConfig
+import uniffi.bae_bridge.configureDiagnostics
+
+private const val DIAGNOSTICS_TAG = "bae.Diagnostics"
+
+object BaeDiagnostics {
+    @Volatile
+    private var diagnostics: BridgeDiagnostics? = null
+
+    fun configure() {
+        try {
+            diagnostics = configureDiagnostics(bridgeConfig())
+        } catch (e: Exception) {
+            Log.e(DIAGNOSTICS_TAG, "Failed to configure diagnostics", e)
+        }
+    }
+
+    fun log(
+        level: BridgeDiagnosticLevel,
+        target: String,
+        message: String,
+        fields: List<BridgeDiagnosticField> = emptyList(),
+    ) {
+        val configured = diagnostics ?: return
+        try {
+            configured.log(level, target, message, fields)
+        } catch (e: Exception) {
+            Log.d(DIAGNOSTICS_TAG, "Failed to send host diagnostic", e)
+        }
+    }
+
+    private fun bridgeConfig(): BridgeDiagnosticsConfig {
+        if (BuildConfig.BAE_EDITION == "bae") {
+            val datadogSite = configuredString(BuildConfig.BAE_DATADOG_SITE)
+            val clientToken = configuredString(BuildConfig.BAE_DATADOG_CLIENT_TOKEN)
+            val environment = configuredString(BuildConfig.BAE_ENVIRONMENT)
+            if (datadogSite != null && clientToken != null && environment != null) {
+                return BridgeDiagnosticsConfig.Enabled(
+                    BridgeDatadogDiagnosticsConfig(
+                        datadogSite = datadogSite,
+                        clientToken = clientToken,
+                        source = "android",
+                        app =
+                            BridgeAppDiagnosticMetadata(
+                                service = "bae",
+                                environment = environment,
+                                appVersion = BuildConfig.VERSION_NAME,
+                                edition = BuildConfig.BAE_EDITION,
+                                gitCommit = BuildConfig.BAE_GIT_COMMIT,
+                            ),
+                    ),
+                )
+            }
+        }
+
+        return BridgeDiagnosticsConfig.Disabled
+    }
+
+    private fun configuredString(value: String): String? {
+        val trimmed = value.trim()
+        return trimmed.takeIf { it.isNotEmpty() && !it.startsWith("\$(") }
+    }
+}
+
+class BaeLogger(
+    private val tag: String,
+) {
+    fun debug(
+        message: String,
+        throwable: Throwable? = null,
+    ) {
+        log(BridgeDiagnosticLevel.DEBUG, message, throwable)
+    }
+
+    fun info(message: String) {
+        log(BridgeDiagnosticLevel.INFO, message, null)
+    }
+
+    fun warning(
+        message: String,
+        throwable: Throwable? = null,
+    ) {
+        log(BridgeDiagnosticLevel.WARN, message, throwable)
+    }
+
+    fun error(
+        message: String,
+        throwable: Throwable? = null,
+    ) {
+        log(BridgeDiagnosticLevel.ERROR, message, throwable)
+    }
+
+    private fun log(
+        level: BridgeDiagnosticLevel,
+        message: String,
+        throwable: Throwable?,
+    ) {
+        Log.println(androidPriority(level), tag, androidMessage(message, throwable))
+        BaeDiagnostics.log(level, tag, diagnosticMessage(message, throwable))
+    }
+
+    private fun androidPriority(level: BridgeDiagnosticLevel): Int =
+        when (level) {
+            BridgeDiagnosticLevel.TRACE, BridgeDiagnosticLevel.DEBUG -> Log.DEBUG
+            BridgeDiagnosticLevel.INFO -> Log.INFO
+            BridgeDiagnosticLevel.WARN -> Log.WARN
+            BridgeDiagnosticLevel.ERROR -> Log.ERROR
+        }
+
+    private fun androidMessage(
+        message: String,
+        throwable: Throwable?,
+    ): String =
+        if (throwable == null) {
+            message
+        } else {
+            "$message\n${Log.getStackTraceString(throwable)}"
+        }
+
+    private fun diagnosticMessage(
+        message: String,
+        throwable: Throwable?,
+    ): String =
+        if (throwable == null) {
+            message
+        } else {
+            "$message: ${throwable::class.java.simpleName}: ${throwable.message}"
+        }
+}

--- a/bae-android/app/src/main/java/fm/bae/app/MainActivity.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/MainActivity.kt
@@ -5,13 +5,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import fm.bae.app.ui.ContentView
 
 private const val TAG = "bae.MainActivity"
+private val logger = BaeLogger(TAG)
 
 internal fun mainActivityIntent(context: Context): Intent =
     Intent(context, MainActivity::class.java).apply {
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
     // is a no-op after the first decision, so it's safe to fire on every launch.
     private val requestNotificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            Log.i(TAG, "POST_NOTIFICATIONS granted=$granted")
+            logger.info("POST_NOTIFICATIONS granted=$granted")
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/bae-android/app/src/main/java/fm/bae/app/data/LibraryStore.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/LibraryStore.kt
@@ -1,6 +1,6 @@
 package fm.bae.app.data
 
-import android.util.Log
+import fm.bae.app.BaeLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,6 +10,7 @@ import uniffi.bae_bridge.BridgeAlbumDetail
 import uniffi.bae_bridge.BridgeRelease
 
 private const val TAG = "bae.LibraryStore"
+private val logger = BaeLogger(TAG)
 
 /**
  * Normalized cache of library entities, populated by sync-driven library
@@ -101,7 +102,7 @@ class LibraryStore {
         _albumDetails.update { details ->
             val existing =
                 details[albumId] ?: run {
-                    Log.w(TAG, "ReleaseUpdated for un-interned album $albumId (release ${release.id}); dropping")
+                    logger.warning("ReleaseUpdated for un-interned album $albumId (release ${release.id}); dropping")
                     return@update details
                 }
             val releases = existing.releases.map { if (it.id == release.id) release else it }
@@ -120,7 +121,7 @@ class LibraryStore {
         _albumDetails.update { details ->
             val existing =
                 details[albumId] ?: run {
-                    Log.w(TAG, "ReleaseRemoved for un-interned album $albumId (release $releaseId); dropping")
+                    logger.warning("ReleaseRemoved for un-interned album $albumId (release $releaseId); dropping")
                     return@update details
                 }
             val releases = existing.releases.filter { it.id != releaseId }

--- a/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
@@ -1,11 +1,12 @@
 package fm.bae.app.data
 
-import android.util.Log
+import fm.bae.app.BaeLogger
 import fm.bae.app.ErrorLines
 import fm.bae.app.playback.PlaybackEventSink
 import uniffi.bae_bridge.BridgeUiEvent
 
 private const val TAG = "bae.UiEventReducer"
+private val logger = BaeLogger(TAG)
 
 /**
  * Reduces [BridgeUiEvent]s into the [LibraryStore], [ConfigStore], and the
@@ -58,7 +59,7 @@ object UiEventReducer {
 
             // Desktop-only events (import/scan/candidate/preview) never fire
             // on mobile; log if one ever does so a future mobile-firing event is visible.
-            else -> Log.d(TAG, "ignoring ${event::class.simpleName}")
+            else -> logger.debug("ignoring ${event::class.simpleName}")
         }
     }
 

--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -9,7 +9,6 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.net.Uri
 import android.os.Looper
-import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -18,6 +17,7 @@ import androidx.media3.common.SimpleBasePlayer
 import androidx.media3.common.util.Util
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import fm.bae.app.BaeLogger
 import fm.bae.app.data.Library
 import fm.bae.app.formatDurationMs
 import fm.bae.app.formatRemainingMs
@@ -103,6 +103,7 @@ interface PlaybackEventSink {
 }
 
 private const val TAG = "bae.BaeCorePlayer"
+private val logger = BaeLogger(TAG)
 
 internal class PlaybackSystemHooks(
     private val context: Context,
@@ -248,7 +249,7 @@ internal class PlaybackSystemHooks(
         val foreground = isAppForeground()
         val hasCurrentTrack = hasCurrentTrack()
         if (!hasCurrentTrack || !foreground) {
-            Log.d(TAG, "Not starting playback service (currentTrack=$hasCurrentTrack, foreground=$foreground)")
+            logger.debug("Not starting playback service (currentTrack=$hasCurrentTrack, foreground=$foreground)")
             return
         }
         try {
@@ -258,7 +259,7 @@ internal class PlaybackSystemHooks(
             // this call, so Android refused the background service start. A
             // service started earlier in this playback session keeps playing;
             // there's nothing to recover.
-            Log.w(TAG, "Could not start playback service from foreground", e)
+            logger.warning("Could not start playback service from foreground", e)
         }
     }
 
@@ -388,7 +389,7 @@ class BaeCorePlayer(
         ): Long {
             if (meta.trackId != playingTrackId) return C.TIME_UNSET
             if (durationMs == C.TIME_UNSET) {
-                Log.w(TAG, "itemDurationMs missing duration for current track ${meta.trackId}")
+                logger.warning("itemDurationMs missing duration for current track ${meta.trackId}")
             }
             return durationMs
         }
@@ -747,8 +748,7 @@ class BaeCorePlayer(
                 }
 
                 else -> {
-                    Log.w(
-                        TAG,
+                    logger.warning(
                         "getState missing current track $playingTrackId in playlist ${metas.map { it.trackId }}",
                     )
                     C.INDEX_UNSET
@@ -846,7 +846,7 @@ class BaeCorePlayer(
                 if (total > 0L) {
                     appHandle.seekByRatio((positionMs.toDouble() / total.toDouble()).coerceIn(0.0, 1.0))
                 } else {
-                    Log.w(TAG, "handleSeek ignored: no duration for in-track seek")
+                    logger.warning("handleSeek ignored: no duration for in-track seek")
                 }
             }
         }

--- a/bae-android/app/src/main/java/fm/bae/app/playback/PlaybackService.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/PlaybackService.kt
@@ -1,13 +1,14 @@
 package fm.bae.app.playback
 
 import android.app.PendingIntent
-import android.util.Log
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import fm.bae.app.AppSessionHolder
+import fm.bae.app.BaeLogger
 import fm.bae.app.mainActivityIntent
 
 private const val TAG = "bae.PlaybackService"
+private val logger = BaeLogger(TAG)
 private const val SESSION_ACTIVITY_REQUEST_CODE = 1
 
 /**
@@ -33,7 +34,7 @@ class PlaybackService : MediaSessionService() {
             // begun — BaeCorePlayer.ensurePlaybackService starts us. If the
             // library was closed between that start and now, there's nothing to
             // host.
-            Log.e(TAG, "onCreate with no open session; stopping")
+            logger.error("onCreate with no open session; stopping")
             stopSelf()
             return
         }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/AlbumDetailScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/AlbumDetailScreen.kt
@@ -1,6 +1,5 @@
 package fm.bae.app.ui
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -50,6 +49,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import fm.bae.app.BaeLogger
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
 import fm.bae.app.formatDurationMs
@@ -63,6 +63,7 @@ import uniffi.bae_bridge.BridgeAlbumDetail
 import uniffi.bae_bridge.BridgeRelease
 
 private const val TAG = "bae.AlbumDetailScreen"
+private val logger = BaeLogger(TAG)
 
 private data class AlbumPlaybackState(
     val currentTrackId: String?,
@@ -112,7 +113,7 @@ fun AlbumDetailScreen(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to load album detail $albumId", e)
+                logger.error("Failed to load album detail $albumId", e)
                 loadError = e.message ?: appContext.getString(R.string.album_load_failed)
             }
         }
@@ -202,7 +203,7 @@ private fun buildAlbumDetailCallbacks(
                 try {
                     session.appHandle.addReleaseNext(it.id)
                 } catch (e: Exception) {
-                    Log.e(TAG, "addReleaseNext ${it.id} failed", e)
+                    logger.error("addReleaseNext ${it.id} failed", e)
                 }
             }
         },
@@ -211,7 +212,7 @@ private fun buildAlbumDetailCallbacks(
                 try {
                     session.appHandle.addReleaseToQueue(it.id)
                 } catch (e: Exception) {
-                    Log.e(TAG, "addReleaseToQueue ${it.id} failed", e)
+                    logger.error("addReleaseToQueue ${it.id} failed", e)
                 }
             }
         },
@@ -219,14 +220,14 @@ private fun buildAlbumDetailCallbacks(
             try {
                 session.appHandle.addNext(listOf(trackId))
             } catch (e: Exception) {
-                Log.e(TAG, "addNext $trackId failed", e)
+                logger.error("addNext $trackId failed", e)
             }
         },
         onAddTrackToQueue = { trackId ->
             try {
                 session.appHandle.addToQueue(listOf(trackId))
             } catch (e: Exception) {
-                Log.e(TAG, "addToQueue $trackId failed", e)
+                logger.error("addToQueue $trackId failed", e)
             }
         },
     )

--- a/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
@@ -1,6 +1,5 @@
 package fm.bae.app.ui
 
-import android.util.Log
 import androidx.compose.animation.core.animate
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -43,6 +42,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Size
+import fm.bae.app.BaeLogger
 import fm.bae.app.R
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -53,6 +53,7 @@ import java.io.File
 
 private const val FULL_RES_SCALE_THRESHOLD = 1.01f
 private const val TAG = "bae.GalleryDialog"
+private val logger = BaeLogger(TAG)
 
 /**
  * Full-screen artwork viewer over a release's gallery items (cover first, then
@@ -256,7 +257,7 @@ private fun RemoteGalleryImage(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to load gallery image $fileId", e)
+                logger.error("Failed to load gallery image $fileId", e)
                 Result.failure(e)
             }
     }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
@@ -1,7 +1,6 @@
 package fm.bae.app.ui
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -65,6 +64,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import fm.bae.app.BaeLogger
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
 import kotlinx.coroutines.CancellationException
@@ -78,6 +78,7 @@ import uniffi.bae_bridge.BridgeSortDirection
 import uniffi.bae_bridge.BridgeSortField
 
 private const val TAG = "bae.LibraryScreen"
+private val logger = BaeLogger(TAG)
 private const val PAGE_SIZE = 60
 private const val GRID_PREFETCH_AHEAD = 12
 private const val PULL_REFRESH_SETTLE_MS = 900L
@@ -143,7 +144,7 @@ private class LibraryPage(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to load first album page", e)
+            logger.error("Failed to load first album page", e)
             error = PageError(e.message ?: appContext.getString(R.string.library_load_failed), onRetry)
         } finally {
             loading = false
@@ -164,7 +165,7 @@ private class LibraryPage(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to load album page at offset $offset", e)
+            logger.error("Failed to load album page at offset $offset", e)
             error = PageError(e.message ?: appContext.getString(R.string.library_load_more_failed), onRetry)
         }
     }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/OnboardingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/OnboardingScreen.kt
@@ -3,7 +3,6 @@ package fm.bae.app.ui
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -44,6 +43,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import fm.bae.app.BaeLogger
 import fm.bae.app.OAuthLinker
 import fm.bae.app.R
 import kotlinx.coroutines.CancellationException
@@ -60,6 +60,7 @@ import uniffi.bae_bridge.decodeRestoreCode
 import uniffi.bae_bridge.restoreFromCodeOperation
 
 private const val TAG = "bae.OnboardingScreen"
+private val logger = BaeLogger(TAG)
 
 private class LinkFlow(
     val job: Job,
@@ -126,9 +127,9 @@ private class LinkLauncher(
                 try {
                     started.execute(code, oauthLinking, oauthLinkingError, context, onLinked)
                 } catch (e: BridgeException.Cancelled) {
-                    Log.d(TAG, "link flow cancelled by bridge", e)
+                    logger.debug("link flow cancelled by bridge", e)
                 } catch (e: CancellationException) {
-                    Log.d(TAG, "link flow coroutine cancelled", e)
+                    logger.debug("link flow coroutine cancelled", e)
                     throw e
                 } catch (e: Exception) {
                     error = e.toString()

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -1,6 +1,5 @@
 package fm.bae.app.ui
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -34,6 +33,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import fm.bae.app.BaeLogger
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
 import fm.bae.app.playback.NowPlaying
@@ -42,6 +42,7 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
 private const val TAG = "bae.QueueScreen"
+private val logger = BaeLogger(TAG)
 
 /** One row's stable identity for the list. The core queue is a list of track
  *  ids that may repeat (the same track can be enqueued twice), so the track id
@@ -101,7 +102,7 @@ fun QueueScreen(
             try {
                 session.appHandle.reorderQueue(fromPos.toUInt(), coreTo.toUInt())
             } catch (e: Exception) {
-                Log.e(TAG, "reorderQueue $fromPos -> $coreTo failed", e)
+                logger.error("reorderQueue $fromPos -> $coreTo failed", e)
             }
         }
 
@@ -162,14 +163,14 @@ private fun androidx.compose.foundation.lazy.LazyListScope.queueContent(
                                 session.appHandle.skipToQueueIndex(index.toUInt())
                                 onDismiss()
                             } catch (e: Exception) {
-                                Log.e(TAG, "skipToQueueIndex $index failed", e)
+                                logger.error("skipToQueueIndex $index failed", e)
                             }
                         },
                         onRemove = {
                             try {
                                 session.appHandle.removeFromQueue(index.toUInt())
                             } catch (e: Exception) {
-                                Log.e(TAG, "removeFromQueue $index failed", e)
+                                logger.error("removeFromQueue $index failed", e)
                             }
                         },
                     )
@@ -199,7 +200,7 @@ private fun QueueHeader(
                 try {
                     session.appHandle.clearQueue()
                 } catch (e: Exception) {
-                    Log.e(TAG, "clearQueue failed", e)
+                    logger.error("clearQueue failed", e)
                 }
             },
             enabled = !isQueueEmpty,

--- a/bae-ios/bae/bae/Info.plist
+++ b/bae-ios/bae/bae/Info.plist
@@ -20,6 +20,14 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>BaeDatadogClientToken</key>
+	<string>$(BAE_DATADOG_CLIENT_TOKEN)</string>
+	<key>BaeDatadogSite</key>
+	<string>$(BAE_DATADOG_SITE)</string>
+	<key>BaeEnvironment</key>
+	<string>$(BAE_ENVIRONMENT)</string>
+	<key>BaeGitCommit</key>
+	<string>$(BAE_GIT_COMMIT)</string>
 	<key>NSCameraUsageDescription</key>
 	<string>bae uses the camera to scan a QR code from your music library.</string>
 	<key>UIBackgroundModes</key>

--- a/bae-ios/bae/bae/MediaControlService.swift
+++ b/bae-ios/bae/bae/MediaControlService.swift
@@ -129,7 +129,7 @@ final class MediaControlService: @unchecked Sendable {
         }
         catch {
             logger.error(
-                "Failed to deactivate audio session: \(error.localizedDescription, privacy: .public)"
+                "Failed to deactivate audio session: \(error.localizedDescription)"
             )
         }
     }
@@ -146,7 +146,7 @@ final class MediaControlService: @unchecked Sendable {
         }
         catch {
             logger.error(
-                "Failed to activate audio session: \(error.localizedDescription, privacy: .public)"
+                "Failed to activate audio session: \(error.localizedDescription)"
             )
         }
     }

--- a/bae-ios/bae/bae/UiEventReducer.swift
+++ b/bae-ios/bae/bae/UiEventReducer.swift
@@ -87,7 +87,7 @@ enum UiEventReducer {
             reduceConfigAndError(event, into: context)
 
         default:
-            logger.debug("ignoring event \(String(describing: event), privacy: .public)")
+            logger.debug("ignoring event \(String(describing: event))")
         }
     }
 

--- a/bae-ios/bae/bae/Views/GalleryView.swift
+++ b/bae-ios/bae/bae/Views/GalleryView.swift
@@ -164,13 +164,13 @@ private struct ZoomableGalleryImage: View {
         }
         catch is CancellationError {
             logger.debug(
-                "gallery thumbnail load cancelled: \(source.description, privacy: .public)"
+                "gallery thumbnail load cancelled: \(source.description)"
             )
             return
         }
         catch {
             logger.warning(
-                "Failed to decode gallery image (\(source.description, privacy: .public)): \(error)"
+                "Failed to decode gallery image (\(source.description)): \(error)"
             )
             failed = true
         }
@@ -186,7 +186,7 @@ private struct ZoomableGalleryImage: View {
             )
             guard !Task.isCancelled else {
                 logger.debug(
-                    "full-res gallery load cancelled after decode: \(source.description, privacy: .public)"
+                    "full-res gallery load cancelled after decode: \(source.description)"
                 )
                 return
             }
@@ -194,13 +194,13 @@ private struct ZoomableGalleryImage: View {
         }
         catch is CancellationError {
             logger.debug(
-                "full-res gallery load cancelled: \(source.description, privacy: .public)"
+                "full-res gallery load cancelled: \(source.description)"
             )
             return
         }
         catch {
             logger.warning(
-                "Failed to decode full-res gallery image (\(source.description, privacy: .public)): \(error)"
+                "Failed to decode full-res gallery image (\(source.description)): \(error)"
             )
         }
     }
@@ -238,12 +238,12 @@ private struct RemoteGalleryImage: View {
             catch is CancellationError {
                 // The viewer was dismissed mid-fetch; leave state as-is.
                 logger.debug(
-                    "gallery image fetch cancelled: \(fileId, privacy: .public)"
+                    "gallery image fetch cancelled: \(fileId)"
                 )
             }
             catch {
                 logger.warning(
-                    "Failed to load gallery image \(fileId, privacy: .public): \(error)"
+                    "Failed to load gallery image \(fileId): \(error)"
                 )
                 failed = true
             }

--- a/bae-ios/bae/bae/Views/ImageView.swift
+++ b/bae-ios/bae/bae/Views/ImageView.swift
@@ -48,12 +48,12 @@ struct ImageView: View {
             )
         }
         catch is CancellationError {
-            logger.debug("cover load cancelled: \(path, privacy: .public)")
+            logger.debug("cover load cancelled: \(path)")
             return
         }
         catch {
             logger.warning(
-                "Failed to load cover at \(path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                "Failed to load cover at \(path): \(error.localizedDescription)"
             )
             image = nil
         }

--- a/bae-ios/bae/bae/baeApp.swift
+++ b/bae-ios/bae/bae/baeApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os.log
 
 @main
 struct BaeApp: App {
@@ -18,6 +19,8 @@ struct BaeApp: App {
         #endif
         var launchError: String?
         do {
+            BaeDiagnostics.configure(source: "ios")
+            Logger.bae("BaeApp").info("application launched")
             // App processes on iOS have no $HOME, which bae-core needs to locate its
             // data root (`~/.bae`). Point it at our Application Support container
             // before any library access (discover/restore/initApp) so those don't

--- a/bae-ios/bae/project.yml
+++ b/bae-ios/bae/project.yml
@@ -29,7 +29,8 @@ targets:
       # — one copy serves both platforms. Each is AppKit-free and references
       # only bridge methods present on the iOS xcframework (or guards the
       # desktop-only ones behind `#if !os(iOS)`).
-      - path: ../../bae-macos/bae/bae/Logger.swift
+      - path: ../../bae-macos/bae/bae/BaeDiagnostics.swift
+      - path: ../../bae-macos/bae/bae/BaeLogger.swift
       - path: ../../bae-macos/bae/bae/Theme.swift
       # AppKit/UIKit-bridged via a `PlatformImage` typealias behind
       # `#if canImport`, so it compiles AppKit-free on iOS.
@@ -110,6 +111,10 @@ targets:
         INFOPLIST_FILE: bae/Info.plist
         SWIFT_VERSION: "6.2"
         IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        BAE_DATADOG_SITE: $(BAE_DATADOG_SITE)
+        BAE_DATADOG_CLIENT_TOKEN: $(BAE_DATADOG_CLIENT_TOKEN)
+        BAE_ENVIRONMENT: $(BAE_ENVIRONMENT)
+        BAE_GIT_COMMIT: $(BAE_GIT_COMMIT)
         # CODE_SIGN_ENTITLEMENTS is set in Config.xcconfig (full) and overridden
         # by the generated Features.xcconfig (baeium), not here — a setting in this
         # block lands in the pbxproj and would override the xcconfig layer the

--- a/bae-macos/bae/bae/BaeApp.swift
+++ b/bae-macos/bae/bae/BaeApp.swift
@@ -435,6 +435,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
     func applicationDidFinishLaunching(_: Notification) {
         if !Self.isPreview {
+            BaeDiagnostics.configure(source: "macos")
+            logger.info("application launched")
             initKeyring()
             // Hand Rust the CloudKit driver once. It can't build the driver
             // itself (it needs the platform CloudKit APIs); installing it is

--- a/bae-macos/bae/bae/BaeDiagnostics.swift
+++ b/bae-macos/bae/bae/BaeDiagnostics.swift
@@ -1,0 +1,97 @@
+import OSLog
+
+enum BaeDiagnostics {
+    private static let osLog = Logger(
+        subsystem: "fm.bae.desktop",
+        category: "Diagnostics"
+    )
+    @MainActor
+    private static var diagnostics: BridgeDiagnostics?
+
+    @MainActor
+    static func configure(source: String) {
+        do {
+            diagnostics = try configureDiagnostics(
+                config: bridgeConfig(source: source)
+            )
+        }
+        catch {
+            osLog.error(
+                "Failed to configure diagnostics: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    static func log(
+        level: BridgeDiagnosticLevel,
+        target: String,
+        message: String,
+        fields: [BridgeDiagnosticField]? = nil
+    ) {
+        Task { @MainActor in
+            guard let diagnostics else { return }
+            do {
+                try diagnostics.log(
+                    level: level,
+                    target: target,
+                    message: message,
+                    fields: fields ?? []
+                )
+            }
+            catch {
+                osLog.debug(
+                    "Failed to send host diagnostic: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private static func bridgeConfig(
+        source: String
+    ) -> BridgeDiagnosticsConfig {
+        guard edition == "bae",
+            let datadogSite = infoString("BaeDatadogSite"),
+            let clientToken = infoString("BaeDatadogClientToken"),
+            let environment = infoString("BaeEnvironment"),
+            let appVersion = infoString("CFBundleShortVersionString"),
+            let gitCommit = infoString("BaeGitCommit")
+        else {
+            return .disabled
+        }
+
+        return .enabled(
+            config: BridgeDatadogDiagnosticsConfig(
+                datadogSite: datadogSite,
+                clientToken: clientToken,
+                source: source,
+                app: BridgeAppDiagnosticMetadata(
+                    service: "bae",
+                    environment: environment,
+                    appVersion: appVersion,
+                    edition: edition,
+                    gitCommit: gitCommit
+                )
+            )
+        )
+    }
+
+    private static var edition: String {
+        #if BAE_OAUTH_PROVIDERS
+            "bae"
+        #else
+            "baeium"
+        #endif
+    }
+
+    private static func infoString(_ key: String) -> String? {
+        guard let value = Bundle.main.infoDictionary?[key] as? String else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed.hasPrefix("$(") {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/bae-macos/bae/bae/BaeLogger.swift
+++ b/bae-macos/bae/bae/BaeLogger.swift
@@ -1,0 +1,56 @@
+import OSLog
+
+struct BaeLogger {
+    private let osLog: Logger
+    private let target: String
+
+    fileprivate init(category: String) {
+        osLog = Logger(subsystem: "fm.bae.desktop", category: category)
+        target = category
+    }
+
+    func debug(_ message: String) {
+        log(message, level: .debug)
+    }
+
+    func info(_ message: String) {
+        log(message, level: .info)
+    }
+
+    func warning(_ message: String) {
+        log(message, level: .warn)
+    }
+
+    func error(_ message: String) {
+        log(message, level: .error)
+    }
+
+    private func log(
+        _ message: String,
+        level: BridgeDiagnosticLevel,
+        fields: [BridgeDiagnosticField]? = nil
+    ) {
+        switch level {
+        case .trace, .debug:
+            osLog.debug("\(message)")
+        case .info:
+            osLog.info("\(message)")
+        case .warn:
+            osLog.warning("\(message)")
+        case .error:
+            osLog.error("\(message)")
+        }
+        BaeDiagnostics.log(
+            level: level,
+            target: target,
+            message: message,
+            fields: fields
+        )
+    }
+}
+
+extension Logger {
+    static func bae(_ category: String) -> BaeLogger {
+        BaeLogger(category: category)
+    }
+}

--- a/bae-macos/bae/bae/Logger.swift
+++ b/bae-macos/bae/bae/Logger.swift
@@ -1,7 +1,0 @@
-import OSLog
-
-extension Logger {
-    static func bae(_ category: String) -> Logger {
-        Logger(subsystem: "fm.bae.desktop", category: category)
-    }
-}

--- a/bae-macos/bae/bae/Services/CloudKitService.swift
+++ b/bae-macos/bae/bae/Services/CloudKitService.swift
@@ -149,7 +149,7 @@
                 }
                 catch {
                     logger.warning(
-                        "failed to remove temp file \(tempURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                        "failed to remove temp file \(tempURL.path): \(error.localizedDescription)"
                     )
                 }
             }

--- a/bae-macos/bae/bae/Services/PlaybackStore.swift
+++ b/bae-macos/bae/bae/Services/PlaybackStore.swift
@@ -77,7 +77,7 @@ class PlaybackStore {
             // no longer current. Dropping it is correct — the newer load owns
             // the now-playing bar — but record it so a stuck bar is diagnosable.
             logger.debug(
-                "dropping stale loading target for \(trackId, privacy: .public); no longer the current track"
+                "dropping stale loading target for \(trackId); no longer the current track"
             )
             return
         }

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -482,7 +482,7 @@ extension UiEventReducer {
         switch event {
         case .albumAdded(let album):
             logger.info(
-                "reducer: albumAdded for album \(album.album.id, privacy: .public)"
+                "reducer: albumAdded for album \(album.album.id)"
             )
             libraryStore.handleAlbumAdded(album: album)
             libraryStore.libraryShapeSubject.send(

--- a/bae-macos/bae/bae/Services/VisionArtworkAnalyzer.swift
+++ b/bae-macos/bae/bae/Services/VisionArtworkAnalyzer.swift
@@ -57,7 +57,7 @@ final class VisionArtworkAnalyzer: ArtworkAnalyzerCallback {
         }
         catch {
             logger.error(
-                "analyze perform failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                "analyze perform failed for \(path): \(error.localizedDescription)"
             )
             return BridgeArtworkAnalysis(barcodes: [], textLines: [])
         }

--- a/bae-macos/bae/bae/Views/ImageView.swift
+++ b/bae-macos/bae/bae/Views/ImageView.swift
@@ -73,8 +73,8 @@ struct ImageView: View {
             logger.warning(
                 """
                 Failed to load \
-                \(source.description, privacy: .public): \
-                \(error.localizedDescription, privacy: .public)
+                \(source.description): \
+                \(error.localizedDescription)
                 """
             )
             loadState = .pending(.failed)

--- a/bae-macos/bae/bae/Views/Import/ImportSearchFlow.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportSearchFlow.swift
@@ -92,7 +92,7 @@ enum ImportSearchFlow {
             }
             catch is CancellationError {
                 logger.debug(
-                    "Search cancelled for key: \(key, privacy: .public)"
+                    "Search cancelled for key: \(key)"
                 )
                 clearSearching(
                     importStore: importStore,
@@ -258,7 +258,7 @@ extension ImportSearchFlow {
             }
             catch is CancellationError {
                 logger.debug(
-                    "Add as Unknown cancelled for key: \(key, privacy: .public)"
+                    "Add as Unknown cancelled for key: \(key)"
                 )
             }
             catch {
@@ -345,7 +345,7 @@ extension ImportSearchFlow {
             }
             catch is CancellationError {
                 logger.debug(
-                    "Prefetch cancelled for key: \(key, privacy: .public)"
+                    "Prefetch cancelled for key: \(key)"
                 )
             }
             catch {

--- a/bae-macos/bae/bae/Views/ReIdentifySheet.swift
+++ b/bae-macos/bae/bae/Views/ReIdentifySheet.swift
@@ -323,7 +323,7 @@ extension ReIdentifySheet {
             }
             catch is CancellationError {
                 logger.debug(
-                    "Re-identify commit cancelled for release \(releaseId, privacy: .public)"
+                    "Re-identify commit cancelled for release \(releaseId)"
                 )
             }
             catch {
@@ -353,7 +353,7 @@ extension ReIdentifySheet {
             }
             catch is CancellationError {
                 logger.debug(
-                    "Refresh cancelled for release \(releaseId, privacy: .public)"
+                    "Refresh cancelled for release \(releaseId)"
                 )
             }
             catch {

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -490,7 +490,7 @@ extension StorageTableView {
                 // loop, never breaking because the guard above never trips.
                 guard libraryStore.releaseDetails[id] != nil else {
                     logger.warning(
-                        "Detail failed to load for expanded release \(id, privacy: .public); leaving it without file rows"
+                        "Detail failed to load for expanded release \(id); leaving it without file rows"
                     )
                     return
                 }

--- a/bae-macos/bae/bae/Views/WelcomeView.swift
+++ b/bae-macos/bae/bae/Views/WelcomeView.swift
@@ -373,7 +373,7 @@ extension WelcomeView {
         }
         catch {
             logger.warning(
-                "Skipping local library discovery: \(error.localizedDescription, privacy: .public)"
+                "Skipping local library discovery: \(error.localizedDescription)"
             )
             localLibraries = []
         }
@@ -389,7 +389,7 @@ extension WelcomeView {
             }
             catch {
                 logger.warning(
-                    "Skipping unreadable keychain restore entry: \(error.localizedDescription, privacy: .public)"
+                    "Skipping unreadable keychain restore entry: \(error.localizedDescription)"
                 )
             }
         }

--- a/bae-macos/bae/project.yml
+++ b/bae-macos/bae/project.yml
@@ -37,6 +37,10 @@ targets:
         SUFeedURL: https://raw.githubusercontent.com/bae-fm/bae/appcast/appcast.xml
         SUPublicEDKey: cYiouOrDxmQrHspLwOf/XpQOQOMt3isdYDs6xEDBGs8=
         SUEnableAutomaticChecks: true
+        BaeDatadogSite: $(BAE_DATADOG_SITE)
+        BaeDatadogClientToken: $(BAE_DATADOG_CLIENT_TOKEN)
+        BaeEnvironment: $(BAE_ENVIRONMENT)
+        BaeGitCommit: $(BAE_GIT_COMMIT)
         CFBundleDocumentTypes:
           - CFBundleTypeName: Folder
             LSItemContentTypes:

--- a/bae-windows-ffi/Cargo.toml
+++ b/bae-windows-ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 [dependencies]
 bae-core = { path = "../bae-core" }
 tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Complex results cross the C ABI as JSON; the C# side deserializes them.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -8,15 +8,74 @@
 //!
 //! This is the binding foundation — methods are added as the WinUI app needs them.
 
-use std::ffi::{c_char, CStr, CString};
+use std::{
+    ffi::{c_char, CStr, CString},
+    sync::{OnceLock, RwLock},
+};
 
 use bae_core::album_detail::ReleaseStorageState;
 use bae_core::app::{bootstrap, RunningApp};
 use bae_core::db::{AlbumSortCriterion, AlbumSortField, SortDirection};
+use bae_core::diagnostics::{
+    AppDiagnosticMetadata, DatadogDiagnosticsConfig, DiagnosticLevel, Diagnostics,
+    DiagnosticsConfig,
+};
 use bae_core::ui::UiBusEvent;
 use serde::{Deserialize, Serialize};
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt};
 
 mod loc;
+
+static DIAGNOSTICS: OnceLock<RwLock<Diagnostics>> = OnceLock::new();
+static LOGGING_INSTALLED: OnceLock<()> = OnceLock::new();
+
+fn diagnostics_cell() -> &'static RwLock<Diagnostics> {
+    DIAGNOSTICS.get_or_init(|| RwLock::new(Diagnostics::noop()))
+}
+
+fn current_diagnostics() -> Diagnostics {
+    diagnostics_cell()
+        .read()
+        .expect("diagnostics lock poisoned")
+        .clone()
+}
+
+fn replace_diagnostics(diagnostics: Diagnostics) {
+    *diagnostics_cell()
+        .write()
+        .expect("diagnostics lock poisoned") = diagnostics;
+}
+
+fn windows_env_filter() -> Result<tracing_subscriber::EnvFilter, String> {
+    match std::env::var("RUST_LOG") {
+        Err(std::env::VarError::NotPresent) => Ok(tracing_subscriber::EnvFilter::new("info")),
+        Err(std::env::VarError::NotUnicode(_)) => Err("RUST_LOG is not valid Unicode".to_string()),
+        Ok(value) => tracing_subscriber::EnvFilter::try_new(&value)
+            .map_err(|e| format!("RUST_LOG={value:?} is malformed: {e}")),
+    }
+}
+
+fn install_logging(diagnostics: Diagnostics) -> Result<(), String> {
+    if LOGGING_INSTALLED.get().is_some() {
+        return Ok(());
+    }
+
+    let filter = windows_env_filter()?;
+    let subscriber = tracing_subscriber::registry()
+        .with(filter)
+        .with(bae_core::diagnostics::tracing_layer(diagnostics))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_line_number(true)
+                .with_target(false)
+                .with_file(true),
+        );
+    if let Err(error) = subscriber.try_init() {
+        tracing::debug!(%error, "tracing subscriber already installed");
+    }
+    let _ = LOGGING_INSTALLED.set(());
+    Ok(())
+}
 
 /// Allocate an owned C string for a catalog key result, or null when the value
 /// has no key (the C# falls back to a passthrough / generic line). The result
@@ -158,6 +217,39 @@ unsafe fn cstr(ptr: *const c_char) -> Option<String> {
     CStr::from_ptr(ptr).to_str().ok().map(str::to_owned)
 }
 
+/// Read a required borrowed C string into an owned `String`.
+///
+/// # Safety
+/// `ptr` must be a valid NUL-terminated UTF-8 C string.
+unsafe fn required_cstr(ptr: *const c_char, name: &str) -> Result<String, String> {
+    optional_cstr(ptr, name)?.ok_or_else(|| format!("{name} is required"))
+}
+
+/// Read an optional borrowed C string into an owned `String`.
+///
+/// # Safety
+/// `ptr` must be null or a valid NUL-terminated UTF-8 C string.
+unsafe fn optional_cstr(ptr: *const c_char, name: &str) -> Result<Option<String>, String> {
+    if ptr.is_null() {
+        return Ok(None);
+    }
+    CStr::from_ptr(ptr)
+        .to_str()
+        .map(|value| Some(value.to_owned()))
+        .map_err(|_| format!("{name} is not valid UTF-8"))
+}
+
+fn configured_value(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || trimmed.starts_with("$(") {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
 /// Initialize the app for `library_id`. Returns a handle pointer, or null on
 /// failure (the error is logged). Free the result with [`bae_handle_free`].
 ///
@@ -187,6 +279,193 @@ pub unsafe extern "C" fn bae_init(
 #[no_mangle]
 pub extern "C" fn bae_startup() {
     bae_core::config::init_keyring();
+}
+
+fn app_diagnostic_metadata_from_parts(
+    service: String,
+    environment: Option<String>,
+    app_version: String,
+    edition: String,
+    git_commit: Option<String>,
+) -> Option<AppDiagnosticMetadata> {
+    Some(AppDiagnosticMetadata {
+        service,
+        environment: environment?,
+        app_version,
+        edition,
+        git_commit: git_commit?,
+    })
+}
+
+fn diagnostics_config_from_parts(
+    datadog_site: Option<String>,
+    client_token: Option<String>,
+    source: String,
+    app: Option<AppDiagnosticMetadata>,
+) -> DiagnosticsConfig {
+    let Some(app) = app else {
+        return DiagnosticsConfig::Disabled;
+    };
+
+    if app.edition != "bae" {
+        return DiagnosticsConfig::Disabled;
+    }
+
+    let (Some(datadog_site), Some(client_token)) = (datadog_site, client_token) else {
+        return DiagnosticsConfig::Disabled;
+    };
+
+    DiagnosticsConfig::Enabled(DatadogDiagnosticsConfig {
+        datadog_site,
+        client_token,
+        source,
+        app,
+    })
+}
+
+/// Configure process diagnostics. Empty/missing Datadog settings and baeium
+/// builds install no-op diagnostics. Returns null on success, else an error
+/// string. Free with [`bae_string_free`].
+///
+/// # Safety
+/// String pointers must be null where optional or valid NUL-terminated UTF-8 C
+/// strings.
+#[no_mangle]
+pub unsafe extern "C" fn bae_configure_diagnostics(
+    datadog_site: *const c_char,
+    client_token: *const c_char,
+    source: *const c_char,
+    service: *const c_char,
+    environment: *const c_char,
+    app_version: *const c_char,
+    edition: *const c_char,
+    git_commit: *const c_char,
+) -> *mut c_char {
+    let result: Result<(), String> = (|| {
+        let source = required_cstr(source, "source")?;
+        let app = app_diagnostic_metadata_from_parts(
+            required_cstr(service, "service")?,
+            configured_value(optional_cstr(environment, "environment")?),
+            required_cstr(app_version, "app_version")?,
+            required_cstr(edition, "edition")?,
+            configured_value(optional_cstr(git_commit, "git_commit")?),
+        );
+        let config = diagnostics_config_from_parts(
+            configured_value(optional_cstr(datadog_site, "datadog_site")?),
+            configured_value(optional_cstr(client_token, "client_token")?),
+            source,
+            app,
+        );
+        let diagnostics =
+            Diagnostics::configure(config).map_err(|e| format!("diagnostics setup failed: {e}"))?;
+        install_logging(diagnostics.clone())?;
+        replace_diagnostics(diagnostics);
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => std::ptr::null_mut(),
+        Err(error) => error_cstring(&error),
+    }
+}
+
+#[derive(Deserialize)]
+struct FfiDiagnosticField {
+    key: String,
+    value: String,
+}
+
+fn diagnostic_fields_from_json(fields_json: &str) -> Result<Vec<(String, String)>, String> {
+    serde_json::from_str::<Vec<FfiDiagnosticField>>(fields_json)
+        .map(|fields| {
+            fields
+                .into_iter()
+                .map(|field| (field.key, field.value))
+                .collect()
+        })
+        .map_err(|e| format!("invalid diagnostic fields JSON: {e}"))
+}
+
+fn diagnostic_level_from_str(level: &str) -> Option<DiagnosticLevel> {
+    match level {
+        "trace" => Some(DiagnosticLevel::Trace),
+        "debug" => Some(DiagnosticLevel::Debug),
+        "info" => Some(DiagnosticLevel::Info),
+        "warn" => Some(DiagnosticLevel::Warn),
+        "error" => Some(DiagnosticLevel::Error),
+        _ => None,
+    }
+}
+
+/// Emit a host-originated log event. Returns null on success, else an error
+/// string. Free with [`bae_string_free`].
+///
+/// # Safety
+/// String pointers must be valid NUL-terminated UTF-8 C strings.
+#[no_mangle]
+pub unsafe extern "C" fn bae_diagnostics_log(
+    level: *const c_char,
+    target: *const c_char,
+    message: *const c_char,
+    fields_json: *const c_char,
+) -> *mut c_char {
+    let result: Result<(), String> = (|| {
+        let level = required_cstr(level, "level")?;
+        let Some(level) = diagnostic_level_from_str(&level) else {
+            return Err(format!("unknown diagnostic level: {level}"));
+        };
+        let fields = diagnostic_fields_from_json(&required_cstr(fields_json, "fields_json")?)?;
+        current_diagnostics()
+            .log(
+                level,
+                required_cstr(target, "target")?,
+                required_cstr(message, "message")?,
+                fields,
+            )
+            .map_err(|e| e.to_string())
+    })();
+
+    match result {
+        Ok(()) => std::ptr::null_mut(),
+        Err(error) => error_cstring(&error),
+    }
+}
+
+/// Emit a host-originated telemetry event. Returns null on success, else an
+/// error string. Free with [`bae_string_free`].
+///
+/// # Safety
+/// String pointers must be valid NUL-terminated UTF-8 C strings.
+#[no_mangle]
+pub unsafe extern "C" fn bae_diagnostics_event(
+    name: *const c_char,
+    fields_json: *const c_char,
+) -> *mut c_char {
+    let result: Result<(), String> = (|| {
+        let fields = diagnostic_fields_from_json(&required_cstr(fields_json, "fields_json")?)?;
+        current_diagnostics()
+            .event(required_cstr(name, "name")?, fields)
+            .map_err(|e| e.to_string())
+    })();
+
+    match result {
+        Ok(()) => std::ptr::null_mut(),
+        Err(error) => error_cstring(&error),
+    }
+}
+
+/// Flush queued diagnostics. Returns null on success, else an error string.
+/// Free with [`bae_string_free`].
+#[no_mangle]
+pub extern "C" fn bae_flush_diagnostics() -> *mut c_char {
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(e) => return error_cstring(&format!("diagnostics flush runtime: {e}")),
+    };
+    match runtime.block_on(current_diagnostics().flush()) {
+        Ok(()) => std::ptr::null_mut(),
+        Err(e) => error_cstring(&e.to_string()),
+    }
 }
 
 /// Register the host's OAuth client credentials so coven can build authorization
@@ -3738,5 +4017,110 @@ mod tests {
         assert_eq!(ffi.thumbnail_url, "https://cover.example/thumb.jpg");
         assert_eq!(ffi.label, "Cover Source");
         assert_eq!(ffi.source, "musicbrainz");
+    }
+
+    #[test]
+    fn diagnostics_level_tags_map_to_core_levels() {
+        assert_eq!(
+            diagnostic_level_from_str("trace"),
+            Some(DiagnosticLevel::Trace)
+        );
+        assert_eq!(
+            diagnostic_level_from_str("debug"),
+            Some(DiagnosticLevel::Debug)
+        );
+        assert_eq!(
+            diagnostic_level_from_str("info"),
+            Some(DiagnosticLevel::Info)
+        );
+        assert_eq!(
+            diagnostic_level_from_str("warn"),
+            Some(DiagnosticLevel::Warn)
+        );
+        assert_eq!(
+            diagnostic_level_from_str("error"),
+            Some(DiagnosticLevel::Error)
+        );
+        assert_eq!(diagnostic_level_from_str("warning"), None);
+    }
+
+    #[test]
+    fn diagnostics_fields_json_maps_key_value_pairs() {
+        let fields = diagnostic_fields_from_json(
+            r#"[{"key":"action","value":"startup"},{"key":"count","value":"1"}]"#,
+        )
+        .expect("diagnostic fields parse");
+
+        assert_eq!(
+            fields,
+            vec![
+                ("action".to_string(), "startup".to_string()),
+                ("count".to_string(), "1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn diagnostics_fields_json_rejects_bad_payloads() {
+        assert!(diagnostic_fields_from_json(r#"{"key":"action","value":"startup"}"#).is_err());
+        assert!(diagnostic_fields_from_json(r#"[{"key":"action"}]"#).is_err());
+    }
+
+    #[test]
+    fn windows_diagnostics_config_disables_baeium_and_missing_datadog_config() {
+        assert_eq!(
+            diagnostics_config_from_parts(
+                Some("datadoghq.com".to_string()),
+                Some("token".to_string()),
+                "windows".to_string(),
+                Some(AppDiagnosticMetadata {
+                    service: "bae".to_string(),
+                    environment: "dev".to_string(),
+                    app_version: "0.0-dev".to_string(),
+                    edition: "baeium".to_string(),
+                    git_commit: "commit".to_string(),
+                }),
+            ),
+            DiagnosticsConfig::Disabled
+        );
+        assert_eq!(
+            diagnostics_config_from_parts(
+                Some("datadoghq.com".to_string()),
+                None,
+                "windows".to_string(),
+                Some(AppDiagnosticMetadata {
+                    service: "bae".to_string(),
+                    environment: "dev".to_string(),
+                    app_version: "0.0-dev".to_string(),
+                    edition: "bae".to_string(),
+                    git_commit: "commit".to_string(),
+                }),
+            ),
+            DiagnosticsConfig::Disabled
+        );
+    }
+
+    #[test]
+    fn windows_diagnostics_config_enables_complete_bae_config() {
+        let config = diagnostics_config_from_parts(
+            Some("datadoghq.com".to_string()),
+            Some("token".to_string()),
+            "windows".to_string(),
+            Some(AppDiagnosticMetadata {
+                service: "bae".to_string(),
+                environment: "dev".to_string(),
+                app_version: "0.0-dev".to_string(),
+                edition: "bae".to_string(),
+                git_commit: "commit".to_string(),
+            }),
+        );
+
+        let DiagnosticsConfig::Enabled(config) = config else {
+            panic!("complete bae diagnostics config should be enabled");
+        };
+        assert_eq!(config.datadog_site, "datadoghq.com");
+        assert_eq!(config.client_token, "token");
+        assert_eq!(config.source, "windows");
+        assert_eq!(config.app.environment, "dev");
     }
 }

--- a/bae-windows/App.xaml.cs
+++ b/bae-windows/App.xaml.cs
@@ -13,6 +13,9 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        BaeDiagnostics.Configure();
+        BaeDiagnostics.Logger.Info("application launched");
+
         // Register the OS credential store before any library key is read or
         // written (discovery, creation, or open).
         NativeBae.Startup();

--- a/bae-windows/BaeLogger.cs
+++ b/bae-windows/BaeLogger.cs
@@ -1,0 +1,136 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+
+namespace Bae.Windows;
+
+internal static class BaeDiagnostics
+{
+    private static readonly Assembly AppAssembly = Assembly.GetExecutingAssembly();
+
+    internal static BaeLogger Logger { get; } = new("bae.windows");
+
+    internal static void Configure()
+    {
+        var appVersion = AppAssembly.GetName().Version;
+        if (appVersion is null)
+        {
+            Trace.TraceError("Assembly version is missing; diagnostics disabled");
+            return;
+        }
+
+        var error = NativeBae.ConfigureDiagnostics(
+            ConfiguredString("BaeDatadogSite"),
+            ConfiguredString("BaeDatadogClientToken"),
+            "windows",
+            "bae",
+            ConfiguredString("BaeEnvironment"),
+            appVersion.ToString(),
+            NativeBae.SupportsOAuthProviders() ? "bae" : "baeium",
+            ConfiguredString("BaeGitCommit"));
+        if (error is not null)
+        {
+            Trace.TraceError($"Failed to configure diagnostics: {error}");
+        }
+    }
+
+    internal static void Flush()
+    {
+        var error = NativeBae.FlushDiagnostics();
+        if (error is not null)
+        {
+            Trace.TraceError($"Failed to flush diagnostics: {error}");
+        }
+    }
+
+    private static string? ConfiguredString(string name)
+    {
+        var value = AppAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => attribute.Key == name)
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.StartsWith("$(", StringComparison.Ordinal) ? null : trimmed;
+    }
+}
+
+internal sealed class BaeLogger
+{
+    private readonly string _target;
+
+    internal BaeLogger(string target)
+    {
+        _target = target;
+    }
+
+    internal void Debug(string message, Exception? exception = null)
+    {
+        Write("debug", message, exception);
+    }
+
+    internal void Info(string message)
+    {
+        Write("info", message, null);
+    }
+
+    internal void Warning(string message, Exception? exception = null)
+    {
+        Write("warn", message, exception);
+    }
+
+    internal void Error(string message, Exception? exception = null)
+    {
+        Write("error", message, exception);
+    }
+
+    private void Write(
+        string level,
+        string message,
+        Exception? exception)
+    {
+        var formatted = Format(message, exception);
+        TraceMessage(level, formatted);
+        Log(level, formatted);
+    }
+
+    private void Log(
+        string level,
+        string message,
+        IEnumerable<KeyValuePair<string, string>>? fields = null)
+    {
+        var error = NativeBae.DiagnosticsLog(
+            level,
+            _target,
+            message,
+            fields);
+        if (error is not null)
+        {
+            Trace.TraceError($"Failed to send host diagnostic: {error}");
+        }
+    }
+
+    private static string Format(string message, Exception? exception) =>
+        exception is null
+            ? message
+            : $"{message}: {exception.GetType().Name}: {exception.Message}";
+
+    private static void TraceMessage(string level, string message)
+    {
+        switch (level)
+        {
+            case "debug":
+            case "info":
+                Trace.TraceInformation(message);
+                break;
+            case "warn":
+                Trace.TraceWarning(message);
+                break;
+            case "error":
+                Trace.TraceError(message);
+                break;
+        }
+    }
+}

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -4045,5 +4045,6 @@ public sealed partial class MainWindow : Window
             NativeBae.HandleFree(_handle);
             _handle = IntPtr.Zero;
         }
+        BaeDiagnostics.Flush();
     }
 }

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Bae.Windows;
 
@@ -21,6 +22,57 @@ internal static class NativeBae
     /// <summary>One-time startup: register the OS credential store.</summary>
     [DllImport(Dll, EntryPoint = "bae_startup", CallingConvention = CallingConvention.Cdecl)]
     internal static extern void Startup();
+
+    [DllImport(Dll, EntryPoint = "bae_configure_diagnostics", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ConfigureDiagnosticsPtr(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? datadogSite,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? clientToken,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string source,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string service,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? environment,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string appVersion,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string edition,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? gitCommit);
+
+    internal static string? ConfigureDiagnostics(
+        string? datadogSite,
+        string? clientToken,
+        string source,
+        string service,
+        string? environment,
+        string appVersion,
+        string edition,
+        string? gitCommit) =>
+        ResultMessage(ConfigureDiagnosticsPtr(datadogSite, clientToken, source, service, environment, appVersion, edition, gitCommit));
+
+    [DllImport(Dll, EntryPoint = "bae_diagnostics_log", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr DiagnosticsLogPtr(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string level,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string target,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string message,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fieldsJson);
+
+    internal static string? DiagnosticsLog(
+        string level,
+        string target,
+        string message,
+        IEnumerable<KeyValuePair<string, string>>? fields = null) =>
+        ResultMessage(DiagnosticsLogPtr(level, target, message, DiagnosticFieldsJson(fields)));
+
+    [DllImport(Dll, EntryPoint = "bae_diagnostics_event", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr DiagnosticsEventPtr(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fieldsJson);
+
+    internal static string? DiagnosticsEvent(
+        string name,
+        IEnumerable<KeyValuePair<string, string>>? fields = null) =>
+        ResultMessage(DiagnosticsEventPtr(name, DiagnosticFieldsJson(fields)));
+
+    [DllImport(Dll, EntryPoint = "bae_flush_diagnostics", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr FlushDiagnosticsPtr();
+
+    internal static string? FlushDiagnostics() => ResultMessage(FlushDiagnosticsPtr());
 
     [DllImport(Dll, EntryPoint = "bae_set_oauth_client_creds", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr SetOauthClientCredsPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string credsJson);
@@ -722,6 +774,13 @@ internal static class NativeBae
     internal static string? ImportCandidate(
         IntPtr handle, string candidateKey, string folderPath, string chosenReleaseId, string source, string storageMode, string userEditJson, string selectedCoverJson) =>
         ResultMessage(ImportCandidatePtr(handle, candidateKey, folderPath, chosenReleaseId, source, storageMode, userEditJson, selectedCoverJson));
+
+    private static string DiagnosticFieldsJson(IEnumerable<KeyValuePair<string, string>>? fields) =>
+        JsonSerializer.Serialize((fields ?? []).Select(field => new DiagnosticField(field.Key, field.Value)));
+
+    private sealed record DiagnosticField(
+        [property: JsonPropertyName("key")] string Key,
+        [property: JsonPropertyName("value")] string Value);
 
     /// <summary>
     /// Copy a Rust-owned UTF-8 string into managed memory and free the native one,

--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -64,6 +64,25 @@
     <PackageReference Include="MessageFormat" Version="7.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BaeDatadogSite</_Parameter1>
+      <_Parameter2>$(BAE_DATADOG_SITE)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BaeDatadogClientToken</_Parameter1>
+      <_Parameter2>$(BAE_DATADOG_CLIENT_TOKEN)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BaeEnvironment</_Parameter1>
+      <_Parameter2>$(BAE_ENVIRONMENT)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BaeGitCommit</_Parameter1>
+      <_Parameter2>$(BAE_GIT_COMMIT)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <!--
     Generated localization resources.
 


### PR DESCRIPTION
Host apps now configure diagnostics from their build metadata and route app logs through bae-core, while still writing to each platform log sink. Missing Datadog settings and baeium builds install disabled diagnostics, so the same host wrappers can stay in place without network sending. Verified with Rust tests and clippy for bae-windows-ffi, bae-core/bae-bridge clippy, Apple Swift format and SwiftLint, macOS and iOS xcodebuild, and the project commit hook. Android and Windows app builds could not run locally because this machine has no Java runtime or dotnet SDK.