### PR TITLE
Drop the flat per-file uploads from the outbox wire

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1282,12 +1282,6 @@ fn convert_outbox_snapshot(
 ) -> crate::types::BridgeOutboxSnapshot {
     use crate::types::{BridgeDeleteOp, BridgeOutboxSnapshot, BridgeUploadReleaseGroup};
 
-    let uploads = snapshot
-        .uploads
-        .into_iter()
-        .map(convert_upload_op)
-        .collect();
-
     let upload_groups = snapshot
         .upload_groups
         .into_iter()
@@ -1317,7 +1311,6 @@ fn convert_outbox_snapshot(
         .collect();
 
     BridgeOutboxSnapshot {
-        uploads,
         upload_groups,
         deletes,
         per_release,
@@ -1327,32 +1320,6 @@ fn convert_outbox_snapshot(
         paused: snapshot.paused,
         throughput_bps: snapshot.throughput_bps,
         eta_seconds: snapshot.eta_seconds,
-    }
-}
-
-/// `last_error` is lifted out of the `Failed` variant into a flat field beside
-/// the three-state enum so the UI doesn't switch on associated data.
-fn convert_upload_op(op: bae_core::library::UploadOp) -> crate::types::BridgeUploadOp {
-    use crate::types::{BridgeUploadOp, BridgeUploadState};
-    use bae_core::library::UploadState;
-
-    let (state, last_error, bytes_done) = match op.state {
-        UploadState::Queued => (BridgeUploadState::Queued, None, 0),
-        UploadState::Active { bytes_done } => (BridgeUploadState::Active, None, bytes_done),
-        UploadState::Failed { last_error } => (BridgeUploadState::Failed, Some(last_error), 0),
-    };
-    BridgeUploadOp {
-        id: op.id,
-        file_id: op.file_id,
-        release_id: op.release_id,
-        display_name: op.display_name,
-        cloud_key: op.cloud_key,
-        bytes_total: op.bytes_total,
-        bytes_done,
-        created_at: op.created_at,
-        attempt_count: op.attempt_count,
-        state,
-        last_error,
     }
 }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1483,16 +1483,6 @@ pub enum BridgeUiEvent {
     ErrorCleared,
 }
 
-/// An upload's current processing state. `Failed` carries the error in
-/// the item's `last_error`. `Active` carries the bytes uploaded so far
-/// (always 0 today; populated once sub-file progress lands in coven).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
-pub enum BridgeUploadState {
-    Queued,
-    Active,
-    Failed,
-}
-
 /// The dominant activity of a slice of the upload queue, for the storage-row
 /// badge. Mirror of bae-core's `UploadActivity`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
@@ -1500,28 +1490,6 @@ pub enum BridgeUploadActivity {
     Uploading,
     Retrying,
     Queued,
-}
-
-/// One queued upload. Mirror of bae-core's `UploadOp` across the FFI; carries
-/// raw fields the UI renders directly.
-#[derive(Debug, Clone, uniffi::Record)]
-pub struct BridgeUploadOp {
-    pub id: i64,
-    pub file_id: String,
-    /// Owning release id; `None` for an orphaned file.
-    pub release_id: Option<String>,
-    /// The row's primary label: the file's original name, or the cloud key when
-    /// the file is orphaned. Pre-resolved by bae-core; the UI renders it directly.
-    pub display_name: String,
-    pub cloud_key: String,
-    pub bytes_total: u64,
-    pub bytes_done: u64,
-    /// Enqueue time as Unix epoch milliseconds, for the queued relative label.
-    pub created_at: i64,
-    pub attempt_count: i64,
-    pub state: BridgeUploadState,
-    /// The most recent error, present only when `state` is `Failed`.
-    pub last_error: Option<String>,
 }
 
 /// One pending cloud delete.
@@ -1618,8 +1586,7 @@ pub struct BridgeUploadReleaseGroup {
 /// are computed in bae-core; the UI renders them verbatim.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeOutboxSnapshot {
-    pub uploads: Vec<BridgeUploadOp>,
-    /// `uploads` grouped by release for the queue pane's per-release rows.
+    /// Pending uploads grouped by release for the queue pane's per-release rows.
     pub upload_groups: Vec<BridgeUploadReleaseGroup>,
     pub deletes: Vec<BridgeDeleteOp>,
     /// Per-release aggregate, keyed by release id. Releases with no pending

--- a/bae-macos/bae/bae/Services/Store/OutboxStore.swift
+++ b/bae-macos/bae/bae/Services/Store/OutboxStore.swift
@@ -34,7 +34,6 @@ class OutboxStore {
     /// and serves as the fallback if that read fails.
     static var emptySnapshot: BridgeOutboxSnapshot {
         BridgeOutboxSnapshot(
-            uploads: [],
             uploadGroups: [],
             deletes: [],
             perRelease: [:],

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -341,7 +341,7 @@ private struct OutboxSection: View {
 
     var body: some View {
         let snapshot = outboxStore.snapshot
-        if !snapshot.uploads.isEmpty || !snapshot.deletes.isEmpty {
+        if !snapshot.uploadGroups.isEmpty || !snapshot.deletes.isEmpty {
             Divider()
             VStack(spacing: 0) {
                 if !collapsed {

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1645,29 +1645,6 @@ pub unsafe extern "C" fn bae_unmanage_release(
     }
 }
 
-/// One queued upload, as the outbox panel renders it.
-#[derive(Serialize)]
-struct FfiUploadOp {
-    id: i64,
-    /// Album title for an upload that still resolves to a release; null for an
-    /// orphaned file.
-    title: Option<String>,
-    /// Owning release id; null for an orphaned file.
-    release_id: Option<String>,
-    cloud_key: String,
-    /// Total bytes for this file; the C# formats it for the locale.
-    bytes_total: u64,
-    bytes_done: u64,
-    attempt_count: i64,
-    /// "queued", "active", or "failed".
-    state: String,
-    /// The last failure message when `state` is "failed". This is an opaque,
-    /// log-only diagnostic string from the cloud layer (an exception's text),
-    /// not a localized line — the C# shows it verbatim in a copyable disclosure,
-    /// like macOS's `BridgeError::Diagnostic` detail.
-    last_error: Option<String>,
-}
-
 /// One queued cloud delete.
 #[derive(Serialize)]
 struct FfiDeleteOp {
@@ -1701,7 +1678,6 @@ struct FfiUploadReleaseGroup {
 /// band and formats throughput/ETA/bytes for the locale.
 #[derive(Serialize)]
 struct FfiOutboxSnapshot {
-    uploads: Vec<FfiUploadOp>,
     upload_groups: Vec<FfiUploadReleaseGroup>,
     deletes: Vec<FfiDeleteOp>,
     per_release: std::collections::HashMap<String, FfiUploadProgress>,
@@ -1722,28 +1698,7 @@ fn upload_progress_to_ffi(p: &bae_core::library::UploadProgress) -> FfiUploadPro
     }
 }
 
-fn upload_op_to_ffi(op: &bae_core::library::UploadOp) -> FfiUploadOp {
-    use bae_core::library::UploadState;
-    let (state, last_error, bytes_done) = match &op.state {
-        UploadState::Queued => ("queued", None, 0),
-        UploadState::Active { bytes_done } => ("active", None, *bytes_done),
-        UploadState::Failed { last_error } => ("failed", Some(last_error.clone()), 0),
-    };
-    FfiUploadOp {
-        id: op.id,
-        title: op.title.clone(),
-        release_id: op.release_id.clone(),
-        cloud_key: op.cloud_key.clone(),
-        bytes_total: op.bytes_total,
-        bytes_done,
-        attempt_count: op.attempt_count,
-        state: state.to_string(),
-        last_error,
-    }
-}
-
 fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOutboxSnapshot {
-    let uploads = snapshot.uploads.iter().map(upload_op_to_ffi).collect();
     let upload_groups = snapshot
         .upload_groups
         .iter()
@@ -1768,7 +1723,6 @@ fn outbox_snapshot_to_ffi(snapshot: &bae_core::library::OutboxSnapshot) -> FfiOu
         .map(|(k, v)| (k.clone(), upload_progress_to_ffi(v)))
         .collect();
     FfiOutboxSnapshot {
-        uploads,
         upload_groups,
         deletes,
         per_release,

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3284,7 +3284,7 @@ public sealed partial class MainWindow : Window
                 return;
             }
 
-            if (snapshot.Uploads.Count == 0 && snapshot.Deletes.Count == 0)
+            if (snapshot.UploadGroups.Count == 0 && snapshot.Deletes.Count == 0)
             {
                 return;
             }

--- a/bae-windows/OutboxSnapshot.cs
+++ b/bae-windows/OutboxSnapshot.cs
@@ -10,8 +10,6 @@ namespace Bae.Windows;
 /// </summary>
 public sealed class OutboxSnapshot
 {
-    public List<UploadOp> Uploads { get; set; } = new();
-
     /// <summary>Uploads grouped by release for the queue pane's per-release rows
     /// (matching the storage table). Resolved by core.</summary>
     public List<UploadReleaseGroup> UploadGroups { get; set; } = new();
@@ -108,84 +106,6 @@ public sealed class UploadReleaseGroup
     public string DisplayTitle { get; set; } = string.Empty;
     public uint FileCount { get; set; }
     public UploadProgress Progress { get; set; } = new();
-}
-
-/// <summary>One queued upload.</summary>
-public sealed class UploadOp
-{
-    public long Id { get; set; }
-
-    /// <summary>Owning release id; null for an orphaned file. The storage row
-    /// context menu reads this to find a release's queued uploads to cancel.</summary>
-    public string? ReleaseId { get; set; }
-
-    /// <summary>Album title when the upload still resolves to a release; null for an
-    /// orphaned file.</summary>
-    public string? Title { get; set; }
-    public string CloudKey { get; set; } = string.Empty;
-    public long AttemptCount { get; set; }
-
-    /// <summary>Bytes of this file that have reached the cloud so far; advances
-    /// mid-upload while <see cref="State"/> is "active".</summary>
-    public long BytesDone { get; set; }
-
-    /// <summary>Total bytes for this file (the encrypted payload size); formatted
-    /// for the locale by <see cref="SizeLabel"/>.</summary>
-    public long BytesTotal { get; set; }
-
-    /// <summary>"queued", "active", or "failed".</summary>
-    public string State { get; set; } = string.Empty;
-
-    /// <summary>The last failure message when <see cref="State"/> is "failed".
-    /// This is an opaque, log-only diagnostic string from the cloud layer (an
-    /// exception's text), shown verbatim in a copyable disclosure — never
-    /// translated, like a diagnostic error's detail.</summary>
-    public string? LastError { get; set; }
-
-    /// <summary>The total size formatted for the locale, e.g. "12.4 MB".</summary>
-    [JsonIgnore]
-    public string SizeLabel => Loc.Bytes(BytesTotal);
-
-    /// <summary>True while this upload is in flight — drives the per-file mini
-    /// progress bar.</summary>
-    [JsonIgnore]
-    public bool IsActive => State == "active";
-
-    /// <summary>Byte progress as a 0...1 fraction for the active-row mini bar.</summary>
-    [JsonIgnore]
-    public double Fraction => BytesTotal > 0 ? (double)BytesDone / BytesTotal : 0;
-
-    /// <summary>The list row: title-or-key, localized state, size, and attempt
-    /// count. An active upload shows its live byte fraction.</summary>
-    [JsonIgnore]
-    public string Label
-    {
-        get
-        {
-            var name = string.IsNullOrEmpty(Title) ? CloudKey : Title;
-            string detail;
-            if (State == "failed" && !string.IsNullOrEmpty(LastError))
-            {
-                // The failure word is chrome; LastError is the opaque detail.
-                detail = $"{Loc.Chrome("outbox.upload.failed")}: {LastError}";
-            }
-            else if (IsActive && BytesTotal > 0)
-            {
-                detail = Loc.Chrome(
-                    "outbox.upload.active_percent",
-                    "percent", (int)(Fraction * 100));
-            }
-            else
-            {
-                detail = Loc.Chrome($"outbox.upload.state.{State}");
-            }
-            var size = BytesTotal > 0 ? $" · {SizeLabel}" : string.Empty;
-            var attempts = AttemptCount > 0
-                ? $" · {Loc.Chrome("outbox.upload.attempts", "count", AttemptCount)}"
-                : string.Empty;
-            return $"{name} — {Loc.Chrome("outbox.upload.kind")} · {detail}{size}{attempts}";
-        }
-    }
 }
 
 /// <summary>One queued cloud delete.</summary>

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>تعذّرت قراءة صندوق الصادر</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>استئناف</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>إعادة المحاولة الآن</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>جارٍ الرفع · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, zero {# محاولة} one {محاولة واحدة} two {محاولتان} few {# محاولات} many {# محاولة} other {# محاولة}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>فشل</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>رفع</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>نشط</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>فشل</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>في قائمة الانتظار</value></data>
   <data name="queue.clear" xml:space="preserve"><value>مسح قائمة الانتظار</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>إزالة من قائمة الانتظار</value></data>
   <data name="queue.title" xml:space="preserve"><value>قائمة الانتظار</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>изходящата опашка не може да бъде прочетена</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>продължаване</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>повторен опит сега</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>качване · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# опит} other {# опита}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>неуспешно</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>качване</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>активна</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>неуспешно</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>в опашката</value></data>
   <data name="queue.clear" xml:space="preserve"><value>изчистване на опашката</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Премахване от опашката</value></data>
   <data name="queue.title" xml:space="preserve"><value>опашка</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>সারি থেকে সরান</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>nelze přečíst odchozí frontu</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>pokračovat</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>zopakovat hned</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>nahrávání · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# pokus} few {# pokusy} many {# pokusu} other {# pokusů}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>selhalo</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>nahrát</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>aktivní</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>selhalo</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>ve frontě</value></data>
   <data name="queue.clear" xml:space="preserve"><value>vymazat frontu</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Odebrat z fronty</value></data>
   <data name="queue.title" xml:space="preserve"><value>fronta</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>Postausgang konnte nicht gelesen werden</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>fortsetzen</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>jetzt erneut versuchen</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>wird hochgeladen · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# Versuch} other {# Versuche}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>fehlgeschlagen</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>hochladen</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>aktiv</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>fehlgeschlagen</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>in Warteschlange</value></data>
   <data name="queue.clear" xml:space="preserve"><value>Warteschlange leeren</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Aus Warteschlange entfernen</value></data>
   <data name="queue.title" xml:space="preserve"><value>Warteschlange</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>no se pudo leer la bandeja de salida</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>reanudar</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>reintentar ahora</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>subiendo · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# intento} other {# intentos}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>error</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>subir</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>activa</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>error</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>en cola</value></data>
   <data name="queue.clear" xml:space="preserve"><value>vaciar la cola</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Quitar de la cola</value></data>
   <data name="queue.title" xml:space="preserve"><value>cola</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>impossible de lire la file d'envoi</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>reprendre</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>réessayer maintenant</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>envoi · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# tentative} other {# tentatives}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>échec</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>envoyer</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>échec</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>en file</value></data>
   <data name="queue.clear" xml:space="preserve"><value>vider la file</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Retirer de la file</value></data>
   <data name="queue.title" xml:space="preserve"><value>file</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>કતારમાંથી કાઢો</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>לא ניתן לקרוא את תיבת היוצא</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>המשך</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>נסה שוב כעת</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>מעלה · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {ניסיון #} two {# ניסיונות} many {# ניסיונות} other {# ניסיונות}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>נכשל</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>העלאה</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>פעיל</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>נכשל</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>בתור</value></data>
   <data name="queue.clear" xml:space="preserve"><value>נקה תור</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>הסר מהתור</value></data>
   <data name="queue.title" xml:space="preserve"><value>תור</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>कतार से हटाएँ</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>nije moguće pročitati izlazni red</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>nastavi</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>pokušaj sada</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>prijenos · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# pokušaj} few {# pokušaja} other {# pokušaja}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>neuspjelo</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>prijenos</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>aktivno</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>neuspjelo</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>na čekanju</value></data>
   <data name="queue.clear" xml:space="preserve"><value>očisti red</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Ukloni iz reda</value></data>
   <data name="queue.title" xml:space="preserve"><value>red</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>送信箱を読み込めませんでした</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>再開</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>今すぐ再試行</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>アップロード中 · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, other {# 回試行}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>失敗</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>アップロード</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>使用中</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>失敗</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>待機中</value></data>
   <data name="queue.clear" xml:space="preserve"><value>キューをクリア</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>キューから削除</value></data>
   <data name="queue.title" xml:space="preserve"><value>キュー</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>ಸರತಿಯಿಂದ ತೆಗೆದುಹಾಕಿ</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>보낼 항목을 읽을 수 없음</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>재개</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>지금 다시 시도</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>업로드 중 · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, other {#회 시도}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>실패</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>업로드</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>활성</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>실패</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>대기 중</value></data>
   <data name="queue.clear" xml:space="preserve"><value>대기열 지우기</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>대기열에서 제거</value></data>
   <data name="queue.title" xml:space="preserve"><value>대기열</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>ക്യൂയിൽ നിന്ന് നീക്കുക</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>रांगेतून काढा</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>ਕਤਾਰ ਤੋਂ ਹਟਾਓ</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>nie udało się odczytać skrzynki nadawczej</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>wznów</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>ponów teraz</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>wysyłanie · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# próba} few {# próby} many {# prób} other {# próby}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>niepowodzenie</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>wyślij</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>aktywna</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>niepowodzenie</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>w kolejce</value></data>
   <data name="queue.clear" xml:space="preserve"><value>wyczyść kolejkę</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Usuń z kolejki</value></data>
   <data name="queue.title" xml:space="preserve"><value>kolejka</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>não foi possível ler a caixa de saída</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>retomar</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>tentar agora</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>enviando · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# tentativa} other {# tentativas}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>falhou</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>ativa</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>falhou</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>na fila</value></data>
   <data name="queue.clear" xml:space="preserve"><value>limpar fila</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remover da fila</value></data>
   <data name="queue.title" xml:space="preserve"><value>fila</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>வரிசையிலிருந்து அகற்று</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>క్యూ నుండి తీసివేయి</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>นำออกจากคิว</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>не вдалося прочитати чергу надсилання</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>продовжити</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>повторити зараз</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>вивантаження · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# спроба} few {# спроби} many {# спроб} other {# спроби}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>помилка</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>вивантажити</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>активна</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>помилка</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>у черзі</value></data>
   <data name="queue.clear" xml:space="preserve"><value>очистити чергу</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Вилучити з черги</value></data>
   <data name="queue.title" xml:space="preserve"><value>черга</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>قطار سے ہٹائیں</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>无法读取发件箱</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>继续</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>立即重试</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>上传中 · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, other {# 次尝试}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>失败</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>上传</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>活动中</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>失败</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>已排队</value></data>
   <data name="queue.clear" xml:space="preserve"><value>清空队列</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>从队列移除</value></data>
   <data name="queue.title" xml:space="preserve"><value>队列</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -114,13 +114,6 @@
   <data name="outbox.read_failed" xml:space="preserve"><value>couldn't read the outbox</value></data>
   <data name="outbox.resume" xml:space="preserve"><value>resume</value></data>
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
-  <data name="outbox.upload.active_percent" xml:space="preserve"><value>uploading · {percent}%</value></data>
-  <data name="outbox.upload.attempts" xml:space="preserve"><value>{count, plural, one {# attempt} other {# attempts}}</value></data>
-  <data name="outbox.upload.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.kind" xml:space="preserve"><value>upload</value></data>
-  <data name="outbox.upload.state.active" xml:space="preserve"><value>active</value></data>
-  <data name="outbox.upload.state.failed" xml:space="preserve"><value>failed</value></data>
-  <data name="outbox.upload.state.queued" xml:space="preserve"><value>queued</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>從佇列移除</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>


### PR DESCRIPTION
Cleanup following the cancel-any-transition chain (#118–#122). With both desktop apps rendering `upload_groups`, the flat per-file `uploads` list has no UI consumer.

Removes it from the wire — the uniffi bridge (`BridgeOutboxSnapshot.uploads` and the now-dead `BridgeUploadOp`/`BridgeUploadState`), the Windows FFI JSON (`FfiUploadOp`), and the C# DTO (`OutboxSnapshot.Uploads`/`UploadOp`) — plus the `outbox.upload.*` chrome keys that only the C# `UploadOp.Label` referenced, across all 31 locales.

bae-core keeps `OutboxSnapshot.uploads`: it's the per-file outbox view its state-machine tests assert against (per-op state transitions and attempt counts the grouped aggregate doesn't express), and the list the groups, per-release aggregates, and totals are built from.

## Test plan
- `cargo clippy` clean (bae-core/bae-bridge/bae-windows-ffi); core tests unaffected (the per-file field they read stays).
- macOS app builds; periphery clean; `loc-chrome-orphans` reports 0 orphans on all platforms after the resw key removal.
- Windows build verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)