### PR TITLE
macOS: group the sync queue pane by release, cancel from there

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1306,9 +1306,9 @@ fn convert_outbox_snapshot(
         .into_iter()
         .map(|g| BridgeUploadReleaseGroup {
             release_id: g.release_id,
-            title: g.title,
+            display_title: g.display_title,
+            file_count: g.file_count,
             progress: convert_upload_progress(g.progress),
-            uploads: g.uploads.into_iter().map(convert_upload_op).collect(),
         })
         .collect();
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1603,14 +1603,14 @@ pub struct BridgeDownloadSnapshot {
 }
 
 /// A release's pending uploads, grouped for the queue pane's per-release rows.
-/// Mirror of bae-core's `UploadReleaseGroup`. `release_id`/`title` are `None` for
-/// the orphaned-files bucket.
+/// Mirror of bae-core's `UploadReleaseGroup`. `release_id` is `None` for the
+/// orphaned-files bucket; `display_title` is the row's label, resolved by core.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeUploadReleaseGroup {
     pub release_id: Option<String>,
-    pub title: Option<String>,
+    pub display_title: String,
+    pub file_count: u32,
     pub progress: BridgeUploadProgress,
-    pub uploads: Vec<BridgeUploadOp>,
 }
 
 /// The cloud-outbox processing snapshot the Storage Manager renders. The

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -128,15 +128,16 @@ impl UploadProgress {
 
 /// A release's pending uploads, grouped for the queue pane so it renders one row
 /// per release (matching the storage table) instead of a flat per-file list.
-/// `release_id`/`title` are `None` for the orphaned-files bucket (a release row
-/// whose backing release is gone). `progress` is the group's aggregate; the
-/// queue pane reads it for the per-release row and can expand `uploads` to files.
+/// `release_id` is `None` for the orphaned-files bucket (files whose backing
+/// release is gone). `display_title` is what the row labels itself with — the
+/// album title, or the file's own name for an orphan — resolved here so the UI
+/// renders it directly. `progress` and `file_count` are the group's aggregates.
 #[derive(Debug, Clone)]
 pub struct UploadReleaseGroup {
     pub release_id: Option<String>,
-    pub title: Option<String>,
+    pub display_title: String,
+    pub file_count: u32,
     pub progress: UploadProgress,
-    pub uploads: Vec<UploadOp>,
 }
 
 /// Complete snapshot of the cloud outbox. One source of truth for everything
@@ -294,15 +295,28 @@ pub(crate) async fn build_outbox_snapshot(
     let mut group_index: HashMap<Option<String>, usize> = HashMap::new();
     for op in &uploads {
         let idx = *group_index.entry(op.release_id.clone()).or_insert_with(|| {
+            // The album title, or the file's own label for an orphan (a release
+            // deleted mid-upload, so the row has no album to name it by).
+            let display_title = match &op.title {
+                Some(title) => title.clone(),
+                None => {
+                    debug!(
+                        file_id = %op.file_id,
+                        "outbox upload group has no album title (orphaned); labelling by file name"
+                    );
+                    op.display_name.clone()
+                }
+            };
             upload_groups.push(UploadReleaseGroup {
                 release_id: op.release_id.clone(),
-                title: op.title.clone(),
+                display_title,
+                file_count: 0,
                 progress: UploadProgress::default(),
-                uploads: Vec::new(),
             });
             upload_groups.len() - 1
         });
         let group = &mut upload_groups[idx];
+        group.file_count += 1;
         group.progress.bytes_total += op.bytes_total;
         match &op.state {
             UploadState::Queued => group.progress.queued += 1,
@@ -312,7 +326,6 @@ pub(crate) async fn build_outbox_snapshot(
             }
             UploadState::Failed { .. } => group.progress.failed += 1,
         }
-        group.uploads.push(op.clone());
     }
 
     Ok(OutboxSnapshot {
@@ -479,8 +492,8 @@ mod tests {
         assert_eq!(snapshot.upload_groups.len(), 1);
         let group = &snapshot.upload_groups[0];
         assert_eq!(group.release_id.as_deref(), Some("rel-1"));
-        assert_eq!(group.title.as_deref(), Some("Album Title"));
-        assert_eq!(group.uploads.len(), 2);
+        assert_eq!(group.display_title, "Album Title");
+        assert_eq!(group.file_count, 2);
         // Aggregate progress: both queued, summed bytes (100 + 1000).
         assert_eq!(group.progress.queued, 2);
         assert_eq!(group.progress.active, 0);

--- a/bae-macos/bae/bae/BridgeUploadOp+Size.swift
+++ b/bae-macos/bae/bae/BridgeUploadOp+Size.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-extension BridgeUploadOp {
-    /// File size formatted for the current locale, e.g. "70 MB". bae-core emits
-    /// the raw byte count; the UI formats it.
-    var sizeText: String {
-        Int64(bytesTotal).formatted(.byteCount(style: .file))
-    }
-}

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -438,10 +438,17 @@ private struct OutboxSection: View {
     private func itemList(_ snapshot: BridgeOutboxSnapshot) -> some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(snapshot.uploads, id: \.id) { op in
-                    OutboxUploadRow(op: op)
+                // Uploads are grouped per release (matching the storage table);
+                // right-click a release to cancel its transition.
+                ForEach(snapshot.uploadGroups, id: \.releaseId) { group in
+                    OutboxReleaseRow(group: group) {
+                        if let releaseId = group.releaseId {
+                            cancelTransition(releaseId)
+                        }
+                    }
                     Divider()
                 }
+                // Deletes stay per-file — a delete is a single-file operation.
                 ForEach(snapshot.deletes, id: \.id) { op in
                     OutboxDeleteRow(op: op) { cancel(op.id) }
                     Divider()
@@ -450,7 +457,19 @@ private struct OutboxSection: View {
         }
     }
 
-    /// Remove a queued upload or delete, surfacing any failure.
+    /// Cancel a release's in-progress transition, surfacing any failure.
+    private func cancelTransition(_ releaseId: String) {
+        do { try sync.cancelReleaseTransition(releaseId) }
+        catch {
+            uiStore.showError(
+                String(
+                    localized: "Failed to cancel: \(error.localizedDescription)"
+                )
+            )
+        }
+    }
+
+    /// Remove a queued delete, surfacing any failure.
     private func cancel(_ id: Int64) {
         do { try sync.cancelOutboxItem(id) }
         catch {
@@ -502,8 +521,13 @@ private struct OutboxTotalProgress: View {
     }
 }
 
-private struct OutboxUploadRow: View {
-    let op: BridgeUploadOp
+/// One queue-pane row per release (matching the storage table): the release
+/// title, its file count and total size, and an aggregate state badge.
+/// Right-click to cancel the release's transition. The orphaned-files bucket
+/// (no release id) renders without a cancel — there's no release to act on.
+private struct OutboxReleaseRow: View {
+    let group: BridgeUploadReleaseGroup
+    let onCancel: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
@@ -511,10 +535,10 @@ private struct OutboxUploadRow: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 16)
 
-            Text(op.displayName)
+            Text(group.displayTitle)
                 .lineLimit(1)
 
-            Text(op.sizeText)
+            Text("\(Int(group.fileCount)) files · \(sizeText)")
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
@@ -524,34 +548,42 @@ private struct OutboxUploadRow: View {
             stateBadge
                 .font(.caption)
                 .frame(width: 130, alignment: .leading)
-
-            Text(queuedRelativeLabel(op.createdAt))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(width: 90, alignment: .trailing)
         }
         .padding(.horizontal)
         .padding(.vertical, 6)
-        // Always attached; nil/empty when there's no error, so the row's
-        // structure doesn't change as its state flips.
-        .help(op.lastError ?? "")
+        .contentShape(Rectangle())
+        .contextMenu {
+            if group.releaseId != nil {
+                Button("Cancel", role: .destructive, action: onCancel)
+            }
+        }
+    }
+
+    private var sizeText: String {
+        Int64(group.progress.bytesTotal).formatted(.byteCount(style: .file))
     }
 
     @ViewBuilder
     private var stateBadge: some View {
-        switch op.state {
+        let remaining = Int(group.progress.pending)
+        switch group.progress.activity {
         case .queued:
-            Label("Queued", systemImage: "clock")
+            Label("Queued (\(remaining))", systemImage: "clock")
                 .foregroundStyle(.secondary)
-        case .active:
-            Label("Uploading", systemImage: "arrow.up.circle.fill")
-                .foregroundStyle(.orange)
-        case .failed:
+        case .uploading:
             Label(
-                "Retrying (\(op.attemptCount))",
+                "Uploading (\(remaining))",
+                systemImage: "arrow.up.circle.fill"
+            )
+            .foregroundStyle(.orange)
+        case .retrying:
+            Label(
+                "Retrying (\(remaining))",
                 systemImage: "exclamationmark.triangle.fill"
             )
             .foregroundStyle(.red)
+        case .none:
+            EmptyView()
         }
     }
 }

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1686,13 +1686,14 @@ struct FfiUploadProgress {
 }
 
 /// A release's pending uploads, grouped for the queue pane's per-release rows.
-/// `release_id`/`title` are null for the orphaned-files bucket.
+/// `release_id` is null for the orphaned-files bucket; `display_title` is the
+/// row's label, resolved by core.
 #[derive(Serialize)]
 struct FfiUploadReleaseGroup {
     release_id: Option<String>,
-    title: Option<String>,
+    display_title: String,
+    file_count: u32,
     progress: FfiUploadProgress,
-    uploads: Vec<FfiUploadOp>,
 }
 
 /// The cloud outbox snapshot: per-item lists, per-release counts, overall
@@ -1748,9 +1749,9 @@ fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOu
         .iter()
         .map(|g| FfiUploadReleaseGroup {
             release_id: g.release_id.clone(),
-            title: g.title.clone(),
+            display_title: g.display_title.clone(),
+            file_count: g.file_count,
             progress: upload_progress_to_ffi(&g.progress),
-            uploads: g.uploads.iter().map(upload_op_to_ffi).collect(),
         })
         .collect();
     let deletes = snapshot


### PR DESCRIPTION
Fourth of the chain (after #118, #119, #120). The Sync queue pane listed a row per file; it now shows one row per release (matching the storage table), rendering the `upload_groups` from #119: release title, file count + total size, and an aggregate state badge. Right-click a release → "Cancel" stops its transition via `cancel_release_transition` (#118). Deletes stay per-file. The orphaned-files bucket (no release id) renders without a cancel.

Removes the now-unused per-file `OutboxUploadRow` and the orphaned `BridgeUploadOp.sizeText` extension.

## Test plan
- macOS app builds; periphery clean.
- Manually: queue a multi-file release → the pane shows one row for it with aggregate progress; right-click → "Cancel" stops it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)