### PR TITLE
Cancel a release's in-progress upload, keeping it local-only

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -661,6 +661,19 @@ impl AppHandle {
             .map_err(BridgeError::internal)
     }
 
+    /// Stop uploading a release that's mid-`manage` and keep it local-only:
+    /// drops its queued/in-flight upload rows and deletes any blobs already
+    /// uploaded this attempt, leaving the local copy in place.
+    pub fn cancel_release_upload(&self, release_id: String) -> Result<(), BridgeError> {
+        self.runtime
+            .block_on(
+                self.app_services
+                    .library_manager()
+                    .cancel_release_upload(&release_id),
+            )
+            .map_err(BridgeError::internal)
+    }
+
     /// Pause or resume the cloud-upload pipeline. While paused, new enqueues
     /// still land in the outbox but the sync cycle won't drain them; the
     /// snapshot's `paused` field flips so the UI can render the toggle.

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -975,6 +975,13 @@ pub struct LibraryManager {
     /// queue stops draining but in-flight uploads (and new enqueues) keep
     /// flowing. Transient (Running after a restart).
     sync_paused: Arc<std::sync::atomic::AtomicBool>,
+    /// Releases whose in-progress upload the user cancelled ("stop uploading").
+    /// The upload observer consults this so a file that lands after the cancel
+    /// doesn't flip the release to managed; instead its now-orphaned blob is
+    /// queued for deletion, leaving the release local-only. Cleared when the
+    /// release is managed afresh. Shared across clones; transient (a restart
+    /// drops it, by which point the queue rows are already gone).
+    upload_cancelling: Arc<Mutex<std::collections::HashSet<String>>>,
     /// In-memory queue for "Pin for offline". A single serial worker drains it
     /// one release at a time. Shared across manager clones; transient (empty
     /// after a restart — a release that wasn't fully pinned stays cloud-only).
@@ -1032,6 +1039,7 @@ impl Clone for LibraryManager {
             outbox_in_flight: self.outbox_in_flight.clone(),
             upload_throughput: self.upload_throughput.clone(),
             sync_paused: self.sync_paused.clone(),
+            upload_cancelling: self.upload_cancelling.clone(),
             download_queue: self.download_queue.clone(),
             #[cfg(any(test, feature = "test-utils"))]
             test_overrides: self.test_overrides.clone(),
@@ -1071,6 +1079,7 @@ impl LibraryManager {
             outbox_in_flight: Arc::new(Mutex::new(HashMap::new())),
             upload_throughput: Arc::new(crate::library::UploadThroughput::new()),
             sync_paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            upload_cancelling: Arc::new(Mutex::new(std::collections::HashSet::new())),
             download_queue: Arc::new(crate::library::DownloadQueue::new()),
             #[cfg(any(test, feature = "test-utils"))]
             test_overrides: TestOverrides::default(),
@@ -2129,6 +2138,80 @@ impl LibraryManager {
         Ok(())
     }
 
+    /// Stop uploading a release that's mid-`manage` and keep it local-only.
+    ///
+    /// `managed` flips only after a release's *last* file uploads, so stopping
+    /// early leaves the release in a valid local state already — pinned (the
+    /// `storage/` copy stays) or unmanaged (the originals stay). This:
+    ///
+    /// 1. removes the release's still-queued and in-flight upload rows, so no
+    ///    further files leave this device;
+    /// 2. marks the release "cancelling" so a file whose write lands in the gap
+    ///    doesn't flip it to managed — the observer queues that blob's deletion
+    ///    instead (see `ReleaseUploadObserver::mark_managed_if_complete`);
+    /// 3. queues deletions for the files already uploaded this attempt, so the
+    ///    cloud is left holding nothing for the release; and
+    /// 4. clears any "delete the originals once uploaded" intent, so a
+    ///    cloud-only manage doesn't strand the release with no local copy.
+    pub async fn cancel_release_upload(&self, release_id: &str) -> Result<(), LibraryError> {
+        self.upload_cancelling
+            .lock()
+            .unwrap()
+            .insert(release_id.to_string());
+
+        // Pending rows (queued + the single in-flight one) are files whose blob
+        // is not yet durable in the cloud; dropping the rows stops them with
+        // nothing to clean up.
+        let rows = self.database.outbox_items().await?;
+        let mut pending_file_ids = std::collections::HashSet::new();
+        for row in &rows {
+            if row.release_id.as_deref() == Some(release_id)
+                && matches!(row.operation, crate::db::OutboxOpKind::Upload)
+            {
+                pending_file_ids.insert(row.file_id.clone());
+                self.database.remove_cloud_outbox_entry(row.id).await?;
+            }
+        }
+
+        // Files with no pending row already uploaded this attempt: their blobs
+        // are in the cloud, so queue a delete to leave the release local-only.
+        // `cloud_key()` resolves each file's blob key (its stored readable key,
+        // or the hashed-by-id default on an opaque home) — the same resolver
+        // every delete uses.
+        let files = self.database.get_files_for_release(release_id).await?;
+        for file in &files {
+            if !pending_file_ids.contains(&file.id) {
+                self.database
+                    .add_cloud_outbox_delete(&file.cloud_key())
+                    .await?;
+            }
+        }
+
+        // A cloud-only manage may be set to delete the originals once uploaded;
+        // cancel that so stopping never removes the last local copy.
+        self.database
+            .set_release_delete_unmanaged_source_on_upload(release_id, false)
+            .await?;
+
+        self.trigger_sync();
+        self.emit_outbox_changed().await;
+        // Refresh the release row (it no longer reads as "uploading"). A
+        // best-effort UI nudge — the cancel itself already succeeded above.
+        match self.get_release_by_id(release_id).await {
+            Ok(Some(release)) => {
+                self.emit_release_updated(&release.album_id, release_id)
+                    .await
+            }
+            Ok(None) => {
+                warn!("cancel_release_upload: release {release_id} missing; skipped UI refresh")
+            }
+            Err(e) => {
+                warn!("cancel_release_upload: loading release {release_id} for refresh failed: {e}")
+            }
+        }
+        Ok(())
+    }
+
     /// Pause or resume the cloud-upload pipeline. Paused means new enqueues
     /// still land in the outbox but the sync cycle won't drain them; in-flight
     /// uploads finish (coven's `process_uploads` checks the flag between
@@ -2166,6 +2249,7 @@ impl LibraryManager {
             self.outbox_in_flight.clone(),
             self.upload_throughput.clone(),
             self.sync_paused.clone(),
+            self.upload_cancelling.clone(),
             self.event_tx.clone(),
         );
         // coven's `process_uploads` takes the home's at-rest cipher. bae homes are
@@ -4687,6 +4771,9 @@ impl LibraryManager {
         pin: bool,
         delete_unmanaged_source: bool,
     ) -> Result<(), String> {
+        // A fresh manage supersedes any earlier cancel: clear the guard so this
+        // attempt's uploads are allowed to flip the release to managed.
+        self.upload_cancelling.lock().unwrap().remove(release_id);
         let transfer_service = crate::storage::local::transfer::TransferService::new(self.clone());
         let rx =
             transfer_service.manage_release(release_id.to_string(), pin, delete_unmanaged_source);
@@ -5033,6 +5120,7 @@ impl LibraryManager {
             self.outbox_in_flight.clone(),
             self.upload_throughput.clone(),
             self.sync_paused.clone(),
+            self.upload_cancelling.clone(),
             self.event_tx.clone(),
         ));
         self.install_sync_manager(&sm).await;
@@ -6651,6 +6739,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_release_upload_drops_queue_and_deletes_uploaded_blobs() {
+        let (manager, _temp_dir) = setup_test_manager().await;
+        let album = create_test_album();
+        let release = create_test_release(&album.id);
+        manager.database.insert_album(&album).await.unwrap();
+        manager.database.insert_release(&release).await.unwrap();
+        // A managed-in-progress release has a local-copy row (here the originals
+        // at an unmanaged path, the cloud-only manage starting point).
+        manager
+            .database
+            .set_release_unmanaged_path(&release.id, "/tmp/originals")
+            .await
+            .unwrap();
+
+        // One file still queued (not yet uploaded) and one already uploaded this
+        // attempt (no queue row; its blob lives at `cloud_path`).
+        let queued = DbFile {
+            id: format!("{}-queued", release.id),
+            release_id: release.id.clone(),
+            original_filename: "queued.flac".to_string(),
+            file_size: 1000,
+            content_type: crate::util::content_type::ContentType::Flac,
+            cloud_path: None,
+            created_at: Utc::now(),
+        };
+        let uploaded = DbFile {
+            id: format!("{}-uploaded", release.id),
+            release_id: release.id.clone(),
+            original_filename: "uploaded.flac".to_string(),
+            file_size: 1000,
+            content_type: crate::util::content_type::ContentType::Flac,
+            cloud_path: Some("storage/already-uploaded".to_string()),
+            created_at: Utc::now(),
+        };
+        manager.database.insert_file(&queued).await.unwrap();
+        manager.database.insert_file(&uploaded).await.unwrap();
+        manager
+            .add_cloud_outbox_upload(&queued.id, "storage/still-queued", None)
+            .await
+            .unwrap();
+
+        manager.cancel_release_upload(&release.id).await.unwrap();
+
+        // The queued upload is dropped — nothing left to push for the release.
+        assert!(
+            manager
+                .get_pending_cloud_uploads()
+                .await
+                .unwrap()
+                .is_empty(),
+            "cancel removes the release's queued uploads"
+        );
+
+        // The already-uploaded blob is queued for deletion so the cloud is left
+        // holding nothing for the release; the still-queued file (never
+        // uploaded) is not — its blob never landed.
+        let deletes: Vec<String> = manager
+            .get_pending_cloud_deletes()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.cloud_key)
+            .collect();
+        assert_eq!(deletes, vec!["storage/already-uploaded".to_string()]);
+    }
+
+    #[tokio::test]
     async fn outbox_snapshot_tracks_queued_active_failed_and_cancel() {
         use crate::library::UploadState;
 
@@ -6792,6 +6947,7 @@ mod tests {
             manager.outbox_in_flight.clone(),
             manager.upload_throughput.clone(),
             manager.sync_paused.clone(),
+            manager.upload_cancelling.clone(),
             manager.event_tx.clone(),
         );
 

--- a/bae-core/src/sync/blob_plan.rs
+++ b/bae-core/src/sync/blob_plan.rs
@@ -5,7 +5,7 @@
 //! blobs that move with the changeset (deletes go through the cloud outbox, not
 //! here). After a release's storage files finish uploading, the observer marks it
 //! managed (cloud-only) and drops this device's local copy.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use coven::blob::{BlobPlan, BlobRef, BlobScope, BlobUploadObserver, DrainControl};
@@ -164,6 +164,10 @@ pub struct ReleaseUploadObserver {
     in_flight: Arc<Mutex<HashMap<String, u64>>>,
     throughput: Arc<crate::library::UploadThroughput>,
     sync_paused: Arc<std::sync::atomic::AtomicBool>,
+    /// Releases the user stopped uploading mid-`manage`. A file that lands for
+    /// one of these must not flip it to managed; its blob is queued for delete
+    /// instead so the release stays local-only.
+    upload_cancelling: Arc<Mutex<HashSet<String>>>,
     events: broadcast::Sender<LibraryEvent>,
 }
 
@@ -174,6 +178,7 @@ impl ReleaseUploadObserver {
         in_flight: Arc<Mutex<HashMap<String, u64>>>,
         throughput: Arc<crate::library::UploadThroughput>,
         sync_paused: Arc<std::sync::atomic::AtomicBool>,
+        upload_cancelling: Arc<Mutex<HashSet<String>>>,
         events: broadcast::Sender<LibraryEvent>,
     ) -> Self {
         Self {
@@ -182,6 +187,7 @@ impl ReleaseUploadObserver {
             in_flight,
             throughput,
             sync_paused,
+            upload_cancelling,
             events,
         }
     }
@@ -254,6 +260,29 @@ impl ReleaseUploadObserver {
         if release.managed {
             // Its uploads already completed and flipped it; nothing to do.
             debug!("Release {} is already managed; nothing to mark", release.id);
+            return false;
+        }
+        if self.upload_cancelling.lock().unwrap().contains(&release.id) {
+            // The user stopped this release's upload, but this file's write
+            // landed in the gap. Don't flip to managed — queue the now-orphaned
+            // blob for deletion so the release stays local-only.
+            debug!(
+                "Release {} upload was cancelled; deleting orphaned blob for {file_id}",
+                release.id
+            );
+            match self.db.find_file_by_id(file_id).await {
+                Ok(Some(file)) => {
+                    if let Err(e) = self.db.add_cloud_outbox_delete(&file.cloud_key()).await {
+                        warn!("Failed to queue delete for cancelled upload {file_id}: {e}");
+                    }
+                }
+                Ok(None) => {
+                    warn!("Cancelled upload {file_id} has no file row; its blob can't be cleaned")
+                }
+                Err(e) => {
+                    warn!("Failed to look up cancelled upload {file_id} to clean its blob: {e}")
+                }
+            }
             return false;
         }
         let local_copy = match self.db.get_release_local_copy(&release.id).await {
@@ -452,6 +481,130 @@ impl BlobUploadObserver for ReleaseUploadObserver {
 mod tests {
     use super::*;
     use coven::changeset::ChangeOp;
+
+    /// Seed a release with one file (carrying `cloud_path`) and return a
+    /// `(db, observer)` whose `upload_cancelling` already holds the release, so
+    /// `mark_managed_if_complete` exercises the cancelled-mid-upload branch.
+    #[allow(clippy::type_complexity)]
+    async fn observer_with_cancelled_release() -> (
+        Arc<Database>,
+        ReleaseUploadObserver,
+        String,
+        String,
+        tempfile::TempDir,
+    ) {
+        use crate::db::{DbAlbum, DbArtist, DbFile, DbRelease, Pressing, ReleaseMetadataSource};
+        use crate::util::content_type::ContentType;
+        use chrono::Utc;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = Arc::new(
+            Database::new_test(
+                tmp.path().join("test.db").to_str().unwrap(),
+                Arc::new(crate::clock::SystemClock),
+            )
+            .await
+            .unwrap(),
+        );
+        db.insert_artist(&DbArtist {
+            id: "artist-1".into(),
+            name: "Artist Name".into(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+        db.insert_album(&DbAlbum {
+            id: "album-1".into(),
+            title: "Album Title".into(),
+            artist_id: "artist-1".into(),
+            year: None,
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+        db.insert_release(&DbRelease {
+            id: "rel-1".into(),
+            album_id: "album-1".into(),
+            release_name: None,
+            pressing: Pressing {
+                year: None,
+                format: None,
+                label: None,
+                catalog_number: None,
+                country: None,
+                barcode: None,
+            },
+            disc_id: None,
+            metadata_source: ReleaseMetadataSource::FileTags,
+            metadata_source_release_id: None,
+            managed: false,
+            source_folder_name: None,
+            content_hash: None,
+            created_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+        db.insert_file(&DbFile {
+            id: "file-1".into(),
+            release_id: "rel-1".into(),
+            original_filename: "track.flac".into(),
+            file_size: 1000,
+            content_type: ContentType::Flac,
+            cloud_path: Some("storage/rel-1/track".into()),
+            created_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+
+        let cancelling: Arc<Mutex<HashSet<String>>> =
+            Arc::new(Mutex::new(HashSet::from(["rel-1".to_string()])));
+        let (events, _rx) = broadcast::channel(16);
+        let observer = ReleaseUploadObserver::new(
+            db.clone(),
+            LibraryDir::new(tmp.path().to_path_buf()),
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(crate::library::UploadThroughput::new()),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            cancelling,
+            events,
+        );
+        (
+            db,
+            observer,
+            "file-1".to_string(),
+            "storage/rel-1/track".to_string(),
+            tmp,
+        )
+    }
+
+    #[tokio::test]
+    async fn cancelled_release_skips_managed_flip_and_queues_blob_delete() {
+        let (db, observer, file_id, cloud_key, _tmp) = observer_with_cancelled_release().await;
+
+        // The file's blob landed after the user stopped the upload.
+        let flipped = observer.mark_managed_if_complete(&file_id).await;
+
+        assert!(!flipped, "a cancelled release must not flip to managed");
+        let release = db.find_release_for_file(&file_id).await.unwrap().unwrap();
+        assert!(!release.managed, "release stays local-only");
+        let deletes: Vec<String> = db
+            .get_pending_cloud_deletes()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.cloud_key)
+            .collect();
+        assert_eq!(
+            deletes,
+            vec![cloud_key],
+            "the orphaned blob is queued for deletion"
+        );
+    }
 
     fn row(table: &str, op: ChangeOp, cols: &[&str]) -> RowChange {
         RowChange {

--- a/bae-core/src/sync/sync_manager.rs
+++ b/bae-core/src/sync/sync_manager.rs
@@ -51,6 +51,7 @@ pub fn build_sync_manager(
     outbox_in_flight: Arc<Mutex<HashMap<String, u64>>>,
     upload_throughput: Arc<UploadThroughput>,
     sync_paused: Arc<std::sync::atomic::AtomicBool>,
+    upload_cancelling: Arc<Mutex<std::collections::HashSet<String>>>,
     events: broadcast::Sender<LibraryEvent>,
 ) -> SyncManager {
     let clock = database.clock().clone();
@@ -63,6 +64,7 @@ pub fn build_sync_manager(
         outbox_in_flight,
         upload_throughput,
         sync_paused,
+        upload_cancelling,
         events,
     ));
 


### PR DESCRIPTION
Chained on #112.

When a user manages a release to the cloud and changes their mind mid-upload, there was no clean way to stop. The only control was the per-file "x" in the sync queue, which dropped a single outbox row — leaving already-uploaded blobs orphaned in the cloud and racing the file currently in flight. It also wasn't the right shape: stopping an upload is a per-release decision, not a per-file one.

The key observation is that a release only flips to `managed` after its *last* file finishes uploading, so a release stopped part-way is already sitting in a valid local-only state — pinned (the `storage/` copy stays) or unmanaged (the originals stay). So "stop uploading and keep local" doesn't need a file move or a state rebuild; it needs to stop the transfer and clean up the cloud side.

`LibraryManager::cancel_release_upload` does exactly that: it drops the release's queued and in-flight upload rows, queues deletions for the blobs already uploaded this attempt so the cloud holds nothing for the release, and clears any "delete the originals once uploaded" intent so stopping never removes the last local copy. coven's drain is sequential and owns its own cycle, so rather than abort the in-flight write mid-stream (which would strand a partial multipart blob), the upload observer gains a small guard: a file whose write lands *after* the user stopped does not flip the release to managed — its now-orphaned blob is queued for deletion instead. The guard clears when the release is managed afresh.

This is the backend capability, exposed over the bridge as `cancel_release_upload`. The desktop UIs (per-release "Stop uploading" in the storage manager, replacing the per-file control, plus grouping the queue by release) wire to it in the following chained PRs.

## Test plan
- `cargo test -p bae-core --features test-utils` — added `cancel_release_upload_drops_queue_and_deletes_uploaded_blobs` (queued rows dropped; only the already-uploaded blob is queued for delete) and `cancelled_release_skips_managed_flip_and_queues_blob_delete` (the observer race: a file landing after cancel doesn't flip managed and its blob is deleted).
- Full `bae-core` lib suite green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)