### PR TITLE
membership: expose coven device-join + member management via the bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=bac449365d9dc1489482475edd2319791ac43436#bac449365d9dc1489482475edd2319791ac43436"
+source = "git+https://github.com/bae-fm/coven?rev=507c45a50782596e92808eb7f08ed2dcabe4098a#507c45a50782596e92808eb7f08ed2dcabe4098a"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -615,6 +615,47 @@ impl AppHandle {
             .map_err(BridgeError::config)
     }
 
+    /// The library's members (devices), with this device flagged. Reads the
+    /// membership chain from cloud storage, so it runs on a runtime worker.
+    pub async fn get_members(&self) -> Result<Vec<crate::types::BridgeMember>, BridgeError> {
+        let services = self.app_services.clone();
+        let members = self
+            .spawn_on_runtime(async move { services.library_manager().get_members().await })
+            .await
+            .map_err(BridgeError::internal)?;
+        Ok(members
+            .into_iter()
+            .map(crate::types::bridge_member)
+            .collect())
+    }
+
+    /// Approve a joining device by its public key (from its join-request code),
+    /// returning the invite code to hand back to that device.
+    pub async fn invite_member(&self, public_key_hex: String) -> Result<String, BridgeError> {
+        let services = self.app_services.clone();
+        self.spawn_on_runtime(async move {
+            services
+                .library_manager()
+                .invite_member(&public_key_hex)
+                .await
+        })
+        .await
+        .map_err(BridgeError::internal)
+    }
+
+    /// Remove a device from the library and rotate the library key.
+    pub async fn remove_member(&self, public_key_hex: String) -> Result<(), BridgeError> {
+        let services = self.app_services.clone();
+        self.spawn_on_runtime(async move {
+            services
+                .library_manager()
+                .remove_member(&public_key_hex)
+                .await
+        })
+        .await
+        .map_err(BridgeError::internal)
+    }
+
     /// Forget the active local library on this device: delete its key, clear the
     /// active pointer, and remove its data directory (the owner's cloud copy is
     /// untouched). The caller must drop this handle right after — the database

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -84,13 +84,13 @@ use std::sync::{Arc, Mutex};
 use tracing::info;
 
 use bae_core::config::Config;
-use bae_core::library::{CancellationToken, RestoreFromCodeError};
+use bae_core::library::{CancellationToken, JoinFromCodeError, RestoreFromCodeError};
 
 #[cfg(feature = "oauth-providers")]
 use crate::types::bridge_cloud_provider_to_core;
 use crate::types::{
-    bridge_cloud_provider, BridgeCloudProvider, BridgeError, BridgeLibrary, BridgeRestoreCodeInfo,
-    BridgeRestoreSource,
+    bridge_cloud_provider, BridgeCloudProvider, BridgeError, BridgeInviteCodeInfo,
+    BridgeJoinRequestInfo, BridgeLibrary, BridgeRestoreCodeInfo, BridgeRestoreSource,
 };
 
 #[cfg(feature = "cloudkit")]
