### PR TITLE
macOS: stop a release's upload from the storage row

### DIFF
--- a/bae-macos/bae/bae/Services/Store/OutboxStore.swift
+++ b/bae-macos/bae/bae/Services/Store/OutboxStore.swift
@@ -22,6 +22,14 @@ class OutboxStore {
         snapshot.perRelease[releaseId]
     }
 
+    /// Whether the release has upload work queued or in flight. Drives the
+    /// storage row's "Cancel Upload" affordance and the suppression of other
+    /// storage actions while a transfer is mid-flight. Idle releases are absent
+    /// from the per-release map, so presence is the signal.
+    func isUploading(forRelease releaseId: String) -> Bool {
+        snapshot.perRelease[releaseId] != nil
+    }
+
     /// The idle (empty) queue. Seeds the store before the first snapshot read
     /// and serves as the fallback if that read fails.
     static var emptySnapshot: BridgeOutboxSnapshot {

--- a/bae-macos/bae/bae/Services/Sync.swift
+++ b/bae-macos/bae/bae/Services/Sync.swift
@@ -34,6 +34,9 @@ final class Sync: Sendable, Observable {
         @Sendable (_ libraryId: String, _ newName: String) throws -> Void
     /// Cancel one queued outbox entry by id (dequeues it; the local file stays).
     let cancelOutboxItem: @Sendable (_ id: Int64) throws -> Void
+    /// Stop uploading a release and keep it local-only: drops its queued and
+    /// in-flight uploads and deletes any blobs already uploaded this attempt.
+    let cancelReleaseUpload: @Sendable (_ releaseId: String) throws -> Void
     /// Pause or resume the cloud-upload pipeline. In-flight uploads finish; the
     /// queue stops draining until resumed.
     let setSyncPaused: @Sendable (_ paused: Bool) -> Void
@@ -72,6 +75,9 @@ final class Sync: Sendable, Observable {
             throw StubError.notImplemented
         },
         cancelOutboxItem: @escaping @Sendable (Int64) throws -> Void = { _ in },
+        cancelReleaseUpload: @escaping @Sendable (String) throws -> Void = {
+            _ in
+        },
         setSyncPaused: @escaping @Sendable (Bool) -> Void = { _ in },
         triggerSync: @escaping @Sendable () -> Void = {},
         lockActiveLibrary: @escaping @Sendable () throws -> Void = {
@@ -88,6 +94,7 @@ final class Sync: Sendable, Observable {
         self.triggerSync = triggerSync
         self.renameLibrary = renameLibrary
         self.cancelOutboxItem = cancelOutboxItem
+        self.cancelReleaseUpload = cancelReleaseUpload
         self.setSyncPaused = setSyncPaused
         self.lockActiveLibrary = lockActiveLibrary
     }
@@ -127,6 +134,9 @@ final class Sync: Sendable, Observable {
                 try handle.renameLibrary(libraryId: $0, name: $1)
             },
             cancelOutboxItem: { try handle.cancelOutboxItem(id: $0) },
+            cancelReleaseUpload: {
+                try handle.cancelReleaseUpload(releaseId: $0)
+            },
             setSyncPaused: { handle.setSyncPaused(paused: $0) },
             triggerSync: { handle.triggerSync() },
             lockActiveLibrary: { try handle.lockActiveLibrary() }

--- a/bae-macos/bae/bae/Views/StorageActionRunner.swift
+++ b/bae-macos/bae/bae/Views/StorageActionRunner.swift
@@ -83,12 +83,13 @@ final class StorageActionRunner {
         pendingManage = nil
     }
 
-    /// Cancel every queued upload belonging to any of `releaseIds`. The
-    /// caller resolves the outbox op ids from the current snapshot.
-    func cancelUploads(opIds: [Int64]) {
-        for id in opIds {
+    /// Stop uploading each release and keep it local-only: core drops the
+    /// release's queued and in-flight uploads and deletes any blobs already
+    /// uploaded this attempt.
+    func cancelUploads(releaseIds: [String]) {
+        for id in releaseIds {
             do {
-                try sync.cancelOutboxItem(id)
+                try sync.cancelReleaseUpload(id)
             }
             catch {
                 uiStore.showError(

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -48,7 +48,6 @@ struct StorageManagerView: View {
             if let list, let runner {
                 StorageTableView(
                     list: list,
-                    filter: filter,
                     selection: $selection,
                     sort: $sort,
                     libraryStore: libraryStore,
@@ -440,7 +439,7 @@ private struct OutboxSection: View {
         ScrollView {
             LazyVStack(spacing: 0) {
                 ForEach(snapshot.uploads, id: \.id) { op in
-                    OutboxUploadRow(op: op) { cancel(op.id) }
+                    OutboxUploadRow(op: op)
                     Divider()
                 }
                 ForEach(snapshot.deletes, id: \.id) { op in
@@ -505,7 +504,6 @@ private struct OutboxTotalProgress: View {
 
 private struct OutboxUploadRow: View {
     let op: BridgeUploadOp
-    let onCancel: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
@@ -531,12 +529,6 @@ private struct OutboxUploadRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(width: 90, alignment: .trailing)
-
-            Button(action: onCancel) {
-                Image(systemName: "xmark.circle")
-            }
-            .buttonStyle(.plain)
-            .help("Remove from the sync queue")
         }
         .padding(.horizontal)
         .padding(.vertical, 6)

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -131,7 +131,6 @@ private func sortField(forDescriptorKey key: String) -> BridgeStorageSortField?
 /// it).
 struct StorageTableView: NSViewRepresentable {
     let list: StorageList
-    let filter: BridgeStorageFilter
     @Binding
     var selection: Set<String>
     @Binding
@@ -148,7 +147,6 @@ struct StorageTableView: NSViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(
             list: list,
-            filter: filter,
             selection: $selection,
             sort: $sort,
             libraryStore: libraryStore,
@@ -223,7 +221,6 @@ struct StorageTableView: NSViewRepresentable {
 
         coordinator.update(
             list: list,
-            filter: filter,
             mediaPaths: mediaPaths,
             outboxStore: outboxStore,
         )
@@ -248,7 +245,6 @@ extension StorageTableView {
         NSOutlineViewDelegate
     {
         private(set) var list: StorageList
-        private var filter: BridgeStorageFilter
         private let selection: Binding<Set<String>>
         private let sort: Binding<BridgeStorageSort>
         private let libraryStore: LibraryStore
@@ -281,7 +277,6 @@ extension StorageTableView {
 
         init(
             list: StorageList,
-            filter: BridgeStorageFilter,
             selection: Binding<Set<String>>,
             sort: Binding<BridgeStorageSort>,
             libraryStore: LibraryStore,
@@ -291,7 +286,6 @@ extension StorageTableView {
             outboxStore: OutboxStore,
         ) {
             self.list = list
-            self.filter = filter
             self.selection = selection
             self.sort = sort
             self.libraryStore = libraryStore
@@ -303,12 +297,10 @@ extension StorageTableView {
 
         func update(
             list: StorageList,
-            filter: BridgeStorageFilter,
             mediaPaths: MediaPaths,
             outboxStore: OutboxStore,
         ) {
             self.list = list
-            self.filter = filter
             self.mediaPaths = mediaPaths
             self.outboxStore = outboxStore
         }
@@ -746,32 +738,33 @@ extension StorageTableView.Coordinator: NSMenuDelegate {
         let targets = menuTargets(forClicked: item)
         guard !targets.isEmpty else { return }
 
-        switch filter {
-        case .uploading:
-            let opIds = outboxStore.snapshot.uploads
-                .filter { $0.releaseId.map(targets.contains) ?? false }
-                .map(\.id)
+        // A release uploading right now can't be managed/pinned/unmanaged (those
+        // race the observer that completes the transition), so the only action it
+        // offers is stopping the upload — in every tab, not just "Uploading".
+        let uploading = targets.filter {
+            outboxStore.isUploading(forRelease: $0)
+        }
+        if !uploading.isEmpty {
             addMenuItem(
                 to: menu,
                 title: String(localized: "Cancel Upload"),
                 action: #selector(cancelUploadsAction(_:)),
                 symbol: "xmark.circle",
-                representedObject: opIds,
-                isEnabled: !opIds.isEmpty
+                representedObject: uploading
             )
-        case .all, .unmanaged, .managed:
-            for action in intersectedActions(of: targets) {
-                addMenuItem(
-                    to: menu,
-                    title: action.label,
-                    action: #selector(runStorageAction(_:)),
-                    symbol: action.systemImage,
-                    representedObject: StorageActionInvocation(
-                        action: action,
-                        releaseIds: targets
-                    )
+            return
+        }
+        for action in intersectedActions(of: targets) {
+            addMenuItem(
+                to: menu,
+                title: action.label,
+                action: #selector(runStorageAction(_:)),
+                symbol: action.systemImage,
+                representedObject: StorageActionInvocation(
+                    action: action,
+                    releaseIds: targets
                 )
-            }
+            )
         }
     }
 
@@ -827,32 +820,21 @@ extension StorageTableView.Coordinator: NSMenuDelegate {
 
     @objc
     private func cancelUploadsAction(_ sender: NSMenuItem) {
-        guard let opIds = sender.representedObject as? [Int64] else {
-            logger.error("Cancel-upload menu item carried no op ids")
+        guard let releaseIds = sender.representedObject as? [String] else {
+            logger.error("Cancel-upload menu item carried no release ids")
             return
         }
-        runner.cancelUploads(opIds: opIds)
+        runner.cancelUploads(releaseIds: releaseIds)
     }
 
     /// Storage actions every targeted release allows, preserving the order the
     /// core emits them in. Single target → that release's actions; multi-select
     /// → the intersection so the menu only offers transitions applicable to
-    /// all.
-    ///
-    /// Suppressed entirely when any targeted release has uploads in flight:
-    /// acting mid-upload races the observer that completes the
-    /// unmanaged → cloud step (the same gate the album-detail "Storage…" sheet
-    /// applies). The core leaves this gate to the UI because the outbox
-    /// snapshot stays fresher than a cached release.
+    /// all. Callers handle the uploading case before reaching here (an uploading
+    /// release offers only "Cancel Upload").
     private func intersectedActions(
         of releaseIds: [String]
     ) -> [BridgeReleaseStorageAction] {
-        let anyUploading = releaseIds.contains { id in
-            outboxStore.progress(forRelease: id)?.isIdle == false
-        }
-        if anyUploading {
-            return []
-        }
         let perRelease = releaseIds.map { id in
             Set(libraryStore.releaseSummaries[id]?.storageActions ?? [])
         }


### PR DESCRIPTION
Chained on #114 (which is chained on #112).

The sync-queue rows each carried an "x" that dequeued a single queued upload. That was the wrong shape — stopping an upload is a per-release decision, not a per-file one — and the wrong mechanism: it dropped one outbox row and left any blobs already uploaded orphaned in the cloud. #114 added the correct per-release operation (`cancel_release_upload`); this wires the macOS storage manager to it.

Right-clicking a release that's uploading now offers "Cancel Upload" in every storage-manager tab (it previously appeared only in the Uploading tab, and ran the per-file dequeue). An uploading release offers *only* that action, since it can't be managed / pinned / unmanaged mid-transfer — the same suppression that already existed, now expressed as "the one thing you can do is stop." The per-file "x" is gone from the upload rows, which are display-only. Pending-delete rows keep their control — a delete is genuinely a per-file operation.

The Windows storage manager has the same per-file control and gets the same treatment in a follow-up.

## Test plan
- macOS app builds; periphery clean (removed the now-unused `filter` plumbing the Coordinator only needed for the old tab-based menu).
- Manually: start managing a multi-file release; right-click it in Library / Managed / Uploading tabs → "Cancel Upload" appears and stops it, leaving it local; the per-file "x" is gone from the queue rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)