### PR TITLE
Configure release crash symbols

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -38,6 +38,18 @@ on:
         required: false
       ANDROID_KEY_PASSWORD:
         required: false
+      BAE_DATADOG_SITE:
+        required: false
+      BAE_DATADOG_CLIENT_TOKEN:
+        required: false
+      BAE_SENTRY_DSN:
+        required: false
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_ORG:
+        required: false
+      SENTRY_PROJECT:
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -72,15 +84,19 @@ jobs:
       # the full set).
       run: |
         if [ "${{ inputs.edition }}" = "baeium" ]; then
-          echo "BAE_BRIDGE_FEATURES=" >> "$GITHUB_ENV"
-          echo "GRADLE_FLAVOR=Baeium" >> "$GITHUB_ENV"
-          echo "APK_FLAVOR=baeium" >> "$GITHUB_ENV"
-          echo "EDITION_APK=baeium-android.apk" >> "$GITHUB_ENV"
+          {
+            echo "BAE_BRIDGE_FEATURES="
+            echo "GRADLE_FLAVOR=Baeium"
+            echo "APK_FLAVOR=baeium"
+            echo "EDITION_APK=baeium-android.apk"
+          } >> "$GITHUB_ENV"
         else
-          echo "BAE_BRIDGE_FEATURES=oauth-providers" >> "$GITHUB_ENV"
-          echo "GRADLE_FLAVOR=Full" >> "$GITHUB_ENV"
-          echo "APK_FLAVOR=full" >> "$GITHUB_ENV"
-          echo "EDITION_APK=bae-android.apk" >> "$GITHUB_ENV"
+          {
+            echo "BAE_BRIDGE_FEATURES=oauth-providers"
+            echo "GRADLE_FLAVOR=Full"
+            echo "APK_FLAVOR=full"
+            echo "EDITION_APK=bae-android.apk"
+          } >> "$GITHUB_ENV"
         fi
 
     - name: Setup JDK 17
@@ -135,12 +151,20 @@ jobs:
       # build; debug leaves these unset so build.gradle.kts / build.rs use their
       # dev defaults.
       if: inputs.profile == 'release'
+      env:
+        BAE_DATADOG_SITE: ${{ secrets.BAE_DATADOG_SITE }}
+        BAE_DATADOG_CLIENT_TOKEN: ${{ secrets.BAE_DATADOG_CLIENT_TOKEN }}
+        BAE_SENTRY_DSN: ${{ secrets.BAE_SENTRY_DSN }}
       run: |
         {
           echo "BAE_VERSION=${{ inputs.version }}"
           echo "BAE_VERSION_CODE=${{ inputs.version_code }}"
           echo "BAE_GIT_COMMIT=$(git rev-parse --short HEAD)"
           echo "BAE_COVEN_REV=$(scripts/coven-rev.sh)"
+          echo "BAE_ENVIRONMENT=production"
+          echo "BAE_DATADOG_SITE=$BAE_DATADOG_SITE"
+          echo "BAE_DATADOG_CLIENT_TOKEN=$BAE_DATADOG_CLIENT_TOKEN"
+          echo "BAE_SENTRY_DSN=$BAE_SENTRY_DSN"
         } >> "$GITHUB_ENV"
 
     - name: Cross-compile bae-bridge for Android
@@ -216,6 +240,20 @@ jobs:
         "$APKSIGNER" verify --verbose "$APK"
         cp "$APK" "$EDITION_APK"
         echo "Verified signed APK: $APK -> $EDITION_APK"
+
+    - name: Upload Android native symbols to Sentry
+      if: inputs.profile == 'release' && inputs.edition == 'full'
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      run: |
+        if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_ORG:-}" || -z "${SENTRY_PROJECT:-}" ]]; then
+          echo "Sentry native symbol upload skipped: SENTRY_AUTH_TOKEN, SENTRY_ORG, or SENTRY_PROJECT is unset"
+          exit 0
+        fi
+        curl -sL https://sentry.io/get-cli/ | bash
+        sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" bae-android/debug-symbols
 
     - name: Upload signed APK artifact
       if: inputs.profile == 'release'

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -64,6 +64,11 @@ jobs:
     needs: calculate-version
     permissions:
       contents: read
