### PR TITLE
Configure crash reporting

### DIFF
--- a/bae-android/app/build.gradle.kts
+++ b/bae-android/app/build.gradle.kts
@@ -13,13 +13,14 @@ val baeVersionName = System.getenv("BAE_VERSION") ?: "0.0-dev"
 val baeVersionCode = (System.getenv("BAE_VERSION_CODE") ?: "1").toInt()
 val baeGitCommit = System.getenv("BAE_GIT_COMMIT") ?: "dev"
 val baeCovenRev = System.getenv("BAE_COVEN_REV") ?: "dev"
-val baeEnvironment = System.getenv("BAE_ENVIRONMENT") ?: ""
-val baeDatadogSite = System.getenv("BAE_DATADOG_SITE") ?: ""
-val baeDatadogClientToken = System.getenv("BAE_DATADOG_CLIENT_TOKEN") ?: ""
+val baeEnvironment = System.getenv("BAE_ENVIRONMENT")
+val baeDatadogSite = System.getenv("BAE_DATADOG_SITE")
+val baeDatadogClientToken = System.getenv("BAE_DATADOG_CLIENT_TOKEN")
+val baeSentryDsn = System.getenv("BAE_SENTRY_DSN")
 val releaseKeystore = System.getenv("ANDROID_KEYSTORE_FILE")
 
