### PR TITLE
Describe Android localization resources

### DIFF
--- a/bae-android/app/lint.xml
+++ b/bae-android/app/lint.xml
@@ -11,10 +11,9 @@
         <ignore path="**/kotlin-bindings*/**" />
     </issue>
     <!--
-        Android-specific UI strings (strings.xml) have not been added to the
-        translation pipeline. The per-language core_strings.xml files are
-        generated from the Rust localization system; strings.xml is not yet
-        wired into that pipeline.
+        Core strings are generated as per-language core_strings.xml files.
+        Android chrome translations live in checked-in per-language strings.xml
+        files beside the English source.
     -->
     <issue id="MissingTranslation" severity="ignore" />
 </lint>


### PR DESCRIPTION
Android now carries translated chrome strings in checked-in per-language strings.xml files while generated core strings remain in core_strings.xml. This updates the lint suppression comment so it describes that current split instead of saying Android chrome is not localized.

Test plan:
- cargo fmt hook