### PR TITLE
Windows: device membership UI (join, members, recovery)

### DIFF
--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1118,6 +1118,162 @@ pub unsafe extern "C" fn bae_restore_from_code(
     json_cstring(&out)
 }
 
+/// This device's join-request code — its public key — to hand to an existing
+/// member for approval. Returns the code as a C string, or null on error
+/// (logged). The joining device has no library yet, so this needs no handle; it
+/// only requires the keyring initialized ([`bae_startup`]). Free with
+/// [`bae_string_free`].
+#[no_mangle]
+pub extern "C" fn bae_generate_join_request() -> *mut c_char {
+    match bae_core::sync::join_code::generate_join_request(None) {
+        Ok(code) => error_cstring(&code),
+        Err(e) => {
+            tracing::error!("bae_generate_join_request failed: {e}");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// A decoded join-request code: the joining device's public key and an optional
+/// contact email it included.
+#[derive(Serialize)]
+struct FfiJoinRequestInfo {
+    pubkey: String,
+    email: Option<String>,
+}
+
+/// Decode a join-request code to preview the joining device before approving it,
+/// as JSON `{pubkey, email}`, or null when the code is malformed. No handle —
+/// runs on the approving device before any membership change. Free with
+/// [`bae_string_free`].
+///
+/// # Safety
+/// `code` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_decode_join_request(code: *const c_char) -> *mut c_char {
+    let Some(code) = cstr(code) else {
+        tracing::error!("bae_decode_join_request: null or non-UTF-8 code");
+        return std::ptr::null_mut();
+    };
+    match bae_core::sync::join_code::decode_join_request(&code) {
+        Ok(req) => json_cstring(&FfiJoinRequestInfo {
+            pubkey: req.public_key,
+            email: req.email,
+        }),
+        Err(e) => {
+            tracing::error!("bae_decode_join_request failed: {e}");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// What an invite code decodes to, before committing to a join.
+#[derive(Serialize)]
+struct FfiInviteCodeInfo {
+    library_id: String,
+    library_name: String,
+    owner_pubkey: String,
+    provider: String,
+    /// Whether joining this library needs an OAuth sign-in (Google Drive,
+    /// Dropbox, OneDrive). The joining device runs `bae_oauth_authorize` for the
+    /// provider and passes the token JSON to [`bae_join_from_code`] — mirrors
+    /// [`FfiRestoreCodeInfo::needs_oauth`].
+    needs_oauth: bool,
+}
+
+/// Decode an invite code into its `{library_id, library_name, owner_pubkey,
+/// provider, needs_oauth}` (without joining), as JSON, or null when the code is
+/// malformed. Free with [`bae_string_free`]. No handle — runs before
+/// [`bae_init`].
+///
+/// # Safety
+/// `code` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_decode_invite_code(code: *const c_char) -> *mut c_char {
+    let Some(code) = cstr(code) else {
+        tracing::error!("bae_decode_invite_code: null or non-UTF-8 code");
+        return std::ptr::null_mut();
+    };
+    match bae_core::sync::join_code::decode_invite_code_info(&code) {
+        Ok(info) => json_cstring(&FfiInviteCodeInfo {
+            library_id: info.library_id,
+            library_name: info.library_name,
+            owner_pubkey: info.owner_pubkey,
+            provider: cloud_provider_name(&info.cloud_provider).to_string(),
+            needs_oauth: info.needs_oauth,
+        }),
+        Err(e) => {
+            tracing::error!("bae_decode_invite_code failed: {e}");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Join a shared library from an invite code. For OAuth providers (Google Drive,
+/// Dropbox, OneDrive) the caller first runs `bae_oauth_authorize` and passes the
+/// resulting token JSON as `oauth_token_json` (the joining device authorizes its
+/// own cloud account); for credential providers it passes null. Pulls the
+/// library from the cloud, then returns `{library_id, error}` as JSON for the
+/// caller to [`bae_init`]. Mirrors [`bae_restore_from_code`]. No handle — runs
+/// before [`bae_init`]. Free with [`bae_string_free`].
+///
+/// # Safety
+/// `code` must be a valid NUL-terminated UTF-8 C string; `oauth_token_json` must
+/// be null or a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_join_from_code(
+    code: *const c_char,
+    oauth_token_json: *const c_char,
+) -> *mut c_char {
+    let Some(code) = cstr(code) else {
+        return json_cstring(&FfiRestoreResult {
+            library_id: None,
+            error: Some("invalid invite code".to_string()),
+        });
+    };
+    let oauth_tokens = match cstr(oauth_token_json) {
+        Some(json) => match serde_json::from_str::<bae_core::oauth::OAuthTokens>(&json) {
+            Ok(tokens) => Some(tokens),
+            Err(e) => {
+                return json_cstring(&FfiRestoreResult {
+                    library_id: None,
+                    error: Some(format!("invalid oauth token json: {e}")),
+                });
+            }
+        },
+        None => None,
+    };
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("bae_join_from_code: runtime: {e}");
+            return json_cstring(&FfiRestoreResult {
+                library_id: None,
+                error: Some("couldn't start the join runtime".to_string()),
+            });
+        }
+    };
+    let result = runtime.block_on(bae_core::library::join_from_code(
+        &code,
+        oauth_tokens,
+        // cloudkit_ops: Windows has no CloudKit provider, so there is never a
+        // driver to pass (matches bae_restore_from_code).
+        None,
+        |status| tracing::info!("join: {status}"),
+    ));
+    let out = match result {
+        Ok(config) => FfiRestoreResult {
+            library_id: Some(config.library_id.clone()),
+            error: None,
+        },
+        Err(e) => FfiRestoreResult {
+            library_id: None,
+            error: Some(e),
+        },
+    };
+    json_cstring(&out)
+}
+
 /// A manually-entered cloud source to restore from, when there's no restore code
 /// — the user types every connection detail, including the secrets a shareable
 /// code can't carry. Decoded from the `source_json` of [`bae_restore_from_cloud`].
@@ -3349,6 +3505,117 @@ pub unsafe extern "C" fn bae_generate_restore_code(handle: *const BaeHandle) -> 
             tracing::error!("bae_generate_restore_code failed: {e}");
             std::ptr::null_mut()
         }
+    }
+}
+
+/// One device in the library's membership list.
+#[derive(Serialize)]
+struct FfiMember {
+    pubkey: String,
+    /// Lowercase wire role: "owner" / "member" / "follower". bae adds devices as
+    /// "member" and the founder is "owner"; "follower" never originates here but
+    /// is rendered if a future build or another platform writes one.
+    role: String,
+    is_self: bool,
+}
+
+/// The library's current members (devices) as a JSON array of
+/// `{pubkey, role, is_self}`, or null on error (e.g. sync isn't connected;
+/// logged). Free with [`bae_string_free`].
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn bae_get_members(handle: *const BaeHandle) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_get_members: null handle");
+        return std::ptr::null_mut();
+    };
+    let app = &handle.0;
+    let members = match app
+        .runtime
+        .block_on(app.services.library_manager().get_members())
+    {
+        Ok(members) => members,
+        Err(e) => {
+            tracing::error!("bae_get_members failed: {e}");
+            return std::ptr::null_mut();
+        }
+    };
+    let members: Vec<FfiMember> = members
+        .into_iter()
+        .map(|member| FfiMember {
+            pubkey: member.pubkey,
+            role: member.role.as_str().to_string(),
+            is_self: member.is_self,
+        })
+        .collect();
+    json_cstring(&members)
+}
+
+/// Approve a device into the library by its public key (hex), wrapping the
+/// library key to it and signing a membership entry. Returns the invite code to
+/// hand back to the joining device as a C string, or null on error (logged).
+/// bae adds every device as a member; the founding device is the owner. Blocks
+/// on the cloud write — call off the UI thread. Free with [`bae_string_free`].
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed;
+/// `public_key_hex` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_invite_member(
+    handle: *const BaeHandle,
+    public_key_hex: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_invite_member: null handle");
+        return std::ptr::null_mut();
+    };
+    let Some(public_key_hex) = cstr(public_key_hex) else {
+        tracing::error!("bae_invite_member: null or non-UTF-8 public_key_hex");
+        return std::ptr::null_mut();
+    };
+    let app = &handle.0;
+    match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .invite_member(&public_key_hex),
+    ) {
+        Ok(code) => error_cstring(&code),
+        Err(e) => {
+            tracing::error!("bae_invite_member failed: {e}");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Remove a device from the library by its public key (hex) and rotate the
+/// library key so the removed device can no longer read new data. Returns null
+/// on success, or an error-message C string (free with [`bae_string_free`]).
+/// Blocks on the cloud write — call off the UI thread.
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed;
+/// `public_key_hex` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_remove_member(
+    handle: *const BaeHandle,
+    public_key_hex: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        return error_cstring("no app handle");
+    };
+    let Some(public_key_hex) = cstr(public_key_hex) else {
+        return error_cstring("invalid remove-member argument");
+    };
+    let app = &handle.0;
+    match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .remove_member(&public_key_hex),
+    ) {
+        Ok(()) => std::ptr::null_mut(),
+        Err(e) => error_cstring(&e),
     }
 }
 

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -573,6 +573,16 @@ public sealed partial class MainWindow : Window
         };
         restoreButton.Click += async (_, _) => await RestoreFromCode(codeBox.Text ?? string.Empty);
 
+        // Join a library that already exists on another device: this device shows
+        // its join-request code, an existing owner approves it, and the invite
+        // code it returns brings the library down here.
+        var joinButton = new Button
+        {
+            Content = Loc.Chrome("welcome.join_library"),
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        joinButton.Click += async (_, _) => await ShowJoinLibrary();
+
         // Restore by entering the cloud location and credentials directly, when
         // there's no restore code (the code can't carry secrets like S3 keys).
         var restoreCloudButton = new Button
@@ -585,6 +595,7 @@ public sealed partial class MainWindow : Window
         _welcome.Children.Add(createButton);
         _welcome.Children.Add(codeBox);
         _welcome.Children.Add(restoreButton);
+        _welcome.Children.Add(joinButton);
         _welcome.Children.Add(restoreCloudButton);
         EmptyState.Children.Add(_welcome);
     }
@@ -656,6 +667,485 @@ public sealed partial class MainWindow : Window
 
         DismissWelcome();
         OpenLibrary(result.LibraryId);
+    }
+
+    // Copy text to the system clipboard (a shared code the user hands to another
+    // device).
+    private static void CopyToClipboard(string text)
+    {
+        var package = new DataPackage();
+        package.SetText(text);
+        Clipboard.SetContent(package);
+    }
+
+    // A code-display block: the QR image (when it renders), the code as selectable
+    // monospaced text, and a Copy button. Shared by the join screen (this device's
+    // code), the approve flow (the invite code), and the recovery reveal.
+    private static StackPanel BuildCodeDisplay(string code)
+    {
+        var panel = new StackPanel { Spacing = 8, HorizontalAlignment = HorizontalAlignment.Center };
+
+        var qr = QrCode.Image(code);
+        if (qr is not null)
+        {
+            panel.Children.Add(new Image
+            {
+                Source = qr,
+                Width = 180,
+                Height = 180,
+                Stretch = Stretch.Uniform,
+            });
+        }
+
+        panel.Children.Add(new TextBox
+        {
+            Text = code,
+            IsReadOnly = true,
+            TextWrapping = TextWrapping.Wrap,
+            FontFamily = new FontFamily("Consolas"),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        });
+
+        var copy = new Button
+        {
+            Content = Loc.Chrome("action.copy"),
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        copy.Click += (_, _) => CopyToClipboard(code);
+        panel.Children.Add(copy);
+
+        return panel;
+    }
+
+    // Join a library that already lives on another device. This device generates
+    // its join-request code (its public key) and shows it as a QR + text + short
+    // fingerprint; an existing owner approves it (in their Settings → Devices) and
+    // reads back an invite code, which the user pastes or scans here. Decoding the
+    // invite runs the OAuth sign-in when the provider needs it, then JoinFromCode
+    // pulls the library down. Mirrors RestoreFromCode's non-cancellable flow.
+    private async System.Threading.Tasks.Task ShowJoinLibrary()
+    {
+        var content = new StackPanel { Spacing = 12, MinWidth = 360 };
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("join.intro"),
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        // This device's code section, filled once it's generated below.
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("join.this_device_code"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        var deviceCodeHost = new StackPanel { Spacing = 8 };
+        deviceCodeHost.Children.Add(new ProgressRing { IsActive = true, Width = 20, Height = 20 });
+        content.Children.Add(deviceCodeHost);
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("join.show_to_member"),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        });
+
+        // Invite-code section.
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("join.invite_label"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("join.invite_hint"),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        });
+        var inviteBox = new TextBox
+        {
+            PlaceholderText = Loc.Chrome("join.invite_placeholder"),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        var scanButton = new Button { Content = Loc.Chrome("action.scan") };
+        var inviteRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        inviteRow.Children.Add(inviteBox);
+        inviteRow.Children.Add(scanButton);
+        content.Children.Add(inviteRow);
+
+        var invitePreview = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Visibility = Visibility.Collapsed,
+        };
+        content.Children.Add(invitePreview);
+
+        var status = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+            TextWrapping = TextWrapping.Wrap,
+            Visibility = Visibility.Collapsed,
+        };
+        content.Children.Add(status);
+
+        var joinButton = new Button
+        {
+            Content = Loc.Chrome("join.confirm"),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            IsEnabled = false,
+        };
+        content.Children.Add(joinButton);
+
+        var dialog = new ContentDialog
+        {
+            Title = Loc.Chrome("join.title"),
+            Content = new ScrollViewer { Content = content, MaxHeight = 560 },
+            CloseButtonText = Loc.Chrome("action.cancel"),
+            XamlRoot = Content.XamlRoot,
+        };
+
+        // The decoded invite and the OAuth token (when the provider needed one):
+        // both feed the Join click and gate the button.
+        InviteCodeInfo? decoded = null;
+        string? oauthTokenJson = null;
+
+        void ShowStatus(string message)
+        {
+            status.Text = message;
+            status.Visibility = Visibility.Visible;
+        }
+
+        void ClearStatus()
+        {
+            status.Text = string.Empty;
+            status.Visibility = Visibility.Collapsed;
+        }
+
+        // The button is ready once a valid invite is decoded and — for an OAuth
+        // provider — the sign-in has produced a token.
+        void Revalidate()
+        {
+            joinButton.IsEnabled = decoded is not null && (!decoded.NeedsOauth || oauthTokenJson is not null);
+        }
+
+        // Decode the typed/scanned invite and preview the library it joins. The
+        // decode is a fast in-memory parse, so it runs on the UI thread; OAuth
+        // sign-in is deferred to the Join click so the user isn't sent to the
+        // browser just for typing.
+        void DecodeInvite(string code)
+        {
+            decoded = null;
+            oauthTokenJson = null;
+            invitePreview.Visibility = Visibility.Collapsed;
+            ClearStatus();
+            Revalidate();
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                return;
+            }
+
+            var infoJson = NativeBae.DecodeInviteCode(code);
+            var info = infoJson is null
+                ? null
+                : JsonSerializer.Deserialize<InviteCodeInfo>(infoJson, JsonOptions);
+            if (info is null)
+            {
+                ShowStatus(Loc.Chrome("join.invalid_invite"));
+                return;
+            }
+
+            decoded = info;
+            invitePreview.Text = Loc.Chrome("join.invite_for", new Dictionary<string, object?>
+            {
+                ["name"] = info.LibraryName,
+                ["provider"] = ProviderDisplayName(info.Provider),
+                ["fingerprint"] = MemberFormat.Fingerprint(info.OwnerPubkey),
+            });
+            invitePreview.Visibility = Visibility.Visible;
+            Revalidate();
+        }
+
+        inviteBox.TextChanged += (_, _) => DecodeInvite(inviteBox.Text?.Trim() ?? string.Empty);
+        scanButton.Click += async (_, _) =>
+        {
+            var scanned = await QrScanner.ScanFromFileAsync(WinRT.Interop.WindowNative.GetWindowHandle(this));
+            if (scanned is not null)
+            {
+                inviteBox.Text = scanned.Trim();
+            }
+        };
+
+        joinButton.Click += async (_, _) =>
+        {
+            if (decoded is null)
+            {
+                return;
+            }
+
+            var info = decoded;
+            ClearStatus();
+
+            // OAuth providers (Google Drive, Dropbox, OneDrive) need a sign-in
+            // first: the joining device authorizes its own cloud account, exactly
+            // as RestoreFromCode does.
+            if (info.NeedsOauth)
+            {
+                if (!NativeBae.AvailableCloudProviders().Contains(info.Provider))
+                {
+                    ShowStatus(Loc.Chrome("cloud.unsupported_provider", "provider", ProviderDisplayName(info.Provider)));
+                    return;
+                }
+                if (!OAuthCreds.Available)
+                {
+                    ShowStatus(OAuthCreds.RegistrationError ?? Loc.Chrome("cloud.signin.not_configured"));
+                    return;
+                }
+
+                joinButton.IsEnabled = false;
+                status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
+                ShowStatus(Loc.Chrome("cloud.signin.in_progress", "provider", ProviderDisplayName(info.Provider)));
+                var oauthJson = await System.Threading.Tasks.Task.Run(() => NativeBae.OAuthAuthorize(info.Provider));
+                var oauth = oauthJson is null ? null : JsonSerializer.Deserialize<OAuthResult>(oauthJson, JsonOptions);
+                if (oauth?.Token is null)
+                {
+                    status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon);
+                    ShowStatus(oauth?.Error ?? Loc.Chrome("cloud.signin.failed"));
+                    Revalidate();
+                    return;
+                }
+                oauthTokenJson = oauth.Token;
+            }
+
+            joinButton.IsEnabled = false;
+            status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
+            ShowStatus(Loc.Chrome("join.in_progress", "name", info.LibraryName));
+            var code = inviteBox.Text?.Trim() ?? string.Empty;
+            var token = oauthTokenJson;
+            var resultJson = await System.Threading.Tasks.Task.Run(() => NativeBae.JoinFromCode(code, token));
+            var result = resultJson is null
+                ? null
+                : JsonSerializer.Deserialize<RestoreResult>(resultJson, JsonOptions);
+            if (result?.LibraryId is null)
+            {
+                status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon);
+                ShowStatus(result?.Error ?? Loc.Chrome("join.failed"));
+                joinButton.IsEnabled = true;
+                return;
+            }
+
+            dialog.Hide();
+            DismissWelcome();
+            OpenLibrary(result.LibraryId);
+        };
+
+        // Generate this device's join-request code off the UI thread, then render
+        // it (QR + text + Copy) and its fingerprint. A failure leaves the device
+        // section showing only an error — the invite half is unaffected.
+        _ = GenerateJoinCode(deviceCodeHost);
+
+        await dialog.ShowAsync();
+    }
+
+    // Fill the join screen's device-code section: generate the join-request code,
+    // decode it for the fingerprint, and render the code display. Runs the
+    // blocking FFI off the UI thread.
+    private async System.Threading.Tasks.Task GenerateJoinCode(StackPanel host)
+    {
+        var code = await System.Threading.Tasks.Task.Run(() => NativeBae.GenerateJoinRequest());
+        host.Children.Clear();
+        if (code is null)
+        {
+            host.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("join.generate_failed"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+                TextWrapping = TextWrapping.Wrap,
+            });
+            return;
+        }
+
+        host.Children.Add(BuildCodeDisplay(code));
+
+        // The fingerprint is the first eight hex of this device's public key,
+        // which the join-request code carries — decode it to show the same short
+        // form the approving device sees.
+        var infoJson = NativeBae.DecodeJoinRequest(code);
+        var info = infoJson is null
+            ? null
+            : JsonSerializer.Deserialize<JoinRequestInfo>(infoJson, JsonOptions);
+        if (info is not null)
+        {
+            host.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("join.fingerprint", "fingerprint", MemberFormat.Fingerprint(info.Pubkey)),
+                FontFamily = new FontFamily("Consolas"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            });
+        }
+    }
+
+    // Owner-side approve flow: a single dialog whose body swaps between steps —
+    // capture (scan or paste the new device's join-request code) → confirm (its
+    // fingerprint) → invited (the invite code to enter on the new device). Approve
+    // wraps the library key to the device and signs a membership entry; the invite
+    // code it returns is the new device's way in. Mirrors macOS's ApproveDeviceSheet.
+    private async System.Threading.Tasks.Task ShowApproveDevice()
+    {
+        var body = new StackPanel { Spacing = 12, MinWidth = 360 };
+        var dialog = new ContentDialog
+        {
+            Title = Loc.Chrome("members.approve.title"),
+            Content = new ScrollViewer { Content = body, MaxHeight = 560 },
+            CloseButtonText = Loc.Chrome("action.done"),
+            XamlRoot = Content.XamlRoot,
+        };
+
+        void ShowCapture()
+        {
+            body.Children.Clear();
+            body.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("members.approve.capture_hint"),
+                TextWrapping = TextWrapping.Wrap,
+            });
+
+            var pasteBox = new TextBox
+            {
+                PlaceholderText = Loc.Chrome("members.approve.paste_placeholder"),
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+            var decode = new Button { Content = Loc.Chrome("members.approve.decode") };
+            var scan = new Button { Content = Loc.Chrome("action.scan") };
+            var captureRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            captureRow.Children.Add(pasteBox);
+            captureRow.Children.Add(decode);
+            captureRow.Children.Add(scan);
+            body.Children.Add(captureRow);
+
+            var error = new TextBlock
+            {
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+                TextWrapping = TextWrapping.Wrap,
+                Visibility = Visibility.Collapsed,
+            };
+            body.Children.Add(error);
+
+            void TryDecode(string code)
+            {
+                if (string.IsNullOrWhiteSpace(code))
+                {
+                    return;
+                }
+
+                var infoJson = NativeBae.DecodeJoinRequest(code);
+                var info = infoJson is null
+                    ? null
+                    : JsonSerializer.Deserialize<JoinRequestInfo>(infoJson, JsonOptions);
+                if (info is null)
+                {
+                    error.Text = Loc.Chrome("members.approve.invalid_request");
+                    error.Visibility = Visibility.Visible;
+                    return;
+                }
+
+                ShowConfirm(info);
+            }
+
+            decode.Click += (_, _) => TryDecode(pasteBox.Text?.Trim() ?? string.Empty);
+            scan.Click += async (_, _) =>
+            {
+                var scanned = await QrScanner.ScanFromFileAsync(WinRT.Interop.WindowNative.GetWindowHandle(this));
+                if (scanned is not null)
+                {
+                    TryDecode(scanned.Trim());
+                }
+            };
+        }
+
+        void ShowConfirm(JoinRequestInfo info)
+        {
+            body.Children.Clear();
+            body.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("members.approve.confirm_title"),
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            });
+            body.Children.Add(new TextBlock
+            {
+                Text = MemberFormat.Fingerprint(info.Pubkey),
+                FontFamily = new FontFamily("Consolas"),
+            });
+            if (!string.IsNullOrEmpty(info.Email))
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = info.Email,
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                });
+            }
+            body.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("members.approve.confirm_hint"),
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            });
+
+            var error = new TextBlock
+            {
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+                TextWrapping = TextWrapping.Wrap,
+                Visibility = Visibility.Collapsed,
+            };
+
+            var back = new Button { Content = Loc.Chrome("action.back") };
+            back.Click += (_, _) => ShowCapture();
+            var approve = new Button
+            {
+                Content = Loc.Chrome("members.approve.confirm"),
+                Style = Application.Current.Resources["AccentButtonStyle"] as Style,
+            };
+            approve.Click += async (_, _) =>
+            {
+                approve.IsEnabled = false;
+                back.IsEnabled = false;
+                error.Visibility = Visibility.Collapsed;
+                error.Text = Loc.Chrome("members.approve.in_progress");
+                error.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
+                error.Visibility = Visibility.Visible;
+
+                var pubkey = info.Pubkey;
+                var code = await System.Threading.Tasks.Task.Run(() => NativeBae.InviteMember(_handle, pubkey));
+                if (code is null)
+                {
+                    error.Text = Loc.Chrome("members.approve.failed");
+                    error.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon);
+                    error.Visibility = Visibility.Visible;
+                    approve.IsEnabled = true;
+                    back.IsEnabled = true;
+                    return;
+                }
+
+                ShowInvited(code);
+            };
+
+            var buttons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            buttons.Children.Add(back);
+            buttons.Children.Add(approve);
+            body.Children.Add(buttons);
+            body.Children.Add(error);
+        }
+
+        void ShowInvited(string code)
+        {
+            body.Children.Clear();
+            body.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("members.approve.invited_hint"),
+                TextWrapping = TextWrapping.Wrap,
+            });
+            body.Children.Add(BuildCodeDisplay(code));
+        }
+
+        ShowCapture();
+        await dialog.ShowAsync();
     }
 
     // Restore a library by entering its cloud location and credentials directly,
@@ -4141,22 +4631,52 @@ public sealed partial class MainWindow : Window
         content.Children.Add(oauthButtons);
         content.Children.Add(s3Form);
 
-        // Restore code: enter it on another device to restore this library.
-        var restoreCode = new TextBox
+        // Devices (membership): list the library's devices with their role and a
+        // "this device" marker. The owner can add a device (which opens the
+        // approve flow) or remove one (which rotates the library key). The list
+        // loads off the UI thread; the add-device button only renders for an owner.
+        var addDeviceRequested = false;
+        content.Children.Add(new TextBlock
         {
-            Header = Loc.Chrome("settings.restore_code.label"),
+            Text = Loc.Chrome("members.title"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        var membersHost = new StackPanel { Spacing = 8 };
+        membersHost.Children.Add(new ProgressRing { IsActive = true, Width = 20, Height = 20 });
+        content.Children.Add(membersHost);
+
+        // Recovery: the restore code is now a recovery secret only — it restores
+        // this library on a new device when there's no other device available to
+        // approve it. Anyone with it has full access, so it's revealed on demand,
+        // behind a warning, never shown by default.
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("settings.recovery.title"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("settings.recovery.intro"),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        });
+        var recoveryCode = new TextBox
+        {
+            Header = Loc.Chrome("settings.recovery.label"),
             IsReadOnly = true,
             TextWrapping = TextWrapping.Wrap,
+            FontFamily = new FontFamily("Consolas"),
             Visibility = Visibility.Collapsed,
         };
-        var showRestoreCode = new Button { Content = Loc.Chrome("settings.restore_code.show") };
-        showRestoreCode.Click += (_, _) =>
+        var showRecoveryCode = new Button { Content = Loc.Chrome("settings.recovery.show") };
+        showRecoveryCode.Click += async (_, _) =>
         {
-            restoreCode.Text = NativeBae.GenerateRestoreCode(_handle) ?? Loc.Chrome("settings.restore_code.unavailable");
-            restoreCode.Visibility = Visibility.Visible;
+            recoveryCode.Text = await System.Threading.Tasks.Task.Run(() => NativeBae.GenerateRestoreCode(_handle))
+                ?? Loc.Chrome("settings.recovery.unavailable");
+            recoveryCode.Visibility = Visibility.Visible;
         };
-        content.Children.Add(showRestoreCode);
-        content.Children.Add(restoreCode);
+        content.Children.Add(showRecoveryCode);
+        content.Children.Add(recoveryCode);
 
         // Lock this library: forget its encryption key on this device. Sync stops
         // and the library reopens to the unlock prompt; local files stay.
@@ -4176,6 +4696,16 @@ public sealed partial class MainWindow : Window
             lockRequested = true;
             dialog.Hide();
         };
+
+        // Now that the dialog exists, load the device list into its placeholder.
+        // The add-device button (owner-only) arms the approve flow and closes the
+        // settings dialog — a nested ContentDialog can't open over it, so the
+        // approve flow runs after this one returns (mirroring the lock dance).
+        _ = LoadMembersInto(membersHost, () =>
+        {
+            addDeviceRequested = true;
+            dialog.Hide();
+        });
 
         // Re-read the (FFI-pre-computed) settings into the live labels so a
         // ConfigChanged event — or a connect/disconnect in this dialog — updates
@@ -4224,7 +4754,137 @@ public sealed partial class MainWindow : Window
             }
 
             OpenLibrary(s.LibraryId);
+            return;
         }
+
+        // Add-a-device closed settings to open the approve flow (no nested
+        // dialogs). Run it, then reopen settings so the refreshed device list
+        // shows the newly-approved device.
+        if (addDeviceRequested)
+        {
+            await ShowApproveDevice();
+            OnSettingsClick(sender, e);
+        }
+    }
+
+    // Load the library's devices into a host panel: one row per device (short
+    // fingerprint + role + "this device" marker), and — for an owner — an
+    // "Add a device…" button plus a Remove control on each other device. Runs the
+    // blocking FFI off the UI thread. <paramref name="onAddDevice"/> arms the
+    // approve flow (which the caller runs once the settings dialog closes).
+    private async System.Threading.Tasks.Task LoadMembersInto(StackPanel host, Action onAddDevice)
+    {
+        var json = await System.Threading.Tasks.Task.Run(() => NativeBae.GetMembersJson(_handle));
+        host.Children.Clear();
+
+        var members = json is null
+            ? null
+            : JsonSerializer.Deserialize<List<Member>>(json, JsonOptions);
+        if (members is null)
+        {
+            host.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("members.load_failed"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+                TextWrapping = TextWrapping.Wrap,
+            });
+            return;
+        }
+
+        // This device may manage membership only if it is itself an owner.
+        var selfIsOwner = members.Any(member => member.IsSelf && member.Role == "owner");
+
+        foreach (var member in members)
+        {
+            host.Children.Add(BuildMemberRow(member, selfIsOwner, host, onAddDevice));
+        }
+
+        if (selfIsOwner)
+        {
+            var add = new Button { Content = Loc.Chrome("members.add") };
+            add.Click += (_, _) => onAddDevice();
+            host.Children.Add(add);
+        }
+    }
+
+    // One device row: fingerprint + role badge + "this device" marker, plus a
+    // two-step Remove for the owner on every other device. Removing rotates the
+    // library key, so it confirms inline (a second click) — a nested ContentDialog
+    // can't open over the settings dialog.
+    private FrameworkElement BuildMemberRow(Member member, bool selfIsOwner, StackPanel host, Action onAddDevice)
+    {
+        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+
+        var labels = new StackPanel { Spacing = 0 };
+        labels.Children.Add(new TextBlock
+        {
+            Text = MemberFormat.Fingerprint(member.Pubkey),
+            FontFamily = new FontFamily("Consolas"),
+        });
+        if (member.IsSelf)
+        {
+            labels.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("members.this_device"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            });
+        }
+        row.Children.Add(labels);
+
+        row.Children.Add(new TextBlock
+        {
+            Text = MemberFormat.RoleLabel(member.Role),
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+
+        // The owner can remove any device but its own.
+        if (selfIsOwner && !member.IsSelf)
+        {
+            var remove = new Button { Content = Loc.Chrome("members.remove") };
+            var status = new TextBlock
+            {
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+                TextWrapping = TextWrapping.Wrap,
+                Visibility = Visibility.Collapsed,
+            };
+            var armed = false;
+            remove.Click += async (_, _) =>
+            {
+                if (!armed)
+                {
+                    status.Text = Loc.Chrome("members.remove_confirm");
+                    status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
+                    status.Visibility = Visibility.Visible;
+                    armed = true;
+                    return;
+                }
+
+                remove.IsEnabled = false;
+                var pubkey = member.Pubkey;
+                var error = await System.Threading.Tasks.Task.Run(() => NativeBae.RemoveMember(_handle, pubkey));
+                if (error is not null)
+                {
+                    status.Text = error;
+                    status.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon);
+                    status.Visibility = Visibility.Visible;
+                    remove.IsEnabled = true;
+                    armed = false;
+                    return;
+                }
+
+                // Reload the list in place so the removed device disappears.
+                await LoadMembersInto(host, onAddDevice);
+            };
+            row.Children.Add(remove);
+
+            var rowWithStatus = new StackPanel { Spacing = 4 };
+            rowWithStatus.Children.Add(row);
+            rowWithStatus.Children.Add(status);
+            return rowWithStatus;
+        }
+
+        return row;
     }
 
     private void OnClosed(object sender, WindowEventArgs args)

--- a/bae-windows/Membership.cs
+++ b/bae-windows/Membership.cs
@@ -1,0 +1,57 @@
+﻿namespace Bae.Windows;
+
+/// <summary>
+/// UI-side formatting for device membership: the public-key fingerprint and the
+/// localized role label the member list renders.
+/// </summary>
+internal static class MemberFormat
+{
+    /// <summary>
+    /// A device's short fingerprint — the first eight hex characters of its
+    /// public key — shown on both the joining and approving device so the user
+    /// can confirm they're pairing the right one.
+    /// </summary>
+    internal static string Fingerprint(string pubkey) =>
+        pubkey.Length <= 8 ? pubkey : pubkey[..8];
+
+    /// <summary>The localized display name for a wire role tag.</summary>
+    internal static string RoleLabel(string role) => role switch
+    {
+        "owner" => Loc.Chrome("members.role.owner"),
+        "member" => Loc.Chrome("members.role.member"),
+        "follower" => Loc.Chrome("members.role.follower"),
+        _ => role,
+    };
+}
+
+/// <summary>
+/// What a join-request code decodes to (from <c>bae_decode_join_request</c>):
+/// the joining device's public key and an optional contact email it included.
+/// </summary>
+public sealed class JoinRequestInfo
+{
+    public string Pubkey { get; set; } = string.Empty;
+    public string? Email { get; set; }
+}
+
+/// <summary>What an invite code decodes to (from <c>bae_decode_invite_code</c>).</summary>
+public sealed class InviteCodeInfo
+{
+    public string LibraryId { get; set; } = string.Empty;
+    public string LibraryName { get; set; } = string.Empty;
+    public string OwnerPubkey { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+    public bool NeedsOauth { get; set; }
+}
+
+/// <summary>One device in the library (from <c>bae_get_members</c>).</summary>
+public sealed class Member
+{
+    public string Pubkey { get; set; } = string.Empty;
+
+    /// <summary>Lowercase wire role: "owner" / "member" / "follower".</summary>
+    public string Role { get; set; } = string.Empty;
+
+    /// <summary>True for the device this app is running on.</summary>
+    public bool IsSelf { get; set; }
+}

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -233,6 +233,50 @@ internal static class NativeBae
     internal static string? RestoreFromCode(string code, string? oauthTokenJson) =>
         CopyAndFree(RestoreFromCodePtr(code, oauthTokenJson));
 
+    [DllImport(Dll, EntryPoint = "bae_generate_join_request", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr GenerateJoinRequestPtr();
+
+    /// <summary>
+    /// This device's join-request code — its public key — to hand to an existing
+    /// member for approval, or null on error. The joining device has no library
+    /// yet, so this needs no handle; it only requires <see cref="Startup"/>.
+    /// Copies and frees.
+    /// </summary>
+    internal static string? GenerateJoinRequest() => CopyAndFree(GenerateJoinRequestPtr());
+
+    [DllImport(Dll, EntryPoint = "bae_decode_join_request", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr DecodeJoinRequestPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string code);
+
+    /// <summary>
+    /// Decode a join-request code to its info JSON (<c>{pubkey, email}</c>), or
+    /// null if malformed. Copies and frees.
+    /// </summary>
+    internal static string? DecodeJoinRequest(string code) => CopyAndFree(DecodeJoinRequestPtr(code));
+
+    [DllImport(Dll, EntryPoint = "bae_decode_invite_code", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr DecodeInviteCodePtr([MarshalAs(UnmanagedType.LPUTF8Str)] string code);
+
+    /// <summary>
+    /// Decode an invite code to its info JSON (<c>{library_id, library_name,
+    /// owner_pubkey, provider, needs_oauth}</c>), or null if malformed. Copies and
+    /// frees.
+    /// </summary>
+    internal static string? DecodeInviteCode(string code) => CopyAndFree(DecodeInviteCodePtr(code));
+
+    [DllImport(Dll, EntryPoint = "bae_join_from_code", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr JoinFromCodePtr(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string code,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? oauthTokenJson);
+
+    /// <summary>
+    /// Join a shared library from an invite code; returns a result JSON
+    /// (<c>{library_id, error}</c>). For OAuth providers pass the token JSON from
+    /// <see cref="OAuthAuthorize"/>; for credential providers pass null. Blocks on
+    /// a cloud pull — call off the UI thread. Copies and frees.
+    /// </summary>
+    internal static string? JoinFromCode(string code, string? oauthTokenJson) =>
+        CopyAndFree(JoinFromCodePtr(code, oauthTokenJson));
+
     [DllImport(Dll, EntryPoint = "bae_restore_from_cloud", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr RestoreFromCloudPtr(
         [MarshalAs(UnmanagedType.LPUTF8Str)] string libraryId,
@@ -618,6 +662,42 @@ internal static class NativeBae
 
     /// <summary>This library's restore code, or null on error. Copies and frees.</summary>
     internal static string? GenerateRestoreCode(IntPtr handle) => CopyAndFree(GenerateRestoreCodePtr(handle));
+
+    [DllImport(Dll, EntryPoint = "bae_get_members", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr GetMembersPtr(IntPtr handle);
+
+    /// <summary>
+    /// The library's members (devices) as a JSON array of <c>{pubkey, role,
+    /// is_self}</c>, or null on error. Blocks on a cloud read — call off the UI
+    /// thread. Copies and frees.
+    /// </summary>
+    internal static string? GetMembersJson(IntPtr handle) => CopyAndFree(GetMembersPtr(handle));
+
+    [DllImport(Dll, EntryPoint = "bae_invite_member", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr InviteMemberPtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string publicKeyHex);
+
+    /// <summary>
+    /// Approve a device into the library by its public key (hex); returns the
+    /// invite code to hand back to the joining device, or null on error. Blocks on
+    /// the cloud write — call off the UI thread. Copies and frees.
+    /// </summary>
+    internal static string? InviteMember(IntPtr handle, string publicKeyHex) =>
+        CopyAndFree(InviteMemberPtr(handle, publicKeyHex));
+
+    [DllImport(Dll, EntryPoint = "bae_remove_member", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr RemoveMemberPtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string publicKeyHex);
+
+    /// <summary>
+    /// Remove a device from the library by its public key (hex), rotating the
+    /// library key; null on success, else the error. Blocks on the cloud write —
+    /// call off the UI thread.
+    /// </summary>
+    internal static string? RemoveMember(IntPtr handle, string publicKeyHex) =>
+        ResultMessage(RemoveMemberPtr(handle, publicKeyHex));
 
     [DllImport(Dll, EntryPoint = "bae_release_edit_seed", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr ReleaseEditSeedPtr(

--- a/bae-windows/QrCode.cs
+++ b/bae-windows/QrCode.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using Microsoft.UI.Xaml.Media.Imaging;
+using QRCoder;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// Renders a string (a join-request, invite, or recovery code) to a QR
+/// <see cref="BitmapImage"/> for a WinUI image control — the analog of macOS's
+/// <c>QRCode.image(from:)</c>. The codes are scanned by another device's camera,
+/// so the image is just a visual transport of the same text shown beside it.
+///
+/// QRCoder's <see cref="PngByteQRCode"/> produces a PNG byte array directly, so
+/// there's no System.Drawing dependency; the bytes are decoded into a
+/// <c>BitmapImage</c> from an in-memory stream the same way <see cref="CoverImage"/>
+/// decodes a file stream.
+/// </summary>
+public static class QrCode
+{
+    /// <summary>
+    /// A QR image for <paramref name="text"/>, or null when it's empty or the
+    /// encode fails (logged by the caller's null handling). Error-correction level
+    /// M, matching the other platforms.
+    /// </summary>
+    public static BitmapImage? Image(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var generator = new QRCodeGenerator();
+            using var data = generator.CreateQrCode(text, QRCodeGenerator.ECCLevel.M);
+            var png = new PngByteQRCode(data);
+            // 10 px per module gives a crisp image at the ~180-200 px the dialogs
+            // display it; the Image control scales it to fit.
+            var bytes = png.GetGraphic(10);
+
+            using var stream = new MemoryStream(bytes);
+            var bitmap = new BitmapImage();
+            bitmap.SetSource(stream.AsRandomAccessStream());
+            return bitmap;
+        }
+        catch (Exception)
+        {
+            // An over-long payload (past QR's capacity) or an encoder failure
+            // returns null; the caller falls back to the copyable text, which is
+            // always shown beside the QR.
+            return null;
+        }
+    }
+}

--- a/bae-windows/QrScanner.cs
+++ b/bae-windows/QrScanner.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using ZXing;
+using ZXing.Common;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// Reads a QR code from an image the user picks (a screenshot or photo of the
+/// other device's code) and returns the embedded string. The paste field beside
+/// every scan entry point is the always-available fallback.
+///
+/// This scans from an image file rather than a live camera: WinUI 3 has no
+/// <c>CaptureElement</c>, so a live preview would need a custom MediaCapture
+/// frame pipeline. Picking an image of the code is a reliable scan, and the
+/// paste field covers entry without an image.
+/// </summary>
+public static class QrScanner
+{
+    /// <summary>
+    /// Let the user pick an image file, decode its QR, and return the embedded
+    /// text — or null if they cancelled or no QR was found.
+    /// <paramref name="windowHandle"/> is the owning window's HWND, needed to show
+    /// the picker on an unpackaged app.
+    /// </summary>
+    public static async Task<string?> ScanFromFileAsync(IntPtr windowHandle)
+    {
+        var picker = new global::Windows.Storage.Pickers.FileOpenPicker
+        {
+            ViewMode = global::Windows.Storage.Pickers.PickerViewMode.Thumbnail,
+            SuggestedStartLocation = global::Windows.Storage.Pickers.PickerLocationId.PicturesLibrary,
+        };
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, windowHandle);
+        picker.FileTypeFilter.Add(".png");
+        picker.FileTypeFilter.Add(".jpg");
+        picker.FileTypeFilter.Add(".jpeg");
+        picker.FileTypeFilter.Add(".bmp");
+        picker.FileTypeFilter.Add(".gif");
+
+        var file = await picker.PickSingleFileAsync();
+        if (file is null)
+        {
+            return null;
+        }
+
+        return await DecodeFileAsync(file);
+    }
+
+    /// <summary>
+    /// Decode the QR in an image file to its embedded text, or null when the
+    /// image can't be read or holds no QR.
+    /// </summary>
+    private static async Task<string?> DecodeFileAsync(global::Windows.Storage.StorageFile file)
+    {
+        try
+        {
+            using var stream = await file.OpenAsync(global::Windows.Storage.FileAccessMode.Read);
+            var decoder = await global::Windows.Graphics.Imaging.BitmapDecoder.CreateAsync(stream);
+
+            // Decode to BGRA8 straight pixels so the byte layout matches ZXing's
+            // BGRA32 luminance source exactly (4 bytes/pixel, blue-green-red-alpha).
+            using var bitmap = await decoder.GetSoftwareBitmapAsync(
+                global::Windows.Graphics.Imaging.BitmapPixelFormat.Bgra8,
+                global::Windows.Graphics.Imaging.BitmapAlphaMode.Straight);
+
+            var width = bitmap.PixelWidth;
+            var height = bitmap.PixelHeight;
+            var pixels = new byte[width * height * 4];
+            bitmap.CopyToBuffer(pixels.AsBuffer());
+
+            var source = new RGBLuminanceSource(pixels, width, height, RGBLuminanceSource.BitmapFormat.BGRA32);
+            var reader = new BarcodeReaderGeneric
+            {
+                Options = new DecodingOptions
+                {
+                    PossibleFormats = new[] { BarcodeFormat.QR_CODE },
+                    TryHarder = true,
+                },
+            };
+            var result = reader.Decode(source);
+            return result?.Text;
+        }
+        catch (Exception)
+        {
+            // An unreadable or undecodable image returns null; the caller keeps
+            // the paste field available.
+            return null;
+        }
+    }
+}

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -51,6 +51,10 @@
   <data name="cover.remote_sources" xml:space="preserve"><value>Remote sources</value></data>
   <data name="cover.section_title" xml:space="preserve"><value>Cover</value></data>
   <data name="cover.show_failed" xml:space="preserve"><value>couldn't show remote covers: {detail}</value></data>
+  <data name="action.back" xml:space="preserve"><value>back</value></data>
+  <data name="action.copy" xml:space="preserve"><value>copy</value></data>
+  <data name="action.done" xml:space="preserve"><value>done</value></data>
+  <data name="action.scan" xml:space="preserve"><value>scan…</value></data>
   <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
   <data name="error.title" xml:space="preserve"><value>error</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
@@ -86,6 +90,20 @@
   <data name="import.storage.managed" xml:space="preserve"><value>Managed</value></data>
   <data name="import.title" xml:space="preserve"><value>import</value></data>
   <data name="import.view_in_library" xml:space="preserve"><value>view in library</value></data>
+  <data name="join.title" xml:space="preserve"><value>join a library</value></data>
+  <data name="join.intro" xml:space="preserve"><value>add this device to a library you already have on another device.</value></data>
+  <data name="join.this_device_code" xml:space="preserve"><value>this device's code</value></data>
+  <data name="join.show_to_member" xml:space="preserve"><value>on a device already in your library, open settings → devices → add a device and scan or paste this.</value></data>
+  <data name="join.fingerprint" xml:space="preserve"><value>this device: {fingerprint}</value></data>
+  <data name="join.generate_failed" xml:space="preserve"><value>couldn't generate this device's code</value></data>
+  <data name="join.invite_label" xml:space="preserve"><value>invite code</value></data>
+  <data name="join.invite_hint" xml:space="preserve"><value>once that device approves this one, enter the invite code it shows.</value></data>
+  <data name="join.invite_placeholder" xml:space="preserve"><value>paste invite code</value></data>
+  <data name="join.invalid_invite" xml:space="preserve"><value>invalid invite code</value></data>
+  <data name="join.invite_for" xml:space="preserve"><value>{name} · {provider} · owner {fingerprint}</value></data>
+  <data name="join.confirm" xml:space="preserve"><value>join</value></data>
+  <data name="join.in_progress" xml:space="preserve"><value>joining {name}…</value></data>
+  <data name="join.failed" xml:space="preserve"><value>couldn't join the library</value></data>
   <data name="libraries.active" xml:space="preserve"><value>{name}  ·  active</value></data>
   <data name="libraries.new" xml:space="preserve"><value>new library</value></data>
   <data name="libraries.rename" xml:space="preserve"><value>rename</value></data>
@@ -107,6 +125,26 @@
   <data name="menu.play_next" xml:space="preserve"><value>Play Next</value></data>
   <data name="menu.set_primary" xml:space="preserve"><value>Set as primary release</value></data>
   <data name="menu.set_primary_done" xml:space="preserve"><value>set as primary release</value></data>
+  <data name="members.title" xml:space="preserve"><value>devices</value></data>
+  <data name="members.this_device" xml:space="preserve"><value>this device</value></data>
+  <data name="members.role.owner" xml:space="preserve"><value>owner</value></data>
+  <data name="members.role.member" xml:space="preserve"><value>member</value></data>
+  <data name="members.role.follower" xml:space="preserve"><value>follower</value></data>
+  <data name="members.load_failed" xml:space="preserve"><value>couldn't load devices</value></data>
+  <data name="members.add" xml:space="preserve"><value>add a device…</value></data>
+  <data name="members.remove" xml:space="preserve"><value>remove</value></data>
+  <data name="members.remove_confirm" xml:space="preserve"><value>this device will lose access and the library key will be rotated. click remove again to confirm.</value></data>
+  <data name="members.approve.title" xml:space="preserve"><value>add a device</value></data>
+  <data name="members.approve.capture_hint" xml:space="preserve"><value>on the new device, open join a library and show its code. scan it here, or paste it below.</value></data>
+  <data name="members.approve.paste_placeholder" xml:space="preserve"><value>paste the device's code</value></data>
+  <data name="members.approve.decode" xml:space="preserve"><value>decode</value></data>
+  <data name="members.approve.invalid_request" xml:space="preserve"><value>invalid device code</value></data>
+  <data name="members.approve.confirm_title" xml:space="preserve"><value>approve this device?</value></data>
+  <data name="members.approve.confirm_hint" xml:space="preserve"><value>it will be added to your library and able to sync. you'll get a code to enter on it.</value></data>
+  <data name="members.approve.confirm" xml:space="preserve"><value>approve</value></data>
+  <data name="members.approve.in_progress" xml:space="preserve"><value>approving device…</value></data>
+  <data name="members.approve.failed" xml:space="preserve"><value>couldn't approve this device</value></data>
+  <data name="members.approve.invited_hint" xml:space="preserve"><value>enter this code on the new device.</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>
@@ -151,9 +189,11 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
-  <data name="settings.restore_code.label" xml:space="preserve"><value>restore code (enter on another device)</value></data>
-  <data name="settings.restore_code.show" xml:space="preserve"><value>show restore code</value></data>
-  <data name="settings.restore_code.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
+  <data name="settings.recovery.title" xml:space="preserve"><value>recovery</value></data>
+  <data name="settings.recovery.intro" xml:space="preserve"><value>your recovery code restores this library on a new device when you have no other device available to approve it. anyone with it has full access — keep it secret.</value></data>
+  <data name="settings.recovery.label" xml:space="preserve"><value>recovery code</value></data>
+  <data name="settings.recovery.show" xml:space="preserve"><value>show recovery code…</value></data>
+  <data name="settings.recovery.unavailable" xml:space="preserve"><value>(unavailable — is sync connected?)</value></data>
   <data name="settings.s3.connect" xml:space="preserve"><value>connect S3</value></data>
   <data name="settings.s3.connecting" xml:space="preserve"><value>connecting to S3…</value></data>
   <data name="settings.storage.browsable" xml:space="preserve"><value>browsable — stored unencrypted</value></data>
@@ -190,6 +230,7 @@
   <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
   <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
   <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
+  <data name="welcome.join_library" xml:space="preserve"><value>join a library</value></data>
   <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
   <data name="welcome.no_library" xml:space="preserve"><value>no library yet</value></data>
   <data name="welcome.your_libraries" xml:space="preserve"><value>your libraries</value></data>

--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -63,6 +63,14 @@
       variations. Loc.cs wraps it.
     -->
     <PackageReference Include="MessageFormat" Version="7.0.0" />
+    <!--
+      QR generation (join-request / invite / recovery codes shown as a QR image)
+      and scanning (camera capture decoded to a code). QRCoder renders to a PNG
+      byte array (PngByteQRCode), avoiding System.Drawing; ZXing.Net decodes a
+      captured camera frame's pixels to the embedded string.
+    -->
+    <PackageReference Include="QRCoder" Version="1.6.0" />
+    <PackageReference Include="ZXing.Net" Version="0.16.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Windows (C# / WinUI 3) counterpart to the membership-chain feature (bridge #128, macOS #130, Android #132, iOS #133), including the hand-written Rust C-ABI it needs.

**Rust C-ABI (bae-windows-ffi):** 7 new `extern "C"` functions wrapping bae_core, JSON-over-FFI, mirroring the existing restore-code functions: `bae_generate_join_request`, `bae_decode_join_request`, `bae_decode_invite_code`, `bae_join_from_code` (mirrors `bae_restore_from_code`), and handle-scoped `bae_get_members` / `bae_invite_member` / `bae_remove_member`.

**C# (bae-windows):** P/Invoke wrappers in NativeBae.cs; DTOs + MemberFormat in Membership.cs; QR generation (QRCoder) in QrCode.cs; QR scan-from-image (ZXing.Net) in QrScanner.cs. MainWindow gets the Join-a-library flow (show this device's join code as QR+text+fingerprint → paste/scan invite → OAuth if needed → join), a Settings Devices section (member list, owner-only add-device + remove), and the restore code reframed as a recovery secret.

A live-camera scanner isn't included: WinUI 3 removed CaptureElement and the MediaCapture/MediaFrameReader pipeline isn't feasible to write without a Windows host to test on; this ships QR display + scan-from-image + paste everywhere (functionally complete). A follow-up cross-platform bridge change will pre-compute fingerprint/owner-ness fields so the UI stops deriving them.

## Test plan
- Rust FFI verified on macOS: `cargo build/clippy -p bae-windows-ffi` clean, `cargo test -p bae-windows-ffi` (15 pass), `cargo fmt --check`.
- C# builds only on Windows — CI windows.yml is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)