-fun buildConfigString(value: String): String =
-    "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+fun buildConfigString(value: String?): String =
+    value?.let { "\"${it.replace("\\", "\\\\").replace("\"", "\\\"")}\"" } ?: "null"
 
 android {
     namespace = "fm.bae.app"
@@ -37,6 +38,7 @@ android {
         buildConfigField("String", "BAE_ENVIRONMENT", buildConfigString(baeEnvironment))
         buildConfigField("String", "BAE_DATADOG_SITE", buildConfigString(baeDatadogSite))
         buildConfigField("String", "BAE_DATADOG_CLIENT_TOKEN", buildConfigString(baeDatadogClientToken))
+        buildConfigField("String", "BAE_SENTRY_DSN", buildConfigString(baeSentryDsn))
 
         // The launcher label. The baeium flavor overrides it to "baeium" so the two
         // editions are distinguishable once both are installed.
@@ -183,6 +185,7 @@ dependencies {
     implementation("io.coil-kt.coil3:coil-compose:3.0.4")
     implementation("sh.calvin.reorderable:reorderable:2.4.0")
     implementation("androidx.browser:browser:1.8.0")
+    implementation("io.sentry:sentry-android-ndk:8.16.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.15.1")

--- a/bae-android/app/src/main/java/fm/bae/app/BaeApp.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/BaeApp.kt
@@ -18,6 +18,7 @@ class BaeApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        BaeCrashReporting.configure(this)
         BaeDiagnostics.configure()
         logger.info("application launched")
         // Android app processes have no $HOME, which bae-core needs to locate

--- a/bae-android/app/src/main/java/fm/bae/app/BaeCrashReporting.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/BaeCrashReporting.kt
@@ -1,0 +1,56 @@
+package fm.bae.app
+
+import android.content.Context
+import io.sentry.Sentry
+import io.sentry.android.core.SentryAndroid
+
+private const val CRASH_REPORTING_TAG = "bae.CrashReporting"
+private val crashReportingLogger = BaeLogger(CRASH_REPORTING_TAG)
+
+object BaeCrashReporting {
+    fun configure(context: Context) {
+        val config = config() ?: return
+        try {
+            SentryAndroid.init(context) { options ->
+                options.dsn = config.dsn
+                options.environment = config.environment
+                options.release = "bae@${BuildConfig.VERSION_NAME}+${config.gitCommit}"
+                options.dist = config.gitCommit
+                options.isSendDefaultPii = false
+                options.isEnableNdk = true
+            }
+            Sentry.configureScope { scope ->
+                scope.setTag("edition", config.edition)
+                scope.setTag("git_commit", config.gitCommit)
+            }
+        } catch (e: Exception) {
+            crashReportingLogger.error("Failed to configure crash reporting", e)
+        }
+    }
+
+    private fun config(): CrashReportingConfig? {
+        var config: CrashReportingConfig? = null
+        if (BuildConfig.BAE_EDITION == "bae") {
+            val dsn = configuredBuildString(BuildConfig.BAE_SENTRY_DSN)
+            val environment = configuredBuildString(BuildConfig.BAE_ENVIRONMENT)
+            val gitCommit = configuredBuildString(BuildConfig.BAE_GIT_COMMIT)
+            if (dsn != null && environment != null && gitCommit != null) {
+                config =
+                    CrashReportingConfig(
+                        dsn = dsn,
+                        environment = environment,
+                        edition = BuildConfig.BAE_EDITION,
+                        gitCommit = gitCommit,
+                    )
+            }
+        }
+        return config
+    }
+}
+
+private data class CrashReportingConfig(
+    val dsn: String,
+    val environment: String,
+    val edition: String,
+    val gitCommit: String,
+)

--- a/bae-android/app/src/main/java/fm/bae/app/BaeLogger.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/BaeLogger.kt
@@ -39,9 +39,9 @@ object BaeDiagnostics {
 
     private fun bridgeConfig(): BridgeDiagnosticsConfig {
         if (BuildConfig.BAE_EDITION == "bae") {
-            val datadogSite = configuredString(BuildConfig.BAE_DATADOG_SITE)
-            val clientToken = configuredString(BuildConfig.BAE_DATADOG_CLIENT_TOKEN)
-            val environment = configuredString(BuildConfig.BAE_ENVIRONMENT)
+            val datadogSite = configuredBuildString(BuildConfig.BAE_DATADOG_SITE)
+            val clientToken = configuredBuildString(BuildConfig.BAE_DATADOG_CLIENT_TOKEN)
+            val environment = configuredBuildString(BuildConfig.BAE_ENVIRONMENT)
             if (datadogSite != null && clientToken != null && environment != null) {
                 return BridgeDiagnosticsConfig.Enabled(
                     BridgeDatadogDiagnosticsConfig(
@@ -63,11 +63,11 @@ object BaeDiagnostics {
 
         return BridgeDiagnosticsConfig.Disabled
     }
+}
 
-    private fun configuredString(value: String): String? {
-        val trimmed = value.trim()
-        return trimmed.takeIf { it.isNotEmpty() && !it.startsWith("\$(") }
-    }
+internal fun configuredBuildString(value: String?): String? {
+    val trimmed = value?.trim() ?: return null
+    return trimmed.takeIf { it.isNotEmpty() && !it.startsWith("\$(") }
 }
 
 class BaeLogger(

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -982,14 +982,14 @@ pub struct LibraryManager {
     /// Test-only injection points for the cloud read/write paths, so tests
     /// resolve the cloud home and the sync-ready gate without standing up a live
     /// `SyncManager`.
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     test_overrides: TestOverrides,
 }
 
 /// Test-only overrides for state that production reads from a live
 /// `SyncManager`. Tests that exercise the cloud read/write paths inject these
 /// instead of standing up a full sync stack.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 #[derive(Clone, Default)]
 struct TestOverrides {
     /// Cloud home + encryption. Production wires the cloud home through
@@ -1033,7 +1033,7 @@ impl Clone for LibraryManager {
             upload_throughput: self.upload_throughput.clone(),
             sync_paused: self.sync_paused.clone(),
             download_queue: self.download_queue.clone(),
-            #[cfg(feature = "test-utils")]
+            #[cfg(any(test, feature = "test-utils"))]
             test_overrides: self.test_overrides.clone(),
         }
     }
@@ -1072,7 +1072,7 @@ impl LibraryManager {
             upload_throughput: Arc::new(crate::library::UploadThroughput::new()),
             sync_paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             download_queue: Arc::new(crate::library::DownloadQueue::new()),
-            #[cfg(feature = "test-utils")]
+            #[cfg(any(test, feature = "test-utils"))]
             test_overrides: TestOverrides::default(),
         }
     }
@@ -1081,7 +1081,7 @@ impl LibraryManager {
     /// and `get_encryption_service` resolve without a live `SyncManager`. Used
     /// by transfer tests that read/write the cloud (CloudOnly unmanage, manage
     /// → CloudOnly upload).
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn set_cloud_override(
         &mut self,
         cloud_home: Arc<dyn CloudHome>,
@@ -1094,14 +1094,14 @@ impl LibraryManager {
     /// drives uploads by hand via `process_cloud_uploads_with` calls this so the
     /// CloudOnly manage gate treats the pipeline as running; the refusal test
     /// never calls it, leaving the gate to read the real (absent) sync loop.
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn set_force_sync_ready(&mut self) {
         self.test_overrides.force_sync_ready = true;
     }
 
     /// Shorten the deferred storage-cleanup delay so a scheduled drain runs
     /// promptly under test (production waits `CLEANUP_DELAY`).
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn set_cleanup_delay(&mut self, delay: std::time::Duration) {
         self.test_overrides.cleanup_delay = Some(delay);
     }
@@ -1110,7 +1110,7 @@ impl LibraryManager {
     /// browsable read/write paths against an injected cloud override (production
     /// sets this through the cloud-setup wizard). `cloud_blob_cipher` reads it to
     /// pick plaintext vs. encrypted.
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn set_home_storage(&self, storage: crate::config::HomeStorage) {
         self.config_handle
             .update(|c| c.cloud_home.storage = storage)
@@ -1122,7 +1122,7 @@ impl LibraryManager {
     /// `storage_path(id)` default. Mirrors what `ResolvedTrackAudio` threads into
     /// the cloud reader, exposed so a test can assert the read key matches the
     /// stored upload key without setting up full playback.
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub async fn resolve_track_cloud_key_for_test(&self, file_id: &str) -> String {
         let file = self
             .database
@@ -1136,7 +1136,7 @@ impl LibraryManager {
     /// The readable cover `cloud_path` the current home would store for a
     /// release: `Some({artist}/{album}/cover.{ext})` on a browsable home, `None`
     /// on an opaque one. Exposes the same computation `change_cover` performs.
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub async fn cover_cloud_path_for_test(
         &self,
         release_id: &str,
@@ -1153,7 +1153,7 @@ impl LibraryManager {
     /// deletion entry point (delete_release/delete_album/unpin/unmanage) routes
     /// through here so the queued local `storage/` copies are actually removed.
     fn spawn_cleanup(&self) {
-        #[cfg(feature = "test-utils")]
+        #[cfg(any(test, feature = "test-utils"))]
         if let Some(delay) = self.test_overrides.cleanup_delay {
             crate::storage::local::cleanup::schedule_cleanup_after(&self.library_dir, delay);
             return;
@@ -1194,7 +1194,7 @@ impl LibraryManager {
     }
 
     fn encryption_service_inner(&self) -> Option<EncryptionService> {
-        #[cfg(feature = "test-utils")]
+        #[cfg(any(test, feature = "test-utils"))]
         if let Some((_, encryption)) = &self.test_overrides.cloud {
             return Some(encryption.clone());
         }
@@ -1726,7 +1726,7 @@ impl LibraryManager {
     }
 
     pub fn get_cloud_home(&self) -> Option<Arc<dyn CloudHome>> {
-        #[cfg(feature = "test-utils")]
+        #[cfg(any(test, feature = "test-utils"))]
         if let Some((cloud_home, _)) = &self.test_overrides.cloud {
             return Some(cloud_home.clone());
         }
@@ -4807,7 +4807,7 @@ impl LibraryManager {
     /// flip — the release only becomes managed once the upload observer (which
     /// fires from inside the running loop) confirms the last upload landed.
     pub fn is_sync_ready(&self) -> bool {
-        #[cfg(feature = "test-utils")]
+        #[cfg(any(test, feature = "test-utils"))]
         if self.test_overrides.force_sync_ready {
             return true;
         }

--- a/bae-ios/bae/bae/Info.plist
+++ b/bae-ios/bae/bae/Info.plist
@@ -28,6 +28,8 @@
 	<string>$(BAE_ENVIRONMENT)</string>
 	<key>BaeGitCommit</key>
 	<string>$(BAE_GIT_COMMIT)</string>
+	<key>BaeSentryDsn</key>
+	<string>$(BAE_SENTRY_DSN)</string>
 	<key>NSCameraUsageDescription</key>
 	<string>bae uses the camera to scan a QR code from your music library.</string>
 	<key>UIBackgroundModes</key>

--- a/bae-ios/bae/bae/baeApp.swift
+++ b/bae-ios/bae/bae/baeApp.swift
@@ -19,6 +19,7 @@ struct BaeApp: App {
         #endif
         var launchError: String?
         do {
+            BaeCrashReporting.configure()
             BaeDiagnostics.configure(source: "ios")
             Logger.bae("BaeApp").info("application launched")
             // App processes on iOS have no $HOME, which bae-core needs to locate its

--- a/bae-ios/bae/project.yml
+++ b/bae-ios/bae/project.yml
@@ -7,6 +7,10 @@ options:
     # 16.0 (the FFmpeg link floor), which a 17.0 app target satisfies.
     iOS: "17.0"
   xcodeVersion: "26.0"
+packages:
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    exactVersion: "9.18.0"
 targets:
   bae:
     type: application
@@ -30,6 +34,7 @@ targets:
       # only bridge methods present on the iOS xcframework (or guards the
       # desktop-only ones behind `#if !os(iOS)`).
       - path: ../../bae-macos/bae/bae/BaeDiagnostics.swift
+      - path: ../../bae-macos/bae/bae/BaeCrashReporting.swift
       - path: ../../bae-macos/bae/bae/BaeLogger.swift
       - path: ../../bae-macos/bae/bae/Theme.swift
       # AppKit/UIKit-bridged via a `PlatformImage` typealias behind
@@ -102,6 +107,7 @@ targets:
           fi
     dependencies:
       - framework: ../BaeBridgeFFI-ios.xcframework
+      - package: Sentry
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: fm.bae.bae
@@ -115,6 +121,7 @@ targets:
         BAE_DATADOG_CLIENT_TOKEN: $(BAE_DATADOG_CLIENT_TOKEN)
         BAE_ENVIRONMENT: $(BAE_ENVIRONMENT)
         BAE_GIT_COMMIT: $(BAE_GIT_COMMIT)
+        BAE_SENTRY_DSN: $(BAE_SENTRY_DSN)
         # CODE_SIGN_ENTITLEMENTS is set in Config.xcconfig (full) and overridden
         # by the generated Features.xcconfig (baeium), not here — a setting in this
         # block lands in the pbxproj and would override the xcconfig layer the

--- a/bae-macos/bae/bae/BaeApp.swift
+++ b/bae-macos/bae/bae/BaeApp.swift
@@ -435,6 +435,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
     func applicationDidFinishLaunching(_: Notification) {
         if !Self.isPreview {
+            BaeCrashReporting.configure()
             BaeDiagnostics.configure(source: "macos")
             logger.info("application launched")
             initKeyring()

--- a/bae-macos/bae/bae/BaeCrashReporting.swift
+++ b/bae-macos/bae/bae/BaeCrashReporting.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Sentry
+
+enum BaeCrashReporting {
+    static func configure() {
+        guard let config = config() else { return }
+        SentrySDK.start { options in
+            options.dsn = config.dsn
+            options.environment = config.environment
+            options.releaseName = config.releaseName
+            options.dist = config.gitCommit
+            options.sendDefaultPii = false
+        }
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: config.edition, key: "edition")
+            scope.setTag(value: config.gitCommit, key: "git_commit")
+        }
+    }
+
+    private static func config() -> CrashReportingConfig? {
+        guard edition == "bae",
+            let dsn = infoString("BaeSentryDsn"),
+            let environment = infoString("BaeEnvironment"),
+            let appVersion = infoString("CFBundleShortVersionString"),
+            let gitCommit = infoString("BaeGitCommit")
+        else {
+            return nil
+        }
+        return CrashReportingConfig(
+            dsn: dsn,
+            environment: environment,
+            releaseName: "bae@\(appVersion)+\(gitCommit)",
+            edition: edition,
+            gitCommit: gitCommit
+        )
+    }
+
+    private static var edition: String {
+        #if BAE_OAUTH_PROVIDERS
+            "bae"
+        #else
+            "baeium"
+        #endif
+    }
+
+    private static func infoString(_ key: String) -> String? {
+        guard let value = Bundle.main.infoDictionary?[key] as? String else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed.hasPrefix("$(") {
+            return nil
+        }
+        return trimmed
+    }
+}
+
+private struct CrashReportingConfig {
+    let dsn: String
+    let environment: String
+    let releaseName: String
+    let edition: String
+    let gitCommit: String
+}

--- a/bae-macos/bae/project.yml
+++ b/bae-macos/bae/project.yml
@@ -14,6 +14,9 @@ packages:
   swift-collections:
     url: https://github.com/apple/swift-collections
     from: "1.4.1"
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    exactVersion: "9.18.0"
 targets:
   bae:
     type: application
@@ -41,6 +44,7 @@ targets:
         BaeDatadogClientToken: $(BAE_DATADOG_CLIENT_TOKEN)
         BaeEnvironment: $(BAE_ENVIRONMENT)
         BaeGitCommit: $(BAE_GIT_COMMIT)
+        BaeSentryDsn: $(BAE_SENTRY_DSN)
         CFBundleDocumentTypes:
           - CFBundleTypeName: Folder
             LSItemContentTypes:
@@ -88,6 +92,7 @@ targets:
       - framework: ../BaeBridgeFFI.xcframework
         embed: false
       - package: Sparkle
+      - package: Sentry
       - package: swift-collections
         product: OrderedCollections
       - sdk: CoreAudio.framework

--- a/bae-windows/App.xaml.cs
+++ b/bae-windows/App.xaml.cs
@@ -13,6 +13,7 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        BaeCrashReporting.Configure();
         BaeDiagnostics.Configure();
         BaeDiagnostics.Logger.Info("application launched");
 

--- a/bae-windows/BaeCrashReporting.cs
+++ b/bae-windows/BaeCrashReporting.cs
@@ -1,0 +1,162 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using Sentry;
+
+namespace Bae.Windows;
+
+internal static class BaeCrashReporting
+{
+    private static readonly Assembly AppAssembly = Assembly.GetExecutingAssembly();
+    private static IDisposable? _managedSdk;
+
+    internal static void Configure()
+    {
+        if (_managedSdk is not null)
+        {
+            return;
+        }
+
+        var config = Config();
+        if (config is null)
+        {
+            return;
+        }
+
+        _managedSdk = SentrySdk.Init(options =>
+        {
+            options.Dsn = config.Dsn;
+            options.Environment = config.Environment;
+            options.Release = config.Release;
+            options.SendDefaultPii = false;
+        });
+        SentrySdk.ConfigureScope(scope =>
+        {
+            scope.SetTag("edition", config.Edition);
+            scope.SetTag("git_commit", config.GitCommit);
+        });
+        ConfigureNative(config);
+    }
+
+    private static CrashReportingConfig? Config()
+    {
+        if (!NativeBae.SupportsOAuthProviders())
+        {
+            return null;
+        }
+        var appVersion = AppAssembly.GetName().Version;
+        var dsn = ConfiguredString("BaeSentryDsn");
+        var environment = ConfiguredString("BaeEnvironment");
+        var gitCommit = ConfiguredString("BaeGitCommit");
+        if (appVersion is null || dsn is null || environment is null || gitCommit is null)
+        {
+            return null;
+        }
+        return new CrashReportingConfig(
+            dsn,
+            environment,
+            $"bae@{appVersion}+{gitCommit}",
+            "bae",
+            gitCommit);
+    }
+
+    private static void ConfigureNative(CrashReportingConfig config)
+    {
+        try
+        {
+            var appDir = AppContext.BaseDirectory;
+            var handler = Path.Combine(appDir, "crashpad_handler.exe");
+            if (!File.Exists(handler))
+            {
+                BaeDiagnostics.Logger.Error($"Sentry native handler missing at {handler}");
+                return;
+            }
+
+            var options = NativeSentry.OptionsNew();
+            NativeSentry.OptionsSetDsn(options, config.Dsn);
+            NativeSentry.OptionsSetEnvironment(options, config.Environment);
+            NativeSentry.OptionsSetRelease(options, config.Release);
+            NativeSentry.OptionsSetDist(options, config.GitCommit);
+            NativeSentry.OptionsSetDebug(options, 0);
+            NativeSentry.OptionsSetAutoSessionTracking(options, 1);
+            NativeSentry.OptionsSetHandlerPath(options, handler);
+            var databasePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "bae",
+                "sentry-native");
+            Directory.CreateDirectory(databasePath);
+            NativeSentry.OptionsSetDatabasePath(options, databasePath);
+
+            if (NativeSentry.Init(options) != 0)
+            {
+                BaeDiagnostics.Logger.Error("Failed to configure native crash reporting");
+                return;
+            }
+            NativeSentry.SetTag("edition", config.Edition);
+            NativeSentry.SetTag("git_commit", config.GitCommit);
+        }
+        catch (Exception exception) when (
+            exception is DllNotFoundException
+                or EntryPointNotFoundException
+                or BadImageFormatException)
+        {
+            BaeDiagnostics.Logger.Error("Failed to load native crash reporting", exception);
+        }
+    }
+
+    private static string? ConfiguredString(string name)
+    {
+        var value = AppAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => attribute.Key == name)
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.StartsWith("$(", StringComparison.Ordinal) ? null : trimmed;
+    }
+}
+
+internal sealed record CrashReportingConfig(
+    string Dsn,
+    string Environment,
+    string Release,
+    string Edition,
+    string GitCommit);
+
+internal static class NativeSentry
+{
+    [DllImport("sentry", EntryPoint = "sentry_options_new", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint OptionsNew();
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_dsn", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void OptionsSetDsn(nint options, string dsn);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_environment", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void OptionsSetEnvironment(nint options, string environment);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_release", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void OptionsSetRelease(nint options, string release);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_dist", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void OptionsSetDist(nint options, string dist);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_debug", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void OptionsSetDebug(nint options, int debug);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_auto_session_tracking", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void OptionsSetAutoSessionTracking(nint options, int enabled);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_handler_path", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void OptionsSetHandlerPath(nint options, string path);
+
+    [DllImport("sentry", EntryPoint = "sentry_options_set_database_path", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void OptionsSetDatabasePath(nint options, string path);
+
+    [DllImport("sentry", EntryPoint = "sentry_init", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int Init(nint options);
+
+    [DllImport("sentry", EntryPoint = "sentry_set_tag", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    internal static extern void SetTag(string key, string value);
+}

--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -55,6 +55,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260508005" />
+    <PackageReference Include="Sentry" Version="6.6.0" />
     <!--
       ICU MessageFormat 1 runtime. The localization catalog stores each message
       as a verbatim MF1 string (plural / select / named args); this parses it at
@@ -80,6 +81,10 @@
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>BaeGitCommit</_Parameter1>
       <_Parameter2>$(BAE_GIT_COMMIT)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BaeSentryDsn</_Parameter1>
+      <_Parameter2>$(BAE_SENTRY_DSN)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 


### PR DESCRIPTION
This wires platform-native Sentry crash reporting into the full bae edition while leaving baeium unconfigured. The app startup paths initialize crash reporting before diagnostics/core startup, and platform config now carries the Sentry DSN without embedding credentials. The Rust test cfg fix keeps the plain unit-test path compiling when local test overrides are used inside bae-core unit tests.