### PR TITLE
Queue: shuffle as a seeded, re-derivable traversal

### DIFF
--- a/bae-core/src/playback/context.rs
+++ b/bae-core/src/playback/context.rs
@@ -1,12 +1,22 @@
 use crate::playback::queue::QueueEntry;
 
-/// Where to place the cursor when a release becomes the playing context.
+/// How the context's track order was derived, kept so `Context` repeat can
+/// re-derive it: `Sequential` replays the source order; `Shuffled` re-permutes
+/// with a fresh seed each loop.
+#[derive(Clone, Copy)]
+pub enum Traversal {
+    Sequential,
+    Shuffled { seed: u64 },
+}
+
+/// How a release becomes the playing context: at a chosen track in source order,
+/// or shuffled by a seed the caller generated.
 pub enum ContextStart {
     /// Start at this index into the release's track order (validated in range by
     /// the caller).
     Index(usize),
-    /// Permute the release's tracks once and start at the front.
-    Shuffled,
+    /// Permute the release's tracks with this seed and start at the front.
+    Shuffled { seed: u64 },
 }
 
 /// The thing playback is "playing from": a release's track order, traversed by a
@@ -23,37 +33,35 @@ pub struct PlaybackContext {
     pub entries: Vec<QueueEntry>,
     /// Index into `entries` of the context track currently playing.
     pub cursor: usize,
+    /// How `entries` was ordered — replayed/re-derived on `Context` repeat.
+    pub traversal: Traversal,
 }
 
 impl PlaybackContext {
-    /// Build a context from a release's entries (already minted by the queue).
-    /// `entries` is non-empty and an `Index` start is in range — the queue only
-    /// builds a context from a non-empty release and the command layer validates
-    /// the start index, so a present context always has a valid cursor.
-    pub fn new(mut entries: Vec<QueueEntry>, start: ContextStart) -> Self {
-        let cursor = match start {
-            ContextStart::Shuffled => {
-                use rand::seq::SliceRandom;
-                let mut rng = rand::rng();
-                entries.shuffle(&mut rng);
-                0
-            }
-            ContextStart::Index(index) => index,
-        };
-
-        Self { entries, cursor }
-    }
-
     /// The entry currently under the cursor. A present context is non-empty with
-    /// a valid cursor (see `new`), so this is always a real entry.
+    /// a valid cursor (the queue only builds one from a non-empty release and
+    /// keeps the cursor in range), so this is always a real entry.
     pub fn current(&self) -> &QueueEntry {
         &self.entries[self.cursor]
     }
 
     /// The not-yet-played tail of the context: everything after the cursor. The
-    /// cursor is `< entries.len()` (see `new`), so `cursor + 1 <= entries.len()`
-    /// is always a valid slice bound (empty when the cursor is on the last entry).
+    /// cursor is `< entries.len()`, so `cursor + 1 <= entries.len()` is always a
+    /// valid slice bound (empty when the cursor is on the last entry).
     pub fn upcoming(&self) -> &[QueueEntry] {
         &self.entries[self.cursor + 1..]
     }
+}
+
+/// Permute `items` from `seed` and report the matching traversal. The queue uses
+/// this both when first shuffling a release and when re-deriving a shuffled
+/// context for a repeat loop. The same seed yields the same order, so a shuffled
+/// order does not change until it is re-derived — which is what lets Previous
+/// step back over the exact order that was played.
+pub(crate) fn shuffled_traversal<T>(items: &mut [T], seed: u64) -> Traversal {
+    use rand::seq::SliceRandom;
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    items.shuffle(&mut rng);
+    Traversal::Shuffled { seed }
 }

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -4,7 +4,7 @@ use tracing::warn;
 
 use super::RepeatMode;
 use crate::id_provider::IdRef;
-use crate::playback::context::{ContextStart, PlaybackContext};
+use crate::playback::context::{shuffled_traversal, ContextStart, PlaybackContext, Traversal};
 
 /// Per-instance identity for an enqueued track. Distinct from `track_id`: the
 /// same track enqueued twice yields two entries with two ids, each removable,
@@ -143,10 +143,18 @@ impl PlaybackQueue {
     /// manual lane (a fresh playback session). Returns the track to play. The
     /// caller passes a non-empty release (and an in-range `Index`); the context
     /// is therefore non-empty with a valid cursor.
-    pub fn play_release(&mut self, track_ids: Vec<String>, start: ContextStart) -> String {
+    pub fn play_release(&mut self, mut track_ids: Vec<String>, start: ContextStart) -> String {
         self.manual.clear();
-        let entries = track_ids.into_iter().map(|t| self.mint(t)).collect();
-        let context = PlaybackContext::new(entries, start);
+        let (cursor, traversal) = match start {
+            ContextStart::Index(index) => (index, Traversal::Sequential),
+            ContextStart::Shuffled { seed } => (0, shuffled_traversal(&mut track_ids, seed)),
+        };
+        let entries: Vec<QueueEntry> = track_ids.into_iter().map(|t| self.mint(t)).collect();
+        let context = PlaybackContext {
+            entries,
+            cursor,
+            traversal,
+        };
         let track = context.current().track_id.clone();
         self.current = Some(context.current().clone());
         self.context = Some(context);
@@ -353,12 +361,28 @@ impl PlaybackQueue {
         }
 
         // The manual lane and the context tail are both exhausted. Under
-        // `Context` repeat, loop the (non-empty) context from its start.
+        // `Context` repeat, loop the (non-empty) context from its start, re-
+        // deriving a shuffled order with a fresh seed so each pass differs.
         if self.repeat == RepeatMode::Context && self.context.is_some() {
+            self.rederive_context();
             return NextEntry::Play(self.play_context_at(0));
         }
 
         NextEntry::Stop
+    }
+
+    /// Re-derive the context's order for a fresh repeat pass: a shuffled context
+    /// re-permutes its entries with the next seed so the loop is a different
+    /// order; a sequential one is left as-is. The cursor is reset to the start by
+    /// the `play_context_at(0)` that follows.
+    fn rederive_context(&mut self) {
+        let ctx = self
+            .context
+            .as_mut()
+            .expect("rederive_context: context present");
+        if let Traversal::Shuffled { seed } = ctx.traversal {
+            ctx.traversal = shuffled_traversal(&mut ctx.entries, seed.wrapping_add(1));
+        }
     }
 
     /// Advance directly to the upcoming front and make it current, bypassing
@@ -472,6 +496,14 @@ mod tests {
     /// so most assertions are about which tracks sit where.
     fn upcoming_tracks(q: &PlaybackQueue) -> Vec<String> {
         q.upcoming().into_iter().map(|e| e.track_id).collect()
+    }
+
+    /// The full play order from the current track onward: the current track then
+    /// the upcoming projection.
+    fn full_order(q: &PlaybackQueue) -> Vec<String> {
+        let mut order = vec![q.current_track_id().unwrap().to_string()];
+        order.extend(upcoming_tracks(q));
+        order
     }
 
     fn manual_ids(q: &PlaybackQueue) -> Vec<QueueEntryId> {
@@ -636,11 +668,59 @@ mod tests {
     #[test]
     fn test_play_release_shuffled_keeps_all_tracks() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3", "t4"]), ContextStart::Shuffled);
-        let mut all: Vec<String> = vec![q.current_track_id().unwrap().to_string()];
-        all.extend(upcoming_tracks(&q));
+        q.play_release(
+            rel(&["t1", "t2", "t3", "t4"]),
+            ContextStart::Shuffled { seed: 7 },
+        );
+        let mut all = full_order(&q);
         all.sort();
         assert_eq!(all, vec!["t1", "t2", "t3", "t4"]);
+    }
+
+    #[test]
+    fn test_play_release_shuffled_is_deterministic_for_a_seed() {
+        let order = |seed| {
+            let mut q = queue();
+            q.play_release(
+                rel(&["t1", "t2", "t3", "t4", "t5"]),
+                ContextStart::Shuffled { seed },
+            );
+            full_order(&q)
+        };
+        assert_eq!(order(42), order(42), "same seed yields the same order");
+    }
+
+    /// A repeating shuffled context loops a freshly re-derived order each pass,
+    /// not the same order every time. Both passes' orders are read from the queue
+    /// (no re-implementation of the shuffle) and are deterministic for a fixed
+    /// seed.
+    #[test]
+    fn test_context_repeat_shuffled_loops_a_re_derived_order() {
+        let mut q = queue();
+        q.play_release(
+            rel(&["t1", "t2", "t3", "t4", "t5"]),
+            ContextStart::Shuffled { seed: 1 },
+        );
+        q.set_repeat_mode(RepeatMode::Context);
+        let first_pass = full_order(&q);
+        // Advance to the end of the pass, then one more advance loops it.
+        for _ in 0..first_pass.len() - 1 {
+            q.next_entry();
+        }
+        match q.next_entry() {
+            NextEntry::Play(_) => {}
+            other => panic!("expected a looped Play, got {other:?}"),
+        }
+        let second_pass = full_order(&q);
+
+        let (mut a, mut b) = (first_pass.clone(), second_pass.clone());
+        a.sort();
+        b.sort();
+        assert_eq!(a, b, "the loop replays exactly the same tracks");
+        assert_ne!(
+            first_pass, second_pass,
+            "but in a freshly re-derived order each pass"
+        );
     }
 
     #[test]

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -1458,7 +1458,12 @@ impl PlaybackService {
                     self.stop_preview_without_resume();
                     self.main_was_playing_before_preview = false;
                     let start = if shuffle {
-                        ContextStart::Shuffled
+                        // The shuffle seed is read once here, at the command
+                        // boundary, and carried into the context so the order is
+                        // reproducible and `Context` repeat can re-derive it.
+                        ContextStart::Shuffled {
+                            seed: rand::random(),
+                        }
                     } else {
                         // None means "from the first track"; an out-of-range index
                         // is a bad caller value, so clamp to the start and log it.


### PR DESCRIPTION
Release shuffle was a one-time, in-place permutation that kept no memory of how the order was derived, so a repeating shuffled context replayed the identical order every loop. This makes shuffle a property of the playing context: it carries `Traversal::Shuffled { seed }`, the seed is read once at the play command (so the queue and context stay pure — no ambient randomness inside them), and that seed materializes a reproducible order. `Context` repeat re-derives a fresh order with the next seed on each loop, instead of replaying the same one.

This is the third PR of the queue redesign (`plans/playback-queue-redesign.md`), trimmed to what the existing entry point uses: the album-detail "play shuffled" present in all four apps. Toggling shuffle on an already-playing context (`set_shuffle`) and "shuffle the whole library" (`play_library_shuffled` + a `Library` source) arrive with the UI surfaces that drive them — each lands with its consumer rather than as dead core.

## Test plan
- [x] `cargo test -p bae-core` (790 lib incl. seeded-shuffle determinism + repeat re-derivation; 33 preload/behavior integration)
- [x] `cargo clippy` (core/bridge/windows-ffi)
- [ ] CI iOS / Android / Windows (bridge + UIs unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F