### PR TITLE
macOS: cancel any in-progress transition from the storage row

### DIFF
--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -9146,197 +9146,6 @@
         }
       }
     },
-    "Cancel Upload": {
-      "comment": "Storage table context menu: cancel an in-flight upload",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar subida"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Annuler l'envoi"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload abbrechen"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar upload"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アップロードをキャンセル"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消上传"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إلغاء الرفع"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בטל העלאה"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скасувати вивантаження"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отмяна на качването"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anuluj wysyłanie"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zrušit nahrávání"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otkaži prijenos"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "업로드 취소"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel Upload"
-          }
-        }
-      }
-    },
     "Cancel this download": {
       "comment": "Download row: tooltip for the cancel button",
       "localizations": {
@@ -25381,199 +25190,7 @@
         }
       }
     },
-    "Failed to cancel upload: %@": {
-      "comment": "Storage action runner: error cancelling an upload; %@ is the error description",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo cancelar la subida: %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Échec de l'annulation de l'envoi : %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload konnte nicht abgebrochen werden: %@"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falha ao cancelar o upload: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アップロードのキャンセルに失敗しました: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消上传失败：%@"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فشل إلغاء الرفع: %@"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ביטול ההעלאה נכשל: %@"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Не вдалося скасувати вивантаження: %@"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Качването не може да бъде отменено: %@"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie udało się anulować wysyłania: %@"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nepodařilo se zrušit nahrávání: %@"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otkazivanje prijenosa nije uspjelo: %@"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "업로드를 취소할 수 없음: %@"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to cancel upload: %@"
-          }
-        }
-      }
-    },
     "Failed to cancel: %@": {
-      "comment": "Storage Manager: error when cancelling an outbox item fails; %@ is the error description",
       "localizations": {
         "en": {
           "stringUnit": {
@@ -25583,181 +25200,181 @@
         },
         "es": {
           "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo cancelar: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Échec de l'annulation : %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "de": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Abbrechen fehlgeschlagen: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Falha ao cancelar: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
-            "value": "キャンセルに失敗しました: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "translated",
-            "value": "取消失败：%@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "ar": {
           "stringUnit": {
-            "state": "translated",
-            "value": "فشل الإلغاء: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "he": {
           "stringUnit": {
-            "state": "translated",
-            "value": "הביטול נכשל: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "uk": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Не вдалося скасувати: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "bg": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Отмяната не бе успешна: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "pl": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Nie udało się anulować: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "cs": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Nepodařilo se zrušit: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "hr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Otkazivanje nije uspjelo: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "translated",
-            "value": "취소할 수 없음: %@"
+            "state": "new",
+            "value": "Failed to cancel: %@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "it": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "tr": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "vi": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "nl": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "hi": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "bn": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "ta": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "te": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "mr": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "ur": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "gu": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "kn": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "ml": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "pa": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         },
         "th": {
           "stringUnit": {
-            "state": "translated",
+            "state": "new",
             "value": "Failed to cancel: %@"
           }
         }

--- a/bae-macos/bae/bae/Services/Sync.swift
+++ b/bae-macos/bae/bae/Services/Sync.swift
@@ -34,9 +34,9 @@ final class Sync: Sendable, Observable {
         @Sendable (_ libraryId: String, _ newName: String) throws -> Void
     /// Cancel one queued outbox entry by id (dequeues it; the local file stays).
     let cancelOutboxItem: @Sendable (_ id: Int64) throws -> Void
-    /// Stop uploading a release and keep it local-only: drops its queued and
-    /// in-flight uploads and deletes any blobs already uploaded this attempt.
-    let cancelReleaseUpload: @Sendable (_ releaseId: String) throws -> Void
+    /// Cancel whatever transition a release is mid-flight — pin, upload, or
+    /// unmanage — leaving it in its prior state. A no-op if nothing's running.
+    let cancelReleaseTransition: @Sendable (_ releaseId: String) throws -> Void
     /// Pause or resume the cloud-upload pipeline. In-flight uploads finish; the
     /// queue stops draining until resumed.
     let setSyncPaused: @Sendable (_ paused: Bool) -> Void
@@ -75,7 +75,7 @@ final class Sync: Sendable, Observable {
             throw StubError.notImplemented
         },
         cancelOutboxItem: @escaping @Sendable (Int64) throws -> Void = { _ in },
-        cancelReleaseUpload: @escaping @Sendable (String) throws -> Void = {
+        cancelReleaseTransition: @escaping @Sendable (String) throws -> Void = {
             _ in
         },
         setSyncPaused: @escaping @Sendable (Bool) -> Void = { _ in },
@@ -94,7 +94,7 @@ final class Sync: Sendable, Observable {
         self.triggerSync = triggerSync
         self.renameLibrary = renameLibrary
         self.cancelOutboxItem = cancelOutboxItem
-        self.cancelReleaseUpload = cancelReleaseUpload
+        self.cancelReleaseTransition = cancelReleaseTransition
         self.setSyncPaused = setSyncPaused
         self.lockActiveLibrary = lockActiveLibrary
     }
@@ -134,8 +134,8 @@ final class Sync: Sendable, Observable {
                 try handle.renameLibrary(libraryId: $0, name: $1)
             },
             cancelOutboxItem: { try handle.cancelOutboxItem(id: $0) },
-            cancelReleaseUpload: {
-                try handle.cancelReleaseUpload(releaseId: $0)
+            cancelReleaseTransition: {
+                try handle.cancelReleaseTransition(releaseId: $0)
             },
             setSyncPaused: { handle.setSyncPaused(paused: $0) },
             triggerSync: { handle.triggerSync() },

--- a/bae-macos/bae/bae/Views/StorageActionRunner.swift
+++ b/bae-macos/bae/bae/Views/StorageActionRunner.swift
@@ -83,19 +83,18 @@ final class StorageActionRunner {
         pendingManage = nil
     }
 
-    /// Stop uploading each release and keep it local-only: core drops the
-    /// release's queued and in-flight uploads and deletes any blobs already
-    /// uploaded this attempt.
-    func cancelUploads(releaseIds: [String]) {
+    /// Cancel each release's in-progress transition (pin / upload / unmanage),
+    /// leaving it in its prior state — core dispatches to whichever is running.
+    func cancelTransitions(releaseIds: [String]) {
         for id in releaseIds {
             do {
-                try sync.cancelReleaseUpload(id)
+                try sync.cancelReleaseTransition(id)
             }
             catch {
                 uiStore.showError(
                     String(
                         localized:
-                            "Failed to cancel upload: \(error.localizedDescription)"
+                            "Failed to cancel: \(error.localizedDescription)"
                     )
                 )
                 return

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -738,19 +738,21 @@ extension StorageTableView.Coordinator: NSMenuDelegate {
         let targets = menuTargets(forClicked: item)
         guard !targets.isEmpty else { return }
 
-        // A release uploading right now can't be managed/pinned/unmanaged (those
-        // race the observer that completes the transition), so the only action it
-        // offers is stopping the upload — in every tab, not just "Uploading".
-        let uploading = targets.filter {
-            outboxStore.isUploading(forRelease: $0)
+        // A release mid-transition (uploading, pinning, or unmanaging) can't be
+        // managed/pinned/unmanaged (those race the transition), so the only
+        // action it offers is cancelling — in every tab. Uploads live in the
+        // outbox; foreground transfers (pin/unpin/unmanage) set `transfer`.
+        let transitioning = targets.filter { id in
+            outboxStore.isUploading(forRelease: id)
+                || libraryStore.releaseSummaries[id]?.transfer != nil
         }
-        if !uploading.isEmpty {
+        if !transitioning.isEmpty {
             addMenuItem(
                 to: menu,
-                title: String(localized: "Cancel Upload"),
-                action: #selector(cancelUploadsAction(_:)),
+                title: String(localized: "Cancel"),
+                action: #selector(cancelTransitionsAction(_:)),
                 symbol: "xmark.circle",
-                representedObject: uploading
+                representedObject: transitioning
             )
             return
         }
@@ -819,12 +821,12 @@ extension StorageTableView.Coordinator: NSMenuDelegate {
     }
 
     @objc
-    private func cancelUploadsAction(_ sender: NSMenuItem) {
+    private func cancelTransitionsAction(_ sender: NSMenuItem) {
         guard let releaseIds = sender.representedObject as? [String] else {
-            logger.error("Cancel-upload menu item carried no release ids")
+            logger.error("Cancel menu item carried no release ids")
             return
         }
-        runner.cancelUploads(releaseIds: releaseIds)
+        runner.cancelTransitions(releaseIds: releaseIds)
     }
 
     /// Storage actions every targeted release allows, preserving the order the


### PR DESCRIPTION
Third of the cancel-any-transition chain (after #118, #119). The storage-row context menu offered "Cancel Upload" only for uploads — a release that was pinning (downloading) or unmanaging showed an empty menu.

Now a release mid-transition offers a single **Cancel** in every storage tab, wired to `cancel_release_transition` (#118), which dispatches to whichever transition is running. Detection reads the two signals already at the leaf: the outbox (`isUploading`) for the managed upload, and the summary's `transfer` for any foreground transfer (pin / unpin / unmanage — all emit `ReleaseTransferProgress`). No new store wiring was needed: a pin sets `transfer` via the download worker's `drive_transfer`.

Drops the upload-only `Cancel Upload` / `Failed to cancel upload` chrome strings (now orphaned) for the generic `Cancel` (already catalogued) and `Failed to cancel: %@`.

## Test plan
- macOS app builds; periphery clean.
- Manually: right-click a release while uploading / pinning / unmanaging, in any tab → "Cancel" appears and stops it, leaving it in its prior state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)