@@ -394,6 +394,153 @@ impl RestoreFromCodeOperation {
         on_worker(move || async move {
             let config =
                 restore_from_code_config(code, oauth_tokens, cloudkit_ops, Some(cancel)).await?;
+
+            Ok(local_library_active(&config))
+        })
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+}
+
+// =============================================================================
+// Membership: joining a library and managing devices
+// =============================================================================
+
+/// Generate this device's join-request code — its public key — to hand to an
+/// existing member for approval. Safe to call before any library exists on this
+/// device (the joining device has no library yet); it only needs the keyring
+/// initialized.
+#[uniffi::export]
+pub fn generate_join_request() -> Result<String, BridgeError> {
+    bae_core::sync::join_code::generate_join_request(None)
+        .map_err(|e| BridgeError::config(format!("Failed to generate join request: {e}")))
+}
+
+/// Decode a join-request code to preview the joining device before approving it.
+#[uniffi::export]
+pub fn decode_join_request(code: String) -> Result<BridgeJoinRequestInfo, BridgeError> {
+    let req = bae_core::sync::join_code::decode_join_request(&code).map_err(BridgeError::config)?;
+    Ok(BridgeJoinRequestInfo {
+        pubkey: req.public_key,
+        email: req.email,
+    })
+}
+
+/// Decode an invite code string and return info for UI preview (before joining).
+#[uniffi::export]
+pub fn decode_invite_code(code: String) -> Result<BridgeInviteCodeInfo, BridgeError> {
+    let info =
+        bae_core::sync::join_code::decode_invite_code_info(&code).map_err(BridgeError::config)?;
+    Ok(BridgeInviteCodeInfo {
+        library_id: info.library_id,
+        library_name: info.library_name,
+        owner_pubkey: info.owner_pubkey,
+        cloud_provider: bridge_cloud_provider(&info.cloud_provider),
+        needs_oauth: info.needs_oauth,
+    })
+}
+
+fn join_error_to_bridge(error: JoinFromCodeError) -> BridgeError {
+    match error {
+        JoinFromCodeError::Cancelled => BridgeError::Cancelled,
+        JoinFromCodeError::Join(error) => {
+            BridgeError::internal(format!("Failed to join library: {error}"))
+        }
+    }
+}
+
+async fn join_from_code_config(
+    code: String,
+    oauth_tokens: Option<bae_core::oauth::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn bae_core::storage::cloud::cloudkit::CloudKitOps>>,
+    cancel: Option<CancellationToken>,
+) -> Result<Config, BridgeError> {
+    match cancel {
+        Some(cancel) => bae_core::library::join_from_code_cancellable(
+            &code,
+            oauth_tokens,
+            cloudkit_ops,
+            cancel,
+            |status| info!("{}", status),
+        )
+        .await
+        .map_err(join_error_to_bridge),
+        None => bae_core::library::join_from_code(&code, oauth_tokens, cloudkit_ops, |status| {
+            info!("{}", status)
+        })
+        .await
+        .map_err(|e| join_error_to_bridge(JoinFromCodeError::Join(e))),
+    }
+}
+
+/// Join a shared library from an invite code string.
+///
+/// For OAuth providers, the caller must first run the OAuth flow (`oauth_authorize`
+/// on desktop, or `oauth_begin`/`oauth_complete` on mobile) and pass the token
+/// JSON as `oauth_token_json`.
+#[uniffi::export]
+pub fn join_from_code(
+    code: String,
+    oauth_token_json: Option<String>,
+) -> Result<BridgeLibrary, BridgeError> {
+    on_worker(move || async move {
+        let oauth_tokens = oauth_token_json
+            .map(|json| parse_oauth_tokens(&json))
+            .transpose()?;
+
+        let config = join_from_code_config(code, oauth_tokens, get_cloudkit_ops(), None).await?;
+
+        Ok(local_library_active(&config))
+    })
+}
+
+#[derive(uniffi::Object)]
+pub struct JoinFromCodeOperation {
+    code: String,
+    oauth_tokens: Option<bae_core::oauth::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn bae_core::storage::cloud::cloudkit::CloudKitOps>>,
+    cancel: CancellationToken,
+    started: Mutex<bool>,
+}
+
+#[uniffi::export]
+pub fn join_from_code_operation(
+    code: String,
+    oauth_token_json: Option<String>,
+) -> Result<Arc<JoinFromCodeOperation>, BridgeError> {
+    let oauth_tokens = oauth_token_json
+        .map(|json| parse_oauth_tokens(&json))
+        .transpose()?;
+    Ok(Arc::new(JoinFromCodeOperation {
+        code,
+        oauth_tokens,
+        cloudkit_ops: get_cloudkit_ops(),
+        cancel: CancellationToken::new(),
+        started: Mutex::new(false),
+    }))
+}
+
+#[uniffi::export]
+impl JoinFromCodeOperation {
+    pub fn join(&self) -> Result<BridgeLibrary, BridgeError> {
+        {
+            let mut started = self.started.lock().expect("join started mutex poisoned");
+            if *started {
+                return Err(BridgeError::internal(
+                    "join operation already started".to_string(),
+                ));
+            }
+            *started = true;
+        }
+        let code = self.code.clone();
+        let oauth_tokens = self.oauth_tokens.clone();
+        let cloudkit_ops = self.cloudkit_ops.clone();
+        let cancel = self.cancel.clone();
+        on_worker(move || async move {
+            let config =
+                join_from_code_config(code, oauth_tokens, cloudkit_ops, Some(cancel)).await?;
 
             Ok(local_library_active(&config))
         })

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1983,6 +1983,44 @@ pub struct BridgeRestoreCodeInfo {
     pub needs_oauth: bool,
 }
 
+/// A device in the library's membership chain.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeMember {
+    /// Hex-encoded Ed25519 public key — the device's stable identity.
+    pub pubkey: String,
+    pub role: BridgeMemberRole,
+    /// True for the device this app is running on.
+    pub is_self: bool,
+}
+
+/// A member's role. Mirrors coven's `MemberRole`. bae adds devices as `Member`;
+/// the founding device is `Owner`. `Follower` (read-only) exists in coven's model
+/// but bae does not create it — it is mapped through so the conversion stays total.
+#[derive(Debug, Clone, Copy, PartialEq, uniffi::Enum)]
+pub enum BridgeMemberRole {
+    Owner,
+    Member,
+    Follower,
+}
+
+/// Decoded join-request code: the joining device's public key, shown to an
+/// existing member for approval before inviting it.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeJoinRequestInfo {
+    pub pubkey: String,
+    pub email: Option<String>,
+}
+
+/// Decoded invite code info for UI preview (before joining).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeInviteCodeInfo {
+    pub library_id: String,
+    pub library_name: String,
+    pub owner_pubkey: String,
+    pub cloud_provider: BridgeCloudProvider,
+    pub needs_oauth: bool,
+}
+
 /// Per-provider form fields for validating a manual restore configuration.
 #[derive(Debug, uniffi::Enum)]
 pub enum BridgeRestoreFormFields {
@@ -2315,6 +2353,25 @@ pub(crate) fn bridge_cloud_provider(p: &bae_core::config::CloudProvider) -> Brid
         CloudProvider::Dropbox => BridgeCloudProvider::Dropbox,
         CloudProvider::OneDrive => BridgeCloudProvider::OneDrive,
         CloudProvider::CloudKit => BridgeCloudProvider::CloudKit,
+    }
+}
+
+pub(crate) fn bridge_member_role(
+    role: bae_core::sync::sync_manager::MemberRole,
+) -> BridgeMemberRole {
+    use bae_core::sync::sync_manager::MemberRole;
+    match role {
+        MemberRole::Owner => BridgeMemberRole::Owner,
+        MemberRole::Member => BridgeMemberRole::Member,
+        MemberRole::Follower => BridgeMemberRole::Follower,
+    }
+}
+
+pub(crate) fn bridge_member(m: bae_core::sync::sync_manager::MemberInfo) -> BridgeMember {
+    BridgeMember {
+        pubkey: m.pubkey,
+        role: bridge_member_role(m.role),
+        is_self: m.is_self,
     }
 }
 

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -12,7 +12,7 @@ name = "bae_core"
 path = "src/lib.rs"
 
 [dependencies]
