### PR TITLE
Windows: add the Downloads (pin queue) pane

### DIFF
--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1758,20 +1758,40 @@ pub unsafe extern "C" fn bae_outbox_snapshot(handle: *const BaeHandle) -> *mut c
     }
 }
 
-/// One queued download (a release being pinned), as the storage row needs it:
-/// just the release id, so the row context menu can tell a pinning release from
-/// an idle one and offer to cancel it. The download (pin) queue has no Windows
-/// pane, so nothing else is rendered from it yet.
+/// One queued download (a whole release being pinned), as the Downloads pane
+/// renders it: title, file count and size, and the state — "queued", "active"
+/// (with `percent`), or "failed" (with `error`).
 #[derive(Serialize)]
 struct FfiDownloadOp {
     release_id: String,
+    title: String,
+    file_count: i64,
+    total_size: i64,
+    /// "queued", "active", or "failed".
+    state: String,
+    /// Overall release percent — present only while `state` is "active".
+    percent: Option<u8>,
+    /// The failure message when `state` is "failed".
+    error: Option<String>,
 }
 
-/// The in-memory download (pin) queue snapshot: the releases currently queued or
-/// downloading. The storage row reads this to detect a pinning release.
+/// Per-state counts for the download queue, for the pane header's summary and
+/// the retry gate.
+#[derive(Serialize)]
+struct FfiDownloadProgress {
+    queued: u32,
+    active: u32,
+    failed: u32,
+}
+
+/// The in-memory download (pin) queue snapshot the Downloads pane renders, and
+/// which the storage row reads to detect a pinning release.
 #[derive(Serialize)]
 struct FfiDownloadSnapshot {
     downloads: Vec<FfiDownloadOp>,
+    total: FfiDownloadProgress,
+    /// True when the user paused the download queue.
+    paused: bool,
 }
 
 /// The download (pin) queue snapshot as JSON, or null on error. Free with
@@ -1781,6 +1801,7 @@ struct FfiDownloadSnapshot {
 /// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
 #[no_mangle]
 pub unsafe extern "C" fn bae_download_snapshot(handle: *const BaeHandle) -> *mut c_char {
+    use bae_core::library::DownloadState;
     let Some(handle) = handle.as_ref() else {
         tracing::error!("bae_download_snapshot: null handle");
         return std::ptr::null_mut();
@@ -1790,11 +1811,60 @@ pub unsafe extern "C" fn bae_download_snapshot(handle: *const BaeHandle) -> *mut
         downloads: snapshot
             .downloads
             .iter()
-            .map(|op| FfiDownloadOp {
-                release_id: op.release_id.clone(),
+            .map(|op| {
+                let (state, percent, error) = match &op.state {
+                    DownloadState::Queued => ("queued", None, None),
+                    DownloadState::Active { percent } => ("active", Some(*percent), None),
+                    DownloadState::Failed { error } => ("failed", None, Some(error.clone())),
+                };
+                FfiDownloadOp {
+                    release_id: op.release_id.clone(),
+                    title: op.title.clone(),
+                    file_count: op.file_count,
+                    total_size: op.total_size,
+                    state: state.to_string(),
+                    percent,
+                    error,
+                }
             })
             .collect(),
+        total: FfiDownloadProgress {
+            queued: snapshot.total.queued,
+            active: snapshot.total.active,
+            failed: snapshot.total.failed,
+        },
+        paused: snapshot.paused,
     })
+}
+
+/// Pause or resume the download (pin) queue. While paused, the worker waits.
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn bae_set_downloads_paused(handle: *const BaeHandle, paused: bool) {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_set_downloads_paused: null handle");
+        return;
+    };
+    handle
+        .0
+        .services
+        .library_manager()
+        .set_downloads_paused(paused);
+}
+
+/// Retry failed downloads now (clears their failure and re-queues them).
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn bae_retry_downloads(handle: *const BaeHandle) {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_retry_downloads: null handle");
+        return;
+    };
+    handle.0.services.library_manager().retry_downloads();
 }
 
 /// Retry the cloud outbox now (clears backoff and triggers a sync). Returns null
@@ -2176,6 +2246,8 @@ enum FfiEvent {
     ScanFinished,
     /// The cloud upload/delete outbox changed; the storage screen re-reads it.
     OutboxChanged,
+    /// The download (pin) queue changed; the Downloads pane re-reads it.
+    DownloadQueueChanged,
     /// Library config changed (cloud provider connected/disconnected, sync
     /// readiness, library rename, Discogs token). The settings screen re-reads
     /// `bae_settings` so its fields reflect the change without a reopen.
@@ -2441,6 +2513,7 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
         UiBusEvent::ScanCandidateRemoved { key } => FfiEvent::CandidateRemoved { key: key.clone() },
         UiBusEvent::ScanFinished => FfiEvent::ScanFinished,
         UiBusEvent::OutboxChanged { .. } => FfiEvent::OutboxChanged,
+        UiBusEvent::DownloadQueueChanged { .. } => FfiEvent::DownloadQueueChanged,
         UiBusEvent::ConfigChanged { .. } => FfiEvent::ConfigChanged,
         UiBusEvent::CandidateIdentifyStateChanged {
             key,

--- a/bae-windows/DownloadSnapshot.cs
+++ b/bae-windows/DownloadSnapshot.cs
@@ -2,17 +2,45 @@
 
 namespace Bae.Windows;
 
-/// <summary>The in-memory download (pin) queue snapshot. The storage row reads it
-/// to tell a release that's pinning (queued or downloading) from an idle one, so
-/// its context menu can offer to cancel the pin. The pin queue has no Windows
-/// pane yet, so only the release id is carried.</summary>
+/// <summary>The in-memory download (pin) queue snapshot. Drives the Downloads
+/// pane, and the storage row reads it to tell a pinning release (queued or
+/// downloading) from an idle one so the row can offer to cancel the pin.</summary>
 public sealed class DownloadSnapshot
 {
     public List<DownloadOp> Downloads { get; set; } = new();
+
+    /// <summary>Per-state counts rolled up across the queue — drives the pane
+    /// header and the retry gate.</summary>
+    public DownloadProgress Total { get; set; } = new();
+
+    /// <summary>True when the user paused the queue — drives the pause/resume
+    /// toggle.</summary>
+    public bool Paused { get; set; }
 }
 
-/// <summary>One queued download — a release being pinned.</summary>
+/// <summary>Per-state counts for the download queue.</summary>
+public sealed class DownloadProgress
+{
+    public uint Queued { get; set; }
+    public uint Active { get; set; }
+    public uint Failed { get; set; }
+}
+
+/// <summary>One queued download — a whole release being pinned.</summary>
 public sealed class DownloadOp
 {
     public string ReleaseId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public long FileCount { get; set; }
+    public long TotalSize { get; set; }
+
+    /// <summary>"queued", "active", or "failed".</summary>
+    public string State { get; set; } = string.Empty;
+
+    /// <summary>Overall release percent — present only while <see cref="State"/>
+    /// is "active".</summary>
+    public int? Percent { get; set; }
+
+    /// <summary>The failure message when <see cref="State"/> is "failed".</summary>
+    public string? Error { get; set; }
 }

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -84,6 +84,7 @@ public sealed partial class MainWindow : Window
     // Reloads the storage dialog's outbox panel and storage rows; set while that
     // dialog is open so OutboxChanged refreshes them live, null when closed.
     private Action? _refreshOutbox;
+    private Action? _refreshDownloads;
 
     // Re-reads bae_settings into the open settings dialog's labels; set while that
     // dialog is open so ConfigChanged (provider connect/disconnect, sync readiness,
@@ -1010,6 +1011,9 @@ public sealed partial class MainWindow : Window
                 break;
             case "OutboxChanged":
                 _refreshOutbox?.Invoke();
+                break;
+            case "DownloadQueueChanged":
+                _refreshDownloads?.Invoke();
                 break;
             case "ConfigChanged":
                 _refreshSettings?.Invoke();
@@ -3272,6 +3276,106 @@ public sealed partial class MainWindow : Window
         // Cloud outbox: the upload/delete queue with a summary band, a Retry-now
         // button, and per-item Cancel. Hidden (empty panel) when nothing is queued.
         // Reloaded after retry/cancel so the panel reflects the new queue state.
+        var downloadsPanel = new StackPanel { Spacing = 4 };
+        async System.Threading.Tasks.Task LoadDownloads()
+        {
+            downloadsPanel.Children.Clear();
+            var json = await System.Threading.Tasks.Task.Run(() => NativeBae.DownloadSnapshotJson(_handle));
+            var snapshot = json is null
+                ? null
+                : JsonSerializer.Deserialize<DownloadSnapshot>(json, JsonOptions);
+            if (snapshot is null)
+            {
+                storageStatus.Text = Loc.Chrome("storage.read_failed");
+                storageStatus.Visibility = Visibility.Visible;
+                return;
+            }
+
+            // Hidden when the pin queue is idle, like the outbox panel.
+            if (snapshot.Downloads.Count == 0)
+            {
+                return;
+            }
+
+            string StateLabel(DownloadOp op) => op.State switch
+            {
+                "active" => Loc.Chrome("download.state.downloading", "percent", op.Percent ?? 0),
+                "failed" => Loc.Chrome("download.state.failed"),
+                _ => Loc.Chrome("download.state.queued"),
+            };
+
+            // Header: a label (or "paused"), Retry (only with failures), and a
+            // pause/resume toggle — mirroring the outbox panel's band.
+            var band = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            band.Children.Add(new TextBlock
+            {
+                Text = snapshot.Paused ? Loc.Chrome("download.paused") : Loc.Chrome("download.title"),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            var retry = new Button
+            {
+                Content = Loc.Chrome("outbox.retry_now"),
+                IsEnabled = snapshot.Total.Failed > 0,
+            };
+            retry.Click += async (_, _) =>
+            {
+                retry.IsEnabled = false;
+                await System.Threading.Tasks.Task.Run(() => NativeBae.RetryDownloads(_handle));
+                await LoadDownloads();
+            };
+            band.Children.Add(retry);
+            var paused = snapshot.Paused;
+            var pause = new Button { Content = paused ? Loc.Chrome("outbox.resume") : Loc.Chrome("outbox.pause") };
+            pause.Click += async (_, _) =>
+            {
+                pause.IsEnabled = false;
+                await System.Threading.Tasks.Task.Run(() => NativeBae.SetDownloadsPaused(_handle, !paused));
+                await LoadDownloads();
+            };
+            band.Children.Add(pause);
+            downloadsPanel.Children.Add(band);
+
+            // One row per release: title, "N files · size · state", and a cancel.
+            foreach (var op in snapshot.Downloads)
+            {
+                var itemGrid = new Grid { ColumnSpacing = 8 };
+                itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                var labelColumn = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
+                labelColumn.Children.Add(new TextBlock { Text = op.Title, TextWrapping = TextWrapping.Wrap });
+                labelColumn.Children.Add(new TextBlock
+                {
+                    Text = $"{Loc.Chrome("storage.files", "count", op.FileCount)} · {Loc.Bytes(op.TotalSize)} · {StateLabel(op)}",
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                });
+                Grid.SetColumn(labelColumn, 0);
+                itemGrid.Children.Add(labelColumn);
+
+                var releaseId = op.ReleaseId;
+                var cancel = new Button { Content = Loc.Chrome("action.cancel") };
+                cancel.Click += async (_, _) =>
+                {
+                    storageStatus.Visibility = Visibility.Collapsed;
+                    cancel.IsEnabled = false;
+                    var error = await System.Threading.Tasks.Task.Run(
+                        () => NativeBae.CancelReleaseTransition(_handle, releaseId));
+                    if (error is not null)
+                    {
+                        storageStatus.Text = error;
+                        storageStatus.Visibility = Visibility.Visible;
+                        cancel.IsEnabled = true;
+                        return;
+                    }
+
+                    await LoadDownloads();
+                };
+                Grid.SetColumn(cancel, 1);
+                itemGrid.Children.Add(cancel);
+                downloadsPanel.Children.Add(itemGrid);
+            }
+        }
+
         var outboxPanel = new StackPanel { Spacing = 4 };
         async System.Threading.Tasks.Task LoadOutbox()
         {
@@ -3456,10 +3560,12 @@ public sealed partial class MainWindow : Window
             }
         }
 
+        await LoadDownloads();
         await LoadOutbox();
 
         var content = new StackPanel { Spacing = 8 };
         content.Children.Add(storageStatus);
+        content.Children.Add(downloadsPanel);
         content.Children.Add(outboxPanel);
         content.Children.Add(listPanel);
 
@@ -3478,6 +3584,13 @@ public sealed partial class MainWindow : Window
             _ = LoadOutbox();
             _ = LoadStorageRows();
         };
+        // Refresh the Downloads pane live as pins progress and the storage rows
+        // with them (a row's badge/state changes as a pin completes).
+        _refreshDownloads = () =>
+        {
+            _ = LoadDownloads();
+            _ = LoadStorageRows();
+        };
         // A library change (ReleaseUpdated → LibraryChanged) that isn't an outbox
         // change still alters a release's storage state — refresh the rows for it too.
         _refreshStorageRows = () => _ = LoadStorageRows();
@@ -3488,6 +3601,7 @@ public sealed partial class MainWindow : Window
         finally
         {
             _refreshOutbox = null;
+            _refreshDownloads = null;
             _refreshStorageRows = null;
         }
     }

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -449,6 +449,18 @@ internal static class NativeBae
     /// error. Copies into managed memory and frees the native string.</summary>
     internal static string? DownloadSnapshotJson(IntPtr handle) => CopyAndFree(DownloadSnapshotPtr(handle));
 
+    [DllImport(Dll, EntryPoint = "bae_set_downloads_paused", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void SetDownloadsPausedNative(IntPtr handle, [MarshalAs(UnmanagedType.I1)] bool paused);
+
+    /// <summary>Pause or resume the download (pin) queue.</summary>
+    internal static void SetDownloadsPaused(IntPtr handle, bool paused) => SetDownloadsPausedNative(handle, paused);
+
+    [DllImport(Dll, EntryPoint = "bae_retry_downloads", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void RetryDownloadsNative(IntPtr handle);
+
+    /// <summary>Retry failed downloads now (re-queues them).</summary>
+    internal static void RetryDownloads(IntPtr handle) => RetryDownloadsNative(handle);
+
     [DllImport(Dll, EntryPoint = "bae_retry_outbox", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr RetryOutboxPtr(IntPtr handle);
 

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>المزامنة: غير متصلة</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>جاهز</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>المزامنة: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Синхронизиране: не е свързано</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>готово</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Синхронизиране: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>সিঙ্ক: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>সিঙ্ক: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Synchronizace: nepřipojeno</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>připraveno</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Synchronizace: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: nicht verbunden</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>bereit</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Sync: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Sync: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Sincronización: no conectada</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>listo</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Sincronización: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Synchronisation : non connectée</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>prêt</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Synchronisation : {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>સિંક: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>સિંક: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>סנכרון: לא מחובר</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>מוכן</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>סנכרון: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>सिंक: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>सिंक: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Sinkronizacija: nije povezano</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>spremno</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Sinkronizacija: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Sincronizzazione: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Sincronizzazione: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>同期: 未接続</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>準備完了</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>同期: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>ಸಿಂಕ್: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>ಸಿಂಕ್: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>동기화: 연결 안 됨</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>준비됨</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>동기화: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>സിങ്ക്: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>സിങ്ക്: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>समक्रमण: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>समक्रमण: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Synchronisatie: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Synchronisatie: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>ਸਿੰਕ: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>ਸਿੰਕ: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Synchronizacja: nie połączono</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>gotowe</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Synchronizacja: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Sincronização: não conectada</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>pronto</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Sincronização: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>ஒத்திசைவு: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>ஒத்திசைவு: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>సింక్: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>సింక్: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>ซิงค์: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>ซิงค์: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Eşzamanlama: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Eşzamanlama: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Синхронізація: не підключено</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>готово</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Синхронізація: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>مطابقت پذیری: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>مطابقت پذیری: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>Đồng bộ: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>Đồng bộ: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>同步：未连接</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>就绪</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>同步：{provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -200,4 +200,9 @@
   <data name="settings.sync.not_connected" xml:space="preserve"><value>同步: not connected</value></data>
   <data name="settings.sync.ready" xml:space="preserve"><value>ready</value></data>
   <data name="settings.sync.status" xml:space="preserve"><value>同步: {provider}{account} — {state}</value></data>
+  <data name="download.title" xml:space="preserve"><value>downloads</value></data>
+  <data name="download.paused" xml:space="preserve"><value>paused</value></data>
+  <data name="download.state.queued" xml:space="preserve"><value>queued</value></data>
+  <data name="download.state.downloading" xml:space="preserve"><value>downloading {percent}%</value></data>
+  <data name="download.state.failed" xml:space="preserve"><value>failed</value></data>
 </root>


### PR DESCRIPTION
macOS has a Downloads pane in the Storage Manager — a per-release list of in-flight pins with pause/resume, retry, and cancel — but Windows had no view of the pin queue at all (pins were only cancelable indirectly from the storage row). This adds the pane for parity.

The FFI now exposes the full download snapshot (`bae_download_snapshot` carries each release's title, file count, size, and state/percent, plus the queue's paused flag and per-state totals) and gains `bae_set_downloads_paused` / `bae_retry_downloads`. `DownloadQueueChanged` is forwarded to the WinUI event loop so the pane refreshes live as pins progress. The pane mirrors the outbox panel: a header band (label, retry — enabled only with failures, pause/resume) and one row per release (title, "N files · size · state", and a cancel that stops the pin). Cancel routes through `cancel_release_transition` → `cancel_download`.

## Test plan
- `cargo clippy` clean (bae-windows-ffi); macOS/bridge untouched; `loc-chrome-orphans` 0 across all platforms (5 new `download.*` keys added in all 31 locales).
- Windows build + C# format/charset verified by CI.
- Manually (Windows): pin a cloud-only release → the Downloads pane appears with its row + live percent; pause/resume and retry work; cancel stops the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)