### PR TITLE
Queue: per-instance entry identity (fixes duplicate-instance targeting)

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -56,8 +56,11 @@ data class PlaybackPosition(
 
 /** One queue entry the [fm.bae.app.ui.QueueScreen] renders. The UI projection
  *  of the player's internal queue metadata: [durationLabel] is pre-formatted by
- *  core, [coverPath] is already resolved to a local file path. */
+ *  core, [coverPath] is already resolved to a local file path. [entryId] is the
+ *  per-instance id the row keys on and that remove/reorder/skip target — unique
+ *  even when the same track is queued twice. */
 data class QueueItem(
+    val entryId: String,
     val trackId: String,
     val title: String,
     val artist: String,
@@ -326,6 +329,9 @@ class BaeCorePlayer(
      * what's playing, and resilient to queue/playback event ordering).
      */
     internal data class Meta(
+        /** The queue entry's per-instance id, or null for the current-track
+         *  override (which is not a queue entry — see [orderedMetas]). */
+        val entryId: String?,
         val trackId: String,
         val title: String,
         val artist: String,
@@ -620,6 +626,8 @@ class BaeCorePlayer(
         coverImageId: String?,
     ): Meta =
         Meta(
+            // The current-track override is not a queue entry, so it has no id.
+            entryId = null,
             trackId = trackId,
             title = title,
             artist = artist,
@@ -700,11 +708,20 @@ class BaeCorePlayer(
                 elapsedLabel = elapsedLabel,
                 remainingLabel = remainingLabel,
             )
-        _queue.value = entries.map { it.toQueueItem() }
+        _queue.value = entries.mapNotNull { it.toQueueItem() }
     }
 
-    private fun Meta.toQueueItem(): QueueItem =
-        QueueItem(
+    private fun Meta.toQueueItem(): QueueItem? {
+        // Only the current-track override has a null entryId, and it never sits
+        // in the up-next `entries` this maps over; a null here means a queue
+        // entry arrived without its id.
+        val entryId = entryId
+        if (entryId == null) {
+            logger.warning("queue entry $trackId has no entryId; dropping from projection")
+            return null
+        }
+        return QueueItem(
+            entryId = entryId,
             trackId = trackId,
             title = title,
             artist = artist,
@@ -712,9 +729,11 @@ class BaeCorePlayer(
             durationLabel = durationLabel,
             coverPath = coverPath,
         )
+    }
 
     private fun BridgeQueueItem.toEntry(): Meta =
         Meta(
+            entryId = entryId,
             trackId = trackId,
             title = title,
             artist = artistNames,
@@ -836,7 +855,16 @@ class BaeCorePlayer(
             }
 
             Player.COMMAND_SEEK_TO_MEDIA_ITEM -> {
-                appHandle.skipToQueueIndex(mediaItemIndex.toUInt())
+                // The Media3 playlist is the now-playing track followed by the
+                // up-next entries (orderedMetas). Resolve the tapped index to its
+                // queue-entry id; the current-track slot has none, so seeking to
+                // it is a no-op.
+                val entryId = orderedMetas(entries, currentMeta).getOrNull(mediaItemIndex)?.entryId
+                if (entryId != null) {
+                    appHandle.skipToEntry(entryId)
+                } else {
+                    logger.warning("handleSeek to media item $mediaItemIndex has no queue entry id")
+                }
             }
 
             else -> {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -48,35 +48,19 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 private const val TAG = "bae.QueueScreen"
 private val logger = BaeLogger(TAG)
 
-/** One row's stable identity for the list. The core queue is a list of track
- *  ids that may repeat (the same track can be enqueued twice), so the track id
- *  alone is not a unique key; the occurrence index disambiguates duplicates and
- *  keeps the key stable for a given entry across re-hydrations and drags. */
-internal data class KeyedQueueItem(
-    val key: String,
-    val item: QueueItem,
-)
-
-private fun keyed(queue: List<QueueItem>): List<KeyedQueueItem> {
-    val counts = HashMap<String, Int>()
-    return queue.map { item ->
-        val n = counts.getOrDefault(item.trackId, 0)
-        counts[item.trackId] = n + 1
-        KeyedQueueItem("${item.trackId}#$n", item)
-    }
-}
-
 /**
  * The play queue, presented in a bottom sheet: the currently-playing track, then
  * a drag-reorderable "Up Next" list. Reads the authoritative queue and now-
  * playing off the [fm.bae.app.playback.BaeCorePlayer]; mutations go straight to
- * the bridge (`clearQueue`/`removeFromQueue`/`reorderQueue`/`skipToQueueIndex`)
- * and reflect back as a `QueueUpdated` event that re-hydrates the projection.
+ * the bridge (`clearQueue`/`removeEntry`/`reorderEntry`/`skipToEntry`) and
+ * reflect back as a `QueueUpdated` event that re-hydrates the projection.
+ *
+ * Each [QueueItem] carries a unique per-instance `entryId` — stable even when
+ * the same track is queued twice — so rows key on it directly and remove/
+ * reorder/skip target one instance.
  *
  * The whole sheet is one [LazyColumn] (its own scroll container) so it can't hit
  * the unbounded-height measurement a `LazyColumn` nested in a `Column` would.
- * `itemsIndexed`'s index is the position within the up-next list — i.e. the
- * exact index `removeFromQueue`/`skipToQueueIndex` expect.
  */
 @Composable
 fun QueueScreen(
@@ -111,39 +95,46 @@ fun QueueScreen(
 
 /**
  * The optimistic queue order plus its reorderable list state, shared by the queue
- * sheet and the expanded player's embedded queue so the index conventions stay in
- * one place. The order is seeded from the authoritative flow but NOT while a drag
- * is in progress — re-seeding mid-drag would clobber the optimistic move and snap
- * the row back. A drop maps the dragged/target keys to positions and calls core's
- * reorder (gap-index convention: a forward move passes `toPos + 1`).
+ * sheet and the expanded player's embedded queue so the conventions stay in one
+ * place. The order is seeded from the authoritative flow but NOT while a drag is
+ * in progress — re-seeding mid-drag would clobber the optimistic move and snap
+ * the row back. A drop maps the dragged/target entry ids to positions and calls
+ * core's reorder with the entry id of the row the moved item now precedes.
  */
 @Composable
 internal fun rememberReorderableQueue(
     session: OpenLibrary,
     listState: LazyListState,
-): Pair<SnapshotStateList<KeyedQueueItem>, ReorderableLazyListState> {
+): Pair<SnapshotStateList<QueueItem>, ReorderableLazyListState> {
     val queue by session.playback.queue.collectAsState()
-    val order = remember { mutableStateListOf<KeyedQueueItem>() }
+    val order = remember { mutableStateListOf<QueueItem>() }
     val reorderState =
         rememberReorderableLazyListState(listState) { from, to ->
-            // Map the dragged/target keys back to positions in `order` (offset-free:
-            // the non-row header items never match a row key).
-            val fromPos = order.indexOfFirst { it.key == from.key }
-            val toPos = order.indexOfFirst { it.key == to.key }
-            if (fromPos < 0 || toPos < 0) return@rememberReorderableLazyListState
-            order.add(toPos, order.removeAt(fromPos))
-            val coreTo = if (toPos > fromPos) toPos + 1 else toPos
+            // Map the dragged/target keys (entry ids) back to positions in
+            // `order` (offset-free: the non-row header items never match a row
+            // key).
+            val fromPos = order.indexOfFirst { it.entryId == from.key }
+            val toPos = order.indexOfFirst { it.entryId == to.key }
+            if (fromPos < 0 || toPos < 0) {
+                logger.debug("reorder: drag key not a queue row (from=${from.key}, to=${to.key}); ignoring")
+                return@rememberReorderableLazyListState
+            }
+            val moved = order.removeAt(fromPos)
+            order.add(toPos, moved)
+            // The moved entry lands before whatever now follows it in the
+            // optimistic order; a null `before` (it's now last) means the end.
+            val beforeEntryId = order.getOrNull(toPos + 1)?.entryId
             try {
-                session.appHandle.reorderQueue(fromPos.toUInt(), coreTo.toUInt())
+                session.appHandle.reorderEntry(moved.entryId, beforeEntryId)
             } catch (e: Exception) {
-                logger.error("reorderQueue $fromPos -> $coreTo failed", e)
+                logger.error("reorderEntry ${moved.entryId} before $beforeEntryId failed", e)
             }
         }
 
     LaunchedEffect(queue, reorderState.isAnyItemDragging) {
         if (!reorderState.isAnyItemDragging) {
             order.clear()
-            order.addAll(keyed(queue))
+            order.addAll(queue)
         }
     }
     return order to reorderState
@@ -158,7 +149,7 @@ internal fun rememberReorderableQueue(
 // passes `null` because it stays put on skip.
 internal fun LazyListScope.queueContent(
     session: OpenLibrary,
-    order: List<KeyedQueueItem>,
+    order: List<QueueItem>,
     reorderState: ReorderableLazyListState,
     hasNowPlaying: Boolean,
     onSkipped: (() -> Unit)?,
@@ -173,25 +164,25 @@ internal fun LazyListScope.queueContent(
         }
     } else {
         item(key = "uphdr") { SectionLabel(stringResource(R.string.queue_section_up_next)) }
-        itemsIndexed(order, key = { _, k -> k.key }) { index, k ->
-            ReorderableItem(reorderState, key = k.key) { isDragging ->
+        itemsIndexed(order, key = { _, item -> item.entryId }) { _, item ->
+            ReorderableItem(reorderState, key = item.entryId) { isDragging ->
                 Surface(tonalElevation = if (isDragging) 4.dp else 0.dp, color = MaterialTheme.colorScheme.surface) {
                     QueueRow(
-                        item = k.item,
+                        item = item,
                         dragHandleModifier = Modifier.draggableHandle(),
                         onClick = {
                             try {
-                                session.appHandle.skipToQueueIndex(index.toUInt())
+                                session.appHandle.skipToEntry(item.entryId)
                                 onSkipped?.invoke()
                             } catch (e: Exception) {
-                                logger.error("skipToQueueIndex $index failed", e)
+                                logger.error("skipToEntry ${item.entryId} failed", e)
                             }
                         },
                         onRemove = {
                             try {
-                                session.appHandle.removeFromQueue(index.toUInt())
+                                session.appHandle.removeEntry(item.entryId)
                             } catch (e: Exception) {
-                                logger.error("removeFromQueue $index failed", e)
+                                logger.error("removeEntry ${item.entryId} failed", e)
                             }
                         },
                     )

--- a/bae-android/app/src/test/java/fm/bae/app/playback/NowPlayingProjectionTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/NowPlayingProjectionTest.kt
@@ -25,6 +25,7 @@ import uniffi.bae_bridge.BridgeUiEvent
 class NowPlayingProjectionTest {
     private fun meta(id: String) =
         BaeCorePlayer.Meta(
+            entryId = "entry-$id",
             trackId = id,
             title = "Title $id",
             artist = "Artist Name",

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 
 use bae_core::library::AppServices;
+use bae_core::playback::QueueEntryId;
 #[cfg(feature = "desktop")]
 use bae_core::signals::ExtractionSource;
 use tracing::info;
@@ -381,24 +382,28 @@ impl AppHandle {
             .insert_in_queue(track_ids, index as usize);
     }
 
-    pub fn remove_from_queue(&self, index: u32) {
+    pub fn remove_entry(&self, entry_id: String) {
         self.app_services
             .playback()
-            .remove_from_queue(index as usize);
+            .remove_entry(QueueEntryId(entry_id));
     }
 
-    pub fn reorder_queue(&self, from_index: u32, to_index: u32) {
+    /// Move the entry `entry_id` to sit immediately before `before_entry_id`.
+    /// `before_entry_id == None` moves it to the end of the queue.
+    pub fn reorder_entry(&self, entry_id: String, before_entry_id: Option<String>) {
         self.app_services
             .playback()
-            .reorder_queue(from_index as usize, to_index as usize);
+            .reorder_entry(QueueEntryId(entry_id), before_entry_id.map(QueueEntryId));
     }
 
     pub fn clear_queue(&self) {
         self.app_services.playback().clear_queue();
     }
 
-    pub fn skip_to_queue_index(&self, index: u32) {
-        self.app_services.playback().skip_to(index as usize);
+    pub fn skip_to_entry(&self, entry_id: String) {
+        self.app_services
+            .playback()
+            .skip_to_entry(QueueEntryId(entry_id));
     }
 
     // =========================================================================
@@ -1515,6 +1520,7 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             items: items
                 .into_iter()
                 .map(|i| BridgeQueueItem {
+                    entry_id: i.entry_id,
                     track_id: i.track_id,
                     title: i.title,
                     artist_names: i.artist_names,

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1914,6 +1914,10 @@ pub enum BridgeStorageFilter {
 
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeQueueItem {
+    /// Per-instance id: the same track queued twice yields two items with two
+    /// ids, so the UI keys each row on a stable unique identity and targets
+    /// remove/reorder/skip at one instance.
+    pub entry_id: String,
     pub track_id: String,
     pub title: String,
     pub artist_names: String,

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -1,5 +1,7 @@
 use crate::clock::ClockRef;
 use crate::db::models::*;
+use crate::playback::QueueEntry;
+use crate::queue::QueueItem;
 use crate::util::content_type::ContentType;
 use chrono::{DateTime, Utc};
 use coven::database::DbError;
@@ -1406,17 +1408,22 @@ impl Database {
             .await
     }
 
-    /// Enrich a list of track IDs with album/artist metadata for queue display.
-    /// Returns items in the same order as the input IDs (skipping any not found).
-    pub async fn get_queue_items(&self, track_ids: &[String]) -> Result<Vec<DbQueueItem>, DbError> {
-        if track_ids.is_empty() {
+    /// Enrich a list of queue entries with album/artist metadata for display.
+    /// Returns one `QueueItem` per entry, in the same order, each carrying the
+    /// entry's per-instance id. The same track queued twice resolves twice (the
+    /// metadata is fetched once and joined onto every entry of that track).
+    /// Entries whose track is not found are skipped.
+    pub async fn get_queue_items(&self, entries: &[QueueEntry]) -> Result<Vec<QueueItem>, DbError> {
+        if entries.is_empty() {
             return Ok(Vec::new());
         }
 
-        let track_ids = track_ids.to_vec();
+        let entries = entries.to_vec();
         self.inner
             .coven_db
             .call(move |conn| {
+                let track_ids: Vec<String> =
+                    entries.iter().map(|e| e.track_id.clone()).collect();
                 let placeholders = track_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
                 let query = format!(
                     "SELECT \
@@ -1442,15 +1449,14 @@ impl Database {
                 );
 
                 let mut stmt = conn.prepare(&query)?;
-                let mut by_id: HashMap<String, DbQueueItem> = HashMap::new();
+                let mut meta_by_track: HashMap<String, TrackQueueMeta> = HashMap::new();
                 let mut rows = stmt
                     .query(coven::rusqlite::params_from_iter(track_ids.iter()))?;
                 while let Some(row) = rows.next()? {
                     let track_id: String = row.get("track_id")?;
-                    by_id.insert(
-                        track_id.clone(),
-                        DbQueueItem {
-                            track_id,
+                    meta_by_track.insert(
+                        track_id,
+                        TrackQueueMeta {
                             title: row.get("title")?,
                             artist_names: row.get("artist_names")?,
                             duration_ms: row.get("duration_ms")?,
@@ -1460,7 +1466,7 @@ impl Database {
                     );
                 }
 
-                Ok(order_queue_items(&by_id, &track_ids))
+                Ok(resolve_queue_entries(&meta_by_track, &entries))
             })
             .await
     }
@@ -3732,27 +3738,64 @@ fn replace_track_artists(
 
 /// Resolve queue track-ids to their display rows in position order, preserving
 /// duplicates. The same track may be queued more than once, so a repeated id
-/// must resolve every time — hence `get`, not `remove` (which would consume the
-/// row on first hit and silently drop later occurrences, desyncing every
-/// downstream positional index: skip-to, reorder, remove).
-fn order_queue_items(
-    by_id: &std::collections::HashMap<String, DbQueueItem>,
-    track_ids: &[String],
-) -> Vec<DbQueueItem> {
-    track_ids
+/// Per-track display metadata: one row per distinct track in the queue, fetched
+/// once and joined onto every queue entry that plays that track. Carries no
+/// identity (no entry id, no track id) — `resolve_queue_entries` supplies those
+/// from the entries.
+struct TrackQueueMeta {
+    title: String,
+    artist_names: String,
+    duration_ms: Option<i64>,
+    album_title: String,
+    cover_image_id: Option<String>,
+}
+
+/// Join per-track metadata onto each queue entry, preserving order and
+/// duplicates. The same track id appears once in `meta_by_track` but resolves
+/// once per entry — so the metadata lookup is `get`, not `remove` (which would
+/// consume the row on first hit and silently drop later occurrences). Keying
+/// display rows on each entry's per-instance id (rather than a position) is what
+/// lets the UI target duplicate tracks independently.
+fn resolve_queue_entries(
+    meta_by_track: &std::collections::HashMap<String, TrackQueueMeta>,
+    entries: &[QueueEntry],
+) -> Vec<QueueItem> {
+    entries
         .iter()
-        .filter_map(|id| by_id.get(id).cloned())
+        .filter_map(|entry| {
+            let Some(meta) = meta_by_track.get(&entry.track_id) else {
+                // A queue entry whose track has no metadata means the queue
+                // references a track no longer in the library — an inconsistency
+                // (library deletion clears the track from the queue), not a
+                // normal skip. Drop it from the projection but surface it.
+                tracing::warn!(
+                    "queue entry {} references track {} with no metadata; dropping from the queue projection",
+                    entry.id.0,
+                    entry.track_id
+                );
+                return None;
+            };
+            Some(QueueItem {
+                entry_id: entry.id.0.clone(),
+                track_id: entry.track_id.clone(),
+                title: meta.title.clone(),
+                artist_names: meta.artist_names.clone(),
+                duration_ms: meta.duration_ms,
+                album_title: meta.album_title.clone(),
+                cover_image_id: meta.cover_image_id.clone(),
+            })
+        })
         .collect()
 }
 
 #[cfg(test)]
 mod queue_ordering_tests {
     use super::*;
+    use crate::playback::QueueEntryId;
     use std::collections::HashMap;
 
-    fn item(id: &str) -> DbQueueItem {
-        DbQueueItem {
-            track_id: id.to_string(),
+    fn meta(id: &str) -> TrackQueueMeta {
+        TrackQueueMeta {
             title: format!("Title {id}"),
             artist_names: "Artist Name".to_string(),
             duration_ms: Some(1000),
@@ -3761,26 +3804,40 @@ mod queue_ordering_tests {
         }
     }
 
-    #[test]
-    fn preserves_duplicate_queue_entries_in_order() {
-        let mut by_id = HashMap::new();
-        by_id.insert("a".to_string(), item("a"));
-        by_id.insert("b".to_string(), item("b"));
-
-        // The same track queued twice must resolve twice, in position order.
-        let ordered =
-            order_queue_items(&by_id, &["a".to_string(), "a".to_string(), "b".to_string()]);
-
-        let ids: Vec<&str> = ordered.iter().map(|i| i.track_id.as_str()).collect();
-        assert_eq!(ids, vec!["a", "a", "b"]);
+    fn entry(entry_id: &str, track_id: &str) -> QueueEntry {
+        QueueEntry {
+            id: QueueEntryId(entry_id.to_string()),
+            track_id: track_id.to_string(),
+        }
     }
 
     #[test]
-    fn skips_unknown_ids() {
-        let mut by_id = HashMap::new();
-        by_id.insert("a".to_string(), item("a"));
-        let ordered = order_queue_items(&by_id, &["a".to_string(), "missing".to_string()]);
-        assert_eq!(ordered.len(), 1);
+    fn preserves_duplicate_queue_entries_in_order_with_distinct_ids() {
+        let mut meta_by_track = HashMap::new();
+        meta_by_track.insert("a".to_string(), meta("a"));
+        meta_by_track.insert("b".to_string(), meta("b"));
+
+        // The same track queued twice resolves twice, in position order, each
+        // carrying its own entry id.
+        let resolved = resolve_queue_entries(
+            &meta_by_track,
+            &[entry("e0", "a"), entry("e1", "a"), entry("e2", "b")],
+        );
+
+        let track_ids: Vec<&str> = resolved.iter().map(|i| i.track_id.as_str()).collect();
+        assert_eq!(track_ids, vec!["a", "a", "b"]);
+        let entry_ids: Vec<&str> = resolved.iter().map(|i| i.entry_id.as_str()).collect();
+        assert_eq!(entry_ids, vec!["e0", "e1", "e2"]);
+    }
+
+    #[test]
+    fn skips_entries_whose_track_is_unknown() {
+        let mut meta_by_track = HashMap::new();
+        meta_by_track.insert("a".to_string(), meta("a"));
+        let resolved =
+            resolve_queue_entries(&meta_by_track, &[entry("e0", "a"), entry("e1", "missing")]);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].entry_id, "e0");
     }
 }
 

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -14,9 +14,10 @@
 //!
 //! `LibraryManager` in `crate::library::manager` is the resolver: it takes
 //! these raw types and produces the display-ready `AlbumDetail`,
-//! `ReleaseDetail`, `AlbumSummary`, `QueueItem`, `ReleaseStorageSummary`,
-//! and `SearchResults` that live in `crate::album_detail` (and the sibling
-//! `crate::queue`). Those are what the bridge and event payloads carry.
+//! `ReleaseDetail`, `AlbumSummary`, `ReleaseStorageSummary`, and
+//! `SearchResults` that live in `crate::album_detail`. Those are what the
+//! bridge and event payloads carry. (The queue's `crate::queue::QueueItem` is
+//! built directly by `db::get_queue_items` — it has no raw counterpart here.)
 
 use crate::import::MetadataSource;
 use crate::util::content_type::ContentType;
@@ -150,19 +151,6 @@ pub struct DbAlbumSummary {
     /// User-chosen primary release. `None` if unset — the resolver in
     /// `LibraryManager` falls back to the first release.
     pub primary_release_id: Option<String>,
-}
-
-/// Raw queue-item aggregate: a track row joined with album/artist context in
-/// the shape the resolver expects. No formatting — the resolver in
-/// `LibraryManager` produces the display-ready `crate::queue::QueueItem`.
-#[derive(Debug, Clone)]
-pub struct DbQueueItem {
-    pub track_id: String,
-    pub title: String,
-    pub artist_names: String,
-    pub duration_ms: Option<i64>,
-    pub album_title: String,
-    pub cover_image_id: Option<String>,
 }
 
 /// Probe whether the candidate at `release_id` (from a search result) is

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -4,10 +4,9 @@
 //! `LibraryManager` owns `library_dir` and the database handle. The
 //! `resolve_*` helpers near the top of this file each take a `Db*` input
 //! (from `crate::db::models`) and produce its resolved counterpart (in
-//! `crate::album_detail` or the sibling `crate::queue`). Public methods
-//! return the resolved shapes — `AlbumSummary`, `QueueItem`,
-//! `ReleaseStorageSummary`, `SearchResults`, `AlbumDetail`, `ReleaseDetail`
-//! — never the raw `Db*` aggregates.
+//! `crate::album_detail`). Public methods return the resolved shapes —
+//! `AlbumSummary`, `ReleaseStorageSummary`, `SearchResults`, `AlbumDetail`,
+//! `ReleaseDetail` — never the raw `Db*` aggregates.
 //!
 //! Rule for additions: new DB-backed data flows through this layer. If you
 //! need a new resolved shape, add the raw type to `crate::db::models`, the
@@ -34,9 +33,9 @@ use crate::clock::ClockRef;
 use crate::config::{CloudProvider, ConfigHandle};
 use crate::db::{
     Database, DbAlbum, DbAlbumArtist, DbAlbumSearchResult, DbAlbumSummary, DbArtist, DbAudioFormat,
-    DbFile, DbImport, DbLibraryImage, DbLibrarySearchResults, DbQueueItem, DbRelease,
-    DbReleaseLocalCopy, DbReleaseStorageSummary, DbReleaseSummary, DbStorageRow, DbTrack,
-    DbTrackArtist, DbTrackSearchResult, ImportOperationStatus, LibraryImageType, Pressing,
+    DbFile, DbImport, DbLibraryImage, DbLibrarySearchResults, DbRelease, DbReleaseLocalCopy,
+    DbReleaseStorageSummary, DbReleaseSummary, DbStorageRow, DbTrack, DbTrackArtist,
+    DbTrackSearchResult, ImportOperationStatus, LibraryImageType, Pressing,
     SortDirection as DbSortDirection, StorageFilter as DbStorageFilter,
     StorageSortCriterion as DbStorageSortCriterion, StorageSortField as DbStorageSortField,
 };
@@ -48,6 +47,7 @@ use crate::keys::KeyService;
 use crate::library::export::ExportService;
 use crate::library::versioned_image_path::versioned_image_identifier;
 use crate::library_dir::LibraryDir;
+use crate::playback::QueueEntry;
 use crate::queue::QueueItem;
 use crate::storage::cloud::CloudHome;
 use crate::storage::local::cleanup::{append_pending_deletions, PendingDeletion};
@@ -113,18 +113,6 @@ pub(crate) async fn playback_info_from_track_release(
         album_title,
         cover_image_id,
     })
-}
-
-/// Produces a resolved `QueueItem` from a raw `DbQueueItem`.
-fn resolve_queue_item(raw: DbQueueItem) -> QueueItem {
-    QueueItem {
-        track_id: raw.track_id,
-        title: raw.title,
-        artist_names: raw.artist_names,
-        duration_ms: raw.duration_ms,
-        album_title: raw.album_title,
-        cover_image_id: raw.cover_image_id,
-    }
 }
 
 /// Produces a resolved `ReleaseStorageSummary` from a raw
@@ -1258,10 +1246,9 @@ impl LibraryManager {
     }
 
     /// The injected id source. The import layer and the mappers mint row ids
-    /// through this so tests get a deterministic-but-unique sequence.
-    /// Only the desktop import modules call this, so it isn't compiled on
-    /// mobile (where it would otherwise be dead code).
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    /// through this so tests get a deterministic-but-unique sequence; the
+    /// playback queue mints per-instance `QueueEntryId`s through it on every
+    /// platform.
     pub(crate) fn ids(&self) -> &IdRef {
         &self.ids
     }
@@ -3812,10 +3799,9 @@ impl LibraryManager {
     }
     pub async fn get_queue_items(
         &self,
-        track_ids: &[String],
+        entries: &[QueueEntry],
     ) -> Result<Vec<QueueItem>, LibraryError> {
-        let raws = self.database.get_queue_items(track_ids).await?;
-        Ok(raws.into_iter().map(resolve_queue_item).collect())
+        Ok(self.database.get_queue_items(entries).await?)
     }
     pub async fn is_source_folder_name_imported(&self, name: &str) -> Result<bool, LibraryError> {
         Ok(self.database.is_source_folder_name_imported(name).await?)

--- a/bae-core/src/playback/mod.rs
+++ b/bae-core/src/playback/mod.rs
@@ -23,7 +23,7 @@ pub use audio_output::{
 pub use decoded_pcm::DecodedPcm;
 pub use error::PlaybackError;
 pub use progress::{PlaybackProgress, PreviewState};
-pub use queue::{NextTrack, PlaybackQueue, PreviousAction};
+pub use queue::{NextTrack, PlaybackQueue, PreviousAction, QueueEntry, QueueEntryId};
 pub use repeat_mode::RepeatMode;
 pub use service::{
     LoadingTrack, PlaybackHandle, PlaybackService, PlaybackSnapshot, PlaybackState,

--- a/bae-core/src/playback/progress/mod.rs
+++ b/bae-core/src/playback/progress/mod.rs
@@ -37,9 +37,10 @@ pub enum PlaybackProgress {
         track_id: String,
         progress: f64,
     },
-    /// Queue was updated — contains current queue state
+    /// Queue was updated — contains current queue state as per-instance entries
+    /// (id + track id), in order.
     QueueUpdated {
-        tracks: Vec<String>,
+        entries: Vec<crate::playback::QueueEntry>,
         has_next: bool,
         has_previous: bool,
     },

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -1,6 +1,23 @@
 use std::collections::{HashSet, VecDeque};
 
+use tracing::warn;
+
 use super::RepeatMode;
+use crate::id_provider::IdRef;
+
+/// Per-instance identity for an enqueued track. Distinct from `track_id`: the
+/// same track enqueued twice yields two entries with two ids, each removable,
+/// reorderable, and skippable independently. Minted from the injected
+/// `IdProvider` on enqueue.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueueEntryId(pub String);
+
+/// One enqueued instance: a stable per-instance id plus the track it plays.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueEntry {
+    pub id: QueueEntryId,
+    pub track_id: String,
+}
 
 /// What to do when advancing to the next track
 pub enum NextTrack {
@@ -25,72 +42,118 @@ pub enum PreviousAction {
 /// Pure data structure for managing a playback queue.
 ///
 /// Handles queue CRUD and next/previous decision logic without any I/O.
+/// Each enqueued track is wrapped in a `QueueEntry` carrying a unique
+/// `QueueEntryId`; mutations key on that id, not on a position or `track_id`.
 pub struct PlaybackQueue {
-    queue: VecDeque<String>,
+    queue: VecDeque<QueueEntry>,
     current_track_id: Option<String>,
     previous_track_id: Option<String>,
     repeat_mode: RepeatMode,
-}
-
-impl Default for PlaybackQueue {
-    fn default() -> Self {
-        Self::new()
-    }
+    ids: IdRef,
 }
 
 impl PlaybackQueue {
-    pub fn new() -> Self {
+    pub fn new(ids: IdRef) -> Self {
         Self {
             queue: VecDeque::new(),
             current_track_id: None,
             previous_track_id: None,
             repeat_mode: RepeatMode::None,
+            ids,
         }
     }
 
-    /// Add track IDs to the end of the queue.
+    /// Wrap a track id in a fresh `QueueEntry` with a newly minted id.
+    fn mint(&self, track_id: String) -> QueueEntry {
+        QueueEntry {
+            id: QueueEntryId(self.ids.new_id()),
+            track_id,
+        }
+    }
+
+    /// Locate an entry by its id.
+    fn position_of(&self, id: &QueueEntryId) -> Option<usize> {
+        self.queue.iter().position(|e| &e.id == id)
+    }
+
+    /// Add track IDs to the end of the queue, minting a fresh entry id each.
     pub fn add_to_queue(&mut self, track_ids: Vec<String>) {
         for track_id in track_ids {
-            self.queue.push_back(track_id);
+            let entry = self.mint(track_id);
+            self.queue.push_back(entry);
         }
     }
 
-    /// Add track IDs to the front of the queue (play next).
+    /// Add track IDs to the front of the queue (play next), minting ids.
     pub fn add_next(&mut self, track_ids: Vec<String>) {
         for track_id in track_ids.into_iter().rev() {
-            self.queue.push_front(track_id);
+            let entry = self.mint(track_id);
+            self.queue.push_front(entry);
         }
     }
 
-    /// Insert track IDs at a specific position in the queue.
+    /// Insert track IDs at a specific position in the queue, minting ids.
     pub fn insert_at(&mut self, index: usize, track_ids: Vec<String>) {
         let pos = index.min(self.queue.len());
         for (i, track_id) in track_ids.into_iter().enumerate() {
-            self.queue.insert(pos + i, track_id);
+            let entry = self.mint(track_id);
+            self.queue.insert(pos + i, entry);
         }
     }
 
-    /// Remove a track at the given index. Returns the removed track ID if valid.
-    pub fn remove(&mut self, index: usize) -> Option<String> {
-        if index < self.queue.len() {
-            self.queue.remove(index)
-        } else {
-            None
-        }
-    }
-
-    /// Reorder: move track from `from` index to `to` index.
-    /// `to` may equal `queue.len()` to move an item to the end.
-    pub fn reorder(&mut self, from: usize, to: usize) {
-        if from < self.queue.len() && to <= self.queue.len() && from != to {
-            if let Some(track_id) = self.queue.remove(from) {
-                if to > from {
-                    self.queue.insert(to - 1, track_id);
-                } else {
-                    self.queue.insert(to, track_id);
-                }
+    /// Remove the entry with the given id. Returns the removed entry, or logs a
+    /// warning and no-ops when the id is not in the queue.
+    pub fn remove(&mut self, id: &QueueEntryId) -> Option<QueueEntry> {
+        match self.position_of(id) {
+            Some(pos) => self.queue.remove(pos),
+            None => {
+                warn!("remove: queue entry id not found: {}", id.0);
+                None
             }
         }
+    }
+
+    /// Move the entry `id` to sit immediately before `before`. `before = None`
+    /// moves it to the end of the queue. A missing source id, or a missing
+    /// `before` target, logs a warning and no-ops.
+    pub fn reorder(&mut self, id: &QueueEntryId, before: Option<&QueueEntryId>) {
+        let from = match self.position_of(id) {
+            Some(pos) => pos,
+            None => {
+                warn!("reorder: queue entry id not found: {}", id.0);
+                return;
+            }
+        };
+
+        // Resolve the insertion target before removing, so the destination id
+        // is validated against the current queue.
+        let before_pos = match before {
+            Some(before_id) => match self.position_of(before_id) {
+                Some(pos) => Some(pos),
+                None => {
+                    warn!("reorder: before entry id not found: {}", before_id.0);
+                    return;
+                }
+            },
+            None => None,
+        };
+
+        // `from` came from `position_of`, so it is in bounds and `remove` cannot
+        // miss. Reordering an entry to before itself isn't special-cased: it
+        // falls through to a remove-and-reinsert at the same position, which is a
+        // correct no-op.
+        let entry = self
+            .queue
+            .remove(from)
+            .expect("reorder: position_of returned an in-bounds index");
+
+        // After removal, indices past `from` shift down by one.
+        let insert_at = match before_pos {
+            Some(pos) if pos > from => pos - 1,
+            Some(pos) => pos,
+            None => self.queue.len(),
+        };
+        self.queue.insert(insert_at, entry);
     }
 
     /// Clear the queue.
@@ -98,23 +161,27 @@ impl PlaybackQueue {
         self.queue.clear();
     }
 
-    /// Skip to a specific position in the queue.
-    /// Drains all tracks before the target index and pops the target.
-    /// Returns the track ID to play, or None if index is out of bounds.
-    pub fn skip_to(&mut self, index: usize) -> Option<String> {
-        if index >= self.queue.len() {
-            return None;
-        }
+    /// Skip to the entry with the given id: drains every entry ahead of it and
+    /// pops it off. Returns the entry to play, or logs a warning and no-ops
+    /// when the id is not in the queue.
+    pub fn skip_to(&mut self, id: &QueueEntryId) -> Option<QueueEntry> {
+        let pos = match self.position_of(id) {
+            Some(pos) => pos,
+            None => {
+                warn!("skip_to: queue entry id not found: {}", id.0);
+                return None;
+            }
+        };
 
-        for _ in 0..index {
+        for _ in 0..pos {
             self.queue.pop_front();
         }
 
         self.queue.pop_front()
     }
 
-    /// Get the current queue contents as a Vec of track IDs.
-    pub fn tracks(&self) -> Vec<String> {
+    /// Get the current queue contents as a Vec of entries.
+    pub fn entries(&self) -> Vec<QueueEntry> {
         self.queue.iter().cloned().collect()
     }
 
@@ -127,7 +194,8 @@ impl PlaybackQueue {
     }
 
     /// Determine what to do next (called on AutoAdvance or Next).
-    /// Does NOT mutate the queue — caller pops from queue if needed.
+    /// Does NOT mutate the queue beyond popping the played entry — caller pops
+    /// from queue if needed.
     pub fn next_track(&mut self) -> NextTrack {
         if self.repeat_mode == RepeatMode::Track {
             if let Some(ref id) = self.current_track_id {
@@ -135,11 +203,11 @@ impl PlaybackQueue {
             }
         }
 
-        if let Some(next_id) = self.queue.pop_front() {
+        if let Some(next) = self.queue.pop_front() {
             if let Some(old) = self.current_track_id.take() {
                 self.previous_track_id = Some(old);
             }
-            NextTrack::Play(next_id)
+            NextTrack::Play(next.track_id)
         } else if self.repeat_mode == RepeatMode::Album {
             NextTrack::RepeatAlbumNeeded
         } else {
@@ -177,19 +245,20 @@ impl PlaybackQueue {
         self.previous_track_id = track_id;
     }
 
-    /// Replace the entire queue contents.
-    pub fn replace(&mut self, queue: VecDeque<String>) {
-        self.queue = queue;
+    /// Replace the entire queue contents with freshly minted entries for the
+    /// given track ids.
+    pub fn replace(&mut self, track_ids: VecDeque<String>) {
+        self.queue = track_ids.into_iter().map(|t| self.mint(t)).collect();
     }
 
-    /// Pop from the front of the queue.
+    /// Pop the front entry's track id off the queue.
     pub fn pop_front(&mut self) -> Option<String> {
-        self.queue.pop_front()
+        self.queue.pop_front().map(|e| e.track_id)
     }
 
-    /// Peek at the front of the queue.
-    pub fn front(&self) -> Option<&String> {
-        self.queue.front()
+    /// Peek at the front entry's track id.
+    pub fn front(&self) -> Option<&str> {
+        self.queue.front().map(|e| e.track_id.as_str())
     }
 
     /// Number of tracks in the queue.
@@ -202,10 +271,11 @@ impl PlaybackQueue {
         self.queue.is_empty()
     }
 
-    /// Remove all tracks whose IDs are in the given set.
-    /// Also clears `current_track_id` and `previous_track_id` if they match.
+    /// Remove all entries whose track id is in the given set (a deleted track is
+    /// removed everywhere it sits in the queue). Also clears `current_track_id`
+    /// and `previous_track_id` if they match.
     pub fn remove_by_ids(&mut self, ids: &HashSet<String>) {
-        self.queue.retain(|id| !ids.contains(id));
+        self.queue.retain(|entry| !ids.contains(&entry.track_id));
         if let Some(ref current) = self.current_track_id {
             if ids.contains(current) {
                 self.current_track_id = None;
@@ -222,91 +292,173 @@ impl PlaybackQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::id_provider::SequentialIdProvider;
+    use std::sync::Arc;
+
+    fn queue() -> PlaybackQueue {
+        PlaybackQueue::new(Arc::new(SequentialIdProvider::new("entry")))
+    }
+
+    /// Collect the queue's track ids in order — the per-instance ids vary, so
+    /// most behavioral assertions are about which tracks sit where.
+    fn track_ids(q: &PlaybackQueue) -> Vec<String> {
+        q.entries().into_iter().map(|e| e.track_id).collect()
+    }
 
     #[test]
     fn test_add_to_queue() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into()]);
-        assert_eq!(q.tracks(), vec!["a", "b", "c"]);
+        assert_eq!(track_ids(&q), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_add_to_queue_mints_distinct_ids() {
+        let mut q = queue();
+        q.add_to_queue(vec!["a".into(), "a".into()]);
+        let entries = q.entries();
+        assert_eq!(entries.len(), 2);
+        assert_ne!(
+            entries[0].id, entries[1].id,
+            "duplicate tracks get distinct ids"
+        );
+        assert_eq!(entries[0].track_id, entries[1].track_id);
     }
 
     #[test]
     fn test_add_next_preserves_order() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["x".into()]);
         q.add_next(vec!["a".into(), "b".into()]);
-        assert_eq!(q.tracks(), vec!["a", "b", "x"]);
+        assert_eq!(track_ids(&q), vec!["a", "b", "x"]);
     }
 
     #[test]
-    fn test_remove() {
-        let mut q = PlaybackQueue::new();
+    fn test_remove_by_entry_id() {
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into()]);
-        let removed = q.remove(1);
-        assert_eq!(removed, Some("b".into()));
-        assert_eq!(q.tracks(), vec!["a", "c"]);
+        let b_id = q.entries()[1].id.clone();
+        let removed = q.remove(&b_id);
+        assert_eq!(removed.map(|e| e.track_id), Some("b".into()));
+        assert_eq!(track_ids(&q), vec!["a", "c"]);
+    }
+
+    /// The load-bearing dup test: the same track enqueued twice, removing one
+    /// instance by its id leaves the other instance — and its id — intact.
+    #[test]
+    fn test_remove_one_duplicate_keeps_the_other() {
+        let mut q = queue();
+        q.add_to_queue(vec!["dup".into(), "dup".into()]);
+        let entries = q.entries();
+        let first_id = entries[0].id.clone();
+        let second_id = entries[1].id.clone();
+
+        let removed = q.remove(&first_id).expect("first instance removed");
+        assert_eq!(removed.id, first_id);
+        assert_eq!(removed.track_id, "dup");
+
+        let remaining = q.entries();
+        assert_eq!(remaining.len(), 1, "exactly one instance remains");
+        assert_eq!(
+            remaining[0].id, second_id,
+            "the other instance's id survives"
+        );
+        assert_eq!(remaining[0].track_id, "dup");
     }
 
     #[test]
-    fn test_remove_out_of_bounds() {
-        let mut q = PlaybackQueue::new();
+    fn test_remove_unknown_id_is_noop() {
+        let mut q = queue();
         q.add_to_queue(vec!["a".into()]);
-        assert_eq!(q.remove(5), None);
-        assert_eq!(q.tracks(), vec!["a"]);
+        assert_eq!(q.remove(&QueueEntryId("nope".into())), None);
+        assert_eq!(track_ids(&q), vec!["a"]);
     }
 
     #[test]
     fn test_reorder_forward() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
-        q.reorder(0, 2);
-        assert_eq!(q.tracks(), vec!["b", "a", "c", "d"]);
+        let ids: Vec<_> = q.entries().into_iter().map(|e| e.id).collect();
+        // Move "a" before "c": expect b, a, c, d.
+        q.reorder(&ids[0], Some(&ids[2]));
+        assert_eq!(track_ids(&q), vec!["b", "a", "c", "d"]);
     }
 
     #[test]
-    fn test_reorder_forward_to_end() {
-        let mut q = PlaybackQueue::new();
+    fn test_reorder_to_end() {
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
-        q.reorder(0, 4);
-        assert_eq!(q.tracks(), vec!["b", "c", "d", "a"]);
+        let ids: Vec<_> = q.entries().into_iter().map(|e| e.id).collect();
+        // Move "a" to the end (before = None).
+        q.reorder(&ids[0], None);
+        assert_eq!(track_ids(&q), vec!["b", "c", "d", "a"]);
     }
 
     #[test]
     fn test_reorder_backward() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
-        q.reorder(2, 0);
-        assert_eq!(q.tracks(), vec!["c", "a", "b", "d"]);
+        let ids: Vec<_> = q.entries().into_iter().map(|e| e.id).collect();
+        // Move "c" before "a": expect c, a, b, d.
+        q.reorder(&ids[2], Some(&ids[0]));
+        assert_eq!(track_ids(&q), vec!["c", "a", "b", "d"]);
+    }
+
+    #[test]
+    fn test_reorder_before_self_is_noop() {
+        let mut q = queue();
+        q.add_to_queue(vec!["a".into(), "b".into(), "c".into()]);
+        let ids: Vec<_> = q.entries().into_iter().map(|e| e.id).collect();
+        q.reorder(&ids[1], Some(&ids[1]));
+        assert_eq!(track_ids(&q), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_reorder_unknown_source_is_noop() {
+        let mut q = queue();
+        q.add_to_queue(vec!["a".into(), "b".into()]);
+        q.reorder(&QueueEntryId("nope".into()), None);
+        assert_eq!(track_ids(&q), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_reorder_unknown_before_is_noop() {
+        let mut q = queue();
+        q.add_to_queue(vec!["a".into(), "b".into()]);
+        let a_id = q.entries()[0].id.clone();
+        q.reorder(&a_id, Some(&QueueEntryId("nope".into())));
+        assert_eq!(track_ids(&q), vec!["a", "b"]);
     }
 
     #[test]
     fn test_clear() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into()]);
         q.clear();
-        assert!(q.tracks().is_empty());
+        assert!(q.entries().is_empty());
     }
 
     #[test]
-    fn test_skip_to() {
-        let mut q = PlaybackQueue::new();
+    fn test_skip_to_by_entry_id() {
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
-        let track = q.skip_to(2);
-        assert_eq!(track, Some("c".into()));
-        assert_eq!(q.tracks(), vec!["d"]);
+        let c_id = q.entries()[2].id.clone();
+        let entry = q.skip_to(&c_id);
+        assert_eq!(entry.map(|e| e.track_id), Some("c".into()));
+        assert_eq!(track_ids(&q), vec!["d"]);
     }
 
     #[test]
-    fn test_skip_to_out_of_bounds() {
-        let mut q = PlaybackQueue::new();
+    fn test_skip_to_unknown_id_is_noop() {
+        let mut q = queue();
         q.add_to_queue(vec!["a".into()]);
-        assert_eq!(q.skip_to(5), None);
-        assert_eq!(q.tracks(), vec!["a"]);
+        assert_eq!(q.skip_to(&QueueEntryId("nope".into())), None);
+        assert_eq!(track_ids(&q), vec!["a"]);
     }
 
     #[test]
     fn test_set_current_moves_to_previous() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("track1".into());
         assert_eq!(q.current_track_id(), Some("track1"));
         assert_eq!(q.previous_track_id(), None);
@@ -318,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_next_track_from_queue() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("current".into());
         q.add_to_queue(vec!["next1".into(), "next2".into()]);
         match q.next_track() {
@@ -326,12 +478,12 @@ mod tests {
             _ => panic!("Expected Play"),
         }
         assert_eq!(q.previous_track_id(), Some("current"));
-        assert_eq!(q.tracks(), vec!["next2"]);
+        assert_eq!(track_ids(&q), vec!["next2"]);
     }
 
     #[test]
     fn test_next_track_repeat_current() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("track1".into());
         q.set_repeat_mode(RepeatMode::Track);
         match q.next_track() {
@@ -342,7 +494,7 @@ mod tests {
 
     #[test]
     fn test_next_track_repeat_album_needed() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_repeat_mode(RepeatMode::Album);
         match q.next_track() {
             NextTrack::RepeatAlbumNeeded => {}
@@ -352,7 +504,7 @@ mod tests {
 
     #[test]
     fn test_previous_action_restart_when_past_3s() {
-        let q = PlaybackQueue::new();
+        let q = queue();
         match q.previous_action(5000) {
             PreviousAction::RestartCurrent => {}
             _ => panic!("Expected RestartCurrent"),
@@ -361,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_previous_action_go_back() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("track1".into());
         q.set_current("track2".into());
         match q.previous_action(1000) {
@@ -372,7 +524,7 @@ mod tests {
 
     #[test]
     fn test_previous_action_restart_when_no_previous() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("track1".into());
         match q.previous_action(1000) {
             PreviousAction::RestartCurrent => {}
@@ -382,76 +534,85 @@ mod tests {
 
     #[test]
     fn test_repeat_mode_default() {
-        let q = PlaybackQueue::new();
+        let q = queue();
         assert_eq!(q.repeat_mode(), RepeatMode::None);
     }
 
     #[test]
     fn test_insert_at_middle() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into()]);
         q.insert_at(1, vec!["x".into(), "y".into()]);
-        assert_eq!(q.tracks(), vec!["a", "x", "y", "b", "c"]);
+        assert_eq!(track_ids(&q), vec!["a", "x", "y", "b", "c"]);
     }
 
     #[test]
     fn test_insert_at_beginning() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into()]);
         q.insert_at(0, vec!["x".into()]);
-        assert_eq!(q.tracks(), vec!["x", "a", "b"]);
+        assert_eq!(track_ids(&q), vec!["x", "a", "b"]);
     }
 
     #[test]
     fn test_insert_at_end() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into()]);
         q.insert_at(2, vec!["x".into()]);
-        assert_eq!(q.tracks(), vec!["a", "b", "x"]);
+        assert_eq!(track_ids(&q), vec!["a", "b", "x"]);
     }
 
     #[test]
     fn test_insert_at_beyond_end_clamps() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into()]);
         q.insert_at(999, vec!["x".into()]);
-        assert_eq!(q.tracks(), vec!["a", "x"]);
+        assert_eq!(track_ids(&q), vec!["a", "x"]);
     }
 
     #[test]
     fn test_replace() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["old".into()]);
         let mut new_queue = VecDeque::new();
         new_queue.push_back("new1".into());
         new_queue.push_back("new2".into());
         q.replace(new_queue);
-        assert_eq!(q.tracks(), vec!["new1", "new2"]);
+        assert_eq!(track_ids(&q), vec!["new1", "new2"]);
     }
 
     #[test]
     fn test_remove_by_ids_removes_matching_tracks() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.add_to_queue(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
         let ids: HashSet<String> = ["b", "d"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
-        assert_eq!(q.tracks(), vec!["a", "c"]);
+        assert_eq!(track_ids(&q), vec!["a", "c"]);
+    }
+
+    #[test]
+    fn test_remove_by_ids_removes_every_instance_of_a_track() {
+        let mut q = queue();
+        q.add_to_queue(vec!["a".into(), "dup".into(), "b".into(), "dup".into()]);
+        let ids: HashSet<String> = ["dup"].iter().map(|s| s.to_string()).collect();
+        q.remove_by_ids(&ids);
+        assert_eq!(track_ids(&q), vec!["a", "b"]);
     }
 
     #[test]
     fn test_remove_by_ids_clears_current_track() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("track1".into());
         q.add_to_queue(vec!["a".into()]);
         let ids: HashSet<String> = ["track1"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
         assert_eq!(q.current_track_id(), None);
-        assert_eq!(q.tracks(), vec!["a"]);
+        assert_eq!(track_ids(&q), vec!["a"]);
     }
 
     #[test]
     fn test_remove_by_ids_clears_previous_track() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("track1".into());
         q.set_current("track2".into());
         assert_eq!(q.previous_track_id(), Some("track1"));
@@ -463,18 +624,18 @@ mod tests {
 
     #[test]
     fn test_remove_by_ids_no_match_is_noop() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("current".into());
         q.add_to_queue(vec!["a".into(), "b".into()]);
         let ids: HashSet<String> = ["x", "y"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
-        assert_eq!(q.tracks(), vec!["a", "b"]);
+        assert_eq!(track_ids(&q), vec!["a", "b"]);
         assert_eq!(q.current_track_id(), Some("current"));
     }
 
     #[test]
     fn test_remove_by_ids_removes_all() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_current("current".into());
         q.add_to_queue(vec!["a".into(), "b".into()]);
         let ids: HashSet<String> = ["a", "b", "current"]
@@ -482,7 +643,7 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         q.remove_by_ids(&ids);
-        assert!(q.tracks().is_empty());
+        assert!(q.entries().is_empty());
         assert_eq!(q.current_track_id(), None);
     }
 
@@ -490,7 +651,7 @@ mod tests {
     fn test_next_track_repeat_track_without_current_falls_through() {
         // RepeatMode::Track only repeats when there IS a current track. With
         // none set, it must fall through to the normal advance.
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_repeat_mode(RepeatMode::Track);
         q.add_to_queue(vec!["a".into(), "b".into()]);
         match q.next_track() {
@@ -498,31 +659,23 @@ mod tests {
             _ => panic!("expected Play"),
         }
         // And with an empty queue (still no current) it stops rather than repeating.
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         q.set_repeat_mode(RepeatMode::Track);
         assert!(matches!(q.next_track(), NextTrack::Stop));
     }
 
     #[test]
-    fn test_reorder_same_index_is_noop() {
-        let mut q = PlaybackQueue::new();
-        q.add_to_queue(vec!["a".into(), "b".into(), "c".into()]);
-        q.reorder(1, 1);
-        assert_eq!(q.tracks(), vec!["a", "b", "c"]);
-    }
-
-    #[test]
     fn test_front_peeks_without_removing() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         assert_eq!(q.front(), None);
         q.add_to_queue(vec!["a".into(), "b".into()]);
-        assert_eq!(q.front(), Some(&"a".to_string()));
+        assert_eq!(q.front(), Some("a"));
         assert_eq!(q.len(), 2, "front must not consume the queue");
     }
 
     #[test]
     fn test_pop_front_empty_returns_none() {
-        let mut q = PlaybackQueue::new();
+        let mut q = queue();
         assert_eq!(q.pop_front(), None);
     }
 }

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -22,7 +22,7 @@
 //! 8. Send `Seeked` progress event
 
 use super::RepeatMode;
-use super::{NextTrack, PlaybackQueue, PreviousAction};
+use super::{NextTrack, PlaybackQueue, PreviousAction, QueueEntryId};
 use crate::audio_codec::StreamingDecodeError;
 use crate::library::LibraryEvent;
 use crate::library::LibraryManager;
@@ -156,16 +156,19 @@ pub enum PlaybackCommand {
     AddReleaseToQueue(String),
     AddReleaseNext(String),
     InsertInQueue(Vec<String>, usize),
-    RemoveFromQueue(usize),
+    /// Remove the queue entry with this per-instance id.
+    RemoveFromQueue(QueueEntryId),
+    /// Move the entry `entry_id` to sit immediately before `before`.
+    /// `before = None` moves it to the end of the queue.
     ReorderQueue {
-        from: usize,
-        to: usize,
+        entry_id: QueueEntryId,
+        before: Option<QueueEntryId>,
     },
     ClearQueue,
     SetRepeatMode(RepeatMode),
     CycleRepeatMode,
-    /// Skip to a specific position in the queue (manual action, skip pregap)
-    SkipTo(usize),
+    /// Skip to the queue entry with this per-instance id (manual action, skip pregap)
+    SkipTo(QueueEntryId),
     /// Preview a local audio file (toggle: same path stops, different path switches).
     PreviewPlay(String),
     /// Stop any active preview.
@@ -313,11 +316,14 @@ impl PlaybackHandle {
             PlaybackCommand::InsertInQueue(track_ids, index),
         );
     }
-    pub fn remove_from_queue(&self, index: usize) {
-        dispatch_command(&self.command_tx, PlaybackCommand::RemoveFromQueue(index));
+    pub fn remove_entry(&self, entry_id: QueueEntryId) {
+        dispatch_command(&self.command_tx, PlaybackCommand::RemoveFromQueue(entry_id));
     }
-    pub fn reorder_queue(&self, from: usize, to: usize) {
-        dispatch_command(&self.command_tx, PlaybackCommand::ReorderQueue { from, to });
+    pub fn reorder_entry(&self, entry_id: QueueEntryId, before: Option<QueueEntryId>) {
+        dispatch_command(
+            &self.command_tx,
+            PlaybackCommand::ReorderQueue { entry_id, before },
+        );
     }
     pub fn clear_queue(&self) {
         dispatch_command(&self.command_tx, PlaybackCommand::ClearQueue);
@@ -367,8 +373,8 @@ impl PlaybackHandle {
     pub fn get_last_position_display(&self) -> Option<PositionDisplay> {
         self.last_position_display.lock().unwrap().clone()
     }
-    pub fn skip_to(&self, index: usize) {
-        dispatch_command(&self.command_tx, PlaybackCommand::SkipTo(index));
+    pub fn skip_to_entry(&self, entry_id: QueueEntryId) {
+        dispatch_command(&self.command_tx, PlaybackCommand::SkipTo(entry_id));
     }
     /// Preview a local audio file. Same path toggles off, different path switches.
     pub fn preview_play(&self, path: String) {
@@ -1256,12 +1262,13 @@ impl PlaybackService {
                         }
                     },
                 };
+                let queue_ids = library_manager.ids().clone();
                 let mut service = PlaybackService {
                     library_manager,
                     command_tx: command_tx.clone(),
                     command_rx,
                     progress_tx,
-                    playback_queue: PlaybackQueue::new(),
+                    playback_queue: PlaybackQueue::new(queue_ids),
                     current_position_shared: Arc::new(std::sync::Mutex::new(None)),
                     audio_output,
                     stream: None,
@@ -1766,11 +1773,11 @@ impl PlaybackService {
                     self.emit_queue_items_added(count);
                     self.on_queue_mutated().await;
                 }
-                PlaybackCommand::RemoveFromQueue(index) => {
-                    if let Some(removed_track_id) = self.playback_queue.remove(index) {
+                PlaybackCommand::RemoveFromQueue(entry_id) => {
+                    if let Some(removed) = self.playback_queue.remove(&entry_id) {
                         if self
                             .current_track_id()
-                            .map(|id| id == removed_track_id)
+                            .map(|id| id == removed.track_id)
                             .unwrap_or(false)
                         {
                             self.stop().await;
@@ -1780,8 +1787,8 @@ impl PlaybackService {
                         }
                     }
                 }
-                PlaybackCommand::ReorderQueue { from, to } => {
-                    self.playback_queue.reorder(from, to);
+                PlaybackCommand::ReorderQueue { entry_id, before } => {
+                    self.playback_queue.reorder(&entry_id, before.as_ref());
                     self.on_queue_mutated().await;
                 }
                 PlaybackCommand::ClearQueue => {
@@ -1811,17 +1818,17 @@ impl PlaybackService {
                     );
                     self.emit_queue_update();
                 }
-                PlaybackCommand::SkipTo(index) => {
-                    if let Some(track_id) = self.playback_queue.skip_to(index) {
+                PlaybackCommand::SkipTo(entry_id) => {
+                    if let Some(entry) = self.playback_queue.skip_to(&entry_id) {
                         info!(
-                            "SkipTo: jumping to queue position {}, track {}",
-                            index, track_id
+                            "SkipTo: jumping to queue entry {}, track {}",
+                            entry.id.0, entry.track_id
                         );
 
                         self.clear_next_track_state();
                         self.emit_queue_update();
-                        self.playback_queue.set_current(track_id.clone());
-                        self.play_track(&track_id, false, false).await;
+                        self.playback_queue.set_current(entry.track_id.clone());
+                        self.play_track(&entry.track_id, false, false).await;
                     }
                 }
                 PlaybackCommand::PreviewPlay(path) => {
@@ -2034,7 +2041,7 @@ impl PlaybackService {
         info!("Streaming playback started for track: {}", track_id);
 
         // Preload next track
-        if let Some(next_id) = self.playback_queue.front().cloned() {
+        if let Some(next_id) = self.playback_queue.front().map(str::to_string) {
             self.preload_next_track(&next_id).await;
         }
     }
@@ -2151,7 +2158,7 @@ impl PlaybackService {
             None => return,
         };
         let queue_front = match self.playback_queue.front() {
-            Some(id) => id.clone(),
+            Some(id) => id.to_string(),
             None => {
                 self.clear_next_track_state();
                 return;
@@ -2271,7 +2278,7 @@ impl PlaybackService {
         self.emit_current_state();
 
         // Preload (and stage, if same-format) the following track.
-        if let Some(following) = self.playback_queue.front().cloned() {
+        if let Some(following) = self.playback_queue.front().map(str::to_string) {
             self.preload_next_track(&following).await;
         }
     }
@@ -2282,7 +2289,7 @@ impl PlaybackService {
     /// same advance-by-one sequence, and three copies drift.
     fn advance_queue_to(&mut self, track_id: &str) {
         self.playback_queue.set_current(track_id.to_string());
-        if self.playback_queue.front().map(|s| s.as_str()) == Some(track_id) {
+        if self.playback_queue.front() == Some(track_id) {
             self.playback_queue.pop_front();
         }
         self.emit_queue_update();
@@ -2370,7 +2377,7 @@ impl PlaybackService {
         self.emit_current_state();
 
         // Preload next track if available
-        if let Some(next_track_id) = self.playback_queue.front().cloned() {
+        if let Some(next_track_id) = self.playback_queue.front().map(str::to_string) {
             self.preload_next_track(&next_track_id).await;
         }
     }
@@ -3041,7 +3048,7 @@ impl PlaybackService {
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::QueueUpdated {
-                tracks: self.playback_queue.tracks(),
+                entries: self.playback_queue.entries(),
                 has_next,
                 has_previous,
             },
@@ -3071,7 +3078,12 @@ impl PlaybackService {
         Some(PlaybackSnapshot {
             track_id,
             position_ms,
-            queue: self.playback_queue.tracks(),
+            queue: self
+                .playback_queue
+                .entries()
+                .into_iter()
+                .map(|e| e.track_id)
+                .collect(),
             volume: if self.is_muted {
                 self.pre_mute_volume
             } else {

--- a/bae-core/src/queue.rs
+++ b/bae-core/src/queue.rs
@@ -1,13 +1,15 @@
-//! Resolved types for the playback queue.
+//! Resolved type for the playback queue.
 //!
 //! `QueueItem` is the display-ready shape the bridge and UI event payloads
-//! carry. The raw DB-shape aggregate is `DbQueueItem` in `crate::db::models`;
-//! `LibraryManager` turns it into `QueueItem` via `resolve_queue_item`.
+//! carry: a queue entry's per-instance id plus the track's album/artist
+//! context. `db::get_queue_items` builds it directly from a SQL aggregate.
 
-/// Display-ready queue entry: a track with the album/artist context the UI
-/// needs.
+/// Display-ready queue entry: a per-instance `entry_id` (so the UI keys each
+/// row on a stable unique identity even when the same track is queued twice)
+/// plus the track and the album/artist context the UI needs.
 #[derive(Debug, Clone)]
 pub struct QueueItem {
+    pub entry_id: String,
     pub track_id: String,
     pub title: String,
     pub artist_names: String,

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -149,16 +149,17 @@ impl UiEventBus {
                         });
                     }
                     PlaybackProgress::QueueUpdated {
-                        tracks,
+                        entries,
                         has_next,
                         has_previous,
                     } => {
-                        // Resolve the queue's track ids to display-ready items in
-                        // core so the event payload is fully populated. Consumers
-                        // then map it directly instead of each re-querying the DB
-                        // (the macOS reducer used to; Windows didn't, so its queue
+                        // Resolve the queue's entries to display-ready items in
+                        // core so the event payload is fully populated, each row
+                        // carrying its per-instance entry id. Consumers then map
+                        // it directly instead of each re-querying the DB (the
+                        // macOS reducer used to; Windows didn't, so its queue
                         // rows rendered blank).
-                        match lm.get_queue_items(&tracks).await {
+                        match lm.get_queue_items(&entries).await {
                             Ok(items) => {
                                 bus.emit(UiBusEvent::QueueUpdated {
                                     items,
@@ -168,8 +169,8 @@ impl UiEventBus {
                             }
                             Err(e) => {
                                 tracing::warn!(
-                                    "skipping QueueUpdated: failed to resolve {} queue item(s): {e}",
-                                    tracks.len()
+                                    "skipping QueueUpdated: failed to resolve {} queue entry(ies): {e}",
+                                    entries.len()
                                 );
                             }
                         }

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -172,6 +172,35 @@ impl PlaybackTestFixture {
     {
         wait_for_state_on(&mut self.progress_rx, predicate, timeout_duration).await
     }
+    /// Drain progress events up to the Playing state, returning whether Playing
+    /// arrived and the entries from the most recent QueueUpdated seen (each
+    /// carrying a per-instance id). `play` rebuilds the queue with fresh ids, so
+    /// a mutation must target those — captured here, after play settles.
+    async fn wait_for_playing_capturing_queue(
+        &mut self,
+        timeout_duration: Duration,
+    ) -> (bool, Vec<bae_core::playback::QueueEntry>) {
+        let deadline = Instant::now() + timeout_duration;
+        let mut entries = Vec::new();
+        while Instant::now() < deadline {
+            match timeout(Duration::from_millis(100), self.progress_rx.recv()).await {
+                Ok(Some(PlaybackProgress::QueueUpdated {
+                    entries: latest, ..
+                })) => {
+                    entries = latest;
+                }
+                Ok(Some(PlaybackProgress::StateChanged {
+                    state: PlaybackState::Playing { .. },
+                })) => {
+                    return (true, entries);
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) => break,
+                Err(_) => continue,
+            }
+        }
+        (false, entries)
+    }
     /// Wait for a position update with timeout (returns position in ms)
     async fn wait_for_position_update(&mut self, timeout_duration: Duration) -> Option<u64> {
         let deadline = Instant::now() + timeout_duration;
@@ -1717,20 +1746,20 @@ async fn assert_preload_refreshed_after_queue_mutation<F>(
     expected: &str,
     mutate: F,
 ) where
-    F: FnOnce(&bae_core::playback::PlaybackHandle),
+    F: FnOnce(&bae_core::playback::PlaybackHandle, &[bae_core::playback::QueueEntry]),
 {
     fixture.playback_handle.add_to_queue(initial_queue);
     fixture.playback_handle.play(track0.to_string());
 
-    let playing = fixture
-        .wait_for_state(
-            |s| matches!(s, PlaybackState::Playing { .. }),
-            Duration::from_secs(5),
-        )
+    // `play` clears the queue and repopulates it from the track's release
+    // context with fresh entry ids, so capture the entries *after* play settles:
+    // drain up to the Playing state, keeping the latest QueueUpdated.
+    let (played, entries) = fixture
+        .wait_for_playing_capturing_queue(Duration::from_secs(5))
         .await;
-    assert!(playing.is_some(), "track0 should start playing");
+    assert!(played, "track0 should start playing");
 
-    mutate(&fixture.playback_handle);
+    mutate(&fixture.playback_handle, &entries);
     fixture.playback_handle.next();
 
     let next_state = fixture
@@ -1782,7 +1811,7 @@ async fn test_add_next_displaces_preloaded_track() {
         vec![track1],
         &track0,
         &track2,
-        move |h| h.add_next(vec![t2]),
+        move |h, _entries| h.add_next(vec![t2]),
     )
     .await;
 }
@@ -1812,7 +1841,7 @@ async fn test_reorder_queue_displaces_preloaded_track() {
         vec![track1, track2.clone()],
         &track0,
         &track2,
-        |h| h.reorder_queue(1, 0),
+        |h, entries| h.reorder_entry(entries[1].id.clone(), Some(entries[0].id.clone())),
     )
     .await;
 }
@@ -1843,7 +1872,7 @@ async fn test_insert_in_queue_displaces_preloaded_track() {
         vec![track1],
         &track0,
         &track2,
-        move |h| h.insert_in_queue(vec![t2], 0),
+        move |h, _entries| h.insert_in_queue(vec![t2], 0),
     )
     .await;
 }
@@ -1873,7 +1902,7 @@ async fn test_remove_from_queue_refreshes_preloaded_track() {
         vec![track1, track2.clone()],
         &track0,
         &track2,
-        |h| h.remove_from_queue(0),
+        |h, entries| h.remove_entry(entries[0].id.clone()),
     )
     .await;
 }

--- a/bae-ios/bae/bae/Views/QueueView.swift
+++ b/bae-ios/bae/bae/Views/QueueView.swift
@@ -6,8 +6,8 @@ private let logger = Logger.bae("Queue")
 /// The play queue, presented as a sheet: the currently-playing track, then a
 /// reorderable "Up Next" list. Reads the authoritative now-playing and queue
 /// off the shared `PlaybackStore`; mutations go straight to the `Queue` service
-/// (`clearQueue` / `removeFromQueue` / `reorderQueue` / `skipToQueueIndex`) and
-/// reflect back as a `QueueUpdated` event that re-populates `queueItems`.
+/// (`clearQueue` / `removeEntry` / `reorderEntry` / `skipToEntry`) and reflect
+/// back as a `QueueUpdated` event that re-populates `queueItems`.
 ///
 /// The view iterates and renders only — `durationLabel` is pre-formatted and the
 /// queue arrives pre-ordered. The current track is never in `queueItems`; it
@@ -113,14 +113,14 @@ func upNextRows(
     isEditing: Bool,
     onSkipped: @escaping () -> Void
 ) -> some View {
-    // Positional identity: the queue may hold the same track twice, so
-    // `QueueItem.id` (== trackId) isn't unique. Keying on the enumerated offset
-    // makes each row's identity its queue index — exactly what skip/move/delete
-    // report back to core.
-    ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+    // Each item carries a unique per-instance `entryId`, so rows key on
+    // `QueueItem.id` (== entryId) even when the same track is queued twice.
+    // onMove/onDelete report array positions, which we resolve back to the entry
+    // id of the affected row.
+    ForEach(items) { item in
         Button {
             guard !isEditing else { return }
-            queue.skipToQueueIndex(UInt32(index))
+            queue.skipToEntry(item.entryId)
             onSkipped()
         } label: {
             QueueRow(item: item)
@@ -135,16 +135,18 @@ func upNextRows(
             return
         }
         // SwiftUI's destination is a gap index in the original array (item still
-        // present) — the same convention core's reorder expects, so map straight
-        // through with no offset.
-        queue.reorderQueue(UInt32(from), UInt32(destination))
+        // present): the moved entry lands before the item currently at that gap,
+        // or at the end when the gap is past the last row.
+        let beforeEntryId =
+            destination < items.count ? items[destination].entryId : nil
+        queue.reorderEntry(items[from].entryId, beforeEntryId)
     }
     .onDelete { offsets in
         guard let index = offsets.first else {
             logger.warning("onDelete fired with an empty offset set")
             return
         }
-        queue.removeFromQueue(UInt32(index))
+        queue.removeEntry(items[index].entryId)
     }
 }
 

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -14,6 +14,7 @@ enum PreviewData {
 
     static let queueItems: [QueueItem] = [
         BridgeQueueItem(
+            entryId: "e-01",
             trackId: "t-01",
             title: "Static Dreams",
             artistNames: "The Midnight Signal",
@@ -22,6 +23,7 @@ enum PreviewData {
             coverImageId: nil
         ),
         BridgeQueueItem(
+            entryId: "e-02",
             trackId: "t-02",
             title: "Frequency Drift",
             artistNames: "The Midnight Signal",
@@ -30,6 +32,7 @@ enum PreviewData {
             coverImageId: nil
         ),
         BridgeQueueItem(
+            entryId: "e-03",
             trackId: "t-03",
             title: "Tide Pool",
             artistNames: "Glass Harbor",
@@ -38,6 +41,7 @@ enum PreviewData {
             coverImageId: nil
         ),
         BridgeQueueItem(
+            entryId: "e-04",
             trackId: "t-04",
             title: "Harbor Lights",
             artistNames: "Glass Harbor",
@@ -46,6 +50,7 @@ enum PreviewData {
             coverImageId: nil
         ),
         BridgeQueueItem(
+            entryId: "e-05",
             trackId: "t-05",
             title: "Axiom",
             artistNames: "Velvet Mathematics",

--- a/bae-macos/bae/bae/Services/Queue.swift
+++ b/bae-macos/bae/bae/Services/Queue.swift
@@ -1,17 +1,20 @@
 import Foundation
 
 /// Queue mutations — appending, inserting, reordering, removing,
-/// jumping to a queue index. Narrow subset of `AppHandle`.
+/// jumping to a queue entry. Reorder/remove/skip target a per-instance
+/// `entryId`. Narrow subset of `AppHandle`.
 final class Queue: Sendable, Observable {
     let addToQueue: @Sendable (_ trackIds: [String]) -> Void
     let addNext: @Sendable (_ trackIds: [String]) -> Void
     let addReleaseToQueue: @Sendable (_ releaseId: String) -> Void
     let addReleaseNext: @Sendable (_ releaseId: String) -> Void
     let insertInQueue: @Sendable (_ trackIds: [String], _ index: UInt32) -> Void
-    let removeFromQueue: @Sendable (_ index: UInt32) -> Void
+    let removeEntry: @Sendable (_ entryId: String) -> Void
     let clearQueue: @Sendable () -> Void
-    let reorderQueue: @Sendable (_ fromIndex: UInt32, _ toIndex: UInt32) -> Void
-    let skipToQueueIndex: @Sendable (_ index: UInt32) -> Void
+    /// Move `entryId` to sit before `beforeEntryId`; `nil` moves it to the end.
+    let reorderEntry:
+        @Sendable (_ entryId: String, _ beforeEntryId: String?) -> Void
+    let skipToEntry: @Sendable (_ entryId: String) -> Void
 
     init(
         addToQueue: @escaping @Sendable ([String]) -> Void = { _ in },
@@ -22,21 +25,21 @@ final class Queue: Sendable, Observable {
             _,
             _ in
         },
-        removeFromQueue: @escaping @Sendable (UInt32) -> Void = { _ in },
+        removeEntry: @escaping @Sendable (String) -> Void = { _ in },
         clearQueue: @escaping @Sendable () -> Void = {},
-        reorderQueue: @escaping @Sendable (UInt32, UInt32) -> Void = { _, _ in
+        reorderEntry: @escaping @Sendable (String, String?) -> Void = { _, _ in
         },
-        skipToQueueIndex: @escaping @Sendable (UInt32) -> Void = { _ in }
+        skipToEntry: @escaping @Sendable (String) -> Void = { _ in }
     ) {
         self.addToQueue = addToQueue
         self.addNext = addNext
         self.addReleaseToQueue = addReleaseToQueue
         self.addReleaseNext = addReleaseNext
         self.insertInQueue = insertInQueue
-        self.removeFromQueue = removeFromQueue
+        self.removeEntry = removeEntry
         self.clearQueue = clearQueue
-        self.reorderQueue = reorderQueue
-        self.skipToQueueIndex = skipToQueueIndex
+        self.reorderEntry = reorderEntry
+        self.skipToEntry = skipToEntry
     }
 
     convenience init(handle: any AppHandleProtocol) {
@@ -46,10 +49,12 @@ final class Queue: Sendable, Observable {
             addReleaseToQueue: { handle.addReleaseToQueue(releaseId: $0) },
             addReleaseNext: { handle.addReleaseNext(releaseId: $0) },
             insertInQueue: { handle.insertInQueue(trackIds: $0, index: $1) },
-            removeFromQueue: { handle.removeFromQueue(index: $0) },
+            removeEntry: { handle.removeEntry(entryId: $0) },
             clearQueue: { handle.clearQueue() },
-            reorderQueue: { handle.reorderQueue(fromIndex: $0, toIndex: $1) },
-            skipToQueueIndex: { handle.skipToQueueIndex(index: $0) }
+            reorderEntry: {
+                handle.reorderEntry(entryId: $0, beforeEntryId: $1)
+            },
+            skipToEntry: { handle.skipToEntry(entryId: $0) }
         )
     }
 

--- a/bae-macos/bae/bae/Services/Store/QueueItem.swift
+++ b/bae-macos/bae/bae/Services/Store/QueueItem.swift
@@ -1,20 +1,22 @@
 import Foundation
 
 struct QueueItem: Identifiable, Equatable {
-    let trackId: String
+    /// Per-instance id: the same track queued twice yields two items with two
+    /// ids, so the row identity is stable and unique even for duplicates.
+    let entryId: String
     let title: String
     let durationMs: Int64?
     let albumTitle: String
     let coverImageId: String?
 
     var id: String {
-        trackId
+        entryId
     }
 
     var durationLabel: String { DurationClock.text(durationMs) }
 
     init(bridge: BridgeQueueItem) {
-        trackId = bridge.trackId
+        entryId = bridge.entryId
         title = bridge.title
         durationMs = bridge.durationMs
         albumTitle = bridge.albumTitle

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -58,10 +58,10 @@ struct NowPlayingBarContainer: View {
             onToggleMute: { playback.toggleMute() },
             onCycleRepeat: { playback.cycleRepeatMode() },
             onQueueClear: { queue.clearQueue() },
-            onQueueSkipTo: { queue.skipToQueueIndex(UInt32($0)) },
-            onQueueRemove: { queue.removeFromQueue(UInt32($0)) },
-            onQueueReorder: { from, to in
-                queue.reorderQueue(UInt32(from), UInt32(to))
+            onQueueSkipTo: { queue.skipToEntry($0) },
+            onQueueRemove: { queue.removeEntry($0) },
+            onQueueReorder: { entryId, beforeEntryId in
+                queue.reorderEntry(entryId, beforeEntryId)
             },
             onQueueInsertTracks: onQueueInsertTracks,
             onDropToQueue: onDropToQueue,
@@ -120,9 +120,9 @@ struct NowPlayingBar: View {
     let onToggleMute: () -> Void
     let onCycleRepeat: () -> Void
     let onQueueClear: () -> Void
-    let onQueueSkipTo: (Int) -> Void
-    let onQueueRemove: (Int) -> Void
-    let onQueueReorder: (Int, Int) -> Void
+    let onQueueSkipTo: (String) -> Void
+    let onQueueRemove: (String) -> Void
+    let onQueueReorder: (String, String?) -> Void
     let onQueueInsertTracks: ([String], Int) -> Void
     let onDropToQueue: ([String]) -> Void
     let onNavigateToAlbum: () -> Void

--- a/bae-macos/bae/bae/Views/QueueView.swift
+++ b/bae-macos/bae/bae/Views/QueueView.swift
@@ -10,15 +10,17 @@ struct QueueView: View {
     let resolveImagePath: (String?) -> String?
     let onClose: () -> Void
     let onClear: () -> Void
-    let onSkipTo: (Int) -> Void
-    let onRemove: (Int) -> Void
-    let onReorder: (Int, Int) -> Void
+    let onSkipTo: (String) -> Void
+    let onRemove: (String) -> Void
+    /// Move the entry `entryId` to sit before `beforeEntryId`; `nil` moves it
+    /// to the end of the queue.
+    let onReorder: (_ entryId: String, _ beforeEntryId: String?) -> Void
     let onInsertTracks: ([String], Int) -> Void
 
     @State
     private var hoveredIndex: Int?
     @State
-    private var draggedTrackId: String?
+    private var draggedEntryId: String?
     @State
     private var dropInsertIndex: Int?
 
@@ -62,7 +64,7 @@ struct QueueView: View {
                                     .padding(.horizontal, 12)
                                     .padding(.vertical, 4)
                                     .opacity(
-                                        draggedTrackId == item.id ? 0.3 : 1.0
+                                        draggedEntryId == item.id ? 0.3 : 1.0
                                     )
                                 Divider().padding(.leading, 62)
                             }
@@ -71,7 +73,7 @@ struct QueueView: View {
                                 delegate: QueueDropDelegate(
                                     targetIndex: index,
                                     items: items,
-                                    draggedTrackId: $draggedTrackId,
+                                    draggedEntryId: $draggedEntryId,
                                     dropInsertIndex: $dropInsertIndex,
                                     onReorder: onReorder,
                                     onInsertTracks: onInsertTracks,
@@ -91,7 +93,7 @@ struct QueueView: View {
                                 delegate: QueueDropDelegate(
                                     targetIndex: items.count,
                                     items: items,
-                                    draggedTrackId: $draggedTrackId,
+                                    draggedEntryId: $draggedEntryId,
                                     dropInsertIndex: $dropInsertIndex,
                                     onReorder: onReorder,
                                     onInsertTracks: onInsertTracks,
@@ -181,7 +183,7 @@ struct QueueView: View {
                     RoundedRectangle(cornerRadius: 3)
                         .fill(.black.opacity(0.5))
                         .frame(width: 40, height: 40)
-                    Button(action: { onSkipTo(index) }) {
+                    Button(action: { onSkipTo(item.id) }) {
                         Image(systemName: "play.fill")
                             .font(.caption)
                             .foregroundColor(.white)
@@ -203,7 +205,7 @@ struct QueueView: View {
             Spacer()
 
             if hoveredIndex == index {
-                Button(action: { onRemove(index) }) {
+                Button(action: { onRemove(item.id) }) {
                     Image(systemName: "xmark")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -222,15 +224,15 @@ struct QueueView: View {
             hoveredIndex = isHovered ? index : nil
         }
         .onDrag {
-            draggedTrackId = item.id
+            draggedEntryId = item.id
             return NSItemProvider(object: item.id as NSString)
         }
         .onTapGesture(count: 2) {
-            onSkipTo(index)
+            onSkipTo(item.id)
         }
         .contextMenu {
             Button("Remove from Queue") {
-                onRemove(index)
+                onRemove(item.id)
             }
         }
     }
@@ -246,22 +248,23 @@ private struct QueueDropDelegate: DropDelegate {
     let targetIndex: Int
     let items: [QueueItem]
     @Binding
-    var draggedTrackId: String?
+    var draggedEntryId: String?
     @Binding
     var dropInsertIndex: Int?
-    let onReorder: (Int, Int) -> Void
+    /// Move the dragged entry to sit before `beforeEntryId`; `nil` = end.
+    let onReorder: (_ entryId: String, _ beforeEntryId: String?) -> Void
     let onInsertTracks: ([String], Int) -> Void
 
     /// Whether this is an internal reorder (dragged from within the queue).
     private var isInternalDrag: Bool {
-        guard let draggedId = draggedTrackId else {
+        guard let draggedId = draggedEntryId else {
             return false
         }
         return items.contains { $0.id == draggedId }
     }
 
     func dropEntered(info _: DropInfo) {
-        if let draggedId = draggedTrackId,
+        if let draggedId = draggedEntryId,
             let fromIndex = items.firstIndex(where: { $0.id == draggedId })
         {
             // Internal reorder: show insertion line relative to source
@@ -286,16 +289,20 @@ private struct QueueDropDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        if let draggedId = draggedTrackId,
+        if let draggedId = draggedEntryId,
             let fromIndex = items.firstIndex(where: { $0.id == draggedId })
         {
-            // Internal reorder
+            // Internal reorder. `toIndex` is the gap the entry lands in; the
+            // entry it lands before is whatever currently sits at that gap
+            // (nil past the end = move to the queue's end).
             let toIndex =
                 targetIndex > fromIndex ? targetIndex + 1 : targetIndex
             if toIndex != fromIndex {
-                onReorder(fromIndex, toIndex)
+                let beforeEntryId =
+                    toIndex < items.count ? items[toIndex].id : nil
+                onReorder(draggedId, beforeEntryId)
             }
-            draggedTrackId = nil
+            draggedEntryId = nil
             dropInsertIndex = nil
             return true
         }
@@ -345,7 +352,7 @@ private struct QueueDropDelegate: DropDelegate {
 
     func validateDrop(info: DropInfo) -> Bool {
         // Accept both internal drags and external drops with plain text
-        if draggedTrackId != nil {
+        if draggedEntryId != nil {
             return true
         }
         return info.hasItemsConforming(to: [UTType.plainText])

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -20,6 +20,7 @@ use bae_core::diagnostics::{
     AppDiagnosticMetadata, DatadogDiagnosticsConfig, DiagnosticLevel, Diagnostics,
     DiagnosticsConfig,
 };
+use bae_core::playback::QueueEntryId;
 use bae_core::ui::UiBusEvent;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{prelude::*, util::SubscriberInitExt};
@@ -2261,7 +2262,10 @@ pub unsafe extern "C" fn bae_album_detail(
 /// One track in the play queue (carried by `QueueUpdated`).
 #[derive(Serialize)]
 struct FfiQueueItem {
-    track_id: String,
+    /// Per-instance id: the same track queued twice yields two items with two
+    /// ids, so the UI keys rows on it and targets remove/reorder/skip at one
+    /// instance.
+    entry_id: String,
     title: String,
     artist: String,
     /// Raw track length in milliseconds, or null when unknown. The C# formats it.
@@ -2658,7 +2662,7 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             items: items
                 .iter()
                 .map(|item| FfiQueueItem {
-                    track_id: item.track_id.clone(),
+                    entry_id: item.entry_id.clone(),
                     title: item.title.clone(),
                     artist: item.artist_names.clone(),
                     duration_ms: item.duration_ms,
@@ -2975,45 +2979,90 @@ pub unsafe extern "C" fn bae_previous(handle: *const BaeHandle) {
     }
 }
 
-/// Jump to the queue entry at `index`.
+/// Jump to the queue entry with `entry_id`.
 ///
 /// # Safety
 /// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+/// `entry_id` must be a valid NUL-terminated UTF-8 C string.
 #[no_mangle]
-pub unsafe extern "C" fn bae_queue_skip_to(handle: *const BaeHandle, index: u32) {
-    if let Some(handle) = handle.as_ref() {
-        handle.0.services.playback().skip_to(index as usize);
-    }
+pub unsafe extern "C" fn bae_queue_skip_to(handle: *const BaeHandle, entry_id: *const c_char) {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_queue_skip_to: null handle");
+        return;
+    };
+    let Some(entry_id) = cstr(entry_id) else {
+        tracing::error!("bae_queue_skip_to: null or non-UTF-8 entry_id");
+        return;
+    };
+    handle
+        .0
+        .services
+        .playback()
+        .skip_to_entry(QueueEntryId(entry_id));
 }
 
-/// Remove the queue entry at `index`.
+/// Remove the queue entry with `entry_id`.
 ///
 /// # Safety
 /// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+/// `entry_id` must be a valid NUL-terminated UTF-8 C string.
 #[no_mangle]
-pub unsafe extern "C" fn bae_queue_remove(handle: *const BaeHandle, index: u32) {
-    if let Some(handle) = handle.as_ref() {
-        handle
-            .0
-            .services
-            .playback()
-            .remove_from_queue(index as usize);
-    }
+pub unsafe extern "C" fn bae_queue_remove(handle: *const BaeHandle, entry_id: *const c_char) {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_queue_remove: null handle");
+        return;
+    };
+    let Some(entry_id) = cstr(entry_id) else {
+        tracing::error!("bae_queue_remove: null or non-UTF-8 entry_id");
+        return;
+    };
+    handle
+        .0
+        .services
+        .playback()
+        .remove_entry(QueueEntryId(entry_id));
 }
 
-/// Move the queue entry at `from` to `to`.
+/// Move the entry `entry_id` to sit immediately before `before_entry_id`.
+/// A null `before_entry_id` moves it to the end of the queue.
 ///
 /// # Safety
 /// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+/// `entry_id` must be a valid NUL-terminated UTF-8 C string; `before_entry_id`
+/// must be null or such a string.
 #[no_mangle]
-pub unsafe extern "C" fn bae_queue_reorder(handle: *const BaeHandle, from: u32, to: u32) {
-    if let Some(handle) = handle.as_ref() {
-        handle
-            .0
-            .services
-            .playback()
-            .reorder_queue(from as usize, to as usize);
-    }
+pub unsafe extern "C" fn bae_queue_reorder(
+    handle: *const BaeHandle,
+    entry_id: *const c_char,
+    before_entry_id: *const c_char,
+) {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_queue_reorder: null handle");
+        return;
+    };
+    let Some(entry_id) = cstr(entry_id) else {
+        tracing::error!("bae_queue_reorder: null or non-UTF-8 entry_id");
+        return;
+    };
+    // A null `before_entry_id` means "move to the end"; a non-null but non-UTF-8
+    // value is malformed input, surfaced here rather than silently treated as
+    // "end" (matching the other exports that reject non-UTF-8).
+    let before = if before_entry_id.is_null() {
+        None
+    } else {
+        match cstr(before_entry_id) {
+            Some(id) => Some(QueueEntryId(id)),
+            None => {
+                tracing::error!("bae_queue_reorder: non-UTF-8 before_entry_id");
+                return;
+            }
+        }
+    };
+    handle
+        .0
+        .services
+        .playback()
+        .reorder_entry(QueueEntryId(entry_id), before);
 }
 
 /// Clear the play queue.

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -2592,7 +2592,15 @@ public sealed partial class MainWindow : Window
         {
             if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
             {
-                NativeBae.QueueReorder(_handle, (uint)args.OldStartingIndex, (uint)args.NewStartingIndex);
+                // The collection already reflects the move: the entry now sits at
+                // NewStartingIndex and lands before whatever follows it (null when
+                // it's now last = move to the end).
+                var moved = queueItems[args.NewStartingIndex];
+                var beforeIndex = args.NewStartingIndex + 1;
+                var beforeEntryId = beforeIndex < queueItems.Count
+                    ? queueItems[beforeIndex].EntryId
+                    : null;
+                NativeBae.QueueReorder(_handle, moved.EntryId, beforeEntryId);
             }
         };
 
@@ -2607,10 +2615,9 @@ public sealed partial class MainWindow : Window
         };
         list.ItemClick += (_, args) =>
         {
-            var index = queueItems.IndexOf((QueueItem)args.ClickedItem);
-            if (index >= 0)
+            if (args.ClickedItem is QueueItem clicked)
             {
-                NativeBae.QueueSkipTo(_handle, (uint)index);
+                NativeBae.QueueSkipTo(_handle, clicked.EntryId);
             }
         };
         // Right-tap a row to drop it from the queue. Removing locally too keeps the
@@ -2633,14 +2640,15 @@ public sealed partial class MainWindow : Window
             var remove = new MenuFlyoutItem { Text = Loc.Chrome("queue.remove_item") };
             remove.Click += (_, _) =>
             {
-                // Recompute: a reorder between the right-tap and the click could have
-                // moved this item.
+                // The FFI removes by entry id, so a reorder between the right-tap and
+                // the click can't target the wrong row. The local index is only to keep
+                // the open dialog's collection in sync.
                 var idx = queueItems.IndexOf(item);
                 if (idx < 0)
                 {
                     return;
                 }
-                NativeBae.QueueRemove(_handle, (uint)idx);
+                NativeBae.QueueRemove(_handle, item.EntryId);
                 queueItems.RemoveAt(idx);
             };
             menu.Items.Add(remove);

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -979,17 +979,26 @@ internal static class NativeBae
     [DllImport(Dll, EntryPoint = "bae_previous", CallingConvention = CallingConvention.Cdecl)]
     internal static extern void Previous(IntPtr handle);
 
-    /// <summary>Jump to the queue entry at <paramref name="index"/>.</summary>
+    /// <summary>Jump to the queue entry with <paramref name="entryId"/>.</summary>
     [DllImport(Dll, EntryPoint = "bae_queue_skip_to", CallingConvention = CallingConvention.Cdecl)]
-    internal static extern void QueueSkipTo(IntPtr handle, uint index);
+    internal static extern void QueueSkipTo(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string entryId);
 
-    /// <summary>Remove the queue entry at <paramref name="index"/>.</summary>
+    /// <summary>Remove the queue entry with <paramref name="entryId"/>.</summary>
     [DllImport(Dll, EntryPoint = "bae_queue_remove", CallingConvention = CallingConvention.Cdecl)]
-    internal static extern void QueueRemove(IntPtr handle, uint index);
+    internal static extern void QueueRemove(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string entryId);
 
-    /// <summary>Move the queue entry from one index to another.</summary>
+    /// <summary>Move the entry <paramref name="entryId"/> to sit before
+    /// <paramref name="beforeEntryId"/>; a null <paramref name="beforeEntryId"/>
+    /// moves it to the end of the queue.</summary>
     [DllImport(Dll, EntryPoint = "bae_queue_reorder", CallingConvention = CallingConvention.Cdecl)]
-    internal static extern void QueueReorder(IntPtr handle, uint from, uint to);
+    internal static extern void QueueReorder(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string entryId,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? beforeEntryId);
 
     /// <summary>Clear the play queue.</summary>
     [DllImport(Dll, EntryPoint = "bae_queue_clear", CallingConvention = CallingConvention.Cdecl)]

--- a/bae-windows/QueueItem.cs
+++ b/bae-windows/QueueItem.cs
@@ -3,7 +3,10 @@
 /// <summary>One track in the play queue, from the <c>QueueUpdated</c> event JSON.</summary>
 public sealed class QueueItem
 {
-    public string TrackId { get; set; } = string.Empty;
+    /// <summary>Per-instance id: the same track queued twice yields two items
+    /// with two ids, so rows key on it and remove/reorder/skip target one
+    /// instance.</summary>
+    public string EntryId { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string Artist { get; set; } = string.Empty;
 


### PR DESCRIPTION
A queue item was identified only by its `track_id`, so the same track enqueued twice was indistinguishable. Each platform papered over this differently — macOS keyed its list rows on `track_id` (and so collapsed duplicate rows and mis-targeted the wrong copy on remove/drag), iOS keyed on the list offset, and Android synthesized a `track_id#occurrence` string. macOS was simply buggy; the others were ad-hoc workarounds for a model that didn't carry instance identity.

This gives the queue one real identity at the core/bridge boundary: a per-instance `QueueEntry { id, track_id }`, where the `id` is minted from the injected `IdProvider`. Remove, reorder, and skip are keyed on that id instead of a position or a track. The same track can now sit in the queue twice and be removed or reordered independently, and all four UIs key their rows and target their operations on the one id — the three divergent schemes are deleted. Reorder moves to an id-based `reorder(entry_id, before: Option<entry_id>)` (where `before = None` means "move to the end"), and the Windows `CollectionChanged`-Move and Android gap-index drag handlers were rewritten against it. An unknown-id remove/skip now logs a warning and no-ops rather than silently eating an out-of-bounds index.

It also collapses the field-identical `DbQueueItem` into `QueueItem`: the resolver between them was a pure 1:1 field copy and `DbQueueItem` was never persisted (the `Db` prefix was a fiction). With the row identity now `entry_id`, the queue *display* item's `track_id` became dead on macOS/iOS and in the Windows FFI path, and is removed there; the uniffi `BridgeQueueItem.track_id` stays because Android reads it to match the now-playing track against queued entries.

This is the first PR of the playback-queue redesign (`plans/playback-queue-redesign.md`); later PRs add the context/source abstraction, shuffle-as-traversal, and synced playback state.

Known limitation (out of scope for this mechanical PR): on Android's Media3 surface (lock screen / Auto), tapping a *queued duplicate of the currently-playing track* resolves to a null entry id and no-ops. It fails safe (never skips to the wrong track), and the in-app queue screen is unaffected since it skips by `entry_id` directly.

## Test plan

- [x] `cargo test -p bae-core` — lib suite green, including the queue unit tests; the duplicate-removal test is load-bearing (sabotage-verified: keying remove on `track_id` instead of the entry id fails it)
- [x] The 4 preload-refresh integration tests (`test_playback_behavior`) green — reorder/remove now target the entry captured after `play` rebuilds the queue
- [x] `cargo clippy` (incl. `bae-windows-ffi`), macOS `xcodebuild` + periphery green locally
- [ ] CI to confirm iOS / Android / Windows builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F