+    env:
+      BAE_ENVIRONMENT: production
+      BAE_DATADOG_SITE: ${{ secrets.BAE_DATADOG_SITE }}
+      BAE_DATADOG_CLIENT_TOKEN: ${{ secrets.BAE_DATADOG_CLIENT_TOKEN }}
+      BAE_SENTRY_DSN: ${{ secrets.BAE_SENTRY_DSN }}
     strategy:
       # Both editions from one source: full (bae, fm.bae.bae) and baeium (
       # fm.bae.bae.baeium). Each only uploads its .ipa as an artifact; the publish
@@ -123,7 +128,9 @@ jobs:
       run: ./scripts/build-ffmpeg-ios.sh
 
     - name: Set release version
-      run: echo "BAE_VERSION=${{ needs.calculate-version.outputs.version }}" >> "$GITHUB_ENV"
+      run: |
+        echo "BAE_VERSION=${{ needs.calculate-version.outputs.version }}" >> "$GITHUB_ENV"
+        echo "BAE_GIT_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
     - name: Build Rust bridge (iOS xcframework)
       run: |
@@ -165,7 +172,33 @@ jobs:
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
           PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
           PRODUCT_NAME="$PRODUCT_NAME" \
+          DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
           archive
+
+    - name: Package dSYM
+      if: matrix.edition == 'full'
+      run: |
+        DSYM_DIR="build/bae.xcarchive/dSYMs"
+        if [[ ! -d "$DSYM_DIR" ]]; then
+          echo "archive dSYM directory not found at $DSYM_DIR" >&2
+          exit 1
+        fi
+        ditto -c -k --sequesterRsrc --keepParent "$DSYM_DIR" bae-ios.dSYM.zip
+        echo "BAE_DSYM_DIR=$DSYM_DIR" >> "$GITHUB_ENV"
+
+    - name: Upload dSYM to Sentry
+      if: matrix.edition == 'full'
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      run: |
+        if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_ORG:-}" || -z "${SENTRY_PROJECT:-}" ]]; then
+          echo "Sentry dSYM upload skipped: SENTRY_AUTH_TOKEN, SENTRY_ORG, or SENTRY_PROJECT is unset"
+          exit 0
+        fi
+        curl -sL https://sentry.io/get-cli/ | bash
+        sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$BAE_DSYM_DIR"
 
     - name: Package unsigned IPA
       run: |
@@ -190,6 +223,14 @@ jobs:
         path: ${{ env.IPA_NAME }}
         retention-days: 30
 
+    - name: Upload dSYM artifact
+      if: matrix.edition == 'full'
+      uses: actions/upload-artifact@v7
+      with:
+        name: bae-iOS-dSYM
+        path: bae-ios.dSYM.zip
+        retention-days: 30
+
   publish:
     name: Publish release
     needs: [calculate-version, build]
@@ -211,6 +252,12 @@ jobs:
         path: dist
         merge-multiple: true
 
+    - name: Download bae dSYM
+      uses: actions/download-artifact@v8
+      with:
+        name: bae-iOS-dSYM
+        path: dist
+
     - name: Create git tag
       run: |
         VERSION="${{ needs.calculate-version.outputs.version }}"
@@ -230,6 +277,7 @@ jobs:
         files: |
           dist/bae-ios.ipa
           dist/baeium-ios.ipa
