### PR TITLE
iOS/Android: swipe down to dismiss the artwork lightbox; fix its insets

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/GalleryDialog.kt
@@ -5,11 +5,19 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.calculateCentroid
 import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -33,6 +41,7 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -52,15 +61,19 @@ import uniffi.bae_bridge.BridgeGalleryItem
 import java.io.File
 
 private const val FULL_RES_SCALE_THRESHOLD = 1.01f
+private const val DISMISS_THRESHOLD_DP = 150f
+private const val DRAG_FADE_DISTANCE_MULTIPLIER = 2f
+private const val DRAG_BACKDROP_FADE = 0.7f
 private const val TAG = "bae.GalleryDialog"
 private val logger = BaeLogger(TAG)
 
 /**
  * Full-screen artwork viewer over a release's gallery items (cover first, then
- * every image file the release has). Swipeable when there's more than one. An
- * item already on disk renders from its [BridgeGalleryItem.localPath]; a
- * cloud-only item (no local path) is fetched on demand via [loadImage], keyed by
- * the item's id. Each page pinch-zooms and snaps back when you release.
+ * every image file the release has). Swipeable when there's more than one, and a
+ * downward swipe dismisses it. An item already on disk renders from its
+ * [BridgeGalleryItem.localPath]; a cloud-only item (no local path) is fetched on
+ * demand via [loadImage], keyed by the item's id. Each page pinch-zooms and snaps
+ * back when you release.
  */
 @Composable
 fun GalleryDialog(
@@ -73,54 +86,126 @@ fun GalleryDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         val pagerState = rememberPagerState(pageCount = { items.size })
-        Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
-                    val item = items[page]
-                    val localPath = item.localPath
-                    if (localPath != null) {
-                        // The full identifier (with any `#v=<mtime>` suffix) is the
-                        // cache key; [coverFile] strips it to the on-disk path.
-                        ZoomableGalleryImage(
-                            data = coverFile(localPath),
-                            cacheKey = localPath,
-                            contentDescription = item.label,
+        val scope = rememberCoroutineScope()
+        var offsetY by remember { mutableFloatStateOf(0f) }
+        val dismissThresholdPx = with(LocalDensity.current) { DISMISS_THRESHOLD_DP.dp.toPx() }
+        // Fade the backdrop toward the dismiss threshold as the viewer is dragged
+        // down, so the photo appears to lift away over the app behind it.
+        val dragProgress = (offsetY / (dismissThresholdPx * DRAG_FADE_DISTANCE_MULTIPLIER)).coerceIn(0f, 1f)
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = Color.Black.copy(alpha = 1f - dragProgress * DRAG_BACKDROP_FADE),
+        ) {
+            // The outer (untranslated) box owns the vertical swipe-to-dismiss; the
+            // inner box carries the drag offset, so the gesture's coordinate space
+            // stays put. The vertical drag and the pager's horizontal swipe each
+            // wait on their own axis' touch slop, so neither steals the other; a
+            // pinch-zoom consumes its events first, so it doesn't dismiss either.
+            Box(
+                modifier =
+                    Modifier.fillMaxSize().pointerInput(Unit) {
+                        detectVerticalDragGestures(
+                            onVerticalDrag = { change, dragAmount ->
+                                offsetY = (offsetY + dragAmount).coerceAtLeast(0f)
+                                change.consume()
+                            },
+                            onDragEnd = {
+                                if (offsetY > dismissThresholdPx) {
+                                    onDismiss()
+                                } else {
+                                    scope.launch { animate(offsetY, 0f) { value, _ -> offsetY = value } }
+                                }
+                            },
+                            onDragCancel = {
+                                scope.launch { animate(offsetY, 0f) { value, _ -> offsetY = value } }
+                            },
                         )
-                    } else {
-                        RemoteGalleryImage(
-                            fileId = item.id,
-                            label = item.label,
-                            loadImage = loadImage,
-                        )
+                    },
+            ) {
+                Box(modifier = Modifier.fillMaxSize().graphicsLayer { translationY = offsetY }) {
+                    HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+                        GalleryPage(item = items[page], loadImage = loadImage)
                     }
-                }
-                IconButton(
-                    onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.TopEnd).padding(8.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = stringResource(R.string.close),
-                        tint = Color.White,
-                    )
-                }
-                // Current item's label (e.g. "Cover", "Back.jpg") + page counter,
-                // so multi-image galleries aren't a blind swipe-through.
-                Column(
-                    modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    // Core always sets a non-empty label ("Cover" or the file's
-                    // original filename), so render it unconditionally.
-                    Text(text = items[pagerState.currentPage].label, color = Color.White)
-                    if (items.size > 1) {
-                        Text(
-                            text = "${pagerState.currentPage + 1} / ${items.size}",
-                            color = Color.White.copy(alpha = 0.7f),
-                        )
-                    }
+                    GalleryCloseButton(onDismiss = onDismiss)
+                    GalleryCaption(items = items, pagerState = pagerState)
                 }
             }
+        }
+    }
+}
+
+/**
+ * One gallery page: an on-disk item renders from its path; a cloud-only item
+ * fetches its bytes on demand.
+ */
+@Composable
+private fun GalleryPage(
+    item: BridgeGalleryItem,
+    loadImage: suspend (fileId: String) -> ByteArray,
+) {
+    val localPath = item.localPath
+    if (localPath != null) {
+        // The full identifier (with any `#v=<mtime>` suffix) is the cache key;
+        // [coverFile] strips it to the on-disk path.
+        ZoomableGalleryImage(
+            data = coverFile(localPath),
+            cacheKey = localPath,
+            contentDescription = item.label,
+        )
+    } else {
+        RemoteGalleryImage(fileId = item.id, label = item.label, loadImage = loadImage)
+    }
+}
+
+/** Close button, inset out of the status bar and any display cutout. */
+@Composable
+private fun BoxScope.GalleryCloseButton(onDismiss: () -> Unit) {
+    IconButton(
+        onClick = onDismiss,
+        modifier =
+            Modifier
+                .align(Alignment.TopEnd)
+                .windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+                ).padding(8.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Close,
+            contentDescription = stringResource(R.string.close),
+            tint = Color.White,
+        )
+    }
+}
+
+/**
+ * Current item's label (e.g. "Cover", "Back.jpg") and, for a multi-image gallery,
+ * its position — inset above the navigation bar so it isn't a blind swipe-through.
+ * Reads [PagerState.currentPage] here at the leaf so only the caption recomposes
+ * on a page turn, not the parent.
+ */
+@Composable
+private fun BoxScope.GalleryCaption(
+    items: List<BridgeGalleryItem>,
+    pagerState: PagerState,
+) {
+    val currentPage = pagerState.currentPage
+    Column(
+        modifier =
+            Modifier
+                .align(Alignment.BottomCenter)
+                .windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+                ).padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Core always sets a non-empty label ("Cover" or the file's original
+        // filename), so render it unconditionally.
+        Text(text = items[currentPage].label, color = Color.White)
+        if (items.size > 1) {
+            Text(
+                text = "${currentPage + 1} / ${items.size}",
+                color = Color.White.copy(alpha = 0.7f),
+            )
         }
     }
 }

--- a/bae-ios/bae/bae/Views/GalleryView.swift
+++ b/bae-ios/bae/bae/Views/GalleryView.swift
@@ -18,6 +18,14 @@ struct GalleryView: View {
     private var dismiss
     @State
     private var selection = 0
+    /// Downward drag for swipe-to-dismiss: the viewer follows the finger and, on
+    /// release, dismisses once it's past the threshold (or a fast flick) and
+    /// otherwise springs back. Only downward — an upward drag stays at rest, and
+    /// horizontal drags belong to the pager.
+    @State
+    private var dragOffset: CGFloat = 0
+
+    private static let dismissThreshold: CGFloat = 150
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -28,20 +36,29 @@ struct GalleryView: View {
                         .tag(index)
                 }
             }
-            .tabViewStyle(
-                .page(indexDisplayMode: items.count > 1 ? .automatic : .never)
-            )
-            // The current item's label (e.g. "Cover", "Back.jpg") so multi-image
-            // galleries aren't a blind swipe-through. Sits above the page dots
-            // and doesn't intercept swipes. `selection` is TabView-bounded and
-            // the gallery is never shown empty, so the subscript is safe; core
-            // always sets a non-empty label ("Cover" or the filename).
-            Text(items[selection].label)
-                .font(.caption)
-                .foregroundStyle(.white.opacity(0.85))
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-                .padding(.bottom, 44)
-                .allowsHitTesting(false)
+            // Edge-to-edge so the photo fills the whole screen; the built-in page
+            // dots are dropped (they'd land under the home indicator) in favor of
+            // the safe-area "n / N" counter below.
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .ignoresSafeArea()
+            // The current item's label (e.g. "Cover", "Back.jpg") plus, for a
+            // multi-image gallery, its position — so it isn't a blind
+            // swipe-through. Sits in the safe area and doesn't intercept swipes.
+            // `selection` is TabView-bounded and the gallery is never shown empty,
+            // so the subscript is safe; core always sets a non-empty label.
+            VStack(spacing: 2) {
+                Text(items[selection].label)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.85))
+                if items.count > 1 {
+                    Text("\(selection + 1) / \(items.count)")
+                        .font(.caption2)
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .padding(.bottom, 24)
+            .allowsHitTesting(false)
             Button {
                 dismiss()
             } label: {
@@ -51,6 +68,35 @@ struct GalleryView: View {
                     .padding()
             }
         }
+        .offset(y: dragOffset)
+        .simultaneousGesture(dismissDrag)
+    }
+
+    // Vertical-dominant downward swipe to dismiss, run alongside the pager's
+    // horizontal swipe (simultaneousGesture) so it never steals a page turn. The
+    // offset tracks the finger; release past the threshold — or on a fast flick —
+    // dismisses, otherwise it springs back.
+    private var dismissDrag: some Gesture {
+        DragGesture(minimumDistance: 10)
+            .onChanged { value in
+                let translation = value.translation
+                guard translation.height > 0,
+                    translation.height > abs(translation.width)
+                else { return }
+                dragOffset = translation.height
+            }
+            .onEnded { value in
+                let flickedAway =
+                    value.predictedEndTranslation.height > Self.dismissThreshold * 2
+                if value.translation.height > Self.dismissThreshold || flickedAway {
+                    dismiss()
+                }
+                else {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        dragOffset = 0
+                    }
+                }
+            }
     }
 }
 


### PR DESCRIPTION
The fullscreen artwork lightbox only let you page left/right between images — there was no way to swipe it away, only the close button. This adds a downward swipe-to-dismiss on both iOS and Android. The gesture is vertical-dominant only, so it coexists with the pager's horizontal swipe and the pinch-to-zoom: each waits on its own axis' touch slop, and a pinch consumes its events first.

It also fixes the lightbox safe-area handling. On Android the dialog draws edge-to-edge under the system bars (enforced on target SDK 35), so the close button sat under the status bar and the caption/page-counter sat under the navigation bar / gesture pill. They're now inset with safe-drawing padding while the image itself stays edge-to-edge. iOS previously fit the image inside the safe area (letterboxed around the notch and home indicator); it now renders edge-to-edge as well, with a safe-area "n / N" position counter replacing the built-in page dots, which would otherwise land under the home indicator.

## Test plan
- iOS: open a release with multiple images, swipe between them, pinch-zoom, then swipe down to dismiss; confirm a short drag springs back and a flick/long drag dismisses. Check the close button and caption clear the notch/home indicator.
- Android: same, on a gesture-navigation device — confirm the close button clears the status bar and the caption clears the navigation bar, horizontal paging and pinch-zoom still work, and swipe-down dismisses.