-coven = { git = "https://github.com/bae-fm/coven", rev = "bac449365d9dc1489482475edd2319791ac43436" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "507c45a50782596e92808eb7f08ed2dcabe4098a" }
 reqwest = { workspace = true, features = ["form", "json", "query", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -101,7 +101,7 @@ tempfile = "3.8"
 tokio = { version = "1.0", features = ["test-util"] }
 serial_test = "3.4.0"
 # coven's deterministic clock/id fakes for bae's tests (off in production builds).
-coven = { git = "https://github.com/bae-fm/coven", rev = "bac449365d9dc1489482475edd2319791ac43436", features = ["test-utils"] }
+coven = { git = "https://github.com/bae-fm/coven", rev = "507c45a50782596e92808eb7f08ed2dcabe4098a", features = ["test-utils"] }
 
 [[test]]
 name = "test_playback_behavior"

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -148,7 +148,7 @@ pub fn install_test_keyring() {
 }
 
 /// Cloud home provider selection. bae uses coven's enum directly — same
-/// variants, same serialization, same `needs_email` — rather than maintaining a
+/// variants, same serialization, same `needs_oauth` — rather than maintaining a
 /// duplicate it would have to keep mapping back and forth.
 pub use coven::config::CloudProvider;
 

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -1785,6 +1785,42 @@ impl LibraryManager {
             .generate_restore_code()
     }
 
+    /// The library's current members (devices), with this device flagged.
+    pub async fn get_members(&self) -> Result<Vec<crate::sync::sync_manager::MemberInfo>, String> {
+        self.sync_manager_inner()
+            .ok_or_else(|| "Sync not configured".to_string())?
+            .get_members()
+            .await
+    }
+
+    /// Approve a device into the library by its public key, wrapping the library
+    /// key to it and signing a membership entry. Returns the invite code to hand
+    /// back to the joining device. bae adds every device as a `Member`; the
+    /// founding device is the `Owner`.
+    pub async fn invite_member(&self, public_key_hex: &str) -> Result<String, String> {
+        self.sync_manager_inner()
+            .ok_or_else(|| "Sync not configured".to_string())?
+            .invite_member(
+                public_key_hex,
+                crate::sync::sync_manager::MemberRole::Member,
+            )
+            .await
+    }
+
+    /// Remove a device from the library and rotate the library key so the removed
+    /// device can no longer read new data. Records the rotated key's fingerprint
+    /// in this device's config.
+    pub async fn remove_member(&self, public_key_hex: &str) -> Result<(), String> {
+        let fingerprint = self
+            .sync_manager_inner()
+            .ok_or_else(|| "Sync not configured".to_string())?
+            .remove_member(public_key_hex)
+            .await?;
+        self.config_handle
+            .record_encryption_key_fingerprint(fingerprint)
+            .map_err(|e| e.to_string())
+    }
+
     // =========================================================================
     // File paths / storage
     // =========================================================================

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -87,9 +87,9 @@ fn make_blob_plan(library_dir: &LibraryDir) -> Box<dyn coven::blob::BlobPlan> {
     ))
 }
 
-/// coven's restore returns the recovered Config; wrap it in bae's Config
+/// coven's restore/join returns the recovered Config; wrap it in bae's Config
 /// (which adds Discogs fields) and persist it.
-fn save_restored(coven_config: coven::config::Config) -> Result<Config, String> {
+fn save_coven_library(coven_config: coven::config::Config) -> Result<Config, String> {
     let config = Config::from_coven(coven_config);
     config.save_to_config_yaml().map_err(|e| e.to_string())?;
     Ok(config)
@@ -123,7 +123,7 @@ pub async fn restore_from_cloud(
     )
     .await
     .map_err(|e| e.to_string())?;
-    save_restored(coven_config)
+    save_coven_library(coven_config)
 }
 
 /// Restore a library from a restore code. Wraps coven's `restore_from_code`.
@@ -191,7 +191,7 @@ async fn restore_from_code_with_cancel(
         restore.await.map_err(restore_error)?
     };
 
-    save_restored(coven_config).map_err(RestoreFromCodeError::Restore)
+    save_coven_library(coven_config).map_err(RestoreFromCodeError::Restore)
 }
 
 fn cancelled_restore(
@@ -199,23 +199,115 @@ fn cancelled_restore(
     library_dir_existed: bool,
 ) -> RestoreFromCodeError {
     if !library_dir_existed {
-        remove_cancelled_restore_dir(library_dir);
+        remove_cancelled_library_dir(library_dir);
     }
     RestoreFromCodeError::Cancelled
 }
 
-fn remove_cancelled_restore_dir(library_dir: &std::path::Path) {
+/// Remove the library directory a cancelled restore/join left partially built.
+/// Only called when the directory did not exist before the operation, so this
+/// never deletes a pre-existing library.
+fn remove_cancelled_library_dir(library_dir: &std::path::Path) {
     match std::fs::remove_dir_all(library_dir) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => debug!(
             path = %library_dir.display(),
-            "cancelled restore directory already absent"
+            "cancelled library directory already absent"
         ),
         Err(e) => warn!(
             path = %library_dir.display(),
-            "failed to remove cancelled restore directory: {e}"
+            "failed to remove cancelled library directory: {e}"
         ),
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JoinFromCodeError {
+    #[error("join cancelled")]
+    Cancelled,
+    #[error("{0}")]
+    Join(String),
+}
+
+fn join_error(error: impl ToString) -> JoinFromCodeError {
+    JoinFromCodeError::Join(error.to_string())
+}
+
+/// Join a shared library from an invite code. Wraps coven's
+/// `join_from_invite_code`, supplying bae's app dir, clock, id source, and blob
+/// plan. For an OAuth provider the caller fetches `oauth_tokens` first (the
+/// joining device authorizes its own cloud account), exactly as restore does.
+pub async fn join_from_code(
+    code: &str,
+    oauth_tokens: Option<crate::oauth::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::cloudkit::CloudKitOps>>,
+    on_status: impl Fn(&str),
+) -> Result<Config, String> {
+    join_from_code_with_cancel(code, oauth_tokens, cloudkit_ops, None, on_status)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn join_from_code_cancellable(
+    code: &str,
+    oauth_tokens: Option<crate::oauth::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::cloudkit::CloudKitOps>>,
+    cancel: CancellationToken,
+    on_status: impl Fn(&str),
+) -> Result<Config, JoinFromCodeError> {
+    join_from_code_with_cancel(code, oauth_tokens, cloudkit_ops, Some(cancel), on_status).await
+}
+
+async fn join_from_code_with_cancel(
+    code: &str,
+    oauth_tokens: Option<crate::oauth::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::cloudkit::CloudKitOps>>,
+    cancel: Option<CancellationToken>,
+    on_status: impl Fn(&str),
+) -> Result<Config, JoinFromCodeError> {
+    let app_dir = crate::config::bae_dir().map_err(join_error)?;
+    let cancel = if let Some(cancel) = cancel {
+        let info = crate::sync::join_code::decode_invite_code_info(code).map_err(join_error)?;
+        let library_dir = library_dir_path(&app_dir, &info.library_id);
+        let library_dir_existed = library_dir.try_exists().map_err(join_error)?;
+        Some((cancel, library_dir, library_dir_existed))
+    } else {
+        None
+    };
+    let synced_tables = crate::sync::synced_tables();
+
+    let join = crate::sync::join::join_from_invite_code(
+        code,
+        &app_dir,
+        &synced_tables,
+        oauth_tokens,
+        cloudkit_ops,
+        std::sync::Arc::new(crate::clock::SystemClock),
+        std::sync::Arc::new(crate::id_provider::UuidProvider),
+        make_blob_plan,
+        on_status,
+    );
+    let coven_config = if let Some((cancel, library_dir, library_dir_existed)) = cancel {
+        if cancel.is_cancelled() {
+            return Err(cancelled_join(&library_dir, library_dir_existed));
+        }
+        tokio::pin!(join);
+        tokio::select! {
+            result = &mut join => result.map_err(join_error)?,
+            _ = cancel.cancelled() => return Err(cancelled_join(&library_dir, library_dir_existed)),
+        }
+    } else {
+        join.await.map_err(join_error)?
+    };
+
+    save_coven_library(coven_config).map_err(JoinFromCodeError::Join)
+}
+
+fn cancelled_join(library_dir: &std::path::Path, library_dir_existed: bool) -> JoinFromCodeError {
+    if !library_dir_existed {
+        remove_cancelled_library_dir(library_dir);
+    }
+    JoinFromCodeError::Cancelled
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/bae-core/src/sync/mod.rs
+++ b/bae-core/src/sync/mod.rs
@@ -2,7 +2,8 @@
 //! `SyncManager` wrapper layered on top.
 
 // The sync substrate lives in coven; these resolve `crate::sync::<m>` unchanged.
-pub use coven::sync::{cloud_storage, outbox, restore, restore_code};
+pub use coven::join_code;
+pub use coven::sync::{cloud_storage, join, outbox, restore, restore_code};
 
 // Blob-key construction at bae's call sites: `CloudSyncStorage::blob_key` keyed
 // by a `BlobPathScheme`. An opaque home is `Hashed` (keyed by the id), a

--- a/bae-core/src/sync/sync_manager.rs
+++ b/bae-core/src/sync/sync_manager.rs
@@ -19,7 +19,8 @@ use crate::library::{LibraryEvent, UploadThroughput};
 use crate::sync::blob_plan::{BaeBlobPlan, ReleaseUploadObserver};
 
 // coven owns the sync manager; bae uses it directly.
-pub use coven::sync::sync_manager::SyncManager;
+pub use coven::sync::membership::MemberRole;
+pub use coven::sync::sync_manager::{MemberInfo, SyncManager};
 
 /// S3 configuration data for save_s3_config.
 pub struct S3ConfigData {


### PR DESCRIPTION
bae currently adds a device by scanning a QR "restore code" that carries the master encryption key, the cloud credentials, and the owner's signing secret key — so every joined device becomes the same identity. It's a bearer token: whoever has it is in, with no per-device identity, approval, or revocation. That's the wrong model for a personal/household library.

This is the first step toward using coven's membership chain instead: a joining device shows its public key, an existing owner approves that specific key (wrapping the library key to it and signing a chain entry), and the joiner joins. Owners can list devices and remove one, which rotates the library key so the removed device can't read new data. The bearer restore code stays, but only for recovery.

This PR is the Rust surface only — no UI yet. It adds to bae-core thin wrappers over coven (`join_from_code` mirroring `restore_from_code`, plus `get_members`/`invite_member`/`remove_member` on the library manager) and to bae-bridge the uniffi exports and types (`BridgeMember`, `BridgeMemberRole`, `BridgeJoinRequestInfo`, `BridgeInviteCodeInfo`, a `JoinFromCodeOperation` mirroring the restore operation, and the join/membership free functions). bae always invites a device as `Member`; the founding device is `Owner`. It also bumps coven to the rev where `join_from_invite_code` takes caller-provided OAuth tokens, so a joining device runs its own OAuth (needed on mobile) the way restore already does.

## Test plan
- `cargo clippy --workspace -- -D warnings`, plus the full + baeium feature configs — clean
- `cargo test -p bae-core --features bae-core/test-utils -- --test-threads=1` — green
- `cargo test -p bae-bridge --lib` — green
- macOS app builds (pre-commit: build-macos.sh + xcodegen + xcodebuild + periphery) — clean
- coven side (PR bae-fm/coven#80, merged): `cargo test --features oauth-providers` — 302 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)