### PR TITLE
Windows: group the queue pane by release, cancel any transition

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -661,19 +661,6 @@ impl AppHandle {
             .map_err(BridgeError::internal)
     }
 
-    /// Stop uploading a release that's mid-`manage` and keep it local-only:
-    /// drops its queued/in-flight upload rows and deletes any blobs already
-    /// uploaded this attempt, leaving the local copy in place.
-    pub fn cancel_release_upload(&self, release_id: String) -> Result<(), BridgeError> {
-        self.runtime
-            .block_on(
-                self.app_services
-                    .library_manager()
-                    .cancel_release_upload(&release_id),
-            )
-            .map_err(BridgeError::internal)
-    }
-
     /// Cancel whatever transition a release is mid-flight — a pin (download), a
     /// managed upload, or an unmanage — leaving it in its prior state. The UI
     /// calls this from the storage row and the queue pane without knowing which

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1862,15 +1862,15 @@ pub unsafe extern "C" fn bae_cancel_outbox_item(handle: *const BaeHandle, id: i6
     }
 }
 
-/// Stop uploading a release and keep it local-only: drops its queued and
-/// in-flight uploads and deletes any blobs already uploaded this attempt.
-/// Returns null on success, else an owned error string to free with
-/// `bae_free_string`.
+/// Cancel whatever transition a release is mid-flight — a pin (download), a
+/// managed upload, or an unmanage — leaving it in its prior state. A no-op if
+/// nothing is in progress. Returns null on success, else an owned error string
+/// to free with `bae_free_string`.
 ///
 /// # Safety
 /// `handle` must be a live `BaeHandle`; `release_id` a valid C string.
 #[no_mangle]