+          dist/bae-ios.dSYM.zip
         body: |
           iOS builds are **unsigned** .ipa files for sideloading — install with
           AltStore, Sideloadly, or Xcode (they re-sign with your own Apple ID, no

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -63,6 +63,11 @@ jobs:
     needs: [calculate-version, ci]
     permissions:
       contents: read
+    env:
+      BAE_ENVIRONMENT: production
+      BAE_DATADOG_SITE: ${{ secrets.BAE_DATADOG_SITE }}
+      BAE_DATADOG_CLIENT_TOKEN: ${{ secrets.BAE_DATADOG_CLIENT_TOKEN }}
+      BAE_SENTRY_DSN: ${{ secrets.BAE_SENTRY_DSN }}
     strategy:
       # Build both editions from the one source: full (bae, OAuth + iCloud) and
       # baeium (S3-only). Each only uploads its signed DMG + appcast as an
@@ -121,12 +126,13 @@ jobs:
     - name: Set release version
       run: |
         VERSION="${{ needs.calculate-version.outputs.version }}"
-        echo "BAE_VERSION=$VERSION" >> $GITHUB_ENV
+        echo "BAE_VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "BAE_GIT_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
         sed -i '' "s/MARKETING_VERSION: .*/MARKETING_VERSION: \"$VERSION\"/" bae-macos/bae/project.yml
         MACOS_MIN=$(grep 'macOS:' bae-macos/bae/project.yml | head -1 | sed 's/.*"\(.*\)"/\1/')
         # Empty here would stamp an empty sparkle:minimumSystemVersion into the appcast.
         if [[ -z "$MACOS_MIN" ]]; then echo "could not read macOS deployment target from project.yml" >&2; exit 1; fi
-        echo "MACOS_MIN=$MACOS_MIN" >> $GITHUB_ENV
+        echo "MACOS_MIN=$MACOS_MIN" >> "$GITHUB_ENV"
         echo "Building version $VERSION (macOS $MACOS_MIN+)"
 
     - name: Build Rust bridge
@@ -168,9 +174,37 @@ jobs:
           CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
           PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
           PRODUCT_NAME="$PRODUCT_NAME" \
+          DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
           LIBRARY_SEARCH_PATHS="/opt/homebrew/lib /opt/bae-ffmpeg/lib ${FFMPEG_DIR}/lib" \
           build
-        echo "APP_PATH=build/Build/Products/Release/${PRODUCT_NAME}.app" >> $GITHUB_ENV
+        echo "APP_PATH=build/Build/Products/Release/${PRODUCT_NAME}.app" >> "$GITHUB_ENV"
+
+    - name: Package dSYM
+      if: matrix.edition == 'full'
+      run: |
+        mkdir -p target
+        DSYM_PATH="build/Build/Products/Release/${PRODUCT_NAME}.app.dSYM"
+        if [[ ! -d "$DSYM_PATH" ]]; then
+          echo "dSYM bundle not found at $DSYM_PATH" >&2
+          find build/Build/Products/Release -maxdepth 1 -name "*.dSYM" -print || true
+          exit 1
+        fi
+        ditto -c -k --sequesterRsrc --keepParent "$DSYM_PATH" target/bae.dSYM.zip
+        echo "BAE_DSYM_PATH=$DSYM_PATH" >> "$GITHUB_ENV"
+
+    - name: Upload dSYM to Sentry
+      if: matrix.edition == 'full'
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      run: |
+        if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_ORG:-}" || -z "${SENTRY_PROJECT:-}" ]]; then
+          echo "Sentry dSYM upload skipped: SENTRY_AUTH_TOKEN, SENTRY_ORG, or SENTRY_PROJECT is unset"
+          exit 0
+        fi
+        curl -sL https://sentry.io/get-cli/ | bash
+        sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$BAE_DSYM_PATH"
 
     - name: Bundle dylibs into app
       run: ./bae-macos/scripts/bundle_dylibs.sh "$APP_PATH"
@@ -197,8 +231,8 @@ jobs:
         security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-        echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/certificate.p12
-        security import $RUNNER_TEMP/certificate.p12 -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+        echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+        security import "$RUNNER_TEMP/certificate.p12" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
         security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
         security list-keychain -d user -s "$KEYCHAIN_PATH"
 
@@ -255,7 +289,7 @@ jobs:
 
         # Create temporary directory for DMG contents
         DMG_TEMP=$(mktemp -d)
