### PR TITLE
Android: swipe down to dismiss the now-playing player; embed the queue below it

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
@@ -2,18 +2,21 @@ package fm.bae.app.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Repeat
@@ -27,7 +30,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -35,31 +37,33 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.media3.common.C
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
+import kotlinx.coroutines.launch
 import uniffi.bae_bridge.BridgeRepeatMode
 
 /**
- * Full-screen now-playing player, presented as a full-bleed [Dialog] from the
- * compact [NowPlayingBar] when its track area is tapped. Renders the same single
- * source as the bar — the session's [fm.bae.app.playback.BaeCorePlayer] (a pure
- * projection of bae-core's playback) — and sends transport/seek through that
- * player and volume/mute/repeat through the bridge (all non-throwing).
+ * Full-screen now-playing player, presented as a [ModalBottomSheet] (swipe down
+ * to dismiss) from the compact [NowPlayingBar] when its track area is tapped. The
+ * player fills the first screen and the upcoming queue sits below it in the same
+ * scroll, so a swipe up scrolls into the queue and a swipe down from the top
+ * dismisses (the sheet and the list coordinate that handoff via nested scroll).
+ * Renders the session's [fm.bae.app.playback.BaeCorePlayer] (a pure projection of
+ * bae-core's playback) and sends transport/seek through that player and
+ * volume/mute/repeat through the bridge (all non-throwing).
  *
  * Pure iterate-and-render: the seek labels and the software-decode flag are
  * pre-derived by core; this screen formats nothing.
  */
 @OptIn(ExperimentalMaterial3Api::class)
-@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
 fun ExpandedNowPlayingScreen(
     session: OpenLibrary,
@@ -67,74 +71,91 @@ fun ExpandedNowPlayingScreen(
 ) {
     val player = session.playback
     val nowPlaying by player.nowPlaying.collectAsState()
-    val position by player.position.collectAsState()
-    val repeatMode by player.repeatMode.collectAsState()
-    val volume by player.volume.collectAsState()
-    val isMuted by player.isMuted.collectAsState()
-
     val track = nowPlaying ?: return
 
-    var queueOpen by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState()
-    if (queueOpen) {
-        ModalBottomSheet(
-            onDismissRequest = { queueOpen = false },
-            sheetState = sheetState,
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val listState = rememberLazyListState()
+    val (order, reorderState) = rememberReorderableQueue(session, listState)
+    // The sheet handles the top inset; pad the scroll's bottom past the navigation
+    // bar so the last queue row clears it.
+    val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    // A swipe dismisses via the sheet's own animation; the chevron animates the
+    // sheet out first, then tears it down — onDismiss alone would drop it abruptly.
+    val scope = rememberCoroutineScope()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(bottom = bottomInset + 16.dp),
         ) {
-            QueueScreen(session = session, onDismiss = { queueOpen = false })
+            item(key = "player") {
+                ExpandedPlayer(
+                    session = session,
+                    track = track,
+                    onCollapse = {
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            if (!sheetState.isVisible) onDismiss()
+                        }
+                    },
+                )
+            }
+            // The player above already shows the current track, so the embedded
+            // queue is just the up-next list; a row tap skips without closing the
+            // player (`onSkipped = null`).
+            queueContent(
+                session = session,
+                order = order,
+                reorderState = reorderState,
+                hasNowPlaying = true,
+                onSkipped = null,
+            )
         }
     }
+}
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .safeDrawingPadding()
-                        .padding(horizontal = 24.dp, vertical = 16.dp),
-            ) {
-                IconButton(onClick = onDismiss) {
-                    Icon(Icons.Filled.ExpandMore, contentDescription = stringResource(R.string.collapse))
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                CoverImage(
-                    path = track.coverPath,
-                    cornerRadius = 8.dp,
-                    iconPadding = 64.dp,
-                    modifier = Modifier.fillMaxWidth().aspectRatio(1f),
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                ExpandedTrackInfo(title = track.title, artist = track.artist)
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                ExpandedSeekSection(position = position, player = player)
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                ExpandedTransportRow(player = player)
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                ExpandedSecondaryControls(
-                    session = session,
-                    repeatMode = repeatMode,
-                    onOpenQueue = { queueOpen = true },
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                ExpandedVolumeRow(session = session, isMuted = isMuted, volume = volume)
-            }
+@Composable
+private fun ExpandedPlayer(
+    session: OpenLibrary,
+    track: fm.bae.app.playback.NowPlaying,
+    onCollapse: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 8.dp)) {
+        IconButton(onClick = onCollapse) {
+            Icon(Icons.Filled.ExpandMore, contentDescription = stringResource(R.string.collapse))
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        CoverImage(
+            path = track.coverPath,
+            cornerRadius = 8.dp,
+            iconPadding = 64.dp,
+            modifier = Modifier.fillMaxWidth().aspectRatio(1f),
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ExpandedTrackInfo(title = track.title, artist = track.artist)
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ExpandedSeekSection(player = session.playback)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ExpandedTransportRow(player = session.playback)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ExpandedSecondaryControls(session = session)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        ExpandedVolumeRow(session = session)
     }
 }
 
@@ -162,10 +183,8 @@ private fun ExpandedTrackInfo(
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
-private fun ExpandedSeekSection(
-    position: fm.bae.app.playback.PlaybackPosition,
-    player: fm.bae.app.playback.BaeCorePlayer,
-) {
+private fun ExpandedSeekSection(player: fm.bae.app.playback.BaeCorePlayer) {
+    val position by player.position.collectAsState()
     // While dragging, follow the finger; the progress events would otherwise snap
     // the thumb back mid-drag. Null means "not dragging". Same pattern as the bar.
     var dragRatio by remember { mutableStateOf<Float?>(null) }
@@ -176,7 +195,7 @@ private fun ExpandedSeekSection(
         onValueChangeFinished = {
             dragRatio?.let { ratio ->
                 val duration = player.duration
-                if (duration != androidx.media3.common.C.TIME_UNSET && duration > 0L) {
+                if (duration != C.TIME_UNSET && duration > 0L) {
                     player.seekTo((ratio * duration).toLong())
                 }
             }
@@ -235,11 +254,8 @@ private fun ExpandedTransportRow(player: fm.bae.app.playback.BaeCorePlayer) {
 }
 
 @Composable
-private fun ExpandedSecondaryControls(
-    session: OpenLibrary,
-    repeatMode: BridgeRepeatMode,
-    onOpenQueue: () -> Unit,
-) {
+private fun ExpandedSecondaryControls(session: OpenLibrary) {
+    val repeatMode by session.playback.repeatMode.collectAsState()
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
@@ -260,19 +276,13 @@ private fun ExpandedSecondaryControls(
                     },
             )
         }
-        Spacer(modifier = Modifier.width(24.dp))
-        IconButton(onClick = onOpenQueue) {
-            Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = stringResource(R.string.queue))
-        }
     }
 }
 
 @Composable
-private fun ExpandedVolumeRow(
-    session: OpenLibrary,
-    isMuted: Boolean,
-    volume: Float,
-) {
+private fun ExpandedVolumeRow(session: OpenLibrary) {
+    val volume by session.playback.volume.collectAsState()
+    val isMuted by session.playback.isMuted.collectAsState()
     // Mute toggle + level slider. While dragging, follow the finger from a local
     // value (cleared on release); the VolumeChanged events would otherwise snap the
     // thumb back mid-drag, same as the seek slider above. Both bridge calls are

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
@@ -27,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -39,6 +42,7 @@ import fm.bae.app.R
 import fm.bae.app.playback.NowPlaying
 import fm.bae.app.playback.QueueItem
 import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
 private const val TAG = "bae.QueueScreen"
@@ -48,7 +52,7 @@ private val logger = BaeLogger(TAG)
  *  ids that may repeat (the same track can be enqueued twice), so the track id
  *  alone is not a unique key; the occurrence index disambiguates duplicates and
  *  keeps the key stable for a given entry across re-hydrations and drags. */
-private data class KeyedQueueItem(
+internal data class KeyedQueueItem(
     val key: String,
     val item: QueueItem,
 )
@@ -79,13 +83,46 @@ fun QueueScreen(
     session: OpenLibrary,
     onDismiss: () -> Unit,
 ) {
-    val queue by session.playback.queue.collectAsState()
     val nowPlaying by session.playback.nowPlaying.collectAsState()
-
     val listState = rememberLazyListState()
-    // Local optimistic order so a dragged row follows the finger. Seeded from the
-    // authoritative flow, but NOT while a drag is in progress — re-seeding mid-
-    // drag would clobber the optimistic move and snap the row back.
+    val (order, reorderState) = rememberReorderableQueue(session, listState)
+
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+        item(key = "header") { QueueHeader(session = session, isQueueEmpty = order.isEmpty()) }
+        nowPlaying?.let { np ->
+            item(key = "nowplaying") {
+                SectionLabel(stringResource(R.string.queue_section_now_playing))
+                NowPlayingRow(np)
+            }
+        }
+        queueContent(
+            session = session,
+            order = order,
+            reorderState = reorderState,
+            hasNowPlaying = nowPlaying != null,
+            onSkipped = onDismiss,
+        )
+    }
+}
+
+/**
+ * The optimistic queue order plus its reorderable list state, shared by the queue
+ * sheet and the expanded player's embedded queue so the index conventions stay in
+ * one place. The order is seeded from the authoritative flow but NOT while a drag
+ * is in progress — re-seeding mid-drag would clobber the optimistic move and snap
+ * the row back. A drop maps the dragged/target keys to positions and calls core's
+ * reorder (gap-index convention: a forward move passes `toPos + 1`).
+ */
+@Composable
+internal fun rememberReorderableQueue(
+    session: OpenLibrary,
+    listState: LazyListState,
+): Pair<SnapshotStateList<KeyedQueueItem>, ReorderableLazyListState> {
+    val queue by session.playback.queue.collectAsState()
     val order = remember { mutableStateListOf<KeyedQueueItem>() }
     val reorderState =
         rememberReorderableLazyListState(listState) { from, to ->
@@ -95,9 +132,6 @@ fun QueueScreen(
             val toPos = order.indexOfFirst { it.key == to.key }
             if (fromPos < 0 || toPos < 0) return@rememberReorderableLazyListState
             order.add(toPos, order.removeAt(fromPos))
-            // Core's reorder treats `to` as a gap index: a forward move inserts at
-            // `to - 1`, so pass `toPos + 1` to land the item where the drag dropped
-            // it. A backward move maps straight through.
             val coreTo = if (toPos > fromPos) toPos + 1 else toPos
             try {
                 session.appHandle.reorderQueue(fromPos.toUInt(), coreTo.toUInt())
@@ -112,40 +146,27 @@ fun QueueScreen(
             order.addAll(keyed(queue))
         }
     }
-
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(bottom = 24.dp),
-    ) {
-        item(key = "header") { QueueHeader(session = session, isQueueEmpty = order.isEmpty()) }
-        queueContent(
-            session = session,
-            order = order,
-            reorderState = reorderState,
-            nowPlaying = nowPlaying,
-            onDismiss = onDismiss,
-        )
-    }
+    return order to reorderState
 }
 
-private fun androidx.compose.foundation.lazy.LazyListScope.queueContent(
+// The "Up Next" list (header + reorderable rows, or an empty message) — shared by
+// the queue sheet and the expanded player's embedded queue so the reorder / skip /
+// remove index conventions stay in one place. The caller owns the now-playing
+// header above this (the sheet shows a Now Playing row; the player shows the full
+// transport), passing `hasNowPlaying` only to word the empty state. `onSkipped`
+// runs after a tap-to-skip — the sheet passes its dismiss; the embedded player
+// passes `null` because it stays put on skip.
+internal fun LazyListScope.queueContent(
     session: OpenLibrary,
     order: List<KeyedQueueItem>,
-    reorderState: sh.calvin.reorderable.ReorderableLazyListState,
-    nowPlaying: NowPlaying?,
-    onDismiss: () -> Unit,
+    reorderState: ReorderableLazyListState,
+    hasNowPlaying: Boolean,
+    onSkipped: (() -> Unit)?,
 ) {
-    nowPlaying?.let { np ->
-        item(key = "nowplaying") {
-            SectionLabel(stringResource(R.string.queue_section_now_playing))
-            NowPlayingRow(np)
-        }
-    }
     if (order.isEmpty()) {
         item(key = "empty") {
             Text(
-                text = stringResource(if (nowPlaying != null) R.string.queue_nothing_up_next else R.string.queue_empty),
+                text = stringResource(if (hasNowPlaying) R.string.queue_nothing_up_next else R.string.queue_empty),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.fillMaxWidth().padding(32.dp),
             )
@@ -161,7 +182,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.queueContent(
                         onClick = {
                             try {
                                 session.appHandle.skipToQueueIndex(index.toUInt())
-                                onDismiss()
+                                onSkipped?.invoke()
                             } catch (e: Exception) {
                                 logger.error("skipToQueueIndex $index failed", e)
                             }


### PR DESCRIPTION
Tapping the now-playing bar opened the full player as a full-bleed `Dialog` — there was no way to swipe it away, and the upcoming queue lived in a separate bottom sheet behind a button. This reworks the expanded player to behave like a modern now-playing screen.

It's now a `ModalBottomSheet`, so it swipes down to dismiss. The upcoming queue is embedded beneath the player in one `LazyColumn`: the player fills the first screen, a swipe up scrolls into "Up Next", and a swipe down from the top dismisses — the sheet's nested scroll coordinates that handoff natively. Reorder-by-handle, tap-to-skip, and remove all work inline; the standalone queue sheet (still reachable from the bar's queue button) keeps the Now Playing header and Clear.

To avoid duplicating the queue logic, the reorder state (`rememberReorderableQueue`) and the up-next list (`queueContent`) are factored out of `QueueScreen` and shared. The player's sub-controls now read their own flows (position/repeat/volume/mute) at the leaf, so a position tick no longer recomposes the whole sheet.

## Test plan
- Tap the now-playing bar's track area: the player rises as a bottom sheet. Swipe down to dismiss.
- Swipe up: the player scrolls away to reveal "Up Next". Scroll back to the top, then swipe down to dismiss.
- Tap an "Up Next" row → skips to that track (player updates in place, sheet stays). Drag a row's handle → reorders. Tap the row's ✕ → removes it.
- Confirm the seek and volume sliders scrub without scrolling the list, and the bar's queue button still opens the full queue with Clear.