-pub unsafe extern "C" fn bae_cancel_release_upload(
+pub unsafe extern "C" fn bae_cancel_release_transition(
     handle: *const BaeHandle,
     release_id: *const c_char,
 ) -> *mut c_char {
@@ -1884,7 +1884,7 @@ pub unsafe extern "C" fn bae_cancel_release_upload(
     match app.runtime.block_on(
         app.services
             .library_manager()
-            .cancel_release_upload(&release_id),
+            .cancel_release_transition(&release_id),
     ) {
         Ok(()) => std::ptr::null_mut(),
         Err(e) => error_cstring(&e.to_string()),

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3366,64 +3366,84 @@ public sealed partial class MainWindow : Window
             // mini progress bar for an in-flight upload, and a Cancel that
             // dequeues it. `activeUpload` is set only for an upload that's
             // transferring right now, so its bar moves with the live byte count.
-            void AddRow(long id, string label, UploadOp? activeUpload)
+            // A queue row: a label (with an optional progress bar) and an optional
+            // trailing cancel button.
+            void AddOutboxRow(string label, ProgressBar? progress, Button? trailing)
             {
                 var itemGrid = new Grid { ColumnSpacing = 8 };
                 itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
                 itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
                 var labelColumn = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
-                labelColumn.Children.Add(new TextBlock
+                labelColumn.Children.Add(new TextBlock { Text = label, TextWrapping = TextWrapping.Wrap });
+                if (progress is not null)
                 {
-                    Text = label,
-                    TextWrapping = TextWrapping.Wrap,
-                });
-                if (activeUpload is { IsActive: true, BytesTotal: > 0 })
-                {
-                    labelColumn.Children.Add(new ProgressBar
-                    {
-                        Minimum = 0,
-                        Maximum = activeUpload.BytesTotal,
-                        Value = activeUpload.BytesDone,
-                    });
+                    labelColumn.Children.Add(progress);
                 }
                 Grid.SetColumn(labelColumn, 0);
                 itemGrid.Children.Add(labelColumn);
 
-                // Uploads are stopped per-release (right-click the storage row →
-                // "Cancel Upload"), not per file. A pending delete is genuinely a
-                // single-file operation, so it keeps its per-row cancel.
-                if (activeUpload is null)
+                if (trailing is not null)
                 {
-                    var cancel = new Button { Content = Loc.Chrome("outbox.cancel_item") };
-                    cancel.Click += async (_, _) =>
-                    {
-                        storageStatus.Visibility = Visibility.Collapsed;
-                        cancel.IsEnabled = false;
-                        var error = await System.Threading.Tasks.Task.Run(() => NativeBae.CancelOutboxItem(_handle, id));
-                        if (error is not null)
-                        {
-                            storageStatus.Text = error;
-                            storageStatus.Visibility = Visibility.Visible;
-                            cancel.IsEnabled = true;
-                            return;
-                        }
-
-                        await LoadOutbox();
-                    };
-                    Grid.SetColumn(cancel, 1);
-                    itemGrid.Children.Add(cancel);
+                    Grid.SetColumn(trailing, 1);
+                    itemGrid.Children.Add(trailing);
                 }
                 outboxPanel.Children.Add(itemGrid);
             }
 
-            foreach (var upload in snapshot.Uploads)
+            // A cancel button that runs `action` off-thread, surfaces any error to
+            // the status line, and reloads the panel on success.
+            Button CancelButton(string content, Func<string?> action)
             {
-                AddRow(upload.Id, upload.Label, upload);
+                var button = new Button { Content = content };
+                button.Click += async (_, _) =>
+                {
+                    storageStatus.Visibility = Visibility.Collapsed;
+                    button.IsEnabled = false;
+                    var error = await System.Threading.Tasks.Task.Run(action);
+                    if (error is not null)
+                    {
+                        storageStatus.Text = error;
+                        storageStatus.Visibility = Visibility.Visible;
+                        button.IsEnabled = true;
+                        return;
+                    }
+
+                    await LoadOutbox();
+                };
+                return button;
             }
+
+            // Uploads: one row per release (matching the storage table) — title,
+            // aggregate progress, and a cancel that stops the release's transition.
+            // The orphaned-files bucket (no release id) has no release to cancel.
+            foreach (var group in snapshot.UploadGroups)
+            {
+                ProgressBar? progress = group.Progress is { Active: > 0, BytesTotal: > 0 }
+                    ? new ProgressBar
+                    {
+                        Minimum = 0,
+                        Maximum = group.Progress.BytesTotal,
+                        Value = group.Progress.BytesDone,
+                    }
+                    : null;
+                Button? cancel = group.ReleaseId is string releaseId
+                    ? CancelButton(
+                        Loc.Chrome("storage.cancel_upload"),
+                        () => NativeBae.CancelReleaseTransition(_handle, releaseId))
+                    : null;
+                AddOutboxRow(group.DisplayTitle, progress, cancel);
+            }
+            // A pending delete is genuinely a single-file operation, so it keeps
+            // its own per-file cancel.
             foreach (var delete in snapshot.Deletes)
             {
-                AddRow(delete.Id, delete.Label, null);
+                AddOutboxRow(
+                    delete.Label,
+                    null,
+                    CancelButton(
+                        Loc.Chrome("outbox.cancel_item"),
+                        () => NativeBae.CancelOutboxItem(_handle, delete.Id)));
             }
         }
 
@@ -3562,7 +3582,7 @@ public sealed partial class MainWindow : Window
                 foreach (var releaseId in uploadingReleases)
                 {
                     var error = await System.Threading.Tasks.Task.Run(
-                        () => NativeBae.CancelReleaseUpload(_handle, releaseId));
+                        () => NativeBae.CancelReleaseTransition(_handle, releaseId));
                     if (error is not null)
                     {
                         storageStatus.Text = error;

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -459,14 +459,15 @@ internal static class NativeBae
     internal static string? CancelOutboxItem(IntPtr handle, long id) =>
         ResultMessage(CancelOutboxItemPtr(handle, id));
 
-    [DllImport(Dll, EntryPoint = "bae_cancel_release_upload", CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr CancelReleaseUploadPtr(
+    [DllImport(Dll, EntryPoint = "bae_cancel_release_transition", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr CancelReleaseTransitionPtr(
         IntPtr handle,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string releaseId);
 
-    /// <summary>Stop uploading a release and keep it local-only; null on success, else the error.</summary>
-    internal static string? CancelReleaseUpload(IntPtr handle, string releaseId) =>
-        ResultMessage(CancelReleaseUploadPtr(handle, releaseId));
+    /// <summary>Cancel whatever transition a release is mid-flight (pin / upload /
+    /// unmanage), leaving it in its prior state; null on success, else the error.</summary>
+    internal static string? CancelReleaseTransition(IntPtr handle, string releaseId) =>
+        ResultMessage(CancelReleaseTransitionPtr(handle, releaseId));
 
     /// <summary>
     /// Album results for a query as JSON (same shape as a page), or

--- a/bae-windows/OutboxSnapshot.cs
+++ b/bae-windows/OutboxSnapshot.cs
@@ -11,6 +11,11 @@ namespace Bae.Windows;
 public sealed class OutboxSnapshot
 {
     public List<UploadOp> Uploads { get; set; } = new();
+
+    /// <summary>Uploads grouped by release for the queue pane's per-release rows
+    /// (matching the storage table). Resolved by core.</summary>
+    public List<UploadReleaseGroup> UploadGroups { get; set; } = new();
+
     public List<DeleteOp> Deletes { get; set; } = new();
 
     /// <summary>True when the user paused the upload pipeline — drives the
@@ -92,6 +97,17 @@ public sealed class UploadProgress
     public uint Failed { get; set; }
     public long BytesDone { get; set; }
     public long BytesTotal { get; set; }
+}
+
+/// <summary>A release's pending uploads, grouped for the queue pane's per-release
+/// rows. <c>ReleaseId</c> is null for the orphaned-files bucket; <c>DisplayTitle</c>
+/// is the row label, resolved by core.</summary>
+public sealed class UploadReleaseGroup
+{
+    public string? ReleaseId { get; set; }
+    public string DisplayTitle { get; set; } = string.Empty;
+    public uint FileCount { get; set; }
+    public UploadProgress Progress { get; set; } = new();
 }
 
 /// <summary>One queued upload.</summary>


### PR DESCRIPTION
Final PR of the chain (after #118–#121) — brings Windows to macOS parity.

The outbox panel listed a row per file; it now shows one row per release (matching the storage table), rendering the `upload_groups` from #119: release title, an aggregate progress bar, and a cancel. Deletes stay per-file. The orphaned-files bucket renders without a cancel.

Both cancel surfaces — the queue-pane row and the storage-row context menu — call `cancel_release_transition` (#118) via a new `bae_cancel_release_transition` FFI entry point, which dispatches to whichever transition is running. This replaces the upload-only `bae_cancel_release_upload` and its now-dead C# binding; the uniffi bridge's `cancel_release_upload`, unused since macOS moved to the unified call (#120), is removed too. bae-core keeps `cancel_release_upload` — the dispatcher calls it.

## Test plan
- `cargo clippy` clean across bae-core/bae-bridge/bae-windows-ffi; macOS app builds (bridge method removal verified by the pre-commit hook + periphery).
- Windows app build verified by `windows.yml` CI (no local Windows toolchain).
- Manually (Windows): queue a multi-file release → the panel shows one row for it; right-click it in the panel or the storage table → "Cancel Upload" stops it, leaving it local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)