### PR TITLE
Bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
A denial-of-service advisory ([RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185)) landed today for `quinn-proto` 0.11.14, which `cargo audit` flags as a hard error — so the Security Audit job is failing on `main` and on every open PR. `0.11.15` is the advisory's recommended fix; this is a clean patch bump (`Cargo.lock` only).

## Test plan
- [ ] CI green (the Security Audit job in particular)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F