-        trap "rm -rf $DMG_TEMP" EXIT
+        trap 'rm -rf "$DMG_TEMP"' EXIT
 
         # Copy app bundle to temp directory
         cp -R "$APP_PATH" "$DMG_TEMP/${PRODUCT_NAME}.app"
@@ -300,11 +334,11 @@ jobs:
         SIGNATURE=$(echo "$SPARKLE_PRIVATE_KEY" | /tmp/sparkle/bin/sign_update "$DMG_PATH" -f - -p)
         # Empty would publish an unsigned appcast entry that every client rejects.
         if [[ -z "$SIGNATURE" ]]; then echo "Sparkle sign_update produced no signature" >&2; exit 1; fi
-        echo "SPARKLE_SIGNATURE=$SIGNATURE" >> $GITHUB_ENV
+        echo "SPARKLE_SIGNATURE=$SIGNATURE" >> "$GITHUB_ENV"
 
         # Get file size for appcast
         DMG_SIZE=$(stat -f%z "$DMG_PATH")
-        echo "DMG_SIZE=$DMG_SIZE" >> $GITHUB_ENV
+        echo "DMG_SIZE=$DMG_SIZE" >> "$GITHUB_ENV"
 
     - name: Generate appcast.xml
       run: |
@@ -349,6 +383,14 @@ jobs:
           target/${{ env.APPCAST_FILE }}
         retention-days: 30
 
+    - name: Upload dSYM artifact
+      if: matrix.edition == 'full'
+      uses: actions/upload-artifact@v7
+      with:
+        name: bae-macOS-dSYM
+        path: target/bae.dSYM.zip
+        retention-days: 30
+
   publish:
     name: Publish release
     needs: [calculate-version, build]
@@ -371,6 +413,12 @@ jobs:
         path: dist
         merge-multiple: true
 
+    - name: Download bae dSYM
+      uses: actions/download-artifact@v8
+      with:
+        name: bae-macOS-dSYM
+        path: dist
+
     - name: Create git tag
       run: |
         VERSION="${{ needs.calculate-version.outputs.version }}"
@@ -391,6 +439,7 @@ jobs:
         files: |
           dist/bae-macos.dmg
           dist/baeium-macos.dmg
+          dist/bae.dSYM.zip
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -58,6 +58,10 @@ jobs:
     needs: calculate-version
     env:
       FFMPEG_VERSION: v8.0.1-bae8
+      BAE_ENVIRONMENT: production
+      BAE_DATADOG_SITE: ${{ secrets.BAE_DATADOG_SITE }}
+      BAE_DATADOG_CLIENT_TOKEN: ${{ secrets.BAE_DATADOG_CLIENT_TOKEN }}
+      BAE_SENTRY_DSN: ${{ secrets.BAE_SENTRY_DSN }}
     strategy:
       matrix:
         edition: [full, baeium]
@@ -139,11 +143,33 @@ jobs:
         # Self-contained so the zip runs without a separate .NET install. MSBuild
         # (not `dotnet build`) — the WinUI XAML markup compiler needs the full VS
         # toolchain (WMC1509). Publish to a known dir we then stage from.
