### PR TITLE
iOS: swipe down to dismiss the now-playing player; embed the queue below it

### DIFF
--- a/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
+++ b/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 
-/// Full-screen now-playing player, presented as a `.fullScreenCover` from the
-/// compact `NowPlayingBar` when its cover / title area is tapped. Reads the same
-/// single source as the bar — the shared `PlaybackStore`, driven by core's
-/// `BridgeUiEvent`s — and sends transport / seek / repeat / volume / mute
-/// through `Playback` (all non-throwing fire-and-forget).
+/// Full-screen now-playing player, presented as a `.sheet` (swipe down to
+/// dismiss) from the compact `NowPlayingBar` when its cover / title area is
+/// tapped. The player fills the first screen and the upcoming queue sits below it
+/// in the same scroll, so a swipe up scrolls into the queue and a swipe down from
+/// the top dismisses (the sheet and the list coordinate that handoff). Reads the
+/// shared `PlaybackStore` — driven by core's `BridgeUiEvent`s — and sends
+/// transport / seek / repeat / volume / mute through `Playback` and queue
+/// mutations through `Queue` (all non-throwing fire-and-forget).
 ///
 /// Pure iterate-and-render: the seek labels arrive pre-formatted on the position
 /// subject; this view formats nothing.
@@ -13,13 +16,13 @@ struct ExpandedNowPlayingView: View {
     private var playbackStore
     @Environment(Playback.self)
     private var playback
+    @Environment(Queue.self)
+    private var queue
     @Environment(MediaPaths.self)
     private var mediaPaths
     @Environment(\.dismiss)
     private var dismiss
 
-    @State
-    private var showQueue = false
     /// While the user drags the volume slider, follow the finger from this local
     /// value; the round-tripped `playbackStore.volume` would otherwise snap the
     /// thumb back mid-drag. `nil` means "not dragging".
@@ -27,62 +30,72 @@ struct ExpandedNowPlayingView: View {
     private var dragVolume: Float?
 
     var body: some View {
-        // When the track clears (e.g. playback stops) the cover collapses back
-        // to the bar; there's nothing to show full-screen.
+        // When the track clears (e.g. playback stops) the bar collapses and takes
+        // this sheet down with it; there's nothing to show.
         if let track = playbackStore.nowPlaying.track {
-            VStack(spacing: 24) {
-                HStack {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "chevron.down")
-                            .font(.title3)
-                    }
-                    .accessibilityLabel("Collapse")
-                    Spacer(minLength: 0)
+            List {
+                Section {
+                    player(track: track)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
                 }
-
-                ImageView(
-                    path: track.coverImageId
-                        .flatMap(mediaPaths.imagePathIfExists),
-                    pointSize: 320
-                )
-                .aspectRatio(1, contentMode: .fit)
-                .frame(maxWidth: .infinity)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(track.trackTitle)
-                        .font(.title2.weight(.bold))
-                        .lineLimit(1)
-                    Text(track.artistNames)
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                ProgressBar(
-                    positionSubject: playbackStore.playbackPositionSubject,
-                    onSeek: { playback.seekByRatio($0) }
-                )
-
-                transport
-
-                controls
-
-                volume
+                upNext
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
-            .frame(maxHeight: .infinity, alignment: .top)
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
             .background(Theme.background)
             .buttonStyle(.plain)
             .foregroundStyle(.primary)
-            .sheet(isPresented: $showQueue) {
-                QueueView()
-            }
         }
+    }
+
+    private func player(track: NowPlayingTrack) -> some View {
+        VStack(spacing: 24) {
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.title3)
+                }
+                .accessibilityLabel("Collapse")
+                Spacer(minLength: 0)
+            }
+
+            ImageView(
+                path: track.coverImageId
+                    .flatMap(mediaPaths.imagePathIfExists),
+                pointSize: 320
+            )
+            .aspectRatio(1, contentMode: .fit)
+            .frame(maxWidth: .infinity)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(track.trackTitle)
+                    .font(.title2.weight(.bold))
+                    .lineLimit(1)
+                Text(track.artistNames)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            ProgressBar(
+                positionSubject: playbackStore.playbackPositionSubject,
+                onSeek: { playback.seekByRatio($0) }
+            )
+
+            transport
+
+            repeatControl
+
+            volume
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
     }
 
     private var transport: some View {
@@ -111,29 +124,23 @@ struct ExpandedNowPlayingView: View {
         }
     }
 
-    private var controls: some View {
-        HStack(spacing: 48) {
-            Button {
-                playback.cycleRepeatMode()
-            } label: {
-                // Dimmed when off; accented when on (repeat-one glyph for track).
-                Image(
-                    systemName: playbackStore.repeatMode == .track
-                        ? "repeat.1" : "repeat"
-                )
-                .foregroundStyle(
-                    playbackStore.repeatMode == .none
-                        ? Color.secondary : Theme.accent
-                )
-            }
-            .accessibilityLabel("Repeat mode")
-            Button {
-                showQueue = true
-            } label: {
-                Image(systemName: "list.bullet")
-            }
-            .accessibilityLabel("Queue")
+    // Repeat-mode toggle. The queue is embedded below the player now, so there's
+    // no separate button to open it as a sheet.
+    private var repeatControl: some View {
+        Button {
+            playback.cycleRepeatMode()
+        } label: {
+            // Dimmed when off; accented when on (repeat-one glyph for track).
+            Image(
+                systemName: playbackStore.repeatMode == .track
+                    ? "repeat.1" : "repeat"
+            )
+            .foregroundStyle(
+                playbackStore.repeatMode == .none
+                    ? Color.secondary : Theme.accent
+            )
         }
+        .accessibilityLabel("Repeat mode")
     }
 
     private var volume: some View {
@@ -165,6 +172,26 @@ struct ExpandedNowPlayingView: View {
                 }
             )
             .accessibilityLabel("Volume")
+        }
+    }
+
+    // The upcoming queue, embedded below the player so a swipe up scrolls into it.
+    // Tapping a row skips to it (without dismissing — the player follows the new
+    // track); swiping a row removes it. Drag-to-reorder and Clear stay in the
+    // dedicated queue sheet (the bar's queue button), which needs an edit mode
+    // this list omits. The current track isn't in `queueItems` — it's the player
+    // above. The section is dropped when empty so no bare "Up Next" header shows.
+    @ViewBuilder
+    private var upNext: some View {
+        if !playbackStore.queueItems.isEmpty {
+            Section("Up Next") {
+                upNextRows(
+                    items: playbackStore.queueItems,
+                    queue: queue,
+                    isEditing: false,
+                    onSkipped: {}
+                )
+            }
         }
     }
 }

--- a/bae-ios/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-ios/bae/bae/Views/NowPlayingBar.swift
@@ -33,8 +33,13 @@ struct NowPlayingBar: View {
             .sheet(isPresented: $showQueue) {
                 QueueView()
             }
-            .fullScreenCover(isPresented: $showExpanded) {
+            // A sheet (not a cover) so the player can be swiped down to dismiss
+            // and its embedded queue swiped up to scroll — the sheet and the
+            // list coordinate that handoff.
+            .sheet(isPresented: $showExpanded) {
                 ExpandedNowPlayingView()
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
             }
         }
     }

--- a/bae-ios/bae/bae/Views/QueueView.swift
+++ b/bae-ios/bae/bae/Views/QueueView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+import os.log
+
+private let logger = Logger.bae("Queue")
 
 /// The play queue, presented as a sheet: the currently-playing track, then a
 /// reorderable "Up Next" list. Reads the authoritative now-playing and queue
@@ -83,47 +86,65 @@ struct QueueView: View {
         }
         else {
             Section("Up Next") {
-                // Positional identity: the queue may hold the same track twice,
-                // so `QueueItem.id` (== trackId) isn't unique. Keying on the
-                // enumerated offset makes each row's identity its queue index —
-                // which is exactly what onMove/onDelete report back to core.
-                ForEach(
-                    Array(playbackStore.queueItems.enumerated()),
-                    id: \.offset
-                ) { index, item in
-                    Button {
-                        // While editing, a row tap belongs to reorder/delete,
-                        // not skip — don't jump tracks and dismiss mid-edit.
-                        guard !editMode.isEditing else { return }
-                        queue.skipToQueueIndex(UInt32(index))
-                        dismiss()
-                    } label: {
-                        QueueRow(
-                            item: item,
-                            coverPath: item.coverImageId.flatMap(
-                                mediaPaths.imagePathIfExists
-                            )
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-                .onMove { source, destination in
-                    guard let from = source.first else {
-                        return
-                    }
-                    // SwiftUI's destination is a gap index in the original array
-                    // (item still present) — the same convention core's reorder
-                    // expects, so map straight through with no offset.
-                    queue.reorderQueue(UInt32(from), UInt32(destination))
-                }
-                .onDelete { offsets in
-                    guard let index = offsets.first else {
-                        return
-                    }
-                    queue.removeFromQueue(UInt32(index))
-                }
+                // Edit mode surfaces reorder handles here; a row tap is gated to
+                // skip only when not editing, and skipping dismisses the sheet.
+                upNextRows(
+                    items: playbackStore.queueItems,
+                    queue: queue,
+                    isEditing: editMode.isEditing,
+                    onSkipped: { dismiss() }
+                )
             }
         }
+    }
+}
+
+/// The "Up Next" rows — shared by the queue sheet and the expanded player's
+/// embedded queue so the index conventions can't drift. Tapping a row skips to
+/// it (unless `isEditing`, when the tap belongs to reorder/delete) and then runs
+/// `onSkipped`; swiping deletes; `.onMove` reorders. `.onMove` is inert without
+/// an active edit mode, so the embedded queue (which has none) shows no reorder
+/// handles while still getting tap-to-skip and swipe-to-delete.
+@MainActor
+@ViewBuilder
+func upNextRows(
+    items: [QueueItem],
+    queue: Queue,
+    isEditing: Bool,
+    onSkipped: @escaping () -> Void
+) -> some View {
+    // Positional identity: the queue may hold the same track twice, so
+    // `QueueItem.id` (== trackId) isn't unique. Keying on the enumerated offset
+    // makes each row's identity its queue index — exactly what skip/move/delete
+    // report back to core.
+    ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+        Button {
+            guard !isEditing else { return }
+            queue.skipToQueueIndex(UInt32(index))
+            onSkipped()
+        } label: {
+            QueueRow(item: item)
+        }
+        .buttonStyle(.plain)
+    }
+    .onMove { source, destination in
+        guard let from = source.first else {
+            // SwiftUI always hands onMove a non-empty source; an empty set is a
+            // framework anomaly, so surface it rather than silently dropping it.
+            logger.warning("onMove fired with an empty source index set")
+            return
+        }
+        // SwiftUI's destination is a gap index in the original array (item still
+        // present) — the same convention core's reorder expects, so map straight
+        // through with no offset.
+        queue.reorderQueue(UInt32(from), UInt32(destination))
+    }
+    .onDelete { offsets in
+        guard let index = offsets.first else {
+            logger.warning("onDelete fired with an empty offset set")
+            return
+        }
+        queue.removeFromQueue(UInt32(index))
     }
 }
 
@@ -151,15 +172,22 @@ private struct NowPlayingRow: View {
     }
 }
 
-private struct QueueRow: View {
+/// One "Up Next" row — shared by the queue sheet and the expanded now-playing
+/// view's embedded queue. Resolves its own cover path so the lookup (and its
+/// dependency on `MediaPaths`) stays at the leaf.
+struct QueueRow: View {
+    @Environment(MediaPaths.self)
+    private var mediaPaths
     let item: QueueItem
-    let coverPath: String?
 
     var body: some View {
         HStack(spacing: 12) {
-            ImageView(path: coverPath, pointSize: 44)
-                .frame(width: 44, height: 44)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+            ImageView(
+                path: item.coverImageId.flatMap(mediaPaths.imagePathIfExists),
+                pointSize: 44
+            )
+            .frame(width: 44, height: 44)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
                     .font(.body)


### PR DESCRIPTION
Tapping the now-playing bar opened the full player as a `fullScreenCover` — there was no way to swipe it away, and the upcoming queue lived in a separate sheet behind a button. This reworks the expanded player so it behaves like a modern now-playing screen.

It's now presented as a sheet, so it swipes down to dismiss (with a drag indicator for discoverability). The upcoming queue is embedded beneath the player in the same scrolling `List`: the player fills the first screen, a swipe up scrolls into "Up Next", and a swipe down from the top dismisses — the sheet and the list coordinate that handoff natively. Tapping a queue row skips to it; swiping a row deletes it.

Drag-to-reorder and Clear stay in the dedicated queue sheet, which is still reachable from the bar's own queue button, so the inline list deliberately omits the edit-mode chrome those need. `QueueRow` is now shared between the queue sheet and the embedded list.

## Test plan
- Tap the now-playing bar's title/artwork: the player rises as a sheet. Swipe down to dismiss; confirm a short drag springs back.
- Swipe up: the player scrolls away to reveal "Up Next". Scroll back to the top, then swipe down to dismiss.
- Tap an "Up Next" row → skips to that track (player updates in place). Swipe a row → removes it.
- Confirm the seek and volume sliders still scrub without scrolling the list, and the bar's queue button still opens the full queue with reorder/clear.