### PR TITLE
Loudness normalization: measure at import, derive replay gain at playback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,14 @@ jobs:
         # The device-sync round-trip in test_multi_device_sync.rs has a
         # CI-specific parallelism race (tests pass locally at any thread
         # count). Run the whole suite serially so the race can't occur; this is
-        # slower. test_playback_cpu is skipped only because it is re-run in
-        # release mode below for accurate CPU measurement.
+        # slower. test_playback_cpu is skipped here and re-run in release mode
+        # below for accurate CPU measurement.
         cargo test -p bae-core --features bae-core/test-utils -- --test-threads=1 --skip test_playback_cpu
-        cargo test -p bae-core --release --features bae-core/test-utils --test test_playback_cpu
+        # The release CPU benchmarks must also run serially: each measures
+        # process-wide CPU over a wall-clock window, so a concurrent sibling
+        # test's work (e.g. another fixture's import decode) inflates the
+        # reading and trips the threshold.
+        cargo test -p bae-core --release --features bae-core/test-utils --test test_playback_cpu -- --test-threads=1
 
   feature-parity:
     # The split between the baeium (S3-only) build and the full build is enforced

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "dirs",
  "discid",
  "dotenvy",
+ "ebur128",
  "encoding_rs",
  "ffmpeg-next",
  "ffmpeg-sys-next",
@@ -1530,6 +1531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1708,18 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ebur128"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e227cc62d64d6fe01abbef48134b9c1f17d470cef1e7a56337ad05b1f81df7f9"
+dependencies = [
+ "bitflags 1.3.2",
+ "dasp_frame",
+ "dasp_sample",
+ "smallvec",
+]
 
 [[package]]
 name = "ecdsa"

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -79,6 +79,12 @@ dotenvy = "0.15"
 discid = "0.5"
 lofty = "0.23"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+# Loudness + true-peak measurement at import (src/loudness.rs). Pure Rust, no
+# system libs. Desktop-only: import decodes audio only on these targets, and the
+# playback gain is derived from the stored measurements with plain arithmetic
+# (no ebur128 at playback). true_peak returns a linear ratio (1.0 = 0 dBTP),
+# which is stored verbatim as `*_peak_linear`.
+ebur128 = "0.1.10"
 
 # cpal drives the audio sink on desktop and iOS (its CoreAudio/AudioUnit backend
 # covers both). Android uses AAudio (the `ndk` dep above) instead, so cpal is off

--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -72,6 +72,15 @@ CREATE TABLE IF NOT EXISTS releases (
     -- same rip in any parent folder hashes the same. Used to recognize an
     -- already-imported folder and to pick the overwrite target on re-import.
     content_hash TEXT,
+    -- Album-level loudness measured at import (EBU R128 integrated loudness over
+    -- all tracks combined), in LUFS. NULL = not measured (a measurement failure,
+    -- or imported before measurement existed). Playback derives a gain from this
+    -- and a constant target; the stored value is the raw measurement, never a gain.
+    album_loudness_lufs REAL,
+    -- Album-level true peak as a LINEAR ratio (1.0 = 0 dBTP), the max across all
+    -- tracks. NULL = not measured. Playback caps the album gain at 1.0/peak to
+    -- prevent clipping.
+    album_peak_linear REAL,
     _updated_at TEXT NOT NULL,
     created_at TEXT NOT NULL,
     FOREIGN KEY (album_id) REFERENCES albums (id) ON DELETE CASCADE
@@ -185,6 +194,16 @@ CREATE TABLE IF NOT EXISTS audio_formats (
     start_sample INTEGER NOT NULL,
     end_sample INTEGER,
     end_byte INTEGER,
+    -- Per-track loudness measured at import (EBU R128 integrated loudness over
+    -- this track's sample window), in LUFS. NULL = not measured (decode/measure
+    -- failure, or a near-silent track that has no usable loudness). Playback
+    -- derives a gain from this and a constant target; the stored value is the
+    -- raw measurement, never a gain.
+    track_loudness_lufs REAL,
+    -- Per-track true peak as a LINEAR ratio (1.0 = 0 dBTP), the max across
+    -- channels. NULL = not measured. Playback caps the track gain at 1.0/peak
+    -- to prevent clipping.
+    track_peak_linear REAL,
     _updated_at TEXT NOT NULL,
     created_at TEXT NOT NULL,
     FOREIGN KEY (track_id) REFERENCES tracks (id) ON DELETE CASCADE

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -189,6 +189,30 @@ pub enum DiscogsValidation {
     Rejected,
 }
 
+/// How loudness normalization is applied at playback.
+///
+/// - `Off` — no normalization; tracks play at their stored level (unity gain).
+/// - `Track` — normalize each track to the target using its own loudness.
+/// - `Album` — normalize whole albums to the target using album loudness, so
+///   the loudness relationship between an album's tracks is preserved.
+///
+/// The gain is derived at playback from the stored loudness measurements and a
+/// constant target; this only selects which measurement (track vs album) drives
+/// it. Defaults to `Off`. Set by editing `config.yaml`; there is no UI picker
+/// yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReplayGainMode {
+    Off,
+    Track,
+    Album,
+}
+
+/// The serde default for `ConfigYaml.replay_gain_mode`. Enums carry no
+/// `#[derive(Default)]` in this project, so the default is named explicitly.
+fn default_replay_gain_mode() -> ReplayGainMode {
+    ReplayGainMode::Off
+}
+
 /// Whether a usable Discogs API key is configured. Folds the no-key case and
 /// the validation state into the four states a UI shows, so each binding
 /// doesn't re-derive the precedence.
@@ -298,6 +322,9 @@ pub struct ConfigYaml {
     /// Used to detect wrong key without attempting decryption.
     #[serde(default)]
     pub encryption_key_fingerprint: Option<String>,
+    /// How loudness normalization is applied at playback. Defaults to `Off`.
+    #[serde(default = "default_replay_gain_mode")]
+    pub replay_gain_mode: ReplayGainMode,
     /// Cloud home provider + per-provider settings. Flattened so the on-disk
     /// keys sit at the top level. bae uses coven's type — same fields, extracted
     /// from bae — instead of a parallel copy it would map back and forth.
@@ -320,6 +347,7 @@ impl ConfigYaml {
                 cloud_home: self.cloud_home,
             },
             discogs: self.discogs,
+            replay_gain_mode: self.replay_gain_mode,
         }
     }
 }
@@ -333,6 +361,7 @@ impl From<&Config> for ConfigYaml {
             discogs: config.discogs,
             encryption_key_stored: config.encryption_key_stored,
             encryption_key_fingerprint: config.encryption_key_fingerprint.clone(),
+            replay_gain_mode: config.replay_gain_mode,
             cloud_home: config.cloud_home.clone(),
         }
     }