-        run: >
-          msbuild bae-windows\bae-windows.csproj /restore /t:Publish
-          /p:Configuration=Release /p:Platform=x64
-          /p:SelfContained=true /p:RuntimeIdentifier=win-x64
-          /p:PublishDir=publish\
+        shell: pwsh
+        run: |
+          $gitCommit = (git rev-parse --short HEAD).Trim()
+          msbuild bae-windows\bae-windows.csproj /restore /t:Publish `
+            /p:Configuration=Release /p:Platform=x64 `
+            /p:SelfContained=true /p:RuntimeIdentifier=win-x64 `
+            /p:PublishDir=publish\ `
+            /p:BAE_ENVIRONMENT="$env:BAE_ENVIRONMENT" `
+            /p:BAE_DATADOG_SITE="$env:BAE_DATADOG_SITE" `
+            /p:BAE_DATADOG_CLIENT_TOKEN="$env:BAE_DATADOG_CLIENT_TOKEN" `
+            /p:BAE_SENTRY_DSN="$env:BAE_SENTRY_DSN" `
+            /p:BAE_GIT_COMMIT="$gitCommit"
+
+      - name: Build sentry-native
+        if: matrix.edition == 'full'
+        shell: pwsh
+        run: |
+          $version = "0.13.8"
+          curl.exe -L "https://github.com/getsentry/sentry-native/releases/download/$version/sentry-native.zip" -o sentry-native.zip
+          Expand-Archive -Path sentry-native.zip -DestinationPath sentry-native-src -Force
+          cmake -S sentry-native-src -B sentry-native-build -A x64 `
+            -DSENTRY_BACKEND=crashpad `
+            -DSENTRY_BUILD_SHARED_LIBS=ON `
+            -DSENTRY_BUILD_TESTS=OFF `
+            -DSENTRY_BUILD_EXAMPLES=OFF `
+            -DSENTRY_BUILD_BENCHMARKS=OFF
+          cmake --build sentry-native-build --config RelWithDebInfo
 
       - name: Stage the app + native runtime DLLs
         shell: pwsh
@@ -166,6 +192,14 @@ jobs:
             if (Test-Path $src) { Copy-Item $src $stage -Force }
           }
           if (Test-Path "$env:DISCID_BIN\discid.dll") { Copy-Item "$env:DISCID_BIN\discid.dll" $stage -Force }
+          if ("${{ matrix.edition }}" -eq "full") {
+            $sentryDll = Get-ChildItem sentry-native-build -Recurse -Filter sentry.dll | Select-Object -First 1
+            $crashpadHandler = Get-ChildItem sentry-native-build -Recurse -Filter crashpad_handler.exe | Select-Object -First 1
+            if (-not $sentryDll) { Write-Host "FAIL: sentry.dll not found"; exit 1 }
+            if (-not $crashpadHandler) { Write-Host "FAIL: crashpad_handler.exe not found"; exit 1 }
+            Copy-Item $sentryDll.FullName $stage -Force
+            Copy-Item $crashpadHandler.FullName $stage -Force
+          }
 
           # Name the launcher per edition (bae.exe / baeium.exe).
           $exe = Get-ChildItem $stage -Filter "bae-windows.exe" | Select-Object -First 1
@@ -174,6 +208,21 @@ jobs:
 
           Compress-Archive -Path "$PWD\stage\$env:STAGE_DIR" -DestinationPath "$PWD\$env:ZIP_NAME" -Force
           Write-Host "PASS: built $env:ZIP_NAME"
+
+      - name: Upload Windows symbols to Sentry
+        if: matrix.edition == 'full'
+        shell: pwsh
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:SENTRY_AUTH_TOKEN) -or [string]::IsNullOrWhiteSpace($env:SENTRY_ORG) -or [string]::IsNullOrWhiteSpace($env:SENTRY_PROJECT)) {
+            Write-Host "Sentry symbol upload skipped: SENTRY_AUTH_TOKEN, SENTRY_ORG, or SENTRY_PROJECT is unset"
+            exit 0
+          }
+          npm install -g @sentry/cli
+          sentry-cli debug-files upload --org "$env:SENTRY_ORG" --project "$env:SENTRY_PROJECT" "$PWD\stage\$env:STAGE_DIR"
 
       - name: Upload zip artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Release builds now carry the production diagnostics settings into each platform build and upload crash symbols for the full bae edition. The workflows keep baeium on the no-crash-reporting path while attaching dSYM, Android native symbol, and Windows native symbol artifacts where release crashes need symbolication.

Test plan:
- actionlint .github/workflows/android-build.yml .github/workflows/release-ios.yml .github/workflows/release-macos.yml .github/workflows/release-windows.yml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/android-build.yml .github/workflows/release-ios.yml .github/workflows/release-macos.yml .github/workflows/release-windows.yml
- git diff --check