### PR TITLE
Windows: stop a release's upload per-release

### DIFF
--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1841,6 +1841,35 @@ pub unsafe extern "C" fn bae_cancel_outbox_item(handle: *const BaeHandle, id: i6
     }
 }
 
+/// Stop uploading a release and keep it local-only: drops its queued and
+/// in-flight uploads and deletes any blobs already uploaded this attempt.
+/// Returns null on success, else an owned error string to free with
+/// `bae_free_string`.
+///
+/// # Safety
+/// `handle` must be a live `BaeHandle`; `release_id` a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_cancel_release_upload(
+    handle: *const BaeHandle,
+    release_id: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        return error_cstring("no app handle");
+    };
+    let Some(release_id) = cstr(release_id) else {
+        return error_cstring("invalid release id");
+    };
+    let app = &handle.0;
+    match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .cancel_release_upload(&release_id),
+    ) {
+        Ok(()) => std::ptr::null_mut(),
+        Err(e) => error_cstring(&e.to_string()),
+    }
+}
+
 /// One track in an album-detail track list.
 #[derive(Serialize)]
 struct FfiTrack {

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3390,24 +3390,30 @@ public sealed partial class MainWindow : Window
                 Grid.SetColumn(labelColumn, 0);
                 itemGrid.Children.Add(labelColumn);
 
-                var cancel = new Button { Content = Loc.Chrome("outbox.cancel_item") };
-                cancel.Click += async (_, _) =>
+                // Uploads are stopped per-release (right-click the storage row →
+                // "Cancel Upload"), not per file. A pending delete is genuinely a
+                // single-file operation, so it keeps its per-row cancel.
+                if (activeUpload is null)
                 {
-                    storageStatus.Visibility = Visibility.Collapsed;
-                    cancel.IsEnabled = false;
-                    var error = await System.Threading.Tasks.Task.Run(() => NativeBae.CancelOutboxItem(_handle, id));
-                    if (error is not null)
+                    var cancel = new Button { Content = Loc.Chrome("outbox.cancel_item") };
+                    cancel.Click += async (_, _) =>
                     {
-                        storageStatus.Text = error;
-                        storageStatus.Visibility = Visibility.Visible;
-                        cancel.IsEnabled = true;
-                        return;
-                    }
+                        storageStatus.Visibility = Visibility.Collapsed;
+                        cancel.IsEnabled = false;
+                        var error = await System.Threading.Tasks.Task.Run(() => NativeBae.CancelOutboxItem(_handle, id));
+                        if (error is not null)
+                        {
+                            storageStatus.Text = error;
+                            storageStatus.Visibility = Visibility.Visible;
+                            cancel.IsEnabled = true;
+                            return;
+                        }
 
-                    await LoadOutbox();
-                };
-                Grid.SetColumn(cancel, 1);
-                itemGrid.Children.Add(cancel);
+                        await LoadOutbox();
+                    };
+                    Grid.SetColumn(cancel, 1);
+                    itemGrid.Children.Add(cancel);
+                }
                 outboxPanel.Children.Add(itemGrid);
             }
 
@@ -3544,19 +3550,19 @@ public sealed partial class MainWindow : Window
             menu.Items.Add(item);
         }
 
-        // Cancel the queued uploads of any targeted release (the Uploading-state
-        // counterpart to macOS's Uploading tab). Resolved from the live outbox
-        // snapshot since the storage row carries only a pending count.
-        var cancelIds = await UploadOpIdsForReleases(releaseIds);
-        if (cancelIds.Count > 0)
+        // Stop uploading any targeted release that's mid-transfer, keeping it
+        // local-only. Resolved from the live outbox snapshot since the storage
+        // row carries only a pending count.
+        var uploadingReleases = await UploadingReleases(releaseIds);
+        if (uploadingReleases.Count > 0)
         {
             var cancel = new MenuFlyoutItem { Text = Loc.Chrome("storage.cancel_upload") };
             cancel.Click += async (_, _) =>
             {
-                foreach (var id in cancelIds)
+                foreach (var releaseId in uploadingReleases)
                 {
                     var error = await System.Threading.Tasks.Task.Run(
-                        () => NativeBae.CancelOutboxItem(_handle, id));
+                        () => NativeBae.CancelReleaseUpload(_handle, releaseId));
                     if (error is not null)
                     {
                         storageStatus.Text = error;
@@ -3573,30 +3579,26 @@ public sealed partial class MainWindow : Window
         return menu;
     }
 
-    // The queued upload op ids belonging to any of the given releases, read from
-    // the current outbox snapshot. Empty when none are queued or the snapshot
-    // can't be read.
-    private async System.Threading.Tasks.Task<List<long>> UploadOpIdsForReleases(
+    // Of the given releases, those with uploads queued or in flight. Core omits
+    // idle releases from the per-release map, so presence there is the signal.
+    private async System.Threading.Tasks.Task<List<string>> UploadingReleases(
         List<string> releaseIds)
     {
         var json = await System.Threading.Tasks.Task.Run(
             () => NativeBae.OutboxSnapshotJson(_handle));
-        if (json is null)
-        {
-            return new List<long>();
-        }
-
-        var snapshot = JsonSerializer.Deserialize<OutboxSnapshot>(json, JsonOptions);
+        var snapshot = json is null
+            ? null
+            : JsonSerializer.Deserialize<OutboxSnapshot>(json, JsonOptions);
         if (snapshot is null)
         {
-            return new List<long>();
+            // Couldn't read the outbox; surface it like the panel load does
+            // rather than silently dropping the cancel action.
+            storageStatus.Text = Loc.Chrome("outbox.read_failed");
+            storageStatus.Visibility = Visibility.Visible;
+            return new List<string>();
         }
 
-        var targets = new HashSet<string>(releaseIds);
-        return snapshot.Uploads
-            .Where(op => op.ReleaseId is not null && targets.Contains(op.ReleaseId))
-            .Select(op => op.Id)
-            .ToList();
+        return releaseIds.Where(snapshot.PerRelease.ContainsKey).ToList();
     }
 
     // Run a storage transition on every release in the selection off the UI

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -459,6 +459,15 @@ internal static class NativeBae
     internal static string? CancelOutboxItem(IntPtr handle, long id) =>
         ResultMessage(CancelOutboxItemPtr(handle, id));
 
+    [DllImport(Dll, EntryPoint = "bae_cancel_release_upload", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr CancelReleaseUploadPtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string releaseId);
+
+    /// <summary>Stop uploading a release and keep it local-only; null on success, else the error.</summary>
+    internal static string? CancelReleaseUpload(IntPtr handle, string releaseId) =>
+        ResultMessage(CancelReleaseUploadPtr(handle, releaseId));
+
     /// <summary>
     /// Album results for a query as JSON (same shape as a page), or
     /// <see cref="IntPtr.Zero"/> on error. Prefer <see cref="SearchJson"/>.

--- a/bae-windows/OutboxSnapshot.cs
+++ b/bae-windows/OutboxSnapshot.cs
@@ -26,6 +26,12 @@ public sealed class OutboxSnapshot
     /// <summary>Aggregate byte progress; the master bar reads its done/total.</summary>
     public UploadProgress Total { get; set; } = new();
 
+    /// <summary>Per-release upload aggregate, keyed by release id. Core omits
+    /// idle releases, so a key's presence means the release has upload work
+    /// queued or in flight — the storage row reads this to offer "Cancel
+    /// Upload".</summary>
+    public Dictionary<string, UploadProgress> PerRelease { get; set; } = new();
+
     /// <summary>One-line queue summary, e.g. "2 uploading · 1 failed · 3 queued";
     /// empty when the queue is idle so the UI can hide it. Each part is a
     /// localized count message from the shared catalog.</summary>


### PR DESCRIPTION
Brings the Windows storage manager to parity with the macOS change (#115): stopping an upload is a per-release operation, not per-file.

The outbox panel gave each queued upload its own "x", which dequeued a single outbox row — leaving any blobs already uploaded orphaned in the cloud, and modelling a per-release decision as a per-file one. This adds the `bae_cancel_release_upload` FFI entry point over the core operation (#114), and the storage-row context menu's "Cancel Upload" now calls it once per uploading release instead of looping the per-file dequeue across the release's outbox ops. The per-file "x" is gone from the upload rows; pending-delete rows keep theirs, since a delete is genuinely a single-file operation.

## Test plan
- `cargo clippy -p bae-windows-ffi` clean; the new `#[no_mangle]` entry point exports automatically from the cdylib (no symbol list to maintain).
- Windows app build verified by CI (no local Windows toolchain).
- Manually (on Windows): start managing a multi-file release; right-click it → "Cancel Upload" stops it and leaves it local; the per-file "x" is gone from the upload rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)