@@ -362,6 +391,8 @@ pub struct Config {
     /// configured. `Some` doubles as the hint that a key is in the keyring, so
     /// settings render without a keyring read.
     pub discogs: Option<DiscogsValidation>,
+    /// How loudness normalization is applied at playback. Defaults to `Off`.
+    pub replay_gain_mode: ReplayGainMode,
 }
 
 impl std::ops::Deref for Config {
@@ -577,6 +608,7 @@ impl Config {
                 library_name,
             ),
             discogs: None,
+            replay_gain_mode: default_replay_gain_mode(),
         }
     }
 

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -356,6 +356,8 @@ impl Database {
             managed: row.get("managed").unwrap(),
             source_folder_name: row.get("source_folder_name").unwrap(),
             content_hash: row.get("content_hash").unwrap(),
+            album_loudness_lufs: row.get("album_loudness_lufs").unwrap(),
+            album_peak_linear: row.get("album_peak_linear").unwrap(),
             created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
                 .unwrap()
                 .with_timezone(&Utc),
@@ -3259,6 +3261,8 @@ fn row_to_audio_format(row: &Row) -> coven::rusqlite::Result<DbAudioFormat> {
         start_sample: row.get("start_sample")?,
         end_sample: row.get("end_sample")?,
         end_byte: row.get("end_byte")?,
+        track_loudness_lufs: row.get("track_loudness_lufs")?,
+        track_peak_linear: row.get("track_peak_linear")?,
         created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
             .unwrap()
             .with_timezone(&Utc),
@@ -3343,8 +3347,10 @@ fn insert_release_row(conn: &Connection, release: &DbRelease, reg: &str) -> Resu
             disc_id, metadata_source, metadata_source_release_id,
             format, label, catalog_number, country, barcode,
             managed,
-            source_folder_name, content_hash, _updated_at, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            source_folder_name, content_hash,
+            album_loudness_lufs, album_peak_linear,
+            _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
         params![
             release.id,
@@ -3362,6 +3368,8 @@ fn insert_release_row(conn: &Connection, release: &DbRelease, reg: &str) -> Resu
             release.managed,
             release.source_folder_name,
             release.content_hash,
+            release.album_loudness_lufs,
+            release.album_peak_linear,
             reg,
             release.created_at.to_rfc3339(),
         ],
@@ -3447,8 +3455,8 @@ fn insert_audio_format_row(
     conn.execute(
         r#"
         INSERT INTO audio_formats (
-            id, track_id, content_type, pregap_ms, sample_rate, bits_per_sample, channels, file_id, start_sample, end_sample, end_byte, _updated_at, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            id, track_id, content_type, pregap_ms, sample_rate, bits_per_sample, channels, file_id, start_sample, end_sample, end_byte, track_loudness_lufs, track_peak_linear, _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
         params![
             af.id,
@@ -3462,6 +3470,8 @@ fn insert_audio_format_row(
             af.start_sample,
             af.end_sample,
             af.end_byte,
+            af.track_loudness_lufs,
+            af.track_peak_linear,
             reg,
             af.created_at.to_rfc3339(),
         ],

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -278,6 +278,14 @@ pub struct DbRelease {
     /// it (the files didn't change). Used to recognize an already-imported
     /// folder and to pick the overwrite target on re-import.
     pub content_hash: Option<String>,
+    /// Album-level integrated loudness (EBU R128) in LUFS, measured at import
+    /// over all tracks combined. `None` = not measured. Playback derives a gain
+    /// from this against a constant target; the raw measurement is stored, never
+    /// a gain.
+    pub album_loudness_lufs: Option<f64>,
+    /// Album-level true peak as a linear ratio (1.0 = 0 dBTP), the max across
+    /// tracks. `None` = not measured. Playback caps the album gain at `1.0/peak`.
+    pub album_peak_linear: Option<f64>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -438,6 +446,15 @@ pub struct DbAudioFormat {
     /// Playback buffers the rest of the current track up to here, ahead of the
     /// playhead, rather than a fixed window.
     pub end_byte: Option<i64>,
+    /// Per-track integrated loudness (EBU R128) in LUFS, measured at import over
+    /// this track's sample window. `None` = not measured (decode/measure failure
+    /// or a near-silent track with no usable loudness). Playback derives a gain
+    /// from this against a constant target; the raw measurement is stored.
+    pub track_loudness_lufs: Option<f64>,
+    /// Per-track true peak as a linear ratio (1.0 = 0 dBTP), the max across
+    /// channels. `None` = not measured. Playback caps the track gain at
+    /// `1.0/peak`.
+    pub track_peak_linear: Option<f64>,
     pub created_at: DateTime<Utc>,
 }
 impl DbAlbumArtist {
@@ -578,6 +595,8 @@ impl DbRelease {
             managed: true,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: now,
         }
     }
@@ -613,6 +632,8 @@ impl DbRelease {
             managed: false,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: now,
         }
     }
@@ -657,6 +678,8 @@ impl DbRelease {
             managed: false,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: now,
         }
     }
@@ -800,6 +823,8 @@ impl DbAudioFormat {
             start_sample,
             end_sample,
             end_byte: None,
+            track_loudness_lufs: None,
+            track_peak_linear: None,
             created_at: now,
         }
     }

--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -311,6 +311,8 @@ mod tests {
             managed: false,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: Utc::now(),
         };
         database.insert_release(&release).await.unwrap();

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -156,6 +156,10 @@ pub fn map_file_tags_to_db(
         managed: false,
         source_folder_name: None,
         content_hash: None,
+        // Album loudness is measured in `build_audio_formats` and written to the
+        // release row in the finalize transaction, not here.
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: now,
     };
 

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1332,6 +1332,8 @@ mod tests {
             managed: true,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: now,
         }
     }

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -36,7 +36,7 @@ use {
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 use tokio::sync::{broadcast, mpsc};
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Keyed by each file's absolute path — unique identity, no collisions even when
 /// two files share a bare filename across subfolders (e.g. CD1/CDImage.ape and
@@ -1573,12 +1573,27 @@ impl ImportService {
         }
 
         // Audio formats, cover image, and finalize are identical across strategies.
-        let audio_formats = Self::build_audio_formats(
+        let mut audio_formats = Self::build_audio_formats(
             tracks_to_files,
             &file_ids,
             self.library_manager.clock().as_ref(),
             self.library_manager.ids().as_ref(),
         )?;
+
+        // Measure loudness from the source decode — bae stores originals verbatim
+        // (no transcode), so source samples == stored samples. The bytes are
+        // present locally in every storage mode at this point (a managed pin has
+        // copied to `storage/`; cloud-only / unmanaged still reference the
+        // originals); uploads queue only after finalize. Per-track NULLs and an
+        // album NULL are legitimate "not measured" results, each logged at the
+        // skip point inside `measure_loudness`.
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+        {
+            let (album_loudness, album_peak) =
+                Self::measure_loudness(&mut audio_formats, tracks_to_files).await;
+            db_release.album_loudness_lufs = album_loudness;
+            db_release.album_peak_linear = album_peak;
+        }
 
         let local_cover_image = if !remote_cover_set {
             self.build_cover_image_record(&db_release.id, discovered_files, cover_image_path)?
@@ -1916,6 +1931,114 @@ impl ImportService {
         }
 
         Ok(audio_formats)
+    }
+
+    /// Measure each track's loudness + true peak and the album's combined
+    /// loudness, attaching the per-track measurements to `audio_formats` and
+    /// returning the album-level `(loudness_lufs, peak_linear)`.
+    ///
+    /// Each track's window is decoded and measured on a blocking thread (FFmpeg
+    /// decode is blocking CPU work); the per-file source bytes are read once and
+    /// shared across that file's tracks (the tracks of a CUE image). Decoding
+    /// per track window — not the whole image at once — bounds transient PCM
+    /// memory to one track at a time.
+    ///
+    /// A track whose decode/measure fails, or that is too quiet to have a usable
+    /// loudness, keeps NULL loudness/peak and still imports; the skip is logged
+    /// at `warn!`/`debug!` with the file path. A measurement failure never
+    /// aborts the import.
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    async fn measure_loudness(
+        audio_formats: &mut [crate::db::DbAudioFormat],
+        tracks_to_files: &[TrackFile],
+    ) -> (Option<f64>, Option<f64>) {
+        use ebur128::EbuR128;
+
+        // Source bytes per file, read once and shared across that file's tracks
+        // (every CUE track of one image points at the same bytes). An unreadable
+        // file yields `None`, so its tracks are skipped (logged) rather than
+        // measured against missing bytes.
+        let mut file_bytes: HashMap<PathBuf, Option<Arc<Vec<u8>>>> = HashMap::new();
+        for tf in tracks_to_files {
+            let path = tf.file_path().to_path_buf();
+            file_bytes.entry(path.clone()).or_insert_with(|| {
+                match std::fs::read(&path) {
+                    Ok(bytes) => Some(Arc::new(bytes)),
+                    Err(e) => {
+                        warn!("loudness: cannot read {path:?} to measure: {e}; its tracks stay unmeasured");
+                        None
+                    }
+                }
+            });
+        }
+
+        // Spawn one blocking decode+measure per track; collect by index so the
+        // album combine is order-independent and the per-track write is exact.
+        let mut tasks = Vec::with_capacity(audio_formats.len());
+        for (idx, (af, tf)) in audio_formats.iter().zip(tracks_to_files).enumerate() {
+            let path = tf.file_path().to_path_buf();
+            let Some(bytes) = file_bytes.get(&path).and_then(|b| b.clone()) else {
+                continue;
+            };
+            let start_sample = af.start_sample as u64;
+            let end_sample = af.end_sample.map(|s| s as u64);
+            // The source's value range bit depth: `decode_audio` returns i32
+            // samples scaled to the source's bits (16-bit values for 16-bit
+            // FLAC, 24-bit for 24-bit), so the loudness measure must shift them
+            // up to full i32. The stored `bits_per_sample` is the authoritative
+            // source depth (NULL for lossy codecs, where the decoded container
+            // depth is used instead).
+            let source_bits = af.bits_per_sample.map(|b| b as u32);
+            tasks.push(tokio::task::spawn_blocking(move || {
+                let decoded = match crate::audio_codec::decode_audio(
+                    &bytes,
+                    Some(start_sample),
+                    end_sample,
+                ) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        warn!("loudness: decode failed for {path:?}: {e}; track stays unmeasured");
+                        return (idx, None);
+                    }
+                };
+                let sample_bits = source_bits.unwrap_or(decoded.bits_per_sample);
+                match crate::loudness::measure_track(
+                    &decoded.samples,
+                    decoded.channels,
+                    decoded.sample_rate,
+                    sample_bits,
+                ) {
+                    Ok((meter, Some(m))) => (idx, Some((meter, m.loudness_lufs, m.peak_linear))),
+                    Ok((_, None)) => {
+                        debug!("loudness: {path:?} has no usable loudness (silent); unmeasured");
+                        (idx, None)
+                    }
+                    Err(e) => {
+                        warn!("loudness: measure failed for {path:?}: {e}; track stays unmeasured");
+                        (idx, None)
+                    }
+                }
+            }));
+        }
+
+        let mut meters: Vec<EbuR128> = Vec::new();
+        let mut track_peaks: Vec<f64> = Vec::new();
+        for task in tasks {
+            match task.await {
+                Ok((idx, Some((meter, loudness_lufs, peak_linear)))) => {
+                    audio_formats[idx].track_loudness_lufs = Some(loudness_lufs);
+                    audio_formats[idx].track_peak_linear = Some(peak_linear);
+                    meters.push(meter);
+                    track_peaks.push(peak_linear);
+                }
+                Ok((_, None)) => {}
+                Err(e) => warn!("loudness: measurement task panicked: {e}; track stays unmeasured"),
+            }
+        }
+
+        let album_loudness = crate::loudness::album_loudness(&meters);
+        let album_peak = crate::loudness::album_peak(&track_peaks);
+        (album_loudness, album_peak)
     }
 }
 
@@ -2408,6 +2531,8 @@ mod tests {
             managed: true,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: now,
         };
         let track = crate::db::DbTrack {
@@ -2618,6 +2743,8 @@ mod tests {
             managed: true,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: now,
         };
         let track = crate::db::DbTrack {

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -18,6 +18,11 @@ pub mod keys;
 pub mod library;
 pub mod library_dir;
 pub mod library_name;
+// Loudness measurement uses `ebur128`, a desktop-only dependency (import decodes
+// audio only on these targets; playback derives the gain from the stored
+// measurements with plain arithmetic and needs no ebur128).
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+pub mod loudness;
 pub mod musicbrainz;
 pub mod network;
 pub mod oauth;

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -707,6 +707,13 @@ pub struct ResolvedTrackAudio {
     /// import; `None` when the track runs to EOF / a whole-file track). Playback
     /// buffers the rest of the current track up to here instead of a fixed window.
     pub end_byte: Option<u64>,
+    /// Raw loudness/peak measurements (LUFS + linear peak) for this track and its
+    /// album, as stored at import. `None` = not measured. Playback derives the
+    /// replay gain from these against a constant target; nothing here is a gain.
+    pub track_loudness_lufs: Option<f64>,
+    pub track_peak_linear: Option<f64>,
+    pub album_loudness_lufs: Option<f64>,
+    pub album_peak_linear: Option<f64>,
 }
 
 impl ResolvedTrackAudio {
@@ -735,9 +742,53 @@ impl ResolvedTrackAudio {
             start_sample: meta.audio_format.start_sample as u64,
             end_sample: meta.audio_format.end_sample.map(|s| s as u64),
             end_byte: meta.audio_format.end_byte.map(|b| b as u64),
+            track_loudness_lufs: meta.audio_format.track_loudness_lufs,
+            track_peak_linear: meta.audio_format.track_peak_linear,
+            album_loudness_lufs: meta.release.album_loudness_lufs,
+            album_peak_linear: meta.release.album_peak_linear,
         }
     }
+
+    /// Linear playback gain for this track under `mode`. `1.0` = no change.
+    ///
+    /// The gain is a view of (stored measurements, mode, target) — never stored.
+    /// `Off` plays at unity. `Track`/`Album` pick that level's `(loudness, peak)`,
+    /// falling back to the other level when the preferred one wasn't measured,
+    /// and to unity when neither was (NULL measurements, or a silent track). For
+    /// the chosen level the gain brings the measured loudness to the target, then
+    /// is capped at `1.0/peak` so a boosted track can't clip.
+    pub fn replay_gain_linear(&self, mode: crate::config::ReplayGainMode) -> f32 {
+        use crate::config::ReplayGainMode;
+
+        let track = self.track_loudness_lufs.zip(self.track_peak_linear);
+        let album = self.album_loudness_lufs.zip(self.album_peak_linear);
+
+        let chosen = match mode {
+            ReplayGainMode::Off => None,
+            ReplayGainMode::Track => track.or(album),
+            ReplayGainMode::Album => album.or(track),
+        };
+
+        let Some((loudness_lufs, peak_linear)) = chosen else {
+            return 1.0;
+        };
+
+        let gain = 10f64.powf((REPLAY_GAIN_TARGET_LUFS - loudness_lufs) / 20.0);
+        // Cap the gain so the loudest true-peak sample can't exceed full scale.
+        // A non-positive peak (no usable peak) imposes no cap.
+        let max_safe = if peak_linear > 0.0 {
+            1.0 / peak_linear
+        } else {
+            f64::INFINITY
+        };
+        gain.min(max_safe) as f32
+    }
 }
+
+/// Target playback loudness the replay gain aims each track/album at, in LUFS.
+/// A constant in this change; becomes a user setting alongside the picker.
+/// -18 LUFS is a common reference for quiet-listening normalization.
+const REPLAY_GAIN_TARGET_LUFS: f64 = -18.0;
 
 /// Resolved context for starting playback of a track: everything the
 /// playback service needs to set up the queue without chasing back into
@@ -5412,6 +5463,8 @@ mod tests {
             managed: true,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: Utc::now(),
         }
     }

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -437,6 +437,8 @@ mod tests {
             managed: true,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: Utc::now(),
         })
         .await

--- a/bae-core/src/loudness.rs
+++ b/bae-core/src/loudness.rs
@@ -1,0 +1,250 @@
+//! EBU R128 loudness + true-peak measurement at import.
+//!
+//! Each track's PCM is measured once, producing two intrinsic facts: integrated
+//! loudness (LUFS) and true peak (a linear ratio, 1.0 = 0 dBTP). Those raw
+//! measurements are stored per track and combined per album; the playback gain
+//! is derived from them against a constant target at play time, never stored.
+//!
+//! `ebur128::EbuR128::true_peak` already returns a linear ratio, so it is stored
+//! verbatim — no dBTP→linear conversion. The per-track meters are kept so the
+//! album loudness can be combined across them (`EbuR128::loudness_global_multiple`
+//! is order-independent, so per-track decodes can run in parallel).
+
+use ebur128::{EbuR128, Mode};
+use tracing::warn;
+
+/// A track too quiet to derive a gain from. EBU R128 integrated loudness for
+/// silence is `-inf`; without a floor, the derived boost (`target - loudness`)
+/// runs away. A track at or below this measures as "no usable loudness" and
+/// plays at unity gain. -70 LUFS is the EBU R128 absolute gating threshold —
+/// content below it contributes nothing to integrated loudness anyway.
+const SILENCE_FLOOR_LUFS: f64 = -70.0;
+
+/// One track's loudness measurement: integrated loudness in LUFS and true peak
+/// as a linear ratio (1.0 = 0 dBTP), already the max across channels.
+pub struct TrackLoudness {
+    pub loudness_lufs: f64,
+    pub peak_linear: f64,
+}
+
+/// Measure one track's PCM. `samples` is interleaved i32 as `decode_audio`
+/// returns it — values in the source's bit-depth range (16-bit values for a
+/// 16-bit source, 24-bit for 24-bit, full i32 for 32-bit/float), NOT pre-scaled
+/// to full i32. `sample_bits` is that source range (`DecodedAudio.bits_per_sample`),
+/// used to left-shift the samples so full scale maps to `i32::MAX`, which is the
+/// reference `ebur128`'s `add_frames_i32` and `true_peak` assume. The effective
+/// width is floored at 16 bits, because `read_sample` scales an 8-bit source up
+/// into the 16-bit range while still probing it as 8-bit. Skipping the shift
+/// makes a 16-bit track read ~96 dB too quiet (every track measures as silent) —
+/// the loudness equivalent of a unit error.
+///
+/// Returns the measurement alongside the meter the album combine reuses.
+/// `Ok(None)` for a track with no usable loudness (silent / near-silent or a
+/// non-finite reading) — the caller stores NULL and playback applies unity gain.
+/// `Err` is a measurement failure (the caller logs it and stores NULL).
+pub fn measure_track(
+    samples: &[i32],
+    channels: u32,
+    sample_rate: u32,
+    sample_bits: u32,
+) -> Result<(EbuR128, Option<TrackLoudness>), String> {
+    // `read_sample` never emits a value range narrower than 16 bits: an 8-bit
+    // source is scaled up into the 16-bit range (`*256`) at
+    // `audio_codec::read_sample`, even though it is still probed as
+    // `bits_per_sample = 8`. So the shift to full i32 floors the effective width
+    // at 16 — trusting the declared 8 would over-shift by 8 bits and saturate
+    // every loud sample to full scale, measuring garbage loudness and peak.
+    let effective_bits = sample_bits.max(16);
+    let shift = 32u32.saturating_sub(effective_bits);
+    let scaled: Vec<i32> = if shift == 0 {
+        samples.to_vec()
+    } else {
+        // Saturating shift: a decoded sample never actually fills its nominal
+        // bit width to the sign-bit edge, so this won't overflow in practice,
+        // but `wrapping_shl` would silently corrupt a max-magnitude sample.
+        samples
+            .iter()
+            .map(|&s| s.saturating_mul(1 << shift))
+            .collect()
+    };
+
+    let mut meter = EbuR128::new(channels, sample_rate, Mode::I | Mode::TRUE_PEAK)
+        .map_err(|e| format!("ebur128 init failed: {e:?}"))?;
+    meter
+        .add_frames_i32(&scaled)
+        .map_err(|e| format!("ebur128 add_frames failed: {e:?}"))?;
+
+    let loudness_lufs = meter
+        .loudness_global()
+        .map_err(|e| format!("ebur128 loudness_global failed: {e:?}"))?;
+
+    if !loudness_lufs.is_finite() || loudness_lufs < SILENCE_FLOOR_LUFS {
+        return Ok((meter, None));
+    }
+
+    let peak_linear = max_true_peak(&meter, channels)?;
+    Ok((
+        meter,
+        Some(TrackLoudness {
+            loudness_lufs,
+            peak_linear,
+        }),
+    ))
+}
+
+/// The track's true peak: the max linear true-peak across its channels. The
+/// crate already returns a linear ratio (1.0 = 0 dBTP), so it is stored as-is.
+fn max_true_peak(meter: &EbuR128, channels: u32) -> Result<f64, String> {
+    let mut peak = 0.0f64;
+    for ch in 0..channels {
+        let p = meter
+            .true_peak(ch)
+            .map_err(|e| format!("ebur128 true_peak({ch}) failed: {e:?}"))?;
+        if p > peak {
+            peak = p;
+        }
+    }
+    Ok(peak)
+}
+
+/// Album integrated loudness combined across the tracks' meters, in LUFS.
+/// Order-independent (`loudness_global_multiple`). `None` when there are no
+/// meters or the combined loudness is non-finite / below the silence floor (an
+/// all-silent album), so the album falls back to unity gain.
+pub fn album_loudness(meters: &[EbuR128]) -> Option<f64> {
+    if meters.is_empty() {
+        return None;
+    }
+    match EbuR128::loudness_global_multiple(meters.iter()) {
+        Ok(lufs) if lufs.is_finite() && lufs >= SILENCE_FLOOR_LUFS => Some(lufs),
+        Ok(_) => None,
+        Err(e) => {
+            warn!("ebur128 loudness_global_multiple failed: {e:?}; album loudness unmeasured");
+            None
+        }
+    }
+}
+
+/// Album true peak: the max of the per-track linear peaks. `None` when no track
+/// had a usable measurement.
+pub fn album_peak(track_peaks: &[f64]) -> Option<f64> {
+    track_peaks
+        .iter()
+        .copied()
+        .fold(None, |acc, p| Some(acc.map_or(p, |a: f64| a.max(p))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::PI;
+
+    /// Interleaved i32 stereo sine at `amplitude` (0.0..=1.0 of full scale).
+    fn sine(amplitude: f64, freq_hz: f64, sample_rate: u32, secs: f64) -> Vec<i32> {
+        let n = (sample_rate as f64 * secs) as usize;
+        let scale = amplitude * i32::MAX as f64;
+        let mut out = Vec::with_capacity(n * 2);
+        for i in 0..n {
+            let t = i as f64 / sample_rate as f64;
+            let v = (2.0 * PI * freq_hz * t).sin() * scale;
+            let s = v as i32;
+            out.push(s);
+            out.push(s);
+        }
+        out
+    }
+
+    #[test]
+    fn louder_signal_measures_higher_lufs() {
+        let sr = 48_000;
+        let (_, quiet) = measure_track(&sine(0.1, 1_000.0, sr, 3.0), 2, sr, 32).unwrap();
+        let (_, loud) = measure_track(&sine(0.5, 1_000.0, sr, 3.0), 2, sr, 32).unwrap();
+        let quiet = quiet.expect("quiet tone has usable loudness");
+        let loud = loud.expect("loud tone has usable loudness");
+        // A 5x amplitude increase is ~14 dB louder; assert a clear ordering with
+        // margin rather than an exact figure (the algorithm is version-defined).
+        assert!(
+            loud.loudness_lufs > quiet.loudness_lufs + 10.0,
+            "loud {} should exceed quiet {} by >10 LUFS",
+            loud.loudness_lufs,
+            quiet.loudness_lufs
+        );
+    }
+
+    #[test]
+    fn near_full_scale_peak_is_near_unity() {
+        let sr = 48_000;
+        let (_, m) = measure_track(&sine(0.99, 1_000.0, sr, 2.0), 2, sr, 32).unwrap();
+        let m = m.expect("usable loudness");
+        // A 0.99-full-scale sine peaks just under 1.0 linear (true-peak
+        // interpolation can nudge it slightly past the sample peak).
+        assert!(
+            m.peak_linear > 0.9 && m.peak_linear < 1.1,
+            "peak {} should be near 1.0 for a near-full-scale sine",
+            m.peak_linear
+        );
+    }
+
+    #[test]
+    fn silence_has_no_usable_loudness() {
+        let sr = 48_000;
+        let silent = vec![0i32; sr as usize * 2 * 2];
+        let (_, m) = measure_track(&silent, 2, sr, 32).unwrap();
+        assert!(
+            m.is_none(),
+            "silence must measure as no usable loudness (unity gain at playback)"
+        );
+    }
+
+    #[test]
+    fn album_loudness_combines_meters_order_independently() {
+        let sr = 48_000;
+        let (m1, _) = measure_track(&sine(0.1, 1_000.0, sr, 3.0), 2, sr, 32).unwrap();
+        let (m2, _) = measure_track(&sine(0.5, 1_000.0, sr, 3.0), 2, sr, 32).unwrap();
+
+        let forward = album_loudness(&[m1, m2]).expect("usable album loudness");
+
+        let (m1b, _) = measure_track(&sine(0.1, 1_000.0, sr, 3.0), 2, sr, 32).unwrap();
+        let (m2b, _) = measure_track(&sine(0.5, 1_000.0, sr, 3.0), 2, sr, 32).unwrap();
+        let reversed = album_loudness(&[m2b, m1b]).expect("usable album loudness");
+
+        assert!(
+            (forward - reversed).abs() < 1e-6,
+            "album loudness must be order-independent: {forward} vs {reversed}"
+        );
+    }
+
+    #[test]
+    fn album_peak_is_the_max() {
+        assert_eq!(album_peak(&[]), None);
+        assert_eq!(album_peak(&[0.3, 0.9, 0.5]), Some(0.9));
+    }
+
+    #[test]
+    fn declared_8_bit_is_floored_to_16_not_over_shifted() {
+        // `read_sample` upscales an 8-bit source into the 16-bit value range, so
+        // the decoded i32 samples are 16-bit-range even when the probe declares
+        // 8 bits. Measuring at the declared 8 must floor the shift to 16, not
+        // over-shift to 24 and saturate every loud sample — the result must
+        // match measuring the same samples as 16-bit.
+        let sr = 48_000;
+        let n = sr as usize * 3;
+        let sixteen_bit_range: Vec<i32> = (0..n)
+            .flat_map(|i| {
+                let t = i as f64 / sr as f64;
+                let v = ((2.0 * PI * 1_000.0 * t).sin() * 0.5 * i16::MAX as f64) as i32;
+                [v, v]
+            })
+            .collect();
+        let (_, as_eight) = measure_track(&sixteen_bit_range, 2, sr, 8).unwrap();
+        let (_, as_sixteen) = measure_track(&sixteen_bit_range, 2, sr, 16).unwrap();
+        let as_eight = as_eight.expect("declared-8 source measures a usable loudness");
+        let as_sixteen = as_sixteen.expect("16-bit source measures a usable loudness");
+        assert!(
+            (as_eight.loudness_lufs - as_sixteen.loudness_lufs).abs() < 1e-6,
+            "declared-8 loudness {} must equal 16-bit {} (floored, not over-shifted)",
+            as_eight.loudness_lufs,
+            as_sixteen.loudness_lufs
+        );
+    }
+}

--- a/bae-core/src/playback/aaudio_output.rs
+++ b/bae-core/src/playback/aaudio_output.rs
@@ -265,10 +265,14 @@ impl AudioOutput for AAudioOutput {
                     continue;
                 }
 
-                // Apply volume in-place over the filled region.
+                // Apply volume + this track's replay gain in-place over the
+                // filled region as one combined factor. Mute (`vol == 0`) still
+                // zeroes output. The peak cap was applied when the gain was
+                // derived, so no clamp is needed here.
                 let vol = volume.load(Ordering::Relaxed) as f32 / 10000.0;
+                let combined = source_guard.current_replay_gain_linear() * vol;
                 for sample in &mut buf[..read] {
-                    *sample *= vol;
+                    *sample *= combined;
                 }
 
                 if last_position_update.elapsed() >= position_update_interval {

--- a/bae-core/src/playback/cpal_output.rs
+++ b/bae-core/src/playback/cpal_output.rs
@@ -127,9 +127,13 @@ impl AudioOutput for CpalAudioOutput {
                         return;
                     }
 
-                    // Apply volume in-place, zero any unfilled tail
+                    // Apply volume + this track's replay gain in-place as one
+                    // combined factor; zero any unfilled tail. Mute (`vol == 0`)
+                    // still zeroes the output. The peak cap was already applied
+                    // when the gain was derived, so no clamp is needed here.
+                    let combined = source_guard.current_replay_gain_linear() * vol;
                     for sample in &mut data[..read] {
-                        *sample *= vol;
+                        *sample *= combined;
                     }
                     data[read..].fill(0.0);
 

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -407,6 +407,7 @@ impl PlaybackPreparedTrack {
             duration_ms: self.duration.as_millis() as u64,
             pregap_ms: self.pregap_ms,
             position_offset,
+            replay_gain_linear: self.replay_gain_linear,
         }
     }
 
@@ -451,6 +452,10 @@ struct PlaybackPreparedTrack {
     /// whole file). The decoder hands `end_byte` to its reader as the read-ahead
     /// ceiling so the fill buffers the rest of the current track.
     end_byte: Option<u64>,
+    /// Linear playback gain folded into the audio callback's volume multiply.
+    /// Derived once here from the replay-gain mode and the stored loudness/peak
+    /// measurements; `1.0` = no change (Off, or no usable measurement).
+    replay_gain_linear: f32,
 }
 
 /// Finalize a PlaybackPreparedTrack from resolved audio, display info, and buffer.
@@ -459,6 +464,7 @@ fn finalize_playback_track(
     track_info: PlaybackTrackInfo,
     buffer: SharedSparseBuffer,
     buffer_shared: bool,
+    replay_gain_mode: crate::config::ReplayGainMode,
 ) -> PlaybackPreparedTrack {
     let duration = resolved
         .duration_ms
@@ -470,6 +476,8 @@ fn finalize_playback_track(
             );
             std::time::Duration::from_secs(300)
         });
+
+    let replay_gain_linear = resolved.replay_gain_linear(replay_gain_mode);
 
     PlaybackPreparedTrack {
         track_info,
@@ -484,6 +492,7 @@ fn finalize_playback_track(
         start_sample: resolved.start_sample,
         end_sample: resolved.end_sample,
         end_byte: resolved.end_byte,
+        replay_gain_linear,
     }
 }
 
@@ -540,8 +549,16 @@ async fn prepare_track_for_playback(
         buffer
     };
 
+    // Read the replay-gain mode once here and pass it down (DI: one read at the
+    // top, not a static lookup buried in `finalize_playback_track`).
+    let replay_gain_mode = library_manager.get_config().replay_gain_mode;
+
     Ok(finalize_playback_track(
-        resolved, track_info, buffer, is_shared,
+        resolved,
+        track_info,
+        buffer,
+        is_shared,
+        replay_gain_mode,
     ))
 }
 
@@ -2446,6 +2463,8 @@ impl PlaybackService {
             duration_ms: duration.as_millis() as u64,
             pregap_ms: None,
             position_offset: seek_to.unwrap_or(std::time::Duration::ZERO),
+            // Preview plays an unimported file (no stored measurements) at unity.
+            replay_gain_linear: 1.0,
         };
         let (preview_boundary_tx, _preview_boundary_rx) = tokio_mpsc::unbounded_channel();
         let source = Arc::new(Mutex::new(PlaybackSource::new(

--- a/bae-core/src/playback/source.rs
+++ b/bae-core/src/playback/source.rs
@@ -35,6 +35,11 @@ pub struct TrackFmt {
     pub duration_ms: u64,
     pub pregap_ms: Option<i64>,
     pub position_offset: Duration,
+    /// Linear replay gain for this track, folded into the audio callback's
+    /// volume multiply. `1.0` = no change. Per-track and swapped at the gapless
+    /// boundary, so the loudness shifts discontinuously there — which is
+    /// correct: each track carries its own normalization.
+    pub replay_gain_linear: f32,
 }
 
 /// Payload of the boundary signal. Carries the finishing track's identity +
@@ -183,6 +188,14 @@ impl PlaybackSource {
     pub fn channels(&self) -> u32 {
         self.current.channels()
     }
+
+    /// The current track's linear replay gain, read every callback to fold into
+    /// the volume multiply. After a mid-buffer boundary crossing this returns
+    /// the incoming track's gain (the same `current_fmt` the position path
+    /// reads), so the new track's normalization takes effect at the boundary.
+    pub fn current_replay_gain_linear(&self) -> f32 {
+        self.current_fmt.replay_gain_linear
+    }
 }
 
 #[cfg(test)]
@@ -196,6 +209,7 @@ mod tests {
             duration_ms: 1000,
             pregap_ms: None,
             position_offset: Duration::ZERO,
+            replay_gain_linear: 1.0,
         }
     }
 

--- a/bae-core/src/sync/blob_plan.rs
+++ b/bae-core/src/sync/blob_plan.rs
@@ -545,6 +545,8 @@ mod tests {
             managed: false,
             source_folder_name: None,
             content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
             created_at: Utc::now(),
         })
         .await

--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -75,6 +75,8 @@ fn create_test_release(album_id: &str) -> DbRelease {
         managed: true,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: Utc::now(),
     }
 }

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -553,6 +553,222 @@ async fn import_produces_audio_format_records() {
     );
 }
 
+/// Interleaved-stereo 1 kHz sine at `amplitude` (fraction of full scale).
+///
+/// When `spikes` is set, a single full-scale sample is injected every 0.1 s.
+/// These raise the measured true peak to ~1.0 without moving the integrated
+/// loudness (they're far too sparse to form a gating block), which is exactly
+/// the high-crest-factor signal needed to make the playback peak clamp engage:
+/// a quiet track that nonetheless can't be boosted past full scale. A pure sine
+/// can never demonstrate the clamp, because its peak and RMS scale together.
+///
+/// Samples are scaled to the 16-bit range because the FLAC encoder writes S16.
+/// A small deterministic dither keeps the stream from compressing below the
+/// import's FLAC truncation check (file must be >= 10% of raw PCM); the dither
+/// sits ~60 dB down, moving neither the loudness nor the peak.
+fn sine(amplitude: f64, sample_rate: u32, secs: f64, spikes: bool) -> Vec<i32> {
+    use std::f64::consts::PI;
+    let n = (sample_rate as f64 * secs) as usize;
+    let spike_period = (sample_rate as f64 * 0.1) as usize;
+    let full_scale = i16::MAX as i32;
+    let mut rng: u32 = 0x1234_5678;
+    let mut dither = || {
+        rng = rng.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        ((rng >> 16) as i32 & 0x3F) - 32
+    };
+    let mut out = Vec::with_capacity(n * 2);
+    for i in 0..n {
+        let s = if spikes && i % spike_period == 0 {
+            full_scale
+        } else {
+            let t = i as f64 / sample_rate as f64;
+            ((2.0 * PI * 1000.0 * t).sin() * amplitude * i16::MAX as f64) as i32 + dither()
+        };
+        out.push(s);
+        out.push(s);
+    }
+    out
+}
+
+/// Write a synthetic 16-bit stereo FLAC of `samples` to `path`.
+fn write_flac(path: &Path, samples: &[i32], sample_rate: u32) {
+    let bytes = bae_core::audio_codec::encode_to_flac(
+        samples,
+        sample_rate,
+        2,
+        16,
+        &std::sync::atomic::AtomicBool::new(false),
+    )
+    .expect("encode synthetic FLAC");
+    fs::write(path, bytes).unwrap();
+}
+
+/// Loudness normalization, end to end: import two tracks of deliberately
+/// different loudness, confirm the stored per-track measurements differ, and
+/// confirm the gain each track derives at playback reflects its own loudness
+/// (the quieter track is boosted more) with the peak clamp engaging on a quiet
+/// track that nonetheless peaks near full scale.
+///
+/// This is the load-bearing test for the feature: it exercises the real import
+/// measurement path (`ImportService` → `measure_loudness`) and the real playback
+/// derivation (`ResolvedTrackAudio::replay_gain_linear`), not reconstructions.
+#[tokio::test]
+#[serial]
+async fn loudness_measured_at_import_drives_playback_gain() {
+    use bae_core::config::ReplayGainMode;
+
+    support::tracing_init();
+
+    let release = discogs_release("Loudness Album", &["Quiet Track", "Loud Track"]);
+    let release_id_key = seed_discogs_test_release(release);
+    let f = ImportFixture::new().await;
+
+    let album_dir = f.temp_path().join("album");
+    fs::create_dir_all(&album_dir).unwrap();
+    let sr = 44_100;
+    // Quiet track: a low-amplitude sine (so it wants a boost toward the target)
+    // with sparse full-scale spikes that push its true peak to ~1.0 — the
+    // crest factor that makes the playback clamp engage. Loud track: a steady
+    // half-scale sine, clearly louder and pulled down toward the target.
+    write_flac(
+        &album_dir.join("01 Quiet Track.flac"),
+        &sine(0.03, sr, 4.0, true),
+        sr,
+    );
+    write_flac(
+        &album_dir.join("02 Loud Track.flac"),
+        &sine(0.5, sr, 4.0, false),
+        sr,
+    );
+
+    let import_id = uuid::Uuid::new_v4().to_string();
+    f.handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: None,
+            storage_mode: StorageMode::Unmanaged,
+            identity_choice: IdentityChoice::Exact {
+                release_ref: MetadataRef::new(release_id_key, MetadataSource::Discogs),
+            },
+            user_edit: None,
+        })
+        .unwrap();
+
+    let mut progress_rx = f.handle.subscribe_import(import_id);
+    let (release_id, _) = support::wait_for_import_complete(&mut progress_rx).await;
+
+    // ── Stored measurements differ and reflect the two tracks' loudness ──
+    let tracks = f.db.get_tracks_for_release(&release_id).await.unwrap();
+    assert_eq!(tracks.len(), 2);
+    let quiet = tracks.iter().find(|t| t.title == "Quiet Track").unwrap();
+    let loud = tracks.iter().find(|t| t.title == "Loud Track").unwrap();
+
+    let quiet_fmt =
+        f.db.find_audio_format_by_track_id(&quiet.id)
+            .await
+            .unwrap()
+            .unwrap();
+    let loud_fmt =
+        f.db.find_audio_format_by_track_id(&loud.id)
+            .await
+            .unwrap()
+            .unwrap();
+
+    let quiet_lufs = quiet_fmt
+        .track_loudness_lufs
+        .expect("quiet track measured a loudness");
+    let loud_lufs = loud_fmt
+        .track_loudness_lufs
+        .expect("loud track measured a loudness");
+    assert!(
+        loud_lufs > quiet_lufs + 10.0,
+        "loud track ({loud_lufs} LUFS) should be clearly louder than quiet ({quiet_lufs} LUFS)"
+    );
+    // The quiet track's late full-scale burst pushes its peak near 1.0; the
+    // steady half-scale loud track peaks near 0.5.
+    let quiet_peak = quiet_fmt
+        .track_peak_linear
+        .expect("quiet track measured a peak");
+    let loud_peak = loud_fmt
+        .track_peak_linear
+        .expect("loud track measured a peak");
+    assert!(
+        quiet_peak > 0.9,
+        "quiet track's burst should peak near full scale: {quiet_peak}"
+    );
+    assert!(
+        loud_peak < 0.7,
+        "loud track's steady sine should peak near 0.5: {loud_peak}"
+    );
+
+    // Album loudness was written to the release row from the combined meters.
+    // EBU R128 album loudness is the gated integration over both tracks, so the
+    // louder track dominates: the album sits in [quiet, loud] and lands near the
+    // loud track, never below the quiet one.
+    let release = f.db.find_release_by_id(&release_id).await.unwrap().unwrap();
+    let album_lufs = release
+        .album_loudness_lufs
+        .expect("album loudness measured");
+    assert!(
+        album_lufs.is_finite() && album_lufs >= quiet_lufs && album_lufs <= loud_lufs + 0.01,
+        "album loudness {album_lufs} should fall within [{quiet_lufs}, {loud_lufs}]"
+    );
+    let album_peak = release.album_peak_linear.expect("album peak measured");
+    assert!(
+        (album_peak - quiet_peak).abs() < 1e-6,
+        "album peak {album_peak} should be the max of the tracks' peaks ({quiet_peak})"
+    );
+
+    // ── Playback gain reflects each track's own loudness (mode = Track) ──
+    let quiet_audio = f
+        .handle
+        .library_manager
+        .resolve_track_audio(&quiet.id)
+        .await
+        .unwrap();
+    let loud_audio = f
+        .handle
+        .library_manager
+        .resolve_track_audio(&loud.id)
+        .await
+        .unwrap();
+
+    let quiet_gain = quiet_audio.replay_gain_linear(ReplayGainMode::Track);
+    let loud_gain = loud_audio.replay_gain_linear(ReplayGainMode::Track);
+
+    // Off is always unity, regardless of measurements.
+    assert_eq!(quiet_audio.replay_gain_linear(ReplayGainMode::Off), 1.0);
+
+    // The quieter track wants more boost; the louder track is attenuated toward
+    // the target. So the quiet track's gain exceeds the loud track's.
+    assert!(
+        quiet_gain > loud_gain,
+        "quiet track gain {quiet_gain} should exceed loud track gain {loud_gain}"
+    );
+    // The loud track at ~-9 LUFS is pulled DOWN toward -18 (gain < 1, no clamp).
+    assert!(
+        loud_gain < 1.0,
+        "loud track should be attenuated toward the target: {loud_gain}"
+    );
+
+    // ── Peak clamp engages for the quiet, near-full-scale track ──
+    // Unclamped, the quiet track's gain would be 10^((-18 - L)/20), a large
+    // boost. With a peak ~1.0 the clamp caps it at ~1/peak ≈ 1.0, so the applied
+    // gain must equal the clamp, NOT the (much larger) loudness-only gain.
+    let unclamped = 10f64.powf((-18.0 - quiet_lufs) / 20.0) as f32;
+    let clamp = (1.0 / quiet_peak) as f32;
+    assert!(
+        unclamped > clamp + 0.5,
+        "test setup: quiet track's unclamped gain {unclamped} must exceed its clamp {clamp} so the clamp is observable"
+    );
+    assert!(
+        (quiet_gain - clamp).abs() < 0.05,
+        "quiet track's applied gain {quiet_gain} should be the peak clamp {clamp}, not the unclamped {unclamped}"
+    );
+}
+
 /// 5. Two sequential imports both succeed and produce separate albums.
 #[tokio::test]
 #[serial]

--- a/bae-core/tests/test_library_events.rs
+++ b/bae-core/tests/test_library_events.rs
@@ -79,6 +79,8 @@ fn make_release(album_id: &str) -> DbRelease {
         managed: true,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: Utc::now(),
     }
 }

--- a/bae-core/tests/test_reset_metadata.rs
+++ b/bae-core/tests/test_reset_metadata.rs
@@ -82,6 +82,8 @@ fn make_release(album_id: &str) -> DbRelease {
         managed: true,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: Utc::now(),
     }
 }

--- a/bae-core/tests/test_storage_state_machine.rs
+++ b/bae-core/tests/test_storage_state_machine.rs
@@ -108,6 +108,8 @@ async fn create_pinned_release(mgr: &LibraryManager, filenames: &[&str]) -> Stri
         managed: false,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: now,
     };
     let release_id = release.id.clone();
@@ -317,6 +319,8 @@ async fn create_unmanaged_release(
         managed: true,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: now,
     };
     let release_id = release.id.clone();
@@ -618,6 +622,8 @@ async fn create_cloud_only_release(
         managed: true,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: now,
     };
     let release_id = release.id.clone();

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -176,6 +176,8 @@ async fn create_album_and_release(
         managed: unmanaged_path.is_none(),
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: now,
     };
     db.insert_release(&release).await.unwrap();
@@ -457,6 +459,8 @@ async fn test_read_release_file_bytes_rejects_short_read() {
         managed: true,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: Utc::now(),
     };
     // This device pins the release: reads come from the staged `storage/` copy.
@@ -1255,6 +1259,8 @@ async fn create_named_unmanaged_release(
         managed: false,
         source_folder_name: None,
         content_hash: None,
+        album_loudness_lufs: None,
+        album_peak_linear: None,
         created_at: now,
     };
     db.insert_release(&release).await.unwrap();


### PR DESCRIPTION
Tracks across a library are mastered at wildly different loudness, so playback volume lurches from one to the next. bae had no normalization at all. This adds loudness normalization the way the rest of bae is shaped: decide at import, apply at playback, never touch the stored bytes.

At import each track's PCM is decoded once and measured with EBU R128 (`ebur128`, pure Rust) for two intrinsic facts — integrated loudness in LUFS and true peak. Those raw measurements are stored per track on `audio_formats` and per album on `releases`. Crucially we store the *measurements*, not a gain: the gain is a runtime view of (measurement, target, mode), so the target and track-vs-album choice stay free knobs with no re-import. The album figure is the tracks' meters combined with `loudness_global_multiple`, which is order-independent, so per-track decodes run in parallel on blocking threads. A track that fails to decode, or is too quiet to have a usable loudness, stores NULL and is logged — it never aborts the import.

At playback the gain is derived from a −18 LUFS target, capped by the stored true peak so a boosted track can't clip, and folded into the existing per-sample volume multiply in the two Rust audio callbacks (cpal covers macOS/iOS/Windows/Linux, AAudio covers Android — so "all platforms" needs no native code). It's gated by a `replay_gain_mode` setting (`Off` / `Track` / `Album`) that defaults to **Off**: the machinery measures and stores from this change on, but applies nothing until it's turned on, which lands with the cross-album shuffle work that will actually use it.

The change is entirely in bae-core. No bridge types, no settings UI, no Swift/Kotlin/C# — deliberately, so the dark feature carries no surface it doesn't need yet. Two measurement subtleties worth calling out, both verified against the `ebur128` and decoder source: `true_peak` already returns a linear ratio (stored verbatim, no dBTP conversion), and the decoder hands back i32 samples in the *source* bit-depth range, so they're left-shifted to full scale before measuring — with the effective width floored at 16 bits, because the decoder upscales 8-bit sources into the 16-bit range while still probing them as 8-bit.

This is separate from CD pre-emphasis/de-emphasis (#129), which shares the decide-at-import / apply-at-playback shape but solves a different problem.

## Test plan

- [x] `cargo test -p bae-core` — 783 lib tests green, including 6 loudness unit tests
- [x] End-to-end `loudness_measured_at_import_drives_playback_gain`: imports two tracks of deliberately different loudness, asserts the stored per-track measurements differ, the album loudness sits between them, and the gain each track derives at playback reflects its own loudness — with a guard that the peak clamp actually engages (the unclamped gain would exceed it)
- [x] 8-bit-floor unit test is load-bearing — sabotage-verified (removing the floor fails it)
- [x] `cargo clippy -p bae-core --all-targets`, `cargo deny check licenses` (ebur128 + dasp_* MIT/Apache, allow-listed) — clean
- [x] macOS `xcodebuild` and `bae-windows-ffi` build green locally
- [ ] CI to confirm iOS / Android / Windows builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F
