### PR TITLE
Windows: cancel pin and unmanage from the storage row

### DIFF
--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1758,6 +1758,45 @@ pub unsafe extern "C" fn bae_outbox_snapshot(handle: *const BaeHandle) -> *mut c
     }
 }
 
+/// One queued download (a release being pinned), as the storage row needs it:
+/// just the release id, so the row context menu can tell a pinning release from
+/// an idle one and offer to cancel it. The download (pin) queue has no Windows
+/// pane, so nothing else is rendered from it yet.
+#[derive(Serialize)]
+struct FfiDownloadOp {
+    release_id: String,
+}
+
+/// The in-memory download (pin) queue snapshot: the releases currently queued or
+/// downloading. The storage row reads this to detect a pinning release.
+#[derive(Serialize)]
+struct FfiDownloadSnapshot {
+    downloads: Vec<FfiDownloadOp>,
+}
+
+/// The download (pin) queue snapshot as JSON, or null on error. Free with
+/// [`bae_string_free`].
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn bae_download_snapshot(handle: *const BaeHandle) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_download_snapshot: null handle");
+        return std::ptr::null_mut();
+    };
+    let snapshot = handle.0.services.library_manager().download_snapshot();
+    json_cstring(&FfiDownloadSnapshot {
+        downloads: snapshot
+            .downloads
+            .iter()
+            .map(|op| FfiDownloadOp {
+                release_id: op.release_id.clone(),
+            })
+            .collect(),
+    })
+}
+
 /// Retry the cloud outbox now (clears backoff and triggers a sync). Returns null
 /// on success, or an error-message C string (free with [`bae_string_free`]).
 ///

--- a/bae-windows/DownloadSnapshot.cs
+++ b/bae-windows/DownloadSnapshot.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Bae.Windows;
+
+/// <summary>The in-memory download (pin) queue snapshot. The storage row reads it
+/// to tell a release that's pinning (queued or downloading) from an idle one, so
+/// its context menu can offer to cancel the pin. The pin queue has no Windows
+/// pane yet, so only the release id is carried.</summary>
+public sealed class DownloadSnapshot
+{
+    public List<DownloadOp> Downloads { get; set; } = new();
+}
+
+/// <summary>One queued download — a release being pinned.</summary>
+public sealed class DownloadOp
+{
+    public string ReleaseId { get; set; } = string.Empty;
+}

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -54,6 +54,14 @@ public sealed partial class MainWindow : Window
 
     private IntPtr _handle;
 
+    // Releases whose unmanage is running right now. Unmanage is a blocking
+    // foreground transfer (unlike pin, which enqueues, or upload, which lives in
+    // the outbox), so it has no queue snapshot to read — we track it here while
+    // RunStorageActionForReleases awaits, letting the storage row offer to cancel
+    // it. UI-thread only (added/removed around the await, read when building the
+    // menu).
+    private readonly HashSet<string> _unmanagingReleases = new();
+
     // Held for the subscription's lifetime so the GC doesn't collect the delegate
     // while native code holds a pointer to it.
     private NativeBae.EventCallback? _eventCallback;
@@ -3550,6 +3558,39 @@ public sealed partial class MainWindow : Window
     {
         var menu = new MenuFlyout();
 
+        // A release with a transition in flight offers only "Cancel" — the
+        // storage actions (pin/unmanage/…) would race it. Each transition
+        // surfaces differently: an upload sits in the outbox snapshot, a pin in
+        // the download queue snapshot, and an unmanage (a blocking foreground
+        // transfer with no queue) is tracked locally while it runs. Core
+        // dispatches to whichever is running.
+        var transitioning = new HashSet<string>(
+            await UploadingReleases(releaseIds, storageStatus));
+        transitioning.UnionWith(await DownloadingReleases(releaseIds));
+        transitioning.UnionWith(releaseIds.Where(_unmanagingReleases.Contains));
+        if (transitioning.Count > 0)
+        {
+            var cancel = new MenuFlyoutItem { Text = Loc.Chrome("action.cancel") };
+            cancel.Click += async (_, _) =>
+            {
+                foreach (var releaseId in transitioning)
+                {
+                    var error = await System.Threading.Tasks.Task.Run(
+                        () => NativeBae.CancelReleaseTransition(_handle, releaseId));
+                    if (error is not null)
+                    {
+                        storageStatus.Text = error;
+                        storageStatus.Visibility = Visibility.Visible;
+                        return;
+                    }
+                }
+
+                await reload();
+            };
+            menu.Items.Add(cancel);
+            return menu;
+        }
+
         foreach (var action in IntersectedStorageActions(releaseIds, rowsById))
         {
             var act = action;
@@ -3568,32 +3609,6 @@ public sealed partial class MainWindow : Window
                 }
             };
             menu.Items.Add(item);
-        }
-
-        // Stop uploading any targeted release that's mid-transfer, keeping it
-        // local-only. Resolved from the live outbox snapshot since the storage
-        // row carries only a pending count.
-        var uploadingReleases = await UploadingReleases(releaseIds, storageStatus);
-        if (uploadingReleases.Count > 0)
-        {
-            var cancel = new MenuFlyoutItem { Text = Loc.Chrome("storage.cancel_upload") };
-            cancel.Click += async (_, _) =>
-            {
-                foreach (var releaseId in uploadingReleases)
-                {
-                    var error = await System.Threading.Tasks.Task.Run(
-                        () => NativeBae.CancelReleaseTransition(_handle, releaseId));
-                    if (error is not null)
-                    {
-                        storageStatus.Text = error;
-                        storageStatus.Visibility = Visibility.Visible;
-                        return;
-                    }
-                }
-
-                await reload();
-            };
-            menu.Items.Add(cancel);
         }
 
         return menu;
@@ -3622,6 +3637,29 @@ public sealed partial class MainWindow : Window
         return releaseIds.Where(snapshot.PerRelease.ContainsKey).ToList();
     }
 
+    // Of the given releases, those queued or downloading in the pin queue.
+    private async System.Threading.Tasks.Task<List<string>> DownloadingReleases(
+        List<string> releaseIds)
+    {
+        var json = await System.Threading.Tasks.Task.Run(
+            () => NativeBae.DownloadSnapshotJson(_handle));
+        var snapshot = json is null
+            ? null
+            : JsonSerializer.Deserialize<DownloadSnapshot>(json, JsonOptions);
+        if (snapshot is null)
+        {
+            // The pin queue is in-memory and read is infallible bar a dropped
+            // handle, so this is an app-state fault, not a user-facing read
+            // error — log it and offer no pin-cancel rather than a toast.
+            BaeDiagnostics.Logger.Warning(
+                "couldn't read the download snapshot; pin-cancel unavailable");
+            return new List<string>();
+        }
+
+        var pinning = snapshot.Downloads.Select(op => op.ReleaseId).ToHashSet();
+        return releaseIds.Where(pinning.Contains).ToList();
+    }
+
     // Run a storage transition on every release in the selection off the UI
     // thread. "unmanage" asks once for a destination folder, then moves each
     // release into it. Returns null on success (or a cancelled picker), else the
@@ -3642,19 +3680,35 @@ public sealed partial class MainWindow : Window
             }
 
             var path = folder.Path;
-            return await System.Threading.Tasks.Task.Run(() =>
+            // Mark these releases as unmanaging so a right-click can cancel them
+            // while the blocking transfer runs; cleared when it returns.
+            foreach (var releaseId in releaseIds)
+            {
+                _unmanagingReleases.Add(releaseId);
+            }
+            try
+            {
+                return await System.Threading.Tasks.Task.Run(() =>
+                {
+                    foreach (var releaseId in releaseIds)
+                    {
+                        var error = NativeBae.UnmanageRelease(_handle, releaseId, path);
+                        if (error is not null)
+                        {
+                            return error;
+                        }
+                    }
+
+                    return (string?)null;
+                });
+            }
+            finally
             {
                 foreach (var releaseId in releaseIds)
                 {
-                    var error = NativeBae.UnmanageRelease(_handle, releaseId, path);
-                    if (error is not null)
-                    {
-                        return error;
-                    }
+                    _unmanagingReleases.Remove(releaseId);
                 }
-
-                return (string?)null;
-            });
+            }
         }
 
         return await System.Threading.Tasks.Task.Run(() =>

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -442,6 +442,13 @@ internal static class NativeBae
     /// Copies into managed memory and frees the native string.</summary>
     internal static string? OutboxSnapshotJson(IntPtr handle) => CopyAndFree(OutboxSnapshotPtr(handle));
 
+    [DllImport(Dll, EntryPoint = "bae_download_snapshot", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr DownloadSnapshotPtr(IntPtr handle);
+
+    /// <summary>The download (pin) queue snapshot as a JSON string, or null on
+    /// error. Copies into managed memory and frees the native string.</summary>
+    internal static string? DownloadSnapshotJson(IntPtr handle) => CopyAndFree(DownloadSnapshotPtr(handle));
+
     [DllImport(Dll, EntryPoint = "bae_retry_outbox", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr RetryOutboxPtr(IntPtr handle);
 


### PR DESCRIPTION
Closes the Windows gap from the cancel-any-transition chain (#118–#123): the storage-row context menu only cancelled uploads, so a release that was pinning or unmanaging had no cancel. macOS already covers all three (its menu keys off the outbox + the release's `transfer` signal); this brings Windows to parity.

A pin enqueues into the in-memory download queue, which Windows couldn't see — exposed now via a new `bae_download_snapshot` FFI carrying the queued release ids. An unmanage is a blocking foreground transfer with no queue, so the releases it's running on are tracked while `RunStorageActionForReleases` awaits. The menu now shows one **Cancel** when any targeted release is uploading, pinning, or unmanaging — and only Cancel then, since the storage actions would race the transition — wired to `cancel_release_transition`, which dispatches to whichever is running.

Cancelling a blocking unmanage works because the app runtime is multi-threaded: the cancel call's `block_on` runs concurrently with the blocked transfer and fires its cancellation token, which `do_unmanage` observes between files (cleaning partial copies, #118).

## Test plan
- `cargo clippy` clean (bae-windows-ffi); macOS/bridge untouched.
- Windows build verified by CI (no local toolchain).
- Manually (Windows): right-click a release while pinning or unmanaging → "Cancel" appears and stops it; mid-unmanage cancel leaves the release managed with no orphan files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)