### PR TITLE
macOS: sign embedded frameworks so notarization passes

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -268,6 +268,15 @@ jobs:
         find "$APP_PATH/Contents/Frameworks" -name "*.dylib" -exec \
           codesign --force --sign "$IDENTITY" --options runtime {} \;
 
+        # Sign every other embedded framework (e.g. Sentry) with hardened
+        # runtime. Sparkle is signed above — it has nested XPC/Autoupdate/
+        # Updater.app that must be signed inside-out first, so skip its outer
+        # wrapper here. An unsigned nested framework makes notarization Invalid.
+        for fw in "$APP_PATH/Contents/Frameworks"/*.framework; do
+          [[ "$fw" == *"/Sparkle.framework" ]] && continue
+          [[ -d "$fw" ]] && codesign --force --sign "$IDENTITY" --options runtime "$fw"
+        done
+
         # Expand $(AppIdentifierPrefix) in the edition's entitlements (full:
         # bae.entitlements with iCloud container; baeium: bae-baeium.entitlements,
         # keychain only).


### PR DESCRIPTION
The last several macOS releases failed at the Notarize DMG step with status `Invalid`. Apple accepts the upload but rejects the contents, and the workflow doesn't fetch the notarization log, so the cause isn't in the run output.

The trigger was the crash-reporting work that embedded the Sentry framework in the app bundle. The signing step signs `Sparkle.framework` by name, then every `*.dylib`, then the main app — but nothing signs the other embedded frameworks. `bundle_dylibs.sh` only ever copies `.dylib` files, so the only unsigned thing left in `Contents/Frameworks` is `Sentry.framework`. Apple returns `Invalid` for an unsigned nested framework, which blocked every release since Sentry landed.

This signs every embedded framework with the Developer ID identity and hardened runtime, skipping Sparkle's outer wrapper (already signed inside-out above). Any framework a future SPM dependency embeds is now covered automatically.

## Test plan
- [ ] Dispatch Release macOS off main after merge; confirm both editions pass Notarize DMG and the release publishes.