### PR TITLE
Group outbox uploads by release in the snapshot

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1293,33 +1293,22 @@ async fn pump_ui_events(
 fn convert_outbox_snapshot(
     snapshot: bae_core::library::OutboxSnapshot,
 ) -> crate::types::BridgeOutboxSnapshot {
-    use crate::types::{BridgeDeleteOp, BridgeOutboxSnapshot, BridgeUploadOp, BridgeUploadState};
-    use bae_core::library::UploadState;
+    use crate::types::{BridgeDeleteOp, BridgeOutboxSnapshot, BridgeUploadReleaseGroup};
 
     let uploads = snapshot
         .uploads
         .into_iter()
-        .map(|op| {
-            let (state, last_error, bytes_done) = match op.state {
-                UploadState::Queued => (BridgeUploadState::Queued, None, 0),
-                UploadState::Active { bytes_done } => (BridgeUploadState::Active, None, bytes_done),
-                UploadState::Failed { last_error } => {
-                    (BridgeUploadState::Failed, Some(last_error), 0)
-                }
-            };
-            BridgeUploadOp {
-                id: op.id,
-                file_id: op.file_id,
-                release_id: op.release_id,
-                display_name: op.display_name,
-                cloud_key: op.cloud_key,
-                bytes_total: op.bytes_total,
-                bytes_done,
-                created_at: op.created_at,
-                attempt_count: op.attempt_count,
-                state,
-                last_error,
-            }
+        .map(convert_upload_op)
+        .collect();
+
+    let upload_groups = snapshot
+        .upload_groups
+        .into_iter()
+        .map(|g| BridgeUploadReleaseGroup {
+            release_id: g.release_id,
+            title: g.title,
+            progress: convert_upload_progress(g.progress),
+            uploads: g.uploads.into_iter().map(convert_upload_op).collect(),
         })
         .collect();
 
@@ -1342,6 +1331,7 @@ fn convert_outbox_snapshot(
 
     BridgeOutboxSnapshot {
         uploads,
+        upload_groups,
         deletes,
         per_release,
         total: convert_upload_progress(snapshot.total),
@@ -1350,6 +1340,32 @@ fn convert_outbox_snapshot(
         paused: snapshot.paused,
         throughput_bps: snapshot.throughput_bps,
         eta_seconds: snapshot.eta_seconds,
+    }
+}
+
+/// `last_error` is lifted out of the `Failed` variant into a flat field beside
+/// the three-state enum so the UI doesn't switch on associated data.
+fn convert_upload_op(op: bae_core::library::UploadOp) -> crate::types::BridgeUploadOp {
+    use crate::types::{BridgeUploadOp, BridgeUploadState};
+    use bae_core::library::UploadState;
+
+    let (state, last_error, bytes_done) = match op.state {
+        UploadState::Queued => (BridgeUploadState::Queued, None, 0),
+        UploadState::Active { bytes_done } => (BridgeUploadState::Active, None, bytes_done),
+        UploadState::Failed { last_error } => (BridgeUploadState::Failed, Some(last_error), 0),
+    };
+    BridgeUploadOp {
+        id: op.id,
+        file_id: op.file_id,
+        release_id: op.release_id,
+        display_name: op.display_name,
+        cloud_key: op.cloud_key,
+        bytes_total: op.bytes_total,
+        bytes_done,
+        created_at: op.created_at,
+        attempt_count: op.attempt_count,
+        state,
+        last_error,
     }
 }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1602,12 +1602,25 @@ pub struct BridgeDownloadSnapshot {
     pub paused: bool,
 }
 
+/// A release's pending uploads, grouped for the queue pane's per-release rows.
+/// Mirror of bae-core's `UploadReleaseGroup`. `release_id`/`title` are `None` for
+/// the orphaned-files bucket.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeUploadReleaseGroup {
+    pub release_id: Option<String>,
+    pub title: Option<String>,
+    pub progress: BridgeUploadProgress,
+    pub uploads: Vec<BridgeUploadOp>,
+}
+
 /// The cloud-outbox processing snapshot the Storage Manager renders. The
 /// counts, per-release aggregates, one-line `summary`, throughput, and ETA
 /// are computed in bae-core; the UI renders them verbatim.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeOutboxSnapshot {
     pub uploads: Vec<BridgeUploadOp>,
+    /// `uploads` grouped by release for the queue pane's per-release rows.
+    pub upload_groups: Vec<BridgeUploadReleaseGroup>,
     pub deletes: Vec<BridgeDeleteOp>,
     /// Per-release aggregate, keyed by release id. Releases with no pending
     /// work are absent from the map.

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -15,7 +15,8 @@ pub use download_snapshot::{DownloadOp, DownloadProgress, DownloadSnapshot, Down
 pub use export::{ExportFormat, MP3_EXPORT_BITRATE};
 pub use manager::*;
 pub use outbox_snapshot::{
-    DeleteOp, OutboxSnapshot, UploadActivity, UploadOp, UploadProgress, UploadState,
+    DeleteOp, OutboxSnapshot, UploadActivity, UploadOp, UploadProgress, UploadReleaseGroup,
+    UploadState,
 };
 pub use upload_throughput::UploadThroughput;
 

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -126,11 +126,27 @@ impl UploadProgress {
     }
 }
 
+/// A release's pending uploads, grouped for the queue pane so it renders one row
+/// per release (matching the storage table) instead of a flat per-file list.
+/// `release_id`/`title` are `None` for the orphaned-files bucket (a release row
+/// whose backing release is gone). `progress` is the group's aggregate; the
+/// queue pane reads it for the per-release row and can expand `uploads` to files.
+#[derive(Debug, Clone)]
+pub struct UploadReleaseGroup {
+    pub release_id: Option<String>,
+    pub title: Option<String>,
+    pub progress: UploadProgress,
+    pub uploads: Vec<UploadOp>,
+}
+
 /// Complete snapshot of the cloud outbox. One source of truth for everything
 /// upload-related the UI renders.
 #[derive(Debug, Clone, Default)]
 pub struct OutboxSnapshot {
     pub uploads: Vec<UploadOp>,
+    /// `uploads` grouped by release, in first-seen order — the per-release rows
+    /// the queue pane renders.
+    pub upload_groups: Vec<UploadReleaseGroup>,
     pub deletes: Vec<DeleteOp>,
     /// Per-release aggregate, keyed by release id. Drives the "Uploading (N)"
     /// badge on each storage row and gates per-release storage actions.
@@ -270,8 +286,38 @@ pub(crate) async fn build_outbox_snapshot(
     } else {
         Some(bytes_remaining / throughput_bps)
     };
+
+    // Group the flat uploads by release (first-seen order) for the queue pane's
+    // per-release rows. The orphaned-files bucket (release_id `None`) groups
+    // together. Each group's `progress` is accumulated from its own files.
+    let mut upload_groups: Vec<UploadReleaseGroup> = Vec::new();
+    let mut group_index: HashMap<Option<String>, usize> = HashMap::new();
+    for op in &uploads {
+        let idx = *group_index.entry(op.release_id.clone()).or_insert_with(|| {
+            upload_groups.push(UploadReleaseGroup {
+                release_id: op.release_id.clone(),
+                title: op.title.clone(),
+                progress: UploadProgress::default(),
+                uploads: Vec::new(),
+            });
+            upload_groups.len() - 1
+        });
+        let group = &mut upload_groups[idx];
+        group.progress.bytes_total += op.bytes_total;
+        match &op.state {
+            UploadState::Queued => group.progress.queued += 1,
+            UploadState::Active { bytes_done } => {
+                group.progress.active += 1;
+                group.progress.bytes_done += bytes_done;
+            }
+            UploadState::Failed { .. } => group.progress.failed += 1,
+        }
+        group.uploads.push(op.clone());
+    }
+
     Ok(OutboxSnapshot {
         uploads,
+        upload_groups,
         deletes,
         per_release,
         total,
@@ -420,6 +466,25 @@ mod tests {
             .collect();
         names.sort();
         assert_eq!(names, ["01 Track Title.flac", "02 Track Title.flac"]);
+    }
+
+    #[tokio::test]
+    async fn upload_groups_group_a_releases_files_with_aggregate_progress() {
+        let (db, _small, _large, _tmp) = seed_two_queued_uploads().await;
+        let snapshot = build_outbox_snapshot(&db, &HashMap::new(), &UploadThroughput::new(), false)
+            .await
+            .unwrap();
+
+        // The release's two files collapse to one group carrying both.
+        assert_eq!(snapshot.upload_groups.len(), 1);
+        let group = &snapshot.upload_groups[0];
+        assert_eq!(group.release_id.as_deref(), Some("rel-1"));
+        assert_eq!(group.title.as_deref(), Some("Album Title"));
+        assert_eq!(group.uploads.len(), 2);
+        // Aggregate progress: both queued, summed bytes (100 + 1000).
+        assert_eq!(group.progress.queued, 2);
+        assert_eq!(group.progress.active, 0);
+        assert_eq!(group.progress.bytes_total, 1100);
     }
 
     #[tokio::test]

--- a/bae-macos/bae/bae/Services/Store/OutboxStore.swift
+++ b/bae-macos/bae/bae/Services/Store/OutboxStore.swift
@@ -35,6 +35,7 @@ class OutboxStore {
     static var emptySnapshot: BridgeOutboxSnapshot {
         BridgeOutboxSnapshot(
             uploads: [],
+            uploadGroups: [],
             deletes: [],
             perRelease: [:],
             total: BridgeUploadProgress(

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1685,12 +1685,23 @@ struct FfiUploadProgress {
     bytes_total: u64,
 }
 
+/// A release's pending uploads, grouped for the queue pane's per-release rows.
+/// `release_id`/`title` are null for the orphaned-files bucket.
+#[derive(Serialize)]
+struct FfiUploadReleaseGroup {
+    release_id: Option<String>,
+    title: Option<String>,
+    progress: FfiUploadProgress,
+    uploads: Vec<FfiUploadOp>,
+}
+
 /// The cloud outbox snapshot: per-item lists, per-release counts, overall
 /// totals, raw throughput, and raw ETA. The C# composes the localized summary
 /// band and formats throughput/ETA/bytes for the locale.
 #[derive(Serialize)]
 struct FfiOutboxSnapshot {
     uploads: Vec<FfiUploadOp>,
+    upload_groups: Vec<FfiUploadReleaseGroup>,
     deletes: Vec<FfiDeleteOp>,
     per_release: std::collections::HashMap<String, FfiUploadProgress>,
     total: FfiUploadProgress,
@@ -1710,28 +1721,36 @@ fn upload_progress_to_ffi(p: &bae_core::library::UploadProgress) -> FfiUploadPro
     }
 }
 
-fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOutboxSnapshot {
+fn upload_op_to_ffi(op: &bae_core::library::UploadOp) -> FfiUploadOp {
     use bae_core::library::UploadState;
-    let uploads = snapshot
-        .uploads
+    let (state, last_error, bytes_done) = match &op.state {
+        UploadState::Queued => ("queued", None, 0),
+        UploadState::Active { bytes_done } => ("active", None, *bytes_done),
+        UploadState::Failed { last_error } => ("failed", Some(last_error.clone()), 0),
+    };
+    FfiUploadOp {
+        id: op.id,
+        title: op.title.clone(),
+        release_id: op.release_id.clone(),
+        cloud_key: op.cloud_key.clone(),
+        bytes_total: op.bytes_total,
+        bytes_done,
+        attempt_count: op.attempt_count,
+        state: state.to_string(),
+        last_error,
+    }
+}
+
+fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOutboxSnapshot {
+    let uploads = snapshot.uploads.iter().map(upload_op_to_ffi).collect();
+    let upload_groups = snapshot
+        .upload_groups
         .iter()
-        .map(|op| {
-            let (state, last_error, bytes_done) = match &op.state {
-                UploadState::Queued => ("queued", None, 0),
-                UploadState::Active { bytes_done } => ("active", None, *bytes_done),
-                UploadState::Failed { last_error } => ("failed", Some(last_error.clone()), 0),
-            };
-            FfiUploadOp {
-                id: op.id,
-                title: op.title.clone(),
-                release_id: op.release_id.clone(),
-                cloud_key: op.cloud_key.clone(),
-                bytes_total: op.bytes_total,
-                bytes_done,
-                attempt_count: op.attempt_count,
-                state: state.to_string(),
-                last_error,
-            }
+        .map(|g| FfiUploadReleaseGroup {
+            release_id: g.release_id.clone(),
+            title: g.title.clone(),
+            progress: upload_progress_to_ffi(&g.progress),
+            uploads: g.uploads.iter().map(upload_op_to_ffi).collect(),
         })
         .collect();
     let deletes = snapshot
@@ -1749,6 +1768,7 @@ fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOu
         .collect();
     FfiOutboxSnapshot {
         uploads,
+        upload_groups,
         deletes,
         per_release,
         total: upload_progress_to_ffi(&snapshot.total),


### PR DESCRIPTION
Second of the cancel-any-transition chain (after #118). The Sync queue pane lists uploads as a flat row per file; it should show one row per release, like the storage table, so progress and cancellation are per-release there too.

Adds `upload_groups` to the outbox snapshot — the flat uploads grouped by release in first-seen order, each group carrying the release's display title, an aggregate `UploadProgress`, and its files (orphaned files group under a `None` release). The grouping is computed in bae-core so the UI just iterates and renders. Carried across the uniffi bridge and the Windows FFI JSON.

The flat `uploads` field stays for now; the macOS and Windows queue panes move to the groups in the following PRs, after which it's removed.

## Test plan
- `cargo test -p bae-core --features test-utils` — added: a release's files collapse to one group with aggregate progress (queued count, summed bytes) and the release title. Clippy clean across bae-core/bae-bridge/bae-windows-ffi; macOS app builds; periphery clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)