### PR TITLE
Windows: cancel from the queue-pane release rows via right-click

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3370,13 +3370,9 @@ public sealed partial class MainWindow : Window
                 }
             }
 
-            // One row per queued operation: its label, an optional per-file
-            // mini progress bar for an in-flight upload, and a Cancel that
-            // dequeues it. `activeUpload` is set only for an upload that's
-            // transferring right now, so its bar moves with the live byte count.
-            // A queue row: a label (with an optional progress bar) and an optional
-            // trailing cancel button.
-            void AddOutboxRow(string label, ProgressBar? progress, Button? trailing)
+            // A queue row: a label (with an optional progress bar), an optional
+            // trailing button, and an optional right-click menu.
+            void AddOutboxRow(string label, ProgressBar? progress, Button? trailing, MenuFlyout? contextMenu)
             {
                 var itemGrid = new Grid { ColumnSpacing = 8 };
                 itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -3396,35 +3392,44 @@ public sealed partial class MainWindow : Window
                     Grid.SetColumn(trailing, 1);
                     itemGrid.Children.Add(trailing);
                 }
+                if (contextMenu is not null)
+                {
+                    itemGrid.ContextFlyout = contextMenu;
+                }
                 outboxPanel.Children.Add(itemGrid);
             }
 
-            // A cancel button that runs `action` off-thread, surfaces any error to
-            // the status line, and reloads the panel on success.
-            Button CancelButton(string content, Func<string?> action)
+            // Runs `action` off-thread, surfaces any error to the status line, and
+            // reloads the panel on success — shared by the row button and menu.
+            async System.Threading.Tasks.Task RunCancel(Func<string?> action)
             {
-                var button = new Button { Content = content };
-                button.Click += async (_, _) =>
+                storageStatus.Visibility = Visibility.Collapsed;
+                var error = await System.Threading.Tasks.Task.Run(action);
+                if (error is not null)
                 {
-                    storageStatus.Visibility = Visibility.Collapsed;
-                    button.IsEnabled = false;
-                    var error = await System.Threading.Tasks.Task.Run(action);
-                    if (error is not null)
-                    {
-                        storageStatus.Text = error;
-                        storageStatus.Visibility = Visibility.Visible;
-                        button.IsEnabled = true;
-                        return;
-                    }
+                    storageStatus.Text = error;
+                    storageStatus.Visibility = Visibility.Visible;
+                    return;
+                }
 
-                    await LoadOutbox();
-                };
-                return button;
+                await LoadOutbox();
+            }
+
+            // A right-click "Cancel" menu, matching the storage table's per-release
+            // cancel. Used for the upload release rows.
+            MenuFlyout CancelFlyout(Func<string?> action)
+            {
+                var menu = new MenuFlyout();
+                var item = new MenuFlyoutItem { Text = Loc.Chrome("action.cancel") };
+                item.Click += async (_, _) => await RunCancel(action);
+                menu.Items.Add(item);
+                return menu;
             }
 
             // Uploads: one row per release (matching the storage table) — title,
-            // aggregate progress, and a cancel that stops the release's transition.
-            // The orphaned-files bucket (no release id) has no release to cancel.
+            // aggregate progress, and a right-click "Cancel" that stops the
+            // release's transition. The orphaned-files bucket (no release id) has
+            // no release to cancel.
             foreach (var group in snapshot.UploadGroups)
             {
                 ProgressBar? progress = group.Progress is { Active: > 0, BytesTotal: > 0 }
@@ -3435,23 +3440,19 @@ public sealed partial class MainWindow : Window
                         Value = group.Progress.BytesDone,
                     }
                     : null;
-                Button? cancel = group.ReleaseId is string releaseId
-                    ? CancelButton(
-                        Loc.Chrome("storage.cancel_upload"),
-                        () => NativeBae.CancelReleaseTransition(_handle, releaseId))
+                MenuFlyout? menu = group.ReleaseId is string releaseId
+                    ? CancelFlyout(() => NativeBae.CancelReleaseTransition(_handle, releaseId))
                     : null;
-                AddOutboxRow(group.DisplayTitle, progress, cancel);
+                AddOutboxRow(group.DisplayTitle, progress, trailing: null, contextMenu: menu);
             }
             // A pending delete is genuinely a single-file operation, so it keeps
-            // its own per-file cancel.
+            // its own per-file cancel button.
             foreach (var delete in snapshot.Deletes)
             {
-                AddOutboxRow(
-                    delete.Label,
-                    null,
-                    CancelButton(
-                        Loc.Chrome("outbox.cancel_item"),
-                        () => NativeBae.CancelOutboxItem(_handle, delete.Id)));
+                var cancel = new Button { Content = Loc.Chrome("outbox.cancel_item") };
+                var id = delete.Id;
+                cancel.Click += async (_, _) => await RunCancel(() => NativeBae.CancelOutboxItem(_handle, id));
+                AddOutboxRow(delete.Label, null, trailing: cancel, contextMenu: null);
             }
         }
 

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>تثبيت للاستخدام دون اتصال</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>النقل خارج المكتبة…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>إزالة النسخة المحلية</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>إلغاء الرفع</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, zero {# ملف} one {ملف واحد} two {ملفان} few {# ملفات} many {# ملفًا} other {# ملف}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>تعذّر تحميل التخزين</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>تعذّرت قراءة التخزين</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Закачане за офлайн</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Преместване извън библиотеката…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Премахване на локалното копие</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Отмяна на качването</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# файл} other {# файла}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>хранилището не може да бъде заредено</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>хранилището не може да бъде прочетено</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of লাইব্রেরি…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load স্টোরেজ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read স্টোরেজ</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Připnout pro offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Přesunout z knihovny…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Odebrat místní kopii</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Zrušit nahrávání</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# soubor} few {# soubory} many {# souboru} other {# souborů}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>nelze načíst úložiště</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>nelze přečíst úložiště</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Für Offline anheften</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Aus Bibliothek verschieben …</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Lokale Kopie entfernen</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Upload abbrechen</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# Datei} other {# Dateien}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>Speicher konnte nicht geladen werden</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>Speicher konnte nicht gelesen werden</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of library…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load storage</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read storage</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Fijar para sin conexión</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Sacar de la biblioteca…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Quitar copia local</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancelar subida</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# archivo} other {# archivos}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>no se pudo cargar el almacenamiento</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>no se pudo leer el almacenamiento</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Épingler hors ligne</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Déplacer hors de la bibliothèque…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Supprimer la copie locale</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Annuler l'envoi</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# fichier} other {# fichiers}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>impossible de charger le stockage</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>impossible de lire le stockage</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of લાઇબ્રેરી…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load સંગ્રહ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read સંગ્રહ</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>נעץ לזמינות לא מקוונת</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>העבר מחוץ לספרייה…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>הסר עותק מקומי</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>בטל העלאה</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {קובץ #} two {# קבצים} many {# קבצים} other {# קבצים}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>לא ניתן לטעון את האחסון</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>לא ניתן לקרוא את האחסון</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of लाइब्रेरी…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load स्टोरेज</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read स्टोरेज</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Prikvači za izvanmrežni rad</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Premjesti iz fonoteke…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Ukloni lokalnu kopiju</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Otkaži prijenos</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# datoteka} few {# datoteke} other {# datoteka}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>nije moguće učitati pohranu</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>nije moguće pročitati pohranu</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of Libreria…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load Archiviazione</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read Archiviazione</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>オフライン用にピン留め</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>ライブラリから移動…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>ローカルコピーを削除</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>アップロードをキャンセル</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, other {# 個のファイル}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>ストレージを読み込めませんでした</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>ストレージを読み込めませんでした</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of ಲೈಬ್ರರಿ…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load ಸಂಗ್ರಹಣೆ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read ಸಂಗ್ರಹಣೆ</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>오프라인용으로 고정</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>라이브러리 밖으로 이동…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>로컬 복사본 제거</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>업로드 취소</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, other {#개 파일}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>저장소를 불러올 수 없음</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>저장소를 읽을 수 없음</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of ലൈബ്രറി…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load സംഭരണം</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read സംഭരണം</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of लायब्ररी…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load साठवण</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read साठवण</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of Bibliotheek…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load Opslag</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read Opslag</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of ਲਾਇਬ੍ਰੇਰੀ…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load ਸਟੋਰੇਜ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read ਸਟੋਰੇਜ</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Przypnij do trybu offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Przenieś poza bibliotekę…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Usuń kopię lokalną</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Anuluj wysyłanie</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# plik} few {# pliki} many {# plików} other {# pliku}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>nie udało się wczytać magazynu</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>nie udało się odczytać magazynu</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Fixar para offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Mover para fora da biblioteca…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remover cópia local</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancelar upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# arquivo} other {# arquivos}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>não foi possível carregar o armazenamento</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>não foi possível ler o armazenamento</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of நூலகம்…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load சேமிப்பு</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read சேமிப்பு</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of లైబ్రరీ…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load నిల్వ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read నిల్వ</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of ไลบรารี…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load พื้นที่จัดเก็บ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read พื้นที่จัดเก็บ</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of Kitaplık…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load Depolama</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read Depolama</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Закріпити для офлайн-доступу</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Перемістити з бібліотеки…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Вилучити локальну копію</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Скасувати вивантаження</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# файл} few {# файли} many {# файлів} other {# файлу}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>не вдалося завантажити сховище</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>не вдалося прочитати сховище</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of لائبریری…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load اسٹوریج</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read اسٹوریج</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of Thư viện…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load Lưu trữ</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read Lưu trữ</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>固定以离线使用</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>移出库…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>移除本地副本</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>取消上传</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, other {# 个文件}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>无法加载存储</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>无法读取存储</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -176,7 +176,6 @@
   <data name="storage.action.pin" xml:space="preserve"><value>Pin for offline</value></data>
   <data name="storage.action.unmanage" xml:space="preserve"><value>Move out of 資料庫…</value></data>
   <data name="storage.action.unpin" xml:space="preserve"><value>Remove local copy</value></data>
-  <data name="storage.cancel_upload" xml:space="preserve"><value>Cancel upload</value></data>
   <data name="storage.files" xml:space="preserve"><value>{count, plural, one {# file} other {# files}}</value></data>
   <data name="storage.load_failed" xml:space="preserve"><value>couldn't load 儲存空間</value></data>
   <data name="storage.read_failed" xml:space="preserve"><value>couldn't read 儲存空間</value></data>


### PR DESCRIPTION
Final parity touch for the cancel-any-transition goal. The Windows queue pane grouped uploads by release but exposed cancel as a button, whereas the storage table — and macOS in both surfaces — uses a right-click menu. The goal calls for right-clicking releases in the queue pane to cancel, like the storage manager.

The upload release rows now carry a right-click **Cancel** (same `action.cancel` label and `cancel_release_transition` call as the storage table). Delete rows keep their per-file button — they're single files, not releases, mirroring macOS's queue pane.

Drops the now-unused `storage.cancel_upload` chrome key across all locales.

## Test plan
- macOS/bridge untouched; Windows build + C# format/charset verified by CI.
- Manually (Windows): right-click an upload release row in the queue pane → "Cancel" stops it; delete rows still cancel via their button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)