### PR TITLE
Playback: persist the queue in a device-local table, not a JSON snapshot

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -279,3 +279,21 @@ CREATE TABLE IF NOT EXISTS attribution_names (
     pubkey_hex TEXT PRIMARY KEY,
     display_name TEXT NOT NULL
 );
+
+-- Device-local playback queue, restored after a restart on the same device.
+-- NOT synced: no `_updated_at` and absent from `synced_tables()`, the same
+-- device-local convention as coven's own bookkeeping tables. A single row
+-- (id = 'current'). `source` is the context's release id (NULL for a single
+-- track); `shuffle_seed` NULL means sequential, else shuffled with that seed.
+CREATE TABLE IF NOT EXISTS playback_state (
+    id               TEXT PRIMARY KEY,
+    source           TEXT,
+    shuffle_seed     INTEGER,
+    cursor           INTEGER,
+    manual           TEXT NOT NULL,
+    repeat           TEXT NOT NULL,
+    current_track_id TEXT,
+    position_ms      INTEGER,
+    volume           REAL NOT NULL,
+    is_muted         INTEGER NOT NULL
+);

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::info;
+use tracing::{debug, info};
 
 fn row_to_library_image(row: &Row) -> DbLibraryImage {
     DbLibraryImage {
@@ -2508,15 +2508,21 @@ impl Database {
         self.inner
             .coven_db
             .call(move |conn| {
+                // Flatten the context substruct back to the table's three
+                // nullable columns: all three NULL when no context is playing.
+                let (source, shuffle_seed, cursor) = match &state.context {
+                    Some(ctx) => (Some(&ctx.source), ctx.shuffle_seed, Some(ctx.cursor)),
+                    None => (None, None, None),
+                };
                 conn.execute(
                     "INSERT OR REPLACE INTO playback_state \
                      (id, source, shuffle_seed, cursor, manual, repeat, \
                       current_track_id, position_ms, volume, is_muted) \
                      VALUES ('current', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
-                        state.source,
-                        state.shuffle_seed,
-                        state.cursor,
+                        source,
+                        shuffle_seed,
+                        cursor,
                         state.manual,
                         state.repeat,
                         state.current_track_id,
@@ -2542,10 +2548,30 @@ impl Database {
                      FROM playback_state WHERE id = 'current'",
                     [],
                     |row| {
+                        // Reassemble the context substruct: the three columns are
+                        // written together, so a present `source` carries a
+                        // `shuffle_seed` (NULL = sequential) and a `cursor`.
+                        let source: Option<String> = row.get("source")?;
+                        let shuffle_seed: Option<i64> = row.get("shuffle_seed")?;
+                        let cursor: Option<i64> = row.get("cursor")?;
+                        let context = source.map(|source| {
+                            // A present source is written with its cursor, so a
+                            // NULL cursor here is a corrupt cache row — fall back
+                            // to the start rather than dropping the context.
+                            let cursor = cursor.unwrap_or_else(|| {
+                                debug!(
+                                    "playback_state row for {source} has a NULL cursor; using 0"
+                                );
+                                0
+                            });
+                            DbPlaybackContext {
+                                source,
+                                shuffle_seed,
+                                cursor,
+                            }
+                        });
                         Ok(DbPlaybackState {
-                            source: row.get("source")?,
-                            shuffle_seed: row.get("shuffle_seed")?,
-                            cursor: row.get("cursor")?,
+                            context,
                             manual: row.get("manual")?,
                             repeat: row.get("repeat")?,
                             current_track_id: row.get("current_track_id")?,

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -2568,10 +2568,17 @@ impl Database {
                                 cursor,
                             }),
                             (None, None) => None,
-                            (Some(_), None) | (None, Some(_)) => {
+                            (Some(source), None) => {
                                 warn!(
-                                    "discarding the playback resume cache: \
-                                     source and cursor must both be present"
+                                    "discarding the playback resume cache: source {source:?} \
+                                     present but cursor is NULL"
+                                );
+                                return Ok(None);
+                            }
+                            (None, Some(cursor)) => {
+                                warn!(
+                                    "discarding the playback resume cache: cursor {cursor} \
+                                     present but source is NULL"
                                 );
                                 return Ok(None);
                             }

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{info, warn};
 
 fn row_to_library_image(row: &Row) -> DbLibraryImage {
     DbLibraryImage {
@@ -2537,40 +2537,46 @@ impl Database {
             .await
     }
 
-    /// Read the device-local `playback_state` row, or `None` if none is stored.
+    /// Read the device-local `playback_state` row, or `None` if none is stored
+    /// (or if the row is corrupt — the resume cache is discarded at this
+    /// boundary so no caller downstream sees a malformed context).
     pub async fn load_playback_state(&self) -> Result<Option<DbPlaybackState>, DbError> {
         self.inner
             .coven_db
             .call(move |conn| {
+                // The closure yields `Option<DbPlaybackState>`: `None` is a corrupt
+                // row that discards the whole cache, distinct from the outer `None`
+                // for no row at all. The outer `.optional()` then flattens both to
+                // a single "no resume state" answer.
                 conn.query_row(
                     "SELECT source, shuffle_seed, cursor, manual, repeat, \
                      current_track_id, position_ms, volume, is_muted \
                      FROM playback_state WHERE id = 'current'",
                     [],
                     |row| {
-                        // Reassemble the context substruct: the three columns are
-                        // written together, so a present `source` carries a
-                        // `shuffle_seed` (NULL = sequential) and a `cursor`.
+                        // `source` and `cursor` are written together (with
+                        // `shuffle_seed`, NULL = sequential): both present is a
+                        // context, both absent is none, exactly one present is a
+                        // corrupt row.
                         let source: Option<String> = row.get("source")?;
                         let shuffle_seed: Option<i64> = row.get("shuffle_seed")?;
                         let cursor: Option<i64> = row.get("cursor")?;
-                        let context = source.map(|source| {
-                            // A present source is written with its cursor, so a
-                            // NULL cursor here is a corrupt cache row — fall back
-                            // to the start rather than dropping the context.
-                            let cursor = cursor.unwrap_or_else(|| {
-                                debug!(
-                                    "playback_state row for {source} has a NULL cursor; using 0"
-                                );
-                                0
-                            });
-                            DbPlaybackContext {
+                        let context = match (source, cursor) {
+                            (Some(source), Some(cursor)) => Some(DbPlaybackContext {
                                 source,
                                 shuffle_seed,
                                 cursor,
+                            }),
+                            (None, None) => None,
+                            (Some(_), None) | (None, Some(_)) => {
+                                warn!(
+                                    "discarding the playback resume cache: \
+                                     source and cursor must both be present"
+                                );
+                                return Ok(None);
                             }
-                        });
-                        Ok(DbPlaybackState {
+                        };
+                        Ok(Some(DbPlaybackState {
                             context,
                             manual: row.get("manual")?,
                             repeat: row.get("repeat")?,
@@ -2578,10 +2584,11 @@ impl Database {
                             position_ms: row.get("position_ms")?,
                             volume: row.get("volume")?,
                             is_muted: row.get("is_muted")?,
-                        })
+                        }))
                     },
                 )
                 .optional()
+                .map(Option::flatten)
                 .map_err(DbError::from)
             })
             .await
@@ -4013,5 +4020,48 @@ mod readable_cloud_path_tests {
         // broken invariant surfaced as an error, not masked.
         let conn = seeded_conn();
         assert!(resolve_audio_cloud_path(&conn, "no-such-release", "x.flac").is_err());
+    }
+}
+
+#[cfg(test)]
+mod playback_state_load_tests {
+    use super::*;
+    use crate::clock::SystemClock;
+
+    async fn empty_db() -> (Database, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        (db, tmp)
+    }
+
+    /// `source` and `cursor` are written together, so a row carrying one without
+    /// the other is corrupt: `load_playback_state` discards the whole cache and
+    /// returns `None` rather than inventing a cursor.
+    #[tokio::test]
+    async fn mismatched_source_and_cursor_discards_the_cache() {
+        let (db, _tmp) = empty_db().await;
+
+        // Write a row by hand with a present source but a NULL cursor —
+        // `save_playback_state` never produces this, so we insert it directly.
+        db.coven_db()
+            .call(|conn| {
+                conn.execute(
+                    "INSERT INTO playback_state \
+                     (id, source, shuffle_seed, cursor, manual, repeat, \
+                      current_track_id, position_ms, volume, is_muted) \
+                     VALUES ('current', 'rel-1', NULL, NULL, '[]', 'off', \
+                      NULL, NULL, 1.0, 0)",
+                    [],
+                )
+                .map(|_| ())
+                .map_err(DbError::from)
+            })
+            .await
+            .unwrap();
+
+        assert!(db.load_playback_state().await.unwrap().is_none());
     }
 }

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -2501,6 +2501,78 @@ impl Database {
             .await
     }
 
+    /// Write the single device-local `playback_state` row (id = 'current'),
+    /// replacing any existing one. Never synced.
+    pub async fn save_playback_state(&self, state: &DbPlaybackState) -> Result<(), DbError> {
+        let state = state.clone();
+        self.inner
+            .coven_db
+            .call(move |conn| {
+                conn.execute(
+                    "INSERT OR REPLACE INTO playback_state \
+                     (id, source, shuffle_seed, cursor, manual, repeat, \
+                      current_track_id, position_ms, volume, is_muted) \
+                     VALUES ('current', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        state.source,
+                        state.shuffle_seed,
+                        state.cursor,
+                        state.manual,
+                        state.repeat,
+                        state.current_track_id,
+                        state.position_ms,
+                        state.volume,
+                        state.is_muted,
+                    ],
+                )
+                .map(|_| ())
+                .map_err(DbError::from)
+            })
+            .await
+    }
+
+    /// Read the device-local `playback_state` row, or `None` if none is stored.
+    pub async fn load_playback_state(&self) -> Result<Option<DbPlaybackState>, DbError> {
+        self.inner
+            .coven_db
+            .call(move |conn| {
+                conn.query_row(
+                    "SELECT source, shuffle_seed, cursor, manual, repeat, \
+                     current_track_id, position_ms, volume, is_muted \
+                     FROM playback_state WHERE id = 'current'",
+                    [],
+                    |row| {
+                        Ok(DbPlaybackState {
+                            source: row.get("source")?,
+                            shuffle_seed: row.get("shuffle_seed")?,
+                            cursor: row.get("cursor")?,
+                            manual: row.get("manual")?,
+                            repeat: row.get("repeat")?,
+                            current_track_id: row.get("current_track_id")?,
+                            position_ms: row.get("position_ms")?,
+                            volume: row.get("volume")?,
+                            is_muted: row.get("is_muted")?,
+                        })
+                    },
+                )
+                .optional()
+                .map_err(DbError::from)
+            })
+            .await
+    }
+
+    /// Delete the device-local `playback_state` row (playback stopped).
+    pub async fn clear_playback_state(&self) -> Result<(), DbError> {
+        self.inner
+            .coven_db
+            .call(move |conn| {
+                conn.execute("DELETE FROM playback_state", [])
+                    .map(|_| ())
+                    .map_err(DbError::from)
+            })
+            .await
+    }
+
     /// Insert or replace this device's `release_local_copy` row.
     pub async fn upsert_release_local_copy(
         &self,

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -295,15 +295,31 @@ pub struct DbReleaseLocalCopy {
     pub pinned_locally: bool,
 }
 
-/// The single device-local `playback_state` row. Mirrors the table columns;
-/// `shuffle_seed` holds the `u64` shuffle seed reinterpreted as `i64` (SQLite's
-/// integer type) so the high bit round-trips. The playback service maps this to
-/// and from its queue snapshot + live position/volume/mute.
+/// The playing context of a saved `playback_state` row: which release is being
+/// played, how its tracks are ordered, and where the cursor sits. Held as a
+/// substruct so "no context playing" (a single track, or nothing) is one
+/// `None` instead of three separately-nullable columns that are only ever
+/// present or absent together — see `many-fields-none-together-means-a-missing-
+/// type`. The SQLite columns stay flat (`source`, `shuffle_seed`, `cursor`);
+/// the DB client destructures this on save and reassembles it on load.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DbPlaybackContext {
+    /// The release being played from.
+    pub source: String,
+    /// The `u64` shuffle seed reinterpreted as `i64` (SQLite's integer type) so
+    /// the high bit round-trips. `None` = sequential (source) order.
+    pub shuffle_seed: Option<i64>,
+    /// Index into the (ordered) tracks of the track currently playing.
+    pub cursor: i64,
+}
+
+/// The single device-local `playback_state` row. Mirrors the table columns; the
+/// playback service maps this to and from its queue snapshot + live
+/// position/volume/mute.
 #[derive(Debug, Clone)]
 pub struct DbPlaybackState {
-    pub source: Option<String>,
-    pub shuffle_seed: Option<i64>,
-    pub cursor: Option<i64>,
+    /// The playing context, or `None` for a single track / nothing playing.
+    pub context: Option<DbPlaybackContext>,
     pub manual: String,
     pub repeat: String,
     pub current_track_id: Option<String>,

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -295,6 +295,23 @@ pub struct DbReleaseLocalCopy {
     pub pinned_locally: bool,
 }
 
+/// The single device-local `playback_state` row. Mirrors the table columns;
+/// `shuffle_seed` holds the `u64` shuffle seed reinterpreted as `i64` (SQLite's
+/// integer type) so the high bit round-trips. The playback service maps this to
+/// and from its queue snapshot + live position/volume/mute.
+#[derive(Debug, Clone)]
+pub struct DbPlaybackState {
+    pub source: Option<String>,
+    pub shuffle_seed: Option<i64>,
+    pub cursor: Option<i64>,
+    pub manual: String,
+    pub repeat: String,
+    pub current_track_id: Option<String>,
+    pub position_ms: Option<i64>,
+    pub volume: f32,
+    pub is_muted: bool,
+}
+
 /// Where `releases.metadata_source` came from.
 ///
 /// Mirrors the `metadata_source` text column. Distinct from

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -786,6 +786,7 @@ const REPLAY_GAIN_TARGET_LUFS: f64 = -18.0;
 /// `side, track_number, id`) and the selected track's index into it. The
 /// playback service seeds a context from this.
 pub struct PlayContext {
+    pub release_id: String,
     pub track_ids: Vec<String>,
     pub index: usize,
 }
@@ -2031,37 +2032,30 @@ impl LibraryManager {
     // Playback state persistence
     // =========================================================================
 
-    pub fn save_playback_state(&self, snapshot: &crate::playback::PlaybackSnapshot) {
-        let path = self.library_dir.playback_state_path();
-        match serde_json::to_string(snapshot) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(&path, json) {
-                    warn!("Failed to write playback state: {e}");
-                }
-            }
-            Err(e) => warn!("Failed to serialize playback state: {e}"),
+    /// Write the device-local playback-state row. Failure is logged, not fatal —
+    /// losing a resume point is survivable.
+    pub async fn save_playback_state(&self, state: &crate::db::DbPlaybackState) {
+        if let Err(e) = self.database.save_playback_state(state).await {
+            warn!("Failed to save playback state: {e}");
         }
     }
 
-    /// Load and delete playback state (one-shot).
-    pub fn load_playback_state(&self) -> Option<crate::playback::PlaybackSnapshot> {
-        let path = self.library_dir.playback_state_path();
-        let data = match std::fs::read_to_string(&path) {
-            Ok(data) => data,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+    /// Read the device-local playback-state row (kept, not deleted — it's
+    /// overwritten on the next playback change and cleared on stop).
+    pub async fn load_playback_state(&self) -> Option<crate::db::DbPlaybackState> {
+        match self.database.load_playback_state().await {
+            Ok(state) => state,
             Err(e) => {
-                warn!("Failed to read playback state at {}: {e}", path.display());
-                return None;
-            }
-        };
-        let _ = std::fs::remove_file(&path);
-
-        match serde_json::from_str(&data) {
-            Ok(snapshot) => Some(snapshot),
-            Err(e) => {
-                warn!("Failed to parse playback state: {e}");
+                warn!("Failed to load playback state: {e}");
                 None
             }
+        }
+    }
+
+    /// Delete the device-local playback-state row (playback stopped).
+    pub async fn clear_playback_state(&self) {
+        if let Err(e) = self.database.clear_playback_state().await {
+            warn!("Failed to clear playback state: {e}");
         }
     }
 
@@ -3757,7 +3751,11 @@ impl LibraryManager {
                     track_id, release_id
                 ))
             })?;
-        Ok(PlayContext { track_ids, index })
+        Ok(PlayContext {
+            release_id,
+            track_ids,
+            index,
+        })
     }
 
     /// Return the subset of `ids` that still exist in the tracks table.

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -3730,10 +3730,10 @@ impl LibraryManager {
     pub async fn get_track_ids(&self, release_id: &str) -> Result<Vec<String>, LibraryError> {
         Ok(self.database.get_track_ids_for_release(release_id).await?)
     }
-    /// Return the play context for a track: its own ID, its release, the
-    /// track immediately before it in the release (if any), and every
-    /// track after it. Used by the playback service to build the queue
-    /// around a freshly selected track without chaining library calls.
+    /// Return the play context for a track: its release id, the release's full
+    /// track order, and the track's index within it. Used by the playback
+    /// service to build the queue around a freshly selected track without
+    /// chaining library calls.
     pub async fn get_play_context(&self, track_id: &str) -> Result<PlayContext, LibraryError> {
         let track = self
             .database

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -2032,31 +2032,30 @@ impl LibraryManager {
     // Playback state persistence
     // =========================================================================
 
-    /// Write the device-local playback-state row. Failure is logged, not fatal —
-    /// losing a resume point is survivable.
-    pub async fn save_playback_state(&self, state: &crate::db::DbPlaybackState) {
-        if let Err(e) = self.database.save_playback_state(state).await {
-            warn!("Failed to save playback state: {e}");
-        }
+    /// Write the device-local playback-state row. Propagates the DB error so the
+    /// caller can distinguish a write failure from a stored absence; the resume
+    /// row is a device-local cache, so the call site logs and continues rather
+    /// than treating a failed write as fatal to playback.
+    pub async fn save_playback_state(
+        &self,
+        state: &crate::db::DbPlaybackState,
+    ) -> Result<(), LibraryError> {
+        Ok(self.database.save_playback_state(state).await?)
     }
 
     /// Read the device-local playback-state row (kept, not deleted — it's
-    /// overwritten on the next playback change and cleared on stop).
-    pub async fn load_playback_state(&self) -> Option<crate::db::DbPlaybackState> {
-        match self.database.load_playback_state().await {
-            Ok(state) => state,
-            Err(e) => {
-                warn!("Failed to load playback state: {e}");
-                None
-            }
-        }
+    /// overwritten on the next playback change and cleared on stop). `Ok(None)`
+    /// means no row is stored; an `Err` is a read failure, kept distinct from
+    /// absence so the caller doesn't silently start fresh on a DB error.
+    pub async fn load_playback_state(
+        &self,
+    ) -> Result<Option<crate::db::DbPlaybackState>, LibraryError> {
+        Ok(self.database.load_playback_state().await?)
     }
 
     /// Delete the device-local playback-state row (playback stopped).
-    pub async fn clear_playback_state(&self) {
-        if let Err(e) = self.database.clear_playback_state().await {
-            warn!("Failed to clear playback state: {e}");
-        }
+    pub async fn clear_playback_state(&self) -> Result<(), LibraryError> {
+        Ok(self.database.clear_playback_state().await?)
     }
 
     // =========================================================================

--- a/bae-core/src/playback/context.rs
+++ b/bae-core/src/playback/context.rs
@@ -25,10 +25,11 @@ pub enum ContextStart {
 /// The tracks are held as per-instance [`QueueEntry`]s so the cursor walks
 /// forward (advance) and backward (Previous) over stable row ids, and `Context`
 /// repeat loops the stored order without re-fetching it. A release is small, so
-/// the whole order is held expanded. The release id the order came from is not a
-/// field: the queue identifies tracks by `track_id` and rows by entry id, and
-/// nothing keys off which release a context is.
+/// the whole order is held expanded.
 pub struct PlaybackContext {
+    /// The release this order came from. Read by persistence to re-fetch the
+    /// tracks and re-materialize the order on restart.
+    pub source: String,
     /// The release's tracks in play order, each with a stable per-instance id.
     pub entries: Vec<QueueEntry>,
     /// Index into `entries` of the context track currently playing.

--- a/bae-core/src/playback/mod.rs
+++ b/bae-core/src/playback/mod.rs
@@ -8,6 +8,7 @@ pub mod data_source;
 mod decoded_pcm;
 mod error;
 pub mod format;
+mod persisted;
 pub mod progress;
 mod queue;
 mod repeat_mode;
@@ -24,6 +25,7 @@ pub use audio_output::{
 pub use context::{ContextStart, Traversal};
 pub use decoded_pcm::DecodedPcm;
 pub use error::PlaybackError;
+pub use persisted::{repeat_to_str, PersistedPlayback};
 pub use progress::{PlaybackProgress, PreviewState};
 pub use queue::{
     ContextSnapshot, NextEntry, PlaybackQueue, PreviousAction, QueueEntry, QueueEntryId,

--- a/bae-core/src/playback/mod.rs
+++ b/bae-core/src/playback/mod.rs
@@ -21,15 +21,18 @@ pub use audio_output::{wait_for_samples, CaptureAudioOutput};
 pub use audio_output::{
     AudioError, AudioOutput, AudioState, AudioStream, CompletionEvent, PositionEvent,
 };
-pub use context::ContextStart;
+pub use context::{ContextStart, Traversal};
 pub use decoded_pcm::DecodedPcm;
 pub use error::PlaybackError;
 pub use progress::{PlaybackProgress, PreviewState};
-pub use queue::{NextEntry, PlaybackQueue, PreviousAction, QueueEntry, QueueEntryId};
+pub use queue::{
+    ContextSnapshot, NextEntry, PlaybackQueue, PreviousAction, QueueEntry, QueueEntryId,
+    QueueSnapshot,
+};
 pub use repeat_mode::RepeatMode;
 pub use service::{
-    LoadingTrack, PlaybackHandle, PlaybackService, PlaybackSnapshot, PlaybackState,
-    PlaybackTrackInfo, PositionDisplay,
+    LoadingTrack, PlaybackHandle, PlaybackService, PlaybackState, PlaybackTrackInfo,
+    PositionDisplay,
 };
 pub use source::{PlaybackSource, TrackCrossing, TrackFmt};
 pub use sparse_buffer::SharedSparseBuffer;

--- a/bae-core/src/playback/persisted.rs
+++ b/bae-core/src/playback/persisted.rs
@@ -1,0 +1,218 @@
+//! Parse the device-local `playback_state` resume cache at one boundary.
+//!
+//! The row is read back at startup as a single fallible parse: [`from_row`]
+//! either yields a fully-valid [`PersistedPlayback`] or discards the whole cache
+//! (logged once) on any out-of-domain value. No consumer downstream patches a
+//! bad field — by the time the service holds a `PersistedPlayback`, every value
+//! is already in range.
+
+use tracing::warn;
+
+use super::{ContextSnapshot, QueueSnapshot, RepeatMode, Traversal};
+use crate::db::DbPlaybackState;
+
+/// The validated device-local resume cache: a queue snapshot plus the live
+/// position / volume / mute the service replays on startup. Constructed only by
+/// [`PersistedPlayback::from_row`], so holding one means the row parsed cleanly.
+pub struct PersistedPlayback {
+    pub queue: QueueSnapshot,
+    pub position_ms: Option<u64>,
+    pub volume: f32,
+    pub is_muted: bool,
+}
+
+impl PersistedPlayback {
+    /// Parse the raw DB row into a fully-valid shape, or `None` if the row is
+    /// corrupt (the resume cache is then discarded — logged once). Every
+    /// out-of-domain value discards the whole row rather than being patched: the
+    /// row is our own write, so anything out of range means a corrupted local
+    /// cache, and a partial restore is worse than a fresh start.
+    pub fn from_row(row: DbPlaybackState) -> Option<PersistedPlayback> {
+        let manual: Vec<String> = match serde_json::from_str(&row.manual) {
+            Ok(manual) => manual,
+            Err(e) => {
+                warn!("discarding the playback resume cache: manual lane is not valid JSON: {e}");
+                return None;
+            }
+        };
+
+        let repeat = match repeat_from_str(&row.repeat) {
+            Some(repeat) => repeat,
+            None => {
+                warn!(
+                    "discarding the playback resume cache: unrecognized repeat {:?}",
+                    row.repeat
+                );
+                return None;
+            }
+        };
+
+        let context = match row.context {
+            Some(ctx) => {
+                let cursor = match usize::try_from(ctx.cursor) {
+                    Ok(cursor) => cursor,
+                    Err(_) => {
+                        warn!(
+                            "discarding the playback resume cache: negative context cursor {}",
+                            ctx.cursor
+                        );
+                        return None;
+                    }
+                };
+                let traversal = match ctx.shuffle_seed {
+                    Some(seed) => Traversal::Shuffled { seed: seed as u64 },
+                    None => Traversal::Sequential,
+                };
+                Some(ContextSnapshot {
+                    source: ctx.source,
+                    traversal,
+                    cursor,
+                })
+            }
+            None => None,
+        };
+
+        let position_ms = match row.position_ms {
+            Some(position) => match u64::try_from(position) {
+                Ok(position) => Some(position),
+                Err(_) => {
+                    warn!(
+                        "discarding the playback resume cache: negative position {}",
+                        position
+                    );
+                    return None;
+                }
+            },
+            None => None,
+        };
+
+        Some(PersistedPlayback {
+            queue: QueueSnapshot {
+                context,
+                manual,
+                current_track_id: row.current_track_id,
+                repeat,
+            },
+            position_ms,
+            volume: row.volume,
+            is_muted: row.is_muted,
+        })
+    }
+}
+
+/// Serialize `RepeatMode` for the `playback_state.repeat` column.
+pub fn repeat_to_str(mode: RepeatMode) -> &'static str {
+    match mode {
+        RepeatMode::Off => "off",
+        RepeatMode::Track => "track",
+        RepeatMode::Context => "context",
+    }
+}
+
+/// Parse the `playback_state.repeat` column, or `None` for an unrecognized value
+/// (the boundary parse discards the whole cache when this is `None`).
+fn repeat_from_str(s: &str) -> Option<RepeatMode> {
+    match s {
+        "off" => Some(RepeatMode::Off),
+        "track" => Some(RepeatMode::Track),
+        "context" => Some(RepeatMode::Context),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::DbPlaybackContext;
+
+    /// A row with a real context, manual lane, and current track parses into the
+    /// matching `PersistedPlayback`.
+    fn valid_row() -> DbPlaybackState {
+        DbPlaybackState {
+            context: Some(DbPlaybackContext {
+                source: "rel-A".to_string(),
+                shuffle_seed: Some(99),
+                cursor: 2,
+            }),
+            manual: r#"["m1","m2"]"#.to_string(),
+            repeat: "context".to_string(),
+            current_track_id: Some("t3".to_string()),
+            position_ms: Some(42_000),
+            volume: 0.5,
+            is_muted: true,
+        }
+    }
+
+    #[test]
+    fn valid_row_round_trips() {
+        let parsed = PersistedPlayback::from_row(valid_row()).expect("a valid row parses");
+        let context = parsed.queue.context.expect("the context survives");
+        assert_eq!(context.source, "rel-A");
+        assert_eq!(context.cursor, 2);
+        assert!(matches!(
+            context.traversal,
+            Traversal::Shuffled { seed: 99 }
+        ));
+        assert_eq!(parsed.queue.manual, vec!["m1", "m2"]);
+        assert_eq!(parsed.queue.current_track_id.as_deref(), Some("t3"));
+        assert_eq!(parsed.queue.repeat, RepeatMode::Context);
+        assert_eq!(parsed.position_ms, Some(42_000));
+        assert!((parsed.volume - 0.5).abs() < f32::EPSILON);
+        assert!(parsed.is_muted);
+    }
+
+    #[test]
+    fn sequential_context_has_no_seed() {
+        let row = DbPlaybackState {
+            context: Some(DbPlaybackContext {
+                source: "rel-A".to_string(),
+                shuffle_seed: None,
+                cursor: 0,
+            }),
+            ..valid_row()
+        };
+        let parsed = PersistedPlayback::from_row(row).expect("a valid row parses");
+        let context = parsed.queue.context.expect("the context survives");
+        assert!(matches!(context.traversal, Traversal::Sequential));
+    }
+
+    #[test]
+    fn malformed_manual_json_discards_the_row() {
+        let row = DbPlaybackState {
+            manual: "not json".to_string(),
+            ..valid_row()
+        };
+        assert!(PersistedPlayback::from_row(row).is_none());
+    }
+
+    #[test]
+    fn unknown_repeat_discards_the_row() {
+        let row = DbPlaybackState {
+            repeat: "sideways".to_string(),
+            ..valid_row()
+        };
+        assert!(PersistedPlayback::from_row(row).is_none());
+    }
+
+    #[test]
+    fn negative_cursor_discards_the_row() {
+        let row = DbPlaybackState {
+            context: Some(DbPlaybackContext {
+                source: "rel-A".to_string(),
+                shuffle_seed: None,
+                cursor: -1,
+            }),
+            ..valid_row()
+        };
+        assert!(PersistedPlayback::from_row(row).is_none());
+    }
+
+    #[test]
+    fn negative_position_discards_the_row() {
+        let row = DbPlaybackState {
+            position_ms: Some(-1),
+            ..valid_row()
+        };
+        assert!(PersistedPlayback::from_row(row).is_none());
+    }
+}

--- a/bae-core/src/playback/persisted.rs
+++ b/bae-core/src/playback/persisted.rs
@@ -31,7 +31,10 @@ impl PersistedPlayback {
         let manual: Vec<String> = match serde_json::from_str(&row.manual) {
             Ok(manual) => manual,
             Err(e) => {
-                warn!("discarding the playback resume cache: manual lane is not valid JSON: {e}");
+                warn!(
+                    "discarding the playback resume cache: manual lane is not valid JSON ({e}): {:?}",
+                    row.manual
+                );
                 return None;
             }
         };

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -161,6 +161,32 @@ impl PlaybackQueue {
 
     // -- Context ---------------------------------------------------------------
 
+    /// Build a `PlaybackContext` from a release's tracks under a traversal: a
+    /// shuffled traversal re-permutes `tracks` from its seed (the same seed
+    /// yields the same order, so a restored shuffle reproduces what was played);
+    /// a sequential one keeps source order. Mints a fresh per-instance id per
+    /// track and clamps the cursor in range. The caller passes a non-empty
+    /// release, so the context is non-empty with a valid cursor.
+    fn build_context(
+        &self,
+        source: String,
+        mut tracks: Vec<String>,
+        cursor: usize,
+        traversal: Traversal,
+    ) -> PlaybackContext {
+        if let Traversal::Shuffled { seed } = traversal {
+            shuffled_traversal(&mut tracks, seed);
+        }
+        let entries: Vec<QueueEntry> = tracks.into_iter().map(|t| self.mint(t)).collect();
+        let cursor = cursor.min(entries.len() - 1);
+        PlaybackContext {
+            source,
+            entries,
+            cursor,
+            traversal,
+        }
+    }
+
     /// Make a release's tracks the playing context: build their order under
     /// `start`, set the cursor, and make the cursor entry current. Clears the
     /// manual lane (a fresh playback session). Returns the track to play. The
@@ -169,21 +195,15 @@ impl PlaybackQueue {
     pub fn play_release(
         &mut self,
         release_id: String,
-        mut track_ids: Vec<String>,
+        track_ids: Vec<String>,
         start: ContextStart,
     ) -> String {
         self.manual.clear();
         let (cursor, traversal) = match start {
             ContextStart::Index(index) => (index, Traversal::Sequential),
-            ContextStart::Shuffled { seed } => (0, shuffled_traversal(&mut track_ids, seed)),
+            ContextStart::Shuffled { seed } => (0, Traversal::Shuffled { seed }),
         };
-        let entries: Vec<QueueEntry> = track_ids.into_iter().map(|t| self.mint(t)).collect();
-        let context = PlaybackContext {
-            source: release_id,
-            entries,
-            cursor,
-            traversal,
-        };
+        let context = self.build_context(release_id, track_ids, cursor, traversal);
         let track = context.current().track_id.clone();
         self.current = Some(context.current().clone());
         self.context = Some(context);
@@ -226,21 +246,7 @@ impl PlaybackQueue {
         self.manual = snapshot.manual.into_iter().map(|t| self.mint(t)).collect();
         self.context = match snapshot.context {
             Some(cs) if !context_tracks.is_empty() => {
-                let mut tracks = context_tracks;
-                // Re-derive the exact order: shuffled re-permutes from the same
-                // seed; sequential leaves source order.
-                let traversal = match cs.traversal {
-                    Traversal::Shuffled { seed } => shuffled_traversal(&mut tracks, seed),
-                    Traversal::Sequential => Traversal::Sequential,
-                };
-                let entries: Vec<QueueEntry> = tracks.into_iter().map(|t| self.mint(t)).collect();
-                let cursor = cs.cursor.min(entries.len() - 1);
-                Some(PlaybackContext {
-                    source: cs.source,
-                    entries,
-                    cursor,
-                    traversal,
-                })
+                Some(self.build_context(cs.source, context_tracks, cs.cursor, cs.traversal))
             }
             _ => None,
         };

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -255,19 +255,26 @@ impl PlaybackQueue {
             }
             _ => None,
         };
-        // The playing track is a manual entry, the context's cursor entry, or a
-        // standalone single track.
-        self.current = snapshot.current_track_id.map(|tid| {
+        // The playing track is a manual entry or the context's cursor entry. If it
+        // is neither — the track survives but its context was dropped (the release
+        // shrank past the cursor) — resume it as a standalone track.
+        if let Some(tid) = snapshot.current_track_id {
             let from_manual = self.manual.iter().find(|e| e.track_id == tid).cloned();
             let from_context = self
                 .context
                 .as_ref()
                 .filter(|c| c.current().track_id == tid)
                 .map(|c| c.current().clone());
-            from_manual
-                .or(from_context)
-                .unwrap_or_else(|| self.mint(tid))
-        });
+            self.current = Some(from_manual.or(from_context).unwrap_or_else(|| {
+                warn!(
+                    "restored current track {tid:?} is in neither the manual lane nor the \
+                     context cursor; resuming it standalone"
+                );
+                self.mint(tid)
+            }));
+        } else {
+            self.current = None;
+        }
     }
 
     // -- id-based operations across both lanes ---------------------------------

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -45,6 +45,29 @@ enum EntryLocation {
     Context(usize),
 }
 
+/// The persistable view of a playing context (its release and how it's ordered),
+/// without the per-instance entry ids — those are local UI identity, re-minted on
+/// restore. Re-materialized from `source` + `traversal` on load.
+pub struct ContextSnapshot {
+    pub source: String,
+    pub traversal: Traversal,
+    pub cursor: usize,
+}
+
+/// The persistable view of the whole queue. The service pairs this with the live
+/// position / volume / mute to build the `playback_state` row, and on restart
+/// reads the row back into this shape and fetches the context's tracks before
+/// calling [`PlaybackQueue::restore`].
+pub struct QueueSnapshot {
+    /// The playing context, or `None` (a single track, or nothing playing).
+    pub context: Option<ContextSnapshot>,
+    /// The manual lane as track ids in order.
+    pub manual: Vec<String>,
+    /// The track currently playing (resume anchor).
+    pub current_track_id: Option<String>,
+    pub repeat: RepeatMode,
+}
+
 /// The insert index for a reorder, after the source entry at `from` has been
 /// removed from a lane of post-removal length `len`: `before = None` appends at
 /// the end; a `before` position past `from` shifts down by one.
@@ -143,7 +166,12 @@ impl PlaybackQueue {
     /// manual lane (a fresh playback session). Returns the track to play. The
     /// caller passes a non-empty release (and an in-range `Index`); the context
     /// is therefore non-empty with a valid cursor.
-    pub fn play_release(&mut self, mut track_ids: Vec<String>, start: ContextStart) -> String {
+    pub fn play_release(
+        &mut self,
+        release_id: String,
+        mut track_ids: Vec<String>,
+        start: ContextStart,
+    ) -> String {
         self.manual.clear();
         let (cursor, traversal) = match start {
             ContextStart::Index(index) => (index, Traversal::Sequential),
@@ -151,6 +179,7 @@ impl PlaybackQueue {
         };
         let entries: Vec<QueueEntry> = track_ids.into_iter().map(|t| self.mint(t)).collect();
         let context = PlaybackContext {
+            source: release_id,
             entries,
             cursor,
             traversal,
@@ -167,6 +196,67 @@ impl PlaybackQueue {
         self.manual.clear();
         self.context = None;
         self.current = Some(self.mint(track_id));
+    }
+
+    // -- Persistence -----------------------------------------------------------
+
+    /// The persistable view of the queue (track ids and ordering, no entry ids).
+    pub fn snapshot(&self) -> QueueSnapshot {
+        QueueSnapshot {
+            context: self.context.as_ref().map(|ctx| ContextSnapshot {
+                source: ctx.source.clone(),
+                traversal: ctx.traversal,
+                cursor: ctx.cursor,
+            }),
+            manual: self.manual.iter().map(|e| e.track_id.clone()).collect(),
+            current_track_id: self.current.as_ref().map(|e| e.track_id.clone()),
+            repeat: self.repeat,
+        }
+    }
+
+    /// Rebuild from a snapshot. `context_tracks` is the source release's tracks in
+    /// SOURCE order (the service fetched them from the snapshot's context source);
+    /// empty when there is no context. Re-materializes the context order under the
+    /// stored traversal — a shuffled order re-derives identically from its seed, so
+    /// the cursor still lands on the same track — re-instantiates the manual lane
+    /// with fresh entry ids, restores repeat, and sets `current` from
+    /// `current_track_id`.
+    pub fn restore(&mut self, snapshot: QueueSnapshot, context_tracks: Vec<String>) {
+        self.repeat = snapshot.repeat;
+        self.manual = snapshot.manual.into_iter().map(|t| self.mint(t)).collect();
+        self.context = match snapshot.context {
+            Some(cs) if !context_tracks.is_empty() => {
+                let mut tracks = context_tracks;
+                // Re-derive the exact order: shuffled re-permutes from the same
+                // seed; sequential leaves source order.
+                let traversal = match cs.traversal {
+                    Traversal::Shuffled { seed } => shuffled_traversal(&mut tracks, seed),
+                    Traversal::Sequential => Traversal::Sequential,
+                };
+                let entries: Vec<QueueEntry> = tracks.into_iter().map(|t| self.mint(t)).collect();
+                let cursor = cs.cursor.min(entries.len() - 1);
+                Some(PlaybackContext {
+                    source: cs.source,
+                    entries,
+                    cursor,
+                    traversal,
+                })
+            }
+            _ => None,
+        };
+        // The playing track is a manual entry, the context's cursor entry, or a
+        // standalone single track.
+        self.current = snapshot.current_track_id.map(|tid| {
+            let from_manual = self.manual.iter().find(|e| e.track_id == tid).cloned();
+            let from_context = self
+                .context
+                .as_ref()
+                .filter(|c| c.current().track_id == tid)
+                .map(|c| c.current().clone());
+            from_manual
+                .or(from_context)
+                .unwrap_or_else(|| self.mint(tid))
+        });
     }
 
     // -- id-based operations across both lanes ---------------------------------
@@ -620,7 +710,11 @@ mod tests {
     #[test]
     fn test_clear_empties_manual_keeps_context() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(0),
+        );
         q.add_to_queue(rel(&["m1", "m2"]));
         q.clear();
         // Manual gone; context tail (t2, t3) survives.
@@ -651,7 +745,11 @@ mod tests {
     #[test]
     fn test_play_release_sets_current_and_upcoming() {
         let mut q = queue();
-        let first = q.play_release(rel(&["t1", "t2", "t3"]), ContextStart::Index(0));
+        let first = q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(0),
+        );
         assert_eq!(first, "t1");
         assert_eq!(q.current_track_id(), Some("t1"));
         assert_eq!(upcoming_tracks(&q), vec!["t2", "t3"]);
@@ -660,7 +758,11 @@ mod tests {
     #[test]
     fn test_play_release_start_index() {
         let mut q = queue();
-        let first = q.play_release(rel(&["t1", "t2", "t3"]), ContextStart::Index(1));
+        let first = q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(1),
+        );
         assert_eq!(first, "t2");
         assert_eq!(upcoming_tracks(&q), vec!["t3"]);
     }
@@ -669,6 +771,7 @@ mod tests {
     fn test_play_release_shuffled_keeps_all_tracks() {
         let mut q = queue();
         q.play_release(
+            "r1".into(),
             rel(&["t1", "t2", "t3", "t4"]),
             ContextStart::Shuffled { seed: 7 },
         );
@@ -682,6 +785,7 @@ mod tests {
         let order = |seed| {
             let mut q = queue();
             q.play_release(
+                "r1".into(),
                 rel(&["t1", "t2", "t3", "t4", "t5"]),
                 ContextStart::Shuffled { seed },
             );
@@ -698,6 +802,7 @@ mod tests {
     fn test_context_repeat_shuffled_loops_a_re_derived_order() {
         let mut q = queue();
         q.play_release(
+            "r1".into(),
             rel(&["t1", "t2", "t3", "t4", "t5"]),
             ContextStart::Shuffled { seed: 1 },
         );
@@ -723,10 +828,69 @@ mod tests {
         );
     }
 
+    // -- persistence round-trips -----------------------------------------------
+
+    #[test]
+    fn test_snapshot_restore_sequential_context() {
+        let mut q = queue();
+        q.play_release(
+            "rel-A".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(1),
+        );
+        let snap = q.snapshot();
+        assert_eq!(snap.context.as_ref().unwrap().source, "rel-A");
+        assert_eq!(snap.current_track_id.as_deref(), Some("t2"));
+
+        let mut restored = queue();
+        restored.restore(snap, rel(&["t1", "t2", "t3"]));
+        assert_eq!(restored.current_track_id(), Some("t2"));
+        assert_eq!(upcoming_tracks(&restored), vec!["t3"]);
+        assert!(
+            restored.has_previous(),
+            "the cursor (1) restored, so t1 is behind"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_restore_shuffled_keeps_cursor_on_same_track() {
+        let mut q = queue();
+        q.play_release(
+            "rel-A".into(),
+            rel(&["t1", "t2", "t3", "t4", "t5"]),
+            ContextStart::Shuffled { seed: 99 },
+        );
+        q.next_entry();
+        q.next_entry();
+        let current_before = q.current_track_id().unwrap().to_string();
+        let upcoming_before = upcoming_tracks(&q);
+
+        // Restore from the SOURCE order; re-deriving from the same seed reproduces
+        // the shuffled order, so the cursor lands on the same track.
+        let mut restored = queue();
+        restored.restore(q.snapshot(), rel(&["t1", "t2", "t3", "t4", "t5"]));
+        assert_eq!(restored.current_track_id().unwrap(), current_before);
+        assert_eq!(upcoming_tracks(&restored), upcoming_before);
+    }
+
+    #[test]
+    fn test_snapshot_restore_single_track_with_manual_lane() {
+        let mut q = queue();
+        q.play_single("solo".into());
+        q.add_to_queue(rel(&["m1", "m2"]));
+        let snap = q.snapshot();
+        assert!(snap.context.is_none());
+
+        let mut restored = queue();
+        restored.restore(snap, vec![]);
+        assert_eq!(restored.current_track_id(), Some("solo"));
+        assert_eq!(upcoming_tracks(&restored), vec!["m1", "m2"]);
+    }
+
     #[test]
     fn test_manual_drains_before_context() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.add_to_queue(rel(&["m1"]));
         // current = t1; next drains manual (m1) before advancing the context.
         assert!(matches!(q.next_entry(), NextEntry::Play(t) if t == "m1"));
@@ -737,7 +901,11 @@ mod tests {
     #[test]
     fn test_context_advances_by_cursor() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(0),
+        );
         assert!(matches!(q.next_entry(), NextEntry::Play(t) if t == "t2"));
         assert!(matches!(q.next_entry(), NextEntry::Play(t) if t == "t3"));
         assert!(matches!(q.next_entry(), NextEntry::Stop));
@@ -748,7 +916,7 @@ mod tests {
         // The queue holds the context order, so looping reuses it: the queue has
         // no library access, so it structurally cannot re-fetch.
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.set_repeat_mode(RepeatMode::Context);
         assert!(matches!(q.next_entry(), NextEntry::Play(t) if t == "t2"));
         // Exhausted under Context repeat → loop from the start of the same order.
@@ -759,7 +927,7 @@ mod tests {
     #[test]
     fn test_repeat_track_pins_current() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.set_repeat_mode(RepeatMode::Track);
         assert!(matches!(q.next_entry(), NextEntry::RepeatCurrent(t) if t == "t1"));
     }
@@ -767,7 +935,11 @@ mod tests {
     #[test]
     fn test_previous_steps_cursor_back_multiple() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(0),
+        );
         q.next_entry(); // t2
         q.next_entry(); // t3
         assert!(matches!(q.previous_action(1000), PreviousAction::PlayPrevious(t) if t == "t2"));
@@ -782,7 +954,7 @@ mod tests {
     #[test]
     fn test_previous_past_3s_restarts() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(1));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(1));
         assert!(matches!(
             q.previous_action(5000),
             PreviousAction::RestartCurrent
@@ -792,7 +964,11 @@ mod tests {
     #[test]
     fn test_skip_to_context_tail_moves_cursor() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3", "t4"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3", "t4"]),
+            ContextStart::Index(0),
+        );
         let t3_id = q.upcoming()[1].id.clone(); // upcoming = [t2, t3, t4]
         let entry = q.skip_to(&t3_id);
         assert_eq!(entry.map(|e| e.track_id), Some("t3".into()));
@@ -803,7 +979,11 @@ mod tests {
     #[test]
     fn test_remove_context_tail_entry() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(0),
+        );
         let t2_id = q.upcoming()[0].id.clone();
         let removed = q.remove(&t2_id);
         assert_eq!(removed.map(|e| e.track_id), Some("t2".into()));
@@ -813,7 +993,11 @@ mod tests {
     #[test]
     fn test_reorder_context_tail_keeps_cursor() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2", "t3", "t4"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3", "t4"]),
+            ContextStart::Index(0),
+        );
         let up = q.upcoming(); // [t2, t3, t4]
         let t2_id = up[0].id.clone();
         let t3_id = up[1].id.clone();
@@ -830,7 +1014,7 @@ mod tests {
     #[test]
     fn test_reorder_cross_lane_is_noop() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.add_to_queue(rel(&["m1"]));
         let manual_id = manual_ids(&q)[0].clone();
         let context_id = q
@@ -871,7 +1055,11 @@ mod tests {
     #[test]
     fn test_remove_by_ids_clears_manual_and_context() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "dup", "t3"]), ContextStart::Index(0));
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "dup", "t3"]),
+            ContextStart::Index(0),
+        );
         q.add_to_queue(rel(&["dup", "m2"]));
         let ids: HashSet<String> = ["dup"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
@@ -882,7 +1070,11 @@ mod tests {
     #[test]
     fn test_remove_by_ids_keeps_cursor_on_same_track() {
         let mut q = queue();
-        q.play_release(rel(&["gone", "t2", "t3"]), ContextStart::Index(1));
+        q.play_release(
+            "r1".into(),
+            rel(&["gone", "t2", "t3"]),
+            ContextStart::Index(1),
+        );
         // current = t2 (cursor 1). Deleting t1 (before cursor) keeps current at t2.
         let ids: HashSet<String> = ["gone"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
@@ -893,7 +1085,7 @@ mod tests {
     #[test]
     fn test_remove_by_ids_clears_current_when_deleted() {
         let mut q = queue();
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
         let ids: HashSet<String> = ["t1"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
         assert_eq!(q.current_track_id(), None);
@@ -903,7 +1095,7 @@ mod tests {
     fn test_remove_by_ids_deleting_current_last_entry_keeps_cursor_valid() {
         let mut q = queue();
         // current = t2 at the last position (cursor == len-1).
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(1));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(1));
         let ids: HashSet<String> = ["t2"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
         assert_eq!(
@@ -936,7 +1128,7 @@ mod tests {
         let mut q = queue();
         assert!(!q.has_upcoming());
         assert!(!q.has_previous());
-        q.play_release(rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
         assert!(q.has_upcoming());
         assert!(!q.has_previous());
         q.next_entry(); // → t2

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -165,8 +165,10 @@ impl PlaybackQueue {
     /// shuffled traversal re-permutes `tracks` from its seed (the same seed
     /// yields the same order, so a restored shuffle reproduces what was played);
     /// a sequential one keeps source order. Mints a fresh per-instance id per
-    /// track and clamps the cursor in range. The caller passes a non-empty
-    /// release, so the context is non-empty with a valid cursor.
+    /// track. The caller passes a non-empty release and an in-range `cursor`
+    /// (`play_release` validates its index; `restore` validates the saved
+    /// cursor against the re-fetched tracks), so the context is non-empty with
+    /// a valid cursor.
     fn build_context(
         &self,
         source: String,
@@ -178,7 +180,10 @@ impl PlaybackQueue {
             shuffled_traversal(&mut tracks, seed);
         }
         let entries: Vec<QueueEntry> = tracks.into_iter().map(|t| self.mint(t)).collect();
-        let cursor = cursor.min(entries.len() - 1);
+        debug_assert!(
+            cursor < entries.len(),
+            "caller must pass an in-range cursor"
+        );
         PlaybackContext {
             source,
             entries,

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -27,7 +27,7 @@ use super::{
     QueueSnapshot, Traversal,
 };
 use crate::audio_codec::StreamingDecodeError;
-use crate::db::DbPlaybackState;
+use crate::db::{DbPlaybackContext, DbPlaybackState};
 use crate::library::LibraryEvent;
 use crate::library::LibraryManager;
 use crate::library::ResolvedTrackAudio;
@@ -1291,8 +1291,12 @@ impl PlaybackService {
                     last_position_display,
                     boundary_tx,
                 };
-                if let Some(state) = service.library_manager.load_playback_state().await {
-                    service.restore(state).await;
+                match service.library_manager.load_playback_state().await {
+                    Ok(Some(state)) => service.restore(state).await,
+                    Ok(None) => {}
+                    Err(e) => {
+                        warn!("couldn't load the saved playback state: {e}; starting fresh")
+                    }
                 }
                 service.run().await;
             });
@@ -1314,13 +1318,13 @@ impl PlaybackService {
         // Rebuild the queue: re-materialize the context from its source release's
         // current tracks (deleted tracks fall out of `get_track_ids`), under the
         // stored traversal, plus the manual lane and current track.
-        let context = state.source.clone().map(|source| ContextSnapshot {
-            source,
-            traversal: match state.shuffle_seed {
+        let context = state.context.clone().map(|ctx| ContextSnapshot {
+            source: ctx.source,
+            traversal: match ctx.shuffle_seed {
                 Some(seed) => Traversal::Shuffled { seed: seed as u64 },
                 None => Traversal::Sequential,
             },
-            cursor: state.cursor.unwrap_or(0).max(0) as usize,
+            cursor: ctx.cursor.max(0) as usize,
         });
         let mut manual: Vec<String> = serde_json::from_str(&state.manual).unwrap_or_else(|e| {
             warn!("playback_state.manual is not valid JSON ({e}); restoring an empty manual lane");
@@ -1340,6 +1344,11 @@ impl PlaybackService {
             .await
         {
             Ok(existing) => {
+                let dropped: Vec<&String> =
+                    to_check.iter().filter(|t| !existing.contains(*t)).collect();
+                if !dropped.is_empty() {
+                    warn!("dropping playback tracks deleted from the library: {dropped:?}");
+                }
                 manual.retain(|t| existing.contains(t));
                 current_track_id = current_track_id.filter(|t| existing.contains(t));
             }
@@ -1426,30 +1435,32 @@ impl PlaybackService {
     /// Build the device-local `playback_state` row from the current queue and
     /// playback state, and save it — or clear it when playback has stopped. The
     /// queue is device-local; this never syncs.
+    ///
+    /// The write is logged-best-effort, not propagated as fatal: a failed
+    /// resume-cache write only costs the resume point; playback is unaffected.
+    /// The log is the never-mask escape hatch — a write failure is recorded, not
+    /// conflated with "nothing was playing".
     async fn persist_playback_state(&self) {
         use crate::playback::audio_output::AudioState;
         if self.audio_output.get_state() == AudioState::Stopped {
-            self.library_manager.clear_playback_state().await;
+            if let Err(e) = self.library_manager.clear_playback_state().await {
+                warn!("couldn't clear playback state: {e}");
+            }
             return;
         }
         let snap = self.playback_queue.snapshot();
-        let (source, shuffle_seed, cursor) = match snap.context {
-            Some(ctx) => (
-                Some(ctx.source),
-                match ctx.traversal {
-                    Traversal::Shuffled { seed } => Some(seed as i64),
-                    Traversal::Sequential => None,
-                },
-                Some(ctx.cursor as i64),
-            ),
-            None => (None, None, None),
-        };
+        let context = snap.context.map(|ctx| DbPlaybackContext {
+            source: ctx.source,
+            shuffle_seed: match ctx.traversal {
+                Traversal::Shuffled { seed } => Some(seed as i64),
+                Traversal::Sequential => None,
+            },
+            cursor: ctx.cursor as i64,
+        });
         let position_ms =
             (*self.current_position_shared.lock().unwrap()).map(|d| d.as_millis() as i64);
         let row = DbPlaybackState {
-            source,
-            shuffle_seed,
-            cursor,
+            context,
             manual: serde_json::to_string(&snap.manual)
                 .expect("serializing a Vec<String> to JSON cannot fail"),
             repeat: repeat_to_str(snap.repeat).to_string(),
@@ -1462,7 +1473,9 @@ impl PlaybackService {
             },
             is_muted: self.is_muted,
         };
-        self.library_manager.save_playback_state(&row).await;
+        if let Err(e) = self.library_manager.save_playback_state(&row).await {
+            warn!("couldn't persist playback state: {e}");
+        }
     }
 
     async fn run(&mut self) {

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -1554,7 +1554,6 @@ impl PlaybackService {
                 }
                 PlaybackCommand::Stop => {
                     self.stop().await;
-                    self.persist_playback_state().await;
                 }
                 PlaybackCommand::Next => {
                     info!("Next command received");
@@ -2295,6 +2294,9 @@ impl PlaybackService {
         if let Some(following) = self.playback_queue.front().map(str::to_string) {
             self.preload_next_track(&following).await;
         }
+
+        // The gapless boundary advanced the current track without play_track.
+        self.persist_playback_state().await;
     }
 
     /// Advance the queue's current pointer past the finished track to the front
@@ -2417,6 +2419,10 @@ impl PlaybackService {
         if let Some(next_track_id) = self.playback_queue.front().map(str::to_string) {
             self.preload_next_track(&next_track_id).await;
         }
+
+        // The preloaded advance doesn't go through play_track, so persist the
+        // now-playing track here.
+        self.persist_playback_state().await;
     }
 
     /// Pause main player for preview. Called after all fallible setup so that
@@ -2910,6 +2916,10 @@ impl PlaybackService {
                 state: PlaybackState::Stopped,
             },
         );
+        // Audio is now Stopped, so this clears the durable row — covering every
+        // stop path (natural end, halt-on-error, the current track removed),
+        // not just the explicit Stop command.
+        self.persist_playback_state().await;
     }
     async fn seek(&mut self, position: std::time::Duration) {
         // Verify streaming state is available

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -23,8 +23,8 @@
 
 use super::RepeatMode;
 use super::{
-    ContextSnapshot, ContextStart, NextEntry, PlaybackQueue, PreviousAction, QueueEntryId,
-    QueueSnapshot, Traversal,
+    repeat_to_str, ContextStart, NextEntry, PersistedPlayback, PlaybackQueue, PreviousAction,
+    QueueEntryId, QueueSnapshot, Traversal,
 };
 use crate::audio_codec::StreamingDecodeError;
 use crate::db::{DbPlaybackContext, DbPlaybackState};
@@ -1292,7 +1292,13 @@ impl PlaybackService {
                     boundary_tx,
                 };
                 match service.library_manager.load_playback_state().await {
-                    Ok(Some(state)) => service.restore(state).await,
+                    // A corrupt row is discarded by `from_row` (logged there);
+                    // we start fresh.
+                    Ok(Some(state)) => {
+                        if let Some(parsed) = PersistedPlayback::from_row(state) {
+                            service.restore(parsed).await;
+                        }
+                    }
                     Ok(None) => {}
                     Err(e) => {
                         warn!("couldn't load the saved playback state: {e}; starting fresh")
@@ -1304,72 +1310,81 @@ impl PlaybackService {
         handle
     }
 
-    /// Restore playback state from a saved snapshot.
-    /// Validates track IDs against the DB, sets volume/repeat/queue,
-    /// and if the current track is valid, starts it paused at the saved position.
+    /// Restore playback from the validated device-local resume cache.
+    ///
+    /// Atomic: every fallible step (fetching the context's tracks, validating the
+    /// queue against library deletions) runs *before* anything touches the queue
+    /// or audio. A DB error abandons the whole restore — the queue is left empty
+    /// (a fresh start), never half-populated. Only once all fetches succeed does
+    /// the commit run, and the commit is infallible — `parsed` is already
+    /// fully-valid, so no field needs defaulting.
+    ///
     /// StateChanged emissions are suppressed because the UI isn't ready yet;
     /// display state is written to the shared Arc for the UI to query later.
-    async fn restore(&mut self, state: DbPlaybackState) {
+    async fn restore(&mut self, parsed: PersistedPlayback) {
         info!(
             "Restoring playback state: track={:?}",
-            state.current_track_id
+            parsed.queue.current_track_id
         );
 
-        // Rebuild the queue: re-materialize the context from its source release's
-        // current tracks (deleted tracks fall out of `get_track_ids`), under the
-        // stored traversal, plus the manual lane and current track.
-        let context = state.context.clone().map(|ctx| ContextSnapshot {
-            source: ctx.source,
-            traversal: match ctx.shuffle_seed {
-                Some(seed) => Traversal::Shuffled { seed: seed as u64 },
-                None => Traversal::Sequential,
+        // -- All fallible work first; the queue is untouched until it succeeds. --
+
+        // Re-materialize the context from its source release's current tracks
+        // (deleted tracks fall out of `get_track_ids`). A fetch error abandons the
+        // restore; an empty result means the source release is gone, so we drop
+        // the context and restore the manual lane only.
+        let (context, context_tracks) = match &parsed.queue.context {
+            Some(cs) => match self.library_manager.get_track_ids(&cs.source).await {
+                Ok(tracks) if tracks.is_empty() => {
+                    debug!(
+                        "resume context release {} is gone; restoring the manual lane only",
+                        cs.source
+                    );
+                    (None, Vec::new())
+                }
+                Ok(tracks) => (parsed.queue.context, tracks),
+                Err(e) => {
+                    warn!("couldn't load the resume context tracks: {e}; starting fresh");
+                    return;
+                }
             },
-            cursor: ctx.cursor.max(0) as usize,
-        });
-        let mut manual: Vec<String> = serde_json::from_str(&state.manual).unwrap_or_else(|e| {
-            warn!("playback_state.manual is not valid JSON ({e}); restoring an empty manual lane");
-            Vec::new()
-        });
-        let mut current_track_id = state.current_track_id.clone();
-        let repeat = repeat_from_str(&state.repeat);
+            None => (None, Vec::new()),
+        };
 
         // Drop manual-lane tracks and a current track that were deleted from the
-        // library between sessions (the context re-fetch below already excludes
-        // deleted context tracks).
-        let mut to_check = manual.clone();
-        to_check.extend(current_track_id.clone());
-        match self
+        // library between sessions (deleted context tracks already fell out of the
+        // re-fetch above). A validation error abandons the restore.
+        let mut to_check = parsed.queue.manual.clone();
+        to_check.extend(parsed.queue.current_track_id.clone());
+        let existing = match self
             .library_manager
             .filter_existing_track_ids(&to_check)
             .await
         {
-            Ok(existing) => {
-                let dropped: Vec<&String> =
-                    to_check.iter().filter(|t| !existing.contains(*t)).collect();
-                if !dropped.is_empty() {
-                    warn!("dropping playback tracks deleted from the library: {dropped:?}");
-                }
-                manual.retain(|t| existing.contains(t));
-                current_track_id = current_track_id.filter(|t| existing.contains(t));
-            }
+            Ok(existing) => existing,
             Err(e) => {
-                warn!("couldn't validate restored tracks against deletions: {e}; restoring as-is")
+                warn!("couldn't validate restored tracks against deletions: {e}; starting fresh");
+                return;
             }
-        }
-
-        let context_tracks = match &context {
-            Some(cs) => match self.library_manager.get_track_ids(&cs.source).await {
-                Ok(tracks) => tracks,
-                Err(e) => {
-                    warn!(
-                        "couldn't load context tracks for {}: {e}; restoring without a context",
-                        cs.source
-                    );
-                    Vec::new()
-                }
-            },
-            None => Vec::new(),
         };
+        let dropped: Vec<&String> = to_check.iter().filter(|t| !existing.contains(*t)).collect();
+        if !dropped.is_empty() {
+            warn!("dropping playback tracks deleted from the library: {dropped:?}");
+        }
+        let manual: Vec<String> = parsed
+            .queue
+            .manual
+            .into_iter()
+            .filter(|t| existing.contains(t))
+            .collect();
+        let current_track_id = parsed
+            .queue
+            .current_track_id
+            .filter(|t| existing.contains(t));
+        let repeat = parsed.queue.repeat;
+
+        // -- Commit (infallible): everything below applies validated state. --
+
         self.playback_queue.restore(
             QueueSnapshot {
                 context,
@@ -1385,16 +1400,16 @@ impl PlaybackService {
         );
 
         // Volume + mute.
-        self.audio_output.set_volume(state.volume);
+        self.audio_output.set_volume(parsed.volume);
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::VolumeChanged {
-                volume: state.volume,
+                volume: parsed.volume,
             },
         );
-        if state.is_muted {
+        if parsed.is_muted {
             self.is_muted = true;
-            self.pre_mute_volume = state.volume;
+            self.pre_mute_volume = parsed.volume;
             self.audio_output.set_volume(0.0);
             emit_progress(
                 &self.progress_tx,
@@ -1414,12 +1429,14 @@ impl PlaybackService {
                 .set_state(crate::playback::audio_output::AudioState::Paused);
             self.play_track(&track_id, false, true).await;
 
-            let position_ms = state.position_ms.unwrap_or(0).max(0) as u64;
+            let position_ms = parsed.position_ms.unwrap_or(0);
             let position = std::time::Duration::from_millis(position_ms);
             if !position.is_zero() {
                 self.seek(position).await;
             }
-            // Always emit the position display so late-mounting views can query it.
+            // Always emit the position display so late-mounting views can query
+            // it. Until the live position is set, fall back to the position we
+            // just restored to — that's the value the seek landed on, not a mask.
             let actual_pos = self
                 .current_position_shared
                 .lock()
@@ -3122,29 +3139,6 @@ impl PlaybackService {
         }
         let event = PlaybackProgress::QueueItemsAdded { count };
         let _ = self.progress_tx.send(event);
-    }
-}
-
-/// Serialize `RepeatMode` for the `playback_state.repeat` column.
-fn repeat_to_str(mode: RepeatMode) -> &'static str {
-    match mode {
-        RepeatMode::Off => "off",
-        RepeatMode::Track => "track",
-        RepeatMode::Context => "context",
-    }
-}
-
-/// Parse the `playback_state.repeat` column. The column is our own write, so an
-/// unrecognized value means a corrupted local row — log it and fall back to Off.
-fn repeat_from_str(s: &str) -> RepeatMode {
-    match s {
-        "track" => RepeatMode::Track,
-        "context" => RepeatMode::Context,
-        "off" => RepeatMode::Off,
-        other => {
-            warn!("playback_state.repeat has an unrecognized value {other:?}; using Off");
-            RepeatMode::Off
-        }
     }
 }
 

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -1292,13 +1292,16 @@ impl PlaybackService {
                     boundary_tx,
                 };
                 match service.library_manager.load_playback_state().await {
-                    // A corrupt row is discarded by `from_row` (logged there);
-                    // we start fresh.
-                    Ok(Some(state)) => {
-                        if let Some(parsed) = PersistedPlayback::from_row(state) {
-                            service.restore(parsed).await;
+                    Ok(Some(state)) => match PersistedPlayback::from_row(state) {
+                        Some(parsed) => service.restore(parsed).await,
+                        // The row was corrupt (logged in `from_row`). Delete it so
+                        // the bad row doesn't linger durably across restarts.
+                        None => {
+                            if let Err(e) = service.library_manager.clear_playback_state().await {
+                                warn!("couldn't clear the corrupt playback resume cache: {e}");
+                            }
                         }
-                    }
+                    },
                     Ok(None) => {}
                     Err(e) => {
                         warn!("couldn't load the saved playback state: {e}; starting fresh")
@@ -1454,18 +1457,17 @@ impl PlaybackService {
                     self.seek(std::time::Duration::from_millis(pos)).await;
                 }
             }
-            // Always emit the position display so late-mounting views can query
-            // it. Until the live position is set, fall back to the position we
-            // just restored to (0 when we didn't seek) — that's the value the
-            // seek landed on, not a mask.
-            let actual_pos = self
-                .current_position_shared
-                .lock()
-                .unwrap()
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(parsed.position_ms.unwrap_or(0));
-            self.emit_position_display(actual_pos, track_id);
+            // Emit the position we restored to so late-mounting views can read it
+            // on mount. `None` means none was captured — the track's start (0).
+            let restored_pos = parsed.position_ms.unwrap_or(0);
+            self.emit_position_display(restored_pos, track_id);
         }
+
+        // Write the reconciled state back: dropping a dead context or
+        // library-deleted tracks corrected the in-memory queue, so persist makes
+        // that correction durable now (or clears the row if nothing is playing)
+        // rather than leaving the saved row stale until the next change.
+        self.persist_playback_state().await;
 
         info!("Playback state restored");
     }

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -1356,7 +1356,10 @@ impl PlaybackService {
                 }
                 Ok(tracks) => (parsed.queue.context, tracks),
                 Err(e) => {
-                    warn!("couldn't load the resume context tracks: {e}; starting fresh");
+                    warn!(
+                        "couldn't load the resume context tracks for {}: {e}; starting fresh",
+                        cs.source
+                    );
                     return;
                 }
             },
@@ -1375,7 +1378,10 @@ impl PlaybackService {
         {
             Ok(existing) => existing,
             Err(e) => {
-                warn!("couldn't validate restored tracks against deletions: {e}; starting fresh");
+                warn!(
+                    "couldn't validate restored tracks {to_check:?} against deletions: {e}; \
+                     starting fresh"
+                );
                 return;
             }
         };
@@ -1506,7 +1512,10 @@ impl PlaybackService {
             is_muted: self.is_muted,
         };
         if let Err(e) = self.library_manager.save_playback_state(&row).await {
-            warn!("couldn't persist playback state: {e}");
+            warn!(
+                "couldn't persist playback state (current track {:?}): {e}",
+                row.current_track_id
+            );
         }
     }
 

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -1331,13 +1331,25 @@ impl PlaybackService {
 
         // Re-materialize the context from its source release's current tracks
         // (deleted tracks fall out of `get_track_ids`). A fetch error abandons the
-        // restore; an empty result means the source release is gone, so we drop
-        // the context and restore the manual lane only.
+        // restore; an empty result means the source release is gone; a result
+        // shorter than the saved cursor means the release shrank below where we
+        // were playing. Either way we drop the context and restore the manual
+        // lane only, so `build_context` only ever sees an in-range cursor.
         let (context, context_tracks) = match &parsed.queue.context {
             Some(cs) => match self.library_manager.get_track_ids(&cs.source).await {
                 Ok(tracks) if tracks.is_empty() => {
                     debug!(
                         "resume context release {} is gone; restoring the manual lane only",
+                        cs.source
+                    );
+                    (None, Vec::new())
+                }
+                Ok(tracks) if cs.cursor >= tracks.len() => {
+                    warn!(
+                        "saved cursor {} is past the {} current tracks of {}; \
+                         restoring the manual lane only",
+                        cs.cursor,
+                        tracks.len(),
                         cs.source
                     );
                     (None, Vec::new())
@@ -1429,20 +1441,23 @@ impl PlaybackService {
                 .set_state(crate::playback::audio_output::AudioState::Paused);
             self.play_track(&track_id, false, true).await;
 
-            let position_ms = parsed.position_ms.unwrap_or(0);
-            let position = std::time::Duration::from_millis(position_ms);
-            if !position.is_zero() {
-                self.seek(position).await;
+            // A missing position means none was captured: resume from the start,
+            // don't force a seek to 0.
+            if let Some(pos) = parsed.position_ms {
+                if pos > 0 {
+                    self.seek(std::time::Duration::from_millis(pos)).await;
+                }
             }
             // Always emit the position display so late-mounting views can query
             // it. Until the live position is set, fall back to the position we
-            // just restored to — that's the value the seek landed on, not a mask.
+            // just restored to (0 when we didn't seek) — that's the value the
+            // seek landed on, not a mask.
             let actual_pos = self
                 .current_position_shared
                 .lock()
                 .unwrap()
                 .map(|d| d.as_millis() as u64)
-                .unwrap_or(position_ms);
+                .unwrap_or(parsed.position_ms.unwrap_or(0));
             self.emit_position_display(actual_pos, track_id);
         }
 

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -22,8 +22,12 @@
 //! 8. Send `Seeked` progress event
 
 use super::RepeatMode;
-use super::{ContextStart, NextEntry, PlaybackQueue, PreviousAction, QueueEntryId};
+use super::{
+    ContextSnapshot, ContextStart, NextEntry, PlaybackQueue, PreviousAction, QueueEntryId,
+    QueueSnapshot, Traversal,
+};
 use crate::audio_codec::StreamingDecodeError;
+use crate::db::DbPlaybackState;
 use crate::library::LibraryEvent;
 use crate::library::LibraryManager;
 use crate::library::ResolvedTrackAudio;
@@ -43,17 +47,6 @@ use std::sync::{mpsc, Arc, Mutex};
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace, warn};
-
-/// Snapshot of current playback state for persistence.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct PlaybackSnapshot {
-    pub track_id: String,
-    pub position_ms: u64,
-    pub queue: Vec<String>,
-    pub volume: f32,
-    pub repeat_mode: RepeatMode,
-    pub is_muted: bool,
-}
 
 fn log_streaming_decode_failure(context: &str, error: StreamingDecodeError) -> Option<String> {
     match error {
@@ -1298,8 +1291,8 @@ impl PlaybackService {
                     last_position_display,
                     boundary_tx,
                 };
-                if let Some(snapshot) = service.library_manager.load_playback_state() {
-                    service.restore(snapshot).await;
+                if let Some(state) = service.library_manager.load_playback_state().await {
+                    service.restore(state).await;
                 }
                 service.run().await;
             });
@@ -1312,46 +1305,87 @@ impl PlaybackService {
     /// and if the current track is valid, starts it paused at the saved position.
     /// StateChanged emissions are suppressed because the UI isn't ready yet;
     /// display state is written to the shared Arc for the UI to query later.
-    async fn restore(&mut self, snapshot: PlaybackSnapshot) {
-        info!("Restoring playback state: track={}", snapshot.track_id);
+    async fn restore(&mut self, state: DbPlaybackState) {
+        info!(
+            "Restoring playback state: track={:?}",
+            state.current_track_id
+        );
 
-        // Validate the current track and queue in one DB round-trip.
-        let mut ids_to_check = Vec::with_capacity(snapshot.queue.len() + 1);
-        ids_to_check.push(snapshot.track_id.clone());
-        ids_to_check.extend(snapshot.queue.iter().cloned());
-        let existing: HashSet<String> = match self
+        // Rebuild the queue: re-materialize the context from its source release's
+        // current tracks (deleted tracks fall out of `get_track_ids`), under the
+        // stored traversal, plus the manual lane and current track.
+        let context = state.source.clone().map(|source| ContextSnapshot {
+            source,
+            traversal: match state.shuffle_seed {
+                Some(seed) => Traversal::Shuffled { seed: seed as u64 },
+                None => Traversal::Sequential,
+            },
+            cursor: state.cursor.unwrap_or(0).max(0) as usize,
+        });
+        let mut manual: Vec<String> = serde_json::from_str(&state.manual).unwrap_or_else(|e| {
+            warn!("playback_state.manual is not valid JSON ({e}); restoring an empty manual lane");
+            Vec::new()
+        });
+        let mut current_track_id = state.current_track_id.clone();
+        let repeat = repeat_from_str(&state.repeat);
+
+        // Drop manual-lane tracks and a current track that were deleted from the
+        // library between sessions (the context re-fetch below already excludes
+        // deleted context tracks).
+        let mut to_check = manual.clone();
+        to_check.extend(current_track_id.clone());
+        match self
             .library_manager
-            .filter_existing_track_ids(&ids_to_check)
+            .filter_existing_track_ids(&to_check)
             .await
         {
-            Ok(ids) => ids.into_iter().collect(),
-            Err(e) => {
-                error!("Failed to validate restored track IDs: {e}");
-                HashSet::new()
+            Ok(existing) => {
+                manual.retain(|t| existing.contains(t));
+                current_track_id = current_track_id.filter(|t| existing.contains(t));
             }
+            Err(e) => {
+                warn!("couldn't validate restored tracks against deletions: {e}; restoring as-is")
+            }
+        }
+
+        let context_tracks = match &context {
+            Some(cs) => match self.library_manager.get_track_ids(&cs.source).await {
+                Ok(tracks) => tracks,
+                Err(e) => {
+                    warn!(
+                        "couldn't load context tracks for {}: {e}; restoring without a context",
+                        cs.source
+                    );
+                    Vec::new()
+                }
+            },
+            None => Vec::new(),
         };
+        self.playback_queue.restore(
+            QueueSnapshot {
+                context,
+                manual,
+                current_track_id,
+                repeat,
+            },
+            context_tracks,
+        );
+        emit_progress(
+            &self.progress_tx,
+            PlaybackProgress::RepeatModeChanged { mode: repeat },
+        );
 
-        let current_valid = existing.contains(&snapshot.track_id);
-        let valid_queue: Vec<String> = snapshot
-            .queue
-            .iter()
-            .filter(|id| existing.contains(*id))
-            .cloned()
-            .collect();
-
-        // Set volume
-        self.audio_output.set_volume(snapshot.volume);
+        // Volume + mute.
+        self.audio_output.set_volume(state.volume);
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::VolumeChanged {
-                volume: snapshot.volume,
+                volume: state.volume,
             },
         );
-
-        // Set mute state
-        if snapshot.is_muted {
+        if state.is_muted {
             self.is_muted = true;
-            self.pre_mute_volume = snapshot.volume;
+            self.pre_mute_volume = state.volume;
             self.audio_output.set_volume(0.0);
             emit_progress(
                 &self.progress_tx,
@@ -1359,53 +1393,76 @@ impl PlaybackService {
             );
         }
 
-        // Set repeat mode
-        self.playback_queue.set_repeat_mode(snapshot.repeat_mode);
-        emit_progress(
-            &self.progress_tx,
-            PlaybackProgress::RepeatModeChanged {
-                mode: snapshot.repeat_mode,
-            },
-        );
+        self.emit_queue_update();
 
-        // Restore the current track and its saved upcoming list as the manual
-        // lane. The flat snapshot doesn't carry which release was playing, so no
-        // release context is reconstructed — only the current track and the
-        // upcoming track ids are.
-        if current_valid {
-            self.playback_queue.play_single(snapshot.track_id.clone());
-            self.playback_queue.add_to_queue(valid_queue);
-            self.emit_queue_update();
-            // Set audio state to Paused before play_track so preserve_paused keeps it
+        // Start the current track paused at the saved position, if there is one.
+        if let Some(track_id) = self
+            .playback_queue
+            .current_track_id()
+            .map(|s| s.to_string())
+        {
             self.audio_output
                 .set_state(crate::playback::audio_output::AudioState::Paused);
-            self.play_track(&snapshot.track_id, false, true).await;
+            self.play_track(&track_id, false, true).await;
 
-            let position = std::time::Duration::from_millis(snapshot.position_ms);
-
-            // Seek to the saved position if non-zero. When seek runs it will
-            // emit via emit_position_display itself.
+            let position_ms = state.position_ms.unwrap_or(0).max(0) as u64;
+            let position = std::time::Duration::from_millis(position_ms);
             if !position.is_zero() {
                 self.seek(position).await;
             }
-
-            // Always emit the current position display so late-mounting views
-            // (e.g. the progress NSView created after launch) can query
-            // last_position_display on creation. This covers the zero-position
-            // case and the near-zero case where seek() short-circuits.
+            // Always emit the position display so late-mounting views can query it.
             let actual_pos = self
                 .current_position_shared
                 .lock()
                 .unwrap()
                 .map(|d| d.as_millis() as u64)
-                .unwrap_or(snapshot.position_ms);
-            self.emit_position_display(actual_pos, snapshot.track_id.clone());
-        } else if !valid_queue.is_empty() {
-            self.playback_queue.add_to_queue(valid_queue);
-            self.emit_queue_update();
+                .unwrap_or(position_ms);
+            self.emit_position_display(actual_pos, track_id);
         }
 
         info!("Playback state restored");
+    }
+
+    /// Build the device-local `playback_state` row from the current queue and
+    /// playback state, and save it — or clear it when playback has stopped. The
+    /// queue is device-local; this never syncs.
+    async fn persist_playback_state(&self) {
+        use crate::playback::audio_output::AudioState;
+        if self.audio_output.get_state() == AudioState::Stopped {
+            self.library_manager.clear_playback_state().await;
+            return;
+        }
+        let snap = self.playback_queue.snapshot();
+        let (source, shuffle_seed, cursor) = match snap.context {
+            Some(ctx) => (
+                Some(ctx.source),
+                match ctx.traversal {
+                    Traversal::Shuffled { seed } => Some(seed as i64),
+                    Traversal::Sequential => None,
+                },
+                Some(ctx.cursor as i64),
+            ),
+            None => (None, None, None),
+        };
+        let position_ms =
+            (*self.current_position_shared.lock().unwrap()).map(|d| d.as_millis() as i64);
+        let row = DbPlaybackState {
+            source,
+            shuffle_seed,
+            cursor,
+            manual: serde_json::to_string(&snap.manual)
+                .expect("serializing a Vec<String> to JSON cannot fail"),
+            repeat: repeat_to_str(snap.repeat).to_string(),
+            current_track_id: snap.current_track_id,
+            position_ms,
+            volume: if self.is_muted {
+                self.pre_mute_volume
+            } else {
+                self.audio_output.get_volume()
+            },
+            is_muted: self.is_muted,
+        };
+        self.library_manager.save_playback_state(&row).await;
     }
 
     async fn run(&mut self) {
@@ -1428,8 +1485,11 @@ impl PlaybackService {
                     // context, with the cursor at the chosen track.
                     match self.library_manager.get_play_context(&track_id).await {
                         Ok(context) => {
-                            self.playback_queue
-                                .play_release(context.track_ids, ContextStart::Index(context.index));
+                            self.playback_queue.play_release(
+                                context.release_id,
+                                context.track_ids,
+                                ContextStart::Index(context.index),
+                            );
                         }
                         Err(e) => {
                             warn!(
@@ -1480,7 +1540,9 @@ impl PlaybackService {
                         };
                         ContextStart::Index(index)
                     };
-                    let first_track = self.playback_queue.play_release(track_ids, start);
+                    let first_track = self
+                        .playback_queue
+                        .play_release(release_id, track_ids, start);
                     self.emit_queue_update();
                     self.play_track(&first_track, false, false).await;
                 }
@@ -1492,6 +1554,7 @@ impl PlaybackService {
                 }
                 PlaybackCommand::Stop => {
                     self.stop().await;
+                    self.persist_playback_state().await;
                 }
                 PlaybackCommand::Next => {
                     info!("Next command received");
@@ -1755,6 +1818,7 @@ impl PlaybackService {
                             PlaybackProgress::RepeatModeChanged { mode },
                         );
                         self.emit_queue_update();
+                        self.persist_playback_state().await;
                     }
                 }
                 PlaybackCommand::CycleRepeatMode => {
@@ -1769,6 +1833,7 @@ impl PlaybackService {
                         PlaybackProgress::RepeatModeChanged { mode: next },
                     );
                     self.emit_queue_update();
+                    self.persist_playback_state().await;
                 }
                 PlaybackCommand::SkipTo(entry_id) => {
                     if let Some(entry) = self.playback_queue.skip_to(&entry_id) {
@@ -1812,16 +1877,12 @@ impl PlaybackService {
                     let _ = reply.send(self.audio_output.get_volume());
                 }
                 PlaybackCommand::Shutdown(reply) => {
-                    if let Some(snapshot) = self.build_snapshot() {
-                        self.library_manager.save_playback_state(&snapshot);
-                    }
+                    self.persist_playback_state().await;
                     let _ = reply.send(());
                     break;
                 }
                 PlaybackCommand::SaveState(reply) => {
-                    if let Some(snapshot) = self.build_snapshot() {
-                        self.library_manager.save_playback_state(&snapshot);
-                    }
+                    self.persist_playback_state().await;
                     let _ = reply.send(());
                 }
             }
@@ -1994,6 +2055,9 @@ impl PlaybackService {
         if let Some(next_id) = self.playback_queue.front().map(str::to_string) {
             self.preload_next_track(&next_id).await;
         }
+
+        // Persist the now-playing state so a restart on this device resumes here.
+        self.persist_playback_state().await;
     }
     /// Preload the next track for gapless playback.
     /// This eagerly starts the decoder so samples are ready when we switch tracks.
@@ -3012,6 +3076,7 @@ impl PlaybackService {
     async fn on_queue_mutated(&mut self) {
         self.refresh_preload_for_queue_front().await;
         self.emit_queue_update();
+        self.persist_playback_state().await;
     }
 
     fn emit_queue_update(&self) {
@@ -3035,36 +3100,28 @@ impl PlaybackService {
         let event = PlaybackProgress::QueueItemsAdded { count };
         let _ = self.progress_tx.send(event);
     }
+}
 
-    /// Build a snapshot of the current playback state for persistence.
-    /// Returns None if nothing is playing or paused.
-    fn build_snapshot(&self) -> Option<PlaybackSnapshot> {
-        use crate::playback::audio_output::AudioState;
-        let state = self.audio_output.get_state();
-        if state == AudioState::Stopped {
-            return None;
+/// Serialize `RepeatMode` for the `playback_state.repeat` column.
+fn repeat_to_str(mode: RepeatMode) -> &'static str {
+    match mode {
+        RepeatMode::Off => "off",
+        RepeatMode::Track => "track",
+        RepeatMode::Context => "context",
+    }
+}
+
+/// Parse the `playback_state.repeat` column. The column is our own write, so an
+/// unrecognized value means a corrupted local row — log it and fall back to Off.
+fn repeat_from_str(s: &str) -> RepeatMode {
+    match s {
+        "track" => RepeatMode::Track,
+        "context" => RepeatMode::Context,
+        "off" => RepeatMode::Off,
+        other => {
+            warn!("playback_state.repeat has an unrecognized value {other:?}; using Off");
+            RepeatMode::Off
         }
-
-        let track_id = self.current_track_id()?.to_string();
-        let position_ms = (*self.current_position_shared.lock().unwrap())?.as_millis() as u64;
-
-        Some(PlaybackSnapshot {
-            track_id,
-            position_ms,
-            queue: self
-                .playback_queue
-                .upcoming()
-                .into_iter()
-                .map(|e| e.track_id)
-                .collect(),
-            volume: if self.is_muted {
-                self.pre_mute_volume
-            } else {
-                self.audio_output.get_volume()
-            },
-            repeat_mode: self.playback_queue.repeat_mode(),
-            is_muted: self.is_muted,
-        })
     }
 }
 

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -3681,6 +3681,109 @@ async fn test_restore_populates_last_position_display() {
     handle.stop();
 }
 
+/// The persist-on-change wiring is load-bearing: playing a release writes the
+/// device-local `playback_state` row, and stopping clears it — so a restart
+/// resumes a live session but never re-cues a finished one.
+#[tokio::test]
+async fn test_play_persists_then_stop_clears_playback_state() {
+    if should_skip_audio_tests() {
+        eprintln!("Skipping: no audio device");
+        return;
+    }
+    tracing_init();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let album_dir = temp_dir.path().join("album");
+    std::fs::create_dir_all(&album_dir).unwrap();
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+    )
+    .await
+    .unwrap();
+    let database_arc = Arc::new(database.clone());
+    let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
+    let (config_handle, key_service) = test_config_and_keys(&library_dir);
+    let library_manager = LibraryManager::new(
+        (*database_arc).clone(),
+        library_dir.clone(),
+        config_handle,
+        key_service,
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        tokio::runtime::Handle::current(),
+        None,
+    );
+    let runtime_handle = tokio::runtime::Handle::current();
+    let _ = generate_test_flac_files(&album_dir);
+    let discogs_release = create_test_album();
+    let release_id_key = seed_discogs_test_release(discogs_release);
+    let import_handle = start_test_import(runtime_handle.clone(), library_manager.clone());
+    let import_id = uuid::Uuid::new_v4().to_string();
+    import_handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: None,
+            storage_mode: StorageMode::Unmanaged,
+            identity_choice: IdentityChoice::Exact {
+                release_ref: MetadataRef::new(release_id_key, MetadataSource::Discogs),
+            },
+            user_edit: None,
+        })
+        .unwrap();
+    let mut progress_rx = import_handle.subscribe_import(import_id);
+    let _ = wait_for_import_complete(&mut progress_rx).await;
+    let release_id = library_manager
+        .get_releases_for_album(&library_manager.get_albums(&[]).await.unwrap()[0].id)
+        .await
+        .unwrap()[0]
+        .id
+        .clone();
+    let first_track = library_manager.get_tracks(&release_id).await.unwrap()[0]
+        .id
+        .clone();
+
+    std::env::set_var("MUTE_TEST_AUDIO", "1");
+    let handle =
+        bae_core::playback::PlaybackService::start(library_manager.clone(), runtime_handle, 100);
+    handle.set_volume(0.0);
+
+    // Playing a release persists the row: source is the release, current is the
+    // first track.
+    handle.play_release(release_id.clone(), None, false);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut persisted = None;
+    while Instant::now() < deadline {
+        if let Some(row) = library_manager.load_playback_state().await {
+            persisted = Some(row);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let row = persisted.expect("playing a release should persist the playback_state row");
+    assert_eq!(row.source.as_deref(), Some(release_id.as_str()));
+    assert_eq!(row.current_track_id.as_deref(), Some(first_track.as_str()));
+
+    // Stopping clears it, so a restart wouldn't re-cue a finished session.
+    handle.stop();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut cleared = false;
+    while Instant::now() < deadline {
+        if library_manager.load_playback_state().await.is_none() {
+            cleared = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        cleared,
+        "stopping playback should clear the playback_state row"
+    );
+}
+
 /// Seeking a preview while paused must emit a PreviewPositionUpdate even
 /// though no position ticks fire in the paused state. Without this explicit
 /// emission, the progress NSView stays stuck at the old position until the

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -3788,6 +3788,199 @@ async fn test_play_persists_then_stop_clears_playback_state() {
     );
 }
 
+/// An imported test library with no playback service running, so a test can
+/// write a `playback_state` row and then start its own service to exercise
+/// restore without racing a fixture's service for the row.
+struct RestoreTestLibrary {
+    library_manager: LibraryManager,
+    runtime_handle: tokio::runtime::Handle,
+    track_ids: Vec<String>,
+    _temp_dir: TempDir,
+}
+
+async fn restore_test_library() -> RestoreTestLibrary {
+    tracing_init();
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let album_dir = temp_dir.path().join("album");
+    std::fs::create_dir_all(&album_dir).unwrap();
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+    )
+    .await
+    .unwrap();
+    let database_arc = Arc::new(database.clone());
+    let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
+    let (config_handle, key_service) = test_config_and_keys(&library_dir);
+    let library_manager = LibraryManager::new(
+        (*database_arc).clone(),
+        library_dir.clone(),
+        config_handle,
+        key_service,
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        tokio::runtime::Handle::current(),
+        None,
+    );
+    let runtime_handle = tokio::runtime::Handle::current();
+    let _ = generate_test_flac_files(&album_dir);
+    let discogs_release = create_test_album();
+    let release_id_key = seed_discogs_test_release(discogs_release);
+    let import_handle = start_test_import(runtime_handle.clone(), library_manager.clone());
+    let import_id = uuid::Uuid::new_v4().to_string();
+    import_handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: None,
+            storage_mode: StorageMode::Unmanaged,
+            identity_choice: IdentityChoice::Exact {
+                release_ref: MetadataRef::new(release_id_key, MetadataSource::Discogs),
+            },
+            user_edit: None,
+        })
+        .unwrap();
+    let mut progress_rx = import_handle.subscribe_import(import_id);
+    let _ = wait_for_import_complete(&mut progress_rx).await;
+    let releases = library_manager
+        .get_releases_for_album(&library_manager.get_albums(&[]).await.unwrap()[0].id)
+        .await
+        .unwrap();
+    let tracks = library_manager.get_tracks(&releases[0].id).await.unwrap();
+    let track_ids: Vec<String> = tracks.iter().map(|t| t.id.clone()).collect();
+    assert!(!track_ids.is_empty(), "the test album imported some tracks");
+    std::env::set_var("MUTE_TEST_AUDIO", "1");
+    RestoreTestLibrary {
+        library_manager,
+        runtime_handle,
+        track_ids,
+        _temp_dir: temp_dir,
+    }
+}
+
+/// A resume cache whose context release is gone (its `get_track_ids` is empty)
+/// restores the manual lane only — the context drops, the surviving manual
+/// tracks and current track stay. The restored queue re-persists with no
+/// context, which is what we read back.
+#[tokio::test]
+async fn test_restore_drops_deleted_context_keeps_manual() {
+    if should_skip_audio_tests() {
+        eprintln!("Skipping: no audio device");
+        return;
+    }
+    let lib = restore_test_library().await;
+    let track_id = lib.track_ids[0].clone();
+
+    // The context points at a release id that no longer exists, so its
+    // `get_track_ids` returns empty (the deleted-release signal). The manual lane
+    // and current track are a real, surviving track.
+    let state = bae_core::db::DbPlaybackState {
+        context: Some(bae_core::db::DbPlaybackContext {
+            source: "release-that-was-deleted".to_string(),
+            shuffle_seed: None,
+            cursor: 0,
+        }),
+        manual: format!("[{:?}]", track_id),
+        repeat: "off".to_string(),
+        current_track_id: Some(track_id.clone()),
+        position_ms: Some(0),
+        volume: 0.8,
+        is_muted: false,
+    };
+    lib.library_manager
+        .save_playback_state(&state)
+        .await
+        .unwrap();
+
+    let handle = bae_core::playback::PlaybackService::start(
+        lib.library_manager.clone(),
+        lib.runtime_handle,
+        100,
+    );
+    handle.set_volume(0.0);
+
+    // Restore committed once the current (manual) track populates the late-mount
+    // display cache.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && handle.get_last_position_display().is_none() {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        handle.get_last_position_display().is_some(),
+        "the surviving manual track should restore as current"
+    );
+
+    // Force the restored queue to re-persist, then read it back: the dropped
+    // context is gone and the manual track survived.
+    handle.set_repeat_mode(bae_core::playback::RepeatMode::Track);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut row = None;
+    while Instant::now() < deadline {
+        if let Some(loaded) = lib.library_manager.load_playback_state().await.unwrap() {
+            if loaded.repeat == "track" {
+                row = Some(loaded);
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let row = row.expect("the restored, re-persisted row");
+    assert!(
+        row.context.is_none(),
+        "the deleted context release is dropped on restore"
+    );
+    assert_eq!(
+        row.manual,
+        format!("[{:?}]", track_id),
+        "the surviving manual lane restored"
+    );
+
+    handle.stop();
+}
+
+/// A corrupt resume cache (here, manual lane that is not valid JSON) is discarded
+/// by the boundary parse: the service starts with an empty queue and never
+/// panics. The position cache stays `None` because no current track restored.
+#[tokio::test]
+async fn test_restore_corrupt_row_starts_fresh() {
+    if should_skip_audio_tests() {
+        eprintln!("Skipping: no audio device");
+        return;
+    }
+    let lib = restore_test_library().await;
+    let track_id = lib.track_ids[0].clone();
+
+    let state = bae_core::db::DbPlaybackState {
+        context: None,
+        manual: "not valid json".to_string(),
+        repeat: "off".to_string(),
+        current_track_id: Some(track_id),
+        position_ms: Some(0),
+        volume: 0.8,
+        is_muted: false,
+    };
+    lib.library_manager
+        .save_playback_state(&state)
+        .await
+        .unwrap();
+
+    let handle =
+        bae_core::playback::PlaybackService::start(lib.library_manager, lib.runtime_handle, 100);
+    handle.set_volume(0.0);
+
+    // Give restore time to run (and to NOT crash). A discarded cache restores no
+    // current track, so the display cache stays empty.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(
+        handle.get_last_position_display().is_none(),
+        "a discarded resume cache leaves nothing playing (fresh start)"
+    );
+
+    handle.stop();
+}
+
 /// Seeking a preview while paused must emit a PreviewPositionUpdate even
 /// though no position ticks fire in the paused state. Without this explicit
 /// emission, the progress NSView stays stuck at the old position until the

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -3679,6 +3679,133 @@ async fn test_restore_populates_last_position_display() {
     handle.stop();
 }
 
+/// A saved context cursor that points past the source release's *current* tracks
+/// (the release shrank between sessions — tracks were deleted) can't resume
+/// there. Restore must drop the context and keep only the manual lane, never
+/// silently snap the cursor back into range.
+///
+/// `has_previous` is the discriminator: a dropped context has no track before
+/// the cursor (`false`); a context that survived with a snapped-back cursor
+/// would sit past the start (`true`). The manual track must still be queued.
+#[tokio::test]
+async fn test_restore_drops_context_when_cursor_past_shrunk_tracks() {
+    if should_skip_audio_tests() {
+        eprintln!("Skipping: no audio device");
+        return;
+    }
+    tracing_init();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let album_dir = temp_dir.path().join("album");
+    std::fs::create_dir_all(&album_dir).unwrap();
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+    )
+    .await
+    .unwrap();
+    let database_arc = Arc::new(database.clone());
+    let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
+    let (config_handle, key_service) = test_config_and_keys(&library_dir);
+    let library_manager = LibraryManager::new(
+        (*database_arc).clone(),
+        library_dir.clone(),
+        config_handle,
+        key_service,
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        tokio::runtime::Handle::current(),
+        None,
+    );
+    let runtime_handle = tokio::runtime::Handle::current();
+    let _ = generate_test_flac_files(&album_dir);
+    let discogs_release = create_test_album();
+    let release_id_key = seed_discogs_test_release(discogs_release);
+    let import_handle = start_test_import(runtime_handle.clone(), library_manager.clone());
+    let import_id = uuid::Uuid::new_v4().to_string();
+    import_handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: None,
+            storage_mode: StorageMode::Unmanaged,
+            identity_choice: IdentityChoice::Exact {
+                release_ref: MetadataRef::new(release_id_key, MetadataSource::Discogs),
+            },
+            user_edit: None,
+        })
+        .unwrap();
+    let mut import_progress_rx = import_handle.subscribe_import(import_id);
+    let _ = wait_for_import_complete(&mut import_progress_rx).await;
+    let release = library_manager
+        .get_releases_for_album(&library_manager.get_albums(&[]).await.unwrap()[0].id)
+        .await
+        .unwrap()
+        .remove(0);
+    let tracks = library_manager.get_tracks(&release.id).await.unwrap();
+    assert_eq!(tracks.len(), 3, "the fixture release has three tracks");
+    // The manual entry is the last track; it must survive the restore. The
+    // context source is the same release with a cursor past its three tracks.
+    let manual_track_id = tracks[2].id.clone();
+
+    std::env::set_var("MUTE_TEST_AUDIO", "1");
+    let state = bae_core::db::DbPlaybackState {
+        context: Some(bae_core::db::DbPlaybackContext {
+            source: release.id.clone(),
+            shuffle_seed: None,
+            cursor: 5,
+        }),
+        manual: serde_json::to_string(&vec![manual_track_id.clone()]).unwrap(),
+        repeat: "off".to_string(),
+        current_track_id: Some(manual_track_id.clone()),
+        position_ms: Some(0),
+        volume: 0.8,
+        is_muted: false,
+    };
+    library_manager.save_playback_state(&state).await.unwrap();
+
+    let handle = bae_core::playback::PlaybackService::start(library_manager, runtime_handle, 100);
+    handle.set_volume(0.0);
+    let mut progress_rx = handle.subscribe_progress();
+
+    // Wait for the queue update restore emits once it commits the restored queue.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut queue_update = None;
+    while Instant::now() < deadline {
+        match timeout(Duration::from_millis(100), progress_rx.recv()).await {
+            Ok(Some(PlaybackProgress::QueueUpdated {
+                entries,
+                has_previous,
+                ..
+            })) => {
+                queue_update = Some((entries, has_previous));
+                break;
+            }
+            Ok(Some(_)) => continue,
+            Ok(None) | Err(_) => continue,
+        }
+    }
+
+    let (entries, has_previous) = queue_update.expect("restore emits a queue update");
+    let queued: Vec<&str> = entries.iter().map(|e| e.track_id.as_str()).collect();
+    assert!(
+        !has_previous,
+        "the context was dropped, so nothing sits before the cursor"
+    );
+    assert!(
+        queued.contains(&manual_track_id.as_str()),
+        "the manual lane survives the restore: {queued:?}"
+    );
+    assert!(
+        !queued.contains(&tracks[0].id.as_str()) && !queued.contains(&tracks[1].id.as_str()),
+        "the dropped context contributes no tracks: {queued:?}"
+    );
+
+    handle.stop();
+}
+
 /// The persist-on-change wiring is load-bearing: playing a release writes the
 /// device-local `playback_state` row, and stopping clears it — so a restart
 /// resumes a live session but never re-cues a finished one.

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -3641,15 +3641,18 @@ async fn test_restore_populates_last_position_display() {
     // Mute audio for tests and write a snapshot. No service is running yet,
     // so no one can consume the snapshot before our test service starts.
     std::env::set_var("MUTE_TEST_AUDIO", "1");
-    let snapshot = bae_core::playback::PlaybackSnapshot {
-        track_id: track_id.clone(),
-        position_ms: 0,
-        queue: vec![],
+    let state = bae_core::db::DbPlaybackState {
+        source: None,
+        shuffle_seed: None,
+        cursor: None,
+        manual: "[]".to_string(),
+        repeat: "off".to_string(),
+        current_track_id: Some(track_id.clone()),
+        position_ms: Some(0),
         volume: 0.8,
-        repeat_mode: bae_core::playback::RepeatMode::Off,
         is_muted: false,
     };
-    library_manager.save_playback_state(&snapshot);
+    library_manager.save_playback_state(&state).await;
 
     // Start the playback service — restore() runs on the audio thread before
     // run() and calls emit_position_display at its tail.

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -3642,9 +3642,7 @@ async fn test_restore_populates_last_position_display() {
     // so no one can consume the snapshot before our test service starts.
     std::env::set_var("MUTE_TEST_AUDIO", "1");
     let state = bae_core::db::DbPlaybackState {
-        source: None,
-        shuffle_seed: None,
-        cursor: None,
+        context: None,
         manual: "[]".to_string(),
         repeat: "off".to_string(),
         current_track_id: Some(track_id.clone()),
@@ -3652,7 +3650,7 @@ async fn test_restore_populates_last_position_display() {
         volume: 0.8,
         is_muted: false,
     };
-    library_manager.save_playback_state(&state).await;
+    library_manager.save_playback_state(&state).await.unwrap();
 
     // Start the playback service — restore() runs on the audio thread before
     // run() and calls emit_position_display at its tail.
@@ -3757,14 +3755,15 @@ async fn test_play_persists_then_stop_clears_playback_state() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut persisted = None;
     while Instant::now() < deadline {
-        if let Some(row) = library_manager.load_playback_state().await {
+        if let Some(row) = library_manager.load_playback_state().await.unwrap() {
             persisted = Some(row);
             break;
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     let row = persisted.expect("playing a release should persist the playback_state row");
-    assert_eq!(row.source.as_deref(), Some(release_id.as_str()));
+    let context = row.context.expect("playing a release persists its context");
+    assert_eq!(context.source, release_id);
     assert_eq!(row.current_track_id.as_deref(), Some(first_track.as_str()));
 
     // Stopping clears it, so a restart wouldn't re-cue a finished session.
@@ -3772,7 +3771,12 @@ async fn test_play_persists_then_stop_clears_playback_state() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut cleared = false;
     while Instant::now() < deadline {
-        if library_manager.load_playback_state().await.is_none() {
+        if library_manager
+            .load_playback_state()
+            .await
+            .unwrap()
+            .is_none()
+        {
             cleared = true;
             break;
         }

--- a/bae-core/tests/test_playback_state.rs
+++ b/bae-core/tests/test_playback_state.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-utils")]
 //! The device-local `playback_state` table: save, load, replace, clear.
 
-use bae_core::db::{Database, DbPlaybackState};
+use bae_core::db::{Database, DbPlaybackContext, DbPlaybackState};
 use tempfile::TempDir;
 
 async fn setup_db() -> (Database, TempDir) {
@@ -27,9 +27,11 @@ async fn playback_state_saves_loads_replaces_and_clears() {
     // SQLite i64 column round-trip.
     let seed: u64 = 0xFFFF_FFFF_FFFF_FFFF;
     let row = DbPlaybackState {
-        source: Some("rel-1".to_string()),
-        shuffle_seed: Some(seed as i64),
-        cursor: Some(3),
+        context: Some(DbPlaybackContext {
+            source: "rel-1".to_string(),
+            shuffle_seed: Some(seed as i64),
+            cursor: 3,
+        }),
         manual: r#"["t1","t2"]"#.to_string(),
         repeat: "context".to_string(),
         current_track_id: Some("t5".to_string()),
@@ -40,9 +42,10 @@ async fn playback_state_saves_loads_replaces_and_clears() {
     db.save_playback_state(&row).await.unwrap();
 
     let loaded = db.load_playback_state().await.unwrap().expect("a row");
-    assert_eq!(loaded.source.as_deref(), Some("rel-1"));
-    assert_eq!(loaded.shuffle_seed.map(|s| s as u64), Some(seed));
-    assert_eq!(loaded.cursor, Some(3));
+    let context = loaded.context.expect("a context");
+    assert_eq!(context.source, "rel-1");
+    assert_eq!(context.shuffle_seed.map(|s| s as u64), Some(seed));
+    assert_eq!(context.cursor, 3);
     assert_eq!(loaded.manual, r#"["t1","t2"]"#);
     assert_eq!(loaded.repeat, "context");
     assert_eq!(loaded.current_track_id.as_deref(), Some("t5"));
@@ -51,11 +54,9 @@ async fn playback_state_saves_loads_replaces_and_clears() {
     assert!(!loaded.is_muted);
 
     // Saving again replaces the single row (id = 'current') rather than appending
-    // — a no-context single track with nulls where the context fields were.
+    // — a no-context single track with nulls where the context columns were.
     let single = DbPlaybackState {
-        source: None,
-        shuffle_seed: None,
-        cursor: None,
+        context: None,
         manual: "[]".to_string(),
         repeat: "off".to_string(),
         current_track_id: Some("solo".to_string()),
@@ -65,8 +66,7 @@ async fn playback_state_saves_loads_replaces_and_clears() {
     };
     db.save_playback_state(&single).await.unwrap();
     let loaded = db.load_playback_state().await.unwrap().expect("a row");
-    assert_eq!(loaded.source, None);
-    assert_eq!(loaded.shuffle_seed, None);
+    assert_eq!(loaded.context, None);
     assert_eq!(loaded.current_track_id.as_deref(), Some("solo"));
     assert!(loaded.is_muted);
 

--- a/bae-core/tests/test_playback_state.rs
+++ b/bae-core/tests/test_playback_state.rs
@@ -1,0 +1,76 @@
+#![cfg(feature = "test-utils")]
+//! The device-local `playback_state` table: save, load, replace, clear.
+
+use bae_core::db::{Database, DbPlaybackState};
+use tempfile::TempDir;
+
+async fn setup_db() -> (Database, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        std::sync::Arc::new(bae_core::clock::SystemClock),
+    )
+    .await
+    .expect("Failed to create database");
+    (database, temp_dir)
+}
+
+#[tokio::test]
+async fn playback_state_saves_loads_replaces_and_clears() {
+    let (db, _tmp) = setup_db().await;
+
+    // Nothing stored to start.
+    assert!(db.load_playback_state().await.unwrap().is_none());
+
+    // A shuffled context whose seed has the high bit set: it must survive the
+    // SQLite i64 column round-trip.
+    let seed: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+    let row = DbPlaybackState {
+        source: Some("rel-1".to_string()),
+        shuffle_seed: Some(seed as i64),
+        cursor: Some(3),
+        manual: r#"["t1","t2"]"#.to_string(),
+        repeat: "context".to_string(),
+        current_track_id: Some("t5".to_string()),
+        position_ms: Some(42_000),
+        volume: 0.5,
+        is_muted: false,
+    };
+    db.save_playback_state(&row).await.unwrap();
+
+    let loaded = db.load_playback_state().await.unwrap().expect("a row");
+    assert_eq!(loaded.source.as_deref(), Some("rel-1"));
+    assert_eq!(loaded.shuffle_seed.map(|s| s as u64), Some(seed));
+    assert_eq!(loaded.cursor, Some(3));
+    assert_eq!(loaded.manual, r#"["t1","t2"]"#);
+    assert_eq!(loaded.repeat, "context");
+    assert_eq!(loaded.current_track_id.as_deref(), Some("t5"));
+    assert_eq!(loaded.position_ms, Some(42_000));
+    assert!((loaded.volume - 0.5).abs() < f32::EPSILON);
+    assert!(!loaded.is_muted);
+
+    // Saving again replaces the single row (id = 'current') rather than appending
+    // — a no-context single track with nulls where the context fields were.
+    let single = DbPlaybackState {
+        source: None,
+        shuffle_seed: None,
+        cursor: None,
+        manual: "[]".to_string(),
+        repeat: "off".to_string(),
+        current_track_id: Some("solo".to_string()),
+        position_ms: None,
+        volume: 1.0,
+        is_muted: true,
+    };
+    db.save_playback_state(&single).await.unwrap();
+    let loaded = db.load_playback_state().await.unwrap().expect("a row");
+    assert_eq!(loaded.source, None);
+    assert_eq!(loaded.shuffle_seed, None);
+    assert_eq!(loaded.current_track_id.as_deref(), Some("solo"));
+    assert!(loaded.is_muted);
+
+    // Clear removes it.
+    db.clear_playback_state().await.unwrap();
+    assert!(db.load_playback_state().await.unwrap().is_none());
+}


### PR DESCRIPTION
The playback queue is device-specific — it never crosses devices — so its resume state had no business in a JSON file or, as the plan once proposed, a synced table. This swaps the flat `PlaybackSnapshot` JSON for a device-local `playback_state` table.

The table carries no `_updated_at` and isn't registered in `synced_tables()`, which is coven's own convention for device-local data — its `sync_cursors` / `sync_state` / `cloud_outbox` bookkeeping tables work the same way. coven's snapshot machinery strips such tables from the cloud copy it builds (a `VACUUM INTO` copy edited in isolation) while leaving the live row untouched, so the queue persists locally and is simply absent from sync.

Persisting the context — its release source, shuffle seed, and cursor — rather than a flattened upcoming list is what lets repeat, shuffle order, and the manual lane resume after a restart. The shuffled order re-derives deterministically from the stored seed, so the cursor still lands on the same track. The context's release id, dropped in the manual/context split when nothing read it, returns here as the persistence consumer. The row is rewritten on every queue, play, repeat, and stop change, so a restart resumes the latest intent; position is captured at each of those writes and on background/quit. Restore re-fetches the context's current tracks and drops any manual or current track deleted between sessions.

## Test plan
- [x] `cargo test -p bae-core` — 793 lib (queue snapshot/restore round-trips + the sync equality test) + 33 behavior/preload integration (incl. restore) + a new `playback_state` db CRUD test with a high-bit-seed round-trip
- [x] `cargo clippy` (core / bridge / windows-ffi); pre-commit hook (fmt, clippy, loc-gen)
- [ ] CI: iOS / Android / Windows build (bridge + UIs unchanged this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F