### PR TITLE
Bridge: rename repeat vocabulary None/Track/Album → Off/Track/Context

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -495,7 +495,7 @@ class BaeCorePlayer(
     // Repeat mode for the in-app now-playing control. Driven by core's
     // RepeatModeChanged (the same event that sets the Media3 `repeatMode`), so
     // the in-app button and the system controls reflect one source.
-    private val _repeatMode = MutableStateFlow(BridgeRepeatMode.NONE)
+    private val _repeatMode = MutableStateFlow(BridgeRepeatMode.OFF)
     val repeatMode: StateFlow<BridgeRepeatMode> = _repeatMode.asStateFlow()
 
     // Output volume [0,1] and mute, for the expanded now-playing controls.
@@ -652,9 +652,9 @@ class BaeCorePlayer(
     override fun onRepeatModeChanged(mode: BridgeRepeatMode) {
         media3RepeatMode =
             when (mode) {
-                BridgeRepeatMode.NONE -> Player.REPEAT_MODE_OFF
+                BridgeRepeatMode.OFF -> Player.REPEAT_MODE_OFF
                 BridgeRepeatMode.TRACK -> Player.REPEAT_MODE_ONE
-                BridgeRepeatMode.ALBUM -> Player.REPEAT_MODE_ALL
+                BridgeRepeatMode.CONTEXT -> Player.REPEAT_MODE_ALL
             }
         _repeatMode.value = mode
         publish()
@@ -885,8 +885,8 @@ class BaeCorePlayer(
         val mode =
             when (repeatMode) {
                 Player.REPEAT_MODE_ONE -> BridgeRepeatMode.TRACK
-                Player.REPEAT_MODE_ALL -> BridgeRepeatMode.ALBUM
-                else -> BridgeRepeatMode.NONE
+                Player.REPEAT_MODE_ALL -> BridgeRepeatMode.CONTEXT
+                else -> BridgeRepeatMode.OFF
             }
         appHandle.setRepeatMode(mode)
         return Futures.immediateVoidFuture()

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
@@ -262,14 +262,14 @@ private fun ExpandedSecondaryControls(session: OpenLibrary) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // cycle_repeat_mode is non-throwing; core emits RepeatModeChanged which
-        // updates the repeatMode flow. NONE is dimmed; ALBUM and TRACK are accented
+        // updates the repeatMode flow. OFF is dimmed; CONTEXT and TRACK are accented
         // (TRACK uses the repeat-one glyph). Same logic as the compact bar.
         IconButton(onClick = { session.appHandle.cycleRepeatMode() }) {
             Icon(
                 imageVector = if (repeatMode == BridgeRepeatMode.TRACK) Icons.Filled.RepeatOne else Icons.Filled.Repeat,
                 contentDescription = stringResource(R.string.repeat_mode),
                 tint =
-                    if (repeatMode == BridgeRepeatMode.NONE) {
+                    if (repeatMode == BridgeRepeatMode.OFF) {
                         MaterialTheme.colorScheme.onSurfaceVariant
                     } else {
                         MaterialTheme.colorScheme.primary

--- a/bae-android/app/src/main/java/fm/bae/app/ui/NowPlayingBar.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/NowPlayingBar.kt
@@ -159,14 +159,14 @@ private fun NowPlayingTransportButtons(
         Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = stringResource(R.string.queue))
     }
     // cycle_repeat_mode is non-throwing; core emits RepeatModeChanged which updates
-    // the repeatMode flow. NONE is dimmed; ALBUM and TRACK are accented (TRACK uses
+    // the repeatMode flow. OFF is dimmed; CONTEXT and TRACK are accented (TRACK uses
     // the repeat-one glyph).
     IconButton(onClick = { session.appHandle.cycleRepeatMode() }) {
         Icon(
             imageVector = if (repeatMode == BridgeRepeatMode.TRACK) Icons.Filled.RepeatOne else Icons.Filled.Repeat,
             contentDescription = stringResource(R.string.repeat_mode),
             tint =
-                if (repeatMode == BridgeRepeatMode.NONE) {
+                if (repeatMode == BridgeRepeatMode.OFF) {
                     MaterialTheme.colorScheme.onSurfaceVariant
                 } else {
                     MaterialTheme.colorScheme.primary

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -439,25 +439,25 @@ pub struct BridgeAlbumDetail {
 
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum BridgeRepeatMode {
-    None,
+    Off,
     Track,
-    Album,
+    Context,
 }
 
 impl BridgeRepeatMode {
     pub fn to_core(self) -> bae_core::playback::RepeatMode {
         match self {
-            Self::None => bae_core::playback::RepeatMode::Off,
+            Self::Off => bae_core::playback::RepeatMode::Off,
             Self::Track => bae_core::playback::RepeatMode::Track,
-            Self::Album => bae_core::playback::RepeatMode::Context,
+            Self::Context => bae_core::playback::RepeatMode::Context,
         }
     }
 
     pub fn from_core(mode: bae_core::playback::RepeatMode) -> Self {
         match mode {
-            bae_core::playback::RepeatMode::Off => Self::None,
+            bae_core::playback::RepeatMode::Off => Self::Off,
             bae_core::playback::RepeatMode::Track => Self::Track,
-            bae_core::playback::RepeatMode::Context => Self::Album,
+            bae_core::playback::RepeatMode::Context => Self::Context,
         }
     }
 }

--- a/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
+++ b/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
@@ -136,7 +136,7 @@ struct ExpandedNowPlayingView: View {
                     ? "repeat.1" : "repeat"
             )
             .foregroundStyle(
-                playbackStore.repeatMode == .none
+                playbackStore.repeatMode == .off
                     ? Color.secondary : Theme.accent
             )
         }

--- a/bae-ios/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-ios/bae/bae/Views/NowPlayingBar.swift
@@ -119,7 +119,7 @@ struct NowPlayingBar: View {
                     ? "repeat.1" : "repeat"
             )
             .foregroundStyle(
-                playbackStore.repeatMode == .none
+                playbackStore.repeatMode == .off
                     ? Color.secondary : Theme.accent
             )
         }

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -54601,192 +54601,192 @@
         }
       }
     },
-    "Repeat: album": {
-      "comment": "Now-playing bar: repeat button tooltip/a11y when repeating the album",
+    "Repeat: context": {
+      "comment": "Now-playing bar: repeat button tooltip/a11y when repeating the playback context",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Repeat: album"
+            "value": "Repeat: context"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repetir: álbum"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Répétition : album"
           }
         },
         "de": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Wiederholen: Album"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repetir: álbum"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "リピート: アルバム"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "重复：专辑"
           }
         },
         "ar": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "التكرار: الألبوم"
           }
         },
         "he": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "חזרה: אלבום"
           }
         },
         "uk": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Повтор: альбом"
           }
         },
         "bg": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Повторение: албум"
           }
         },
         "pl": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Powtarzanie: album"
           }
         },
         "cs": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Opakování: album"
           }
         },
         "hr": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Ponavljanje: album"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "반복: 앨범"
           }
         },
         "zh-Hant": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "it": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "tr": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "vi": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "nl": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "hi": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "bn": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "ta": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "te": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "mr": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "ur": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "gu": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "kn": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "ml": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "pa": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         },
         "th": {
           "stringUnit": {
-            "state": "translated",
+            "state": "needs_review",
             "value": "Repeat: album"
           }
         }

--- a/bae-macos/bae/bae/Services/PlaybackStore.swift
+++ b/bae-macos/bae/bae/Services/PlaybackStore.swift
@@ -15,7 +15,7 @@ class PlaybackStore {
 
     var volume: Float = 1.0
     var isMuted: Bool = false
-    var repeatMode: RepeatMode = .none
+    var repeatMode: RepeatMode = .off
     var queueItems: [QueueItem] = []
 
     /// Current playback position. Updates at display rate during playback —

--- a/bae-macos/bae/bae/Services/Store/RepeatMode.swift
+++ b/bae-macos/bae/bae/Services/Store/RepeatMode.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 enum RepeatMode: Equatable {
-    case none
+    case off
     case track
-    case album
+    case context
 
     init(bridge: BridgeRepeatMode) {
         switch bridge {
-        case .none: self = .none
+        case .off: self = .off
         case .track: self = .track
-        case .album: self = .album
+        case .context: self = .context
         }
     }
 }

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -326,10 +326,10 @@ struct NowPlayingBar: View {
     private var repeatButton: some View {
         Button(action: onCycleRepeat) {
             switch repeatMode {
-            case .none:
+            case .off:
                 Image(systemName: "repeat")
                     .foregroundStyle(.secondary)
-            case .album:
+            case .context:
                 Image(systemName: "repeat")
                     .foregroundColor(.accentColor)
             case .track:
@@ -345,10 +345,10 @@ struct NowPlayingBar: View {
 
     private var repeatHelp: LocalizedStringKey {
         switch repeatMode {
-        case .none:
+        case .off:
             "Repeat: off"
-        case .album:
-            "Repeat: album"
+        case .context:
+            "Repeat: context"
         case .track:
             "Repeat: track"
         }
@@ -435,19 +435,19 @@ private struct NowPlayingBarPreview: View {
         trackTitle: PreviewData.nowPlayingTitle,
         artistNames: PreviewData.nowPlayingArtist,
         isPlaying: true,
-        repeatMode: .none,
+        repeatMode: .off,
         queueIsActive: true,
         queueItems: PreviewData.queueItems,
     )
     .environment(MediaPaths.stub)
 }
 
-#Preview("Paused — Repeat Album") {
+#Preview("Paused — Repeat Context") {
     NowPlayingBarPreview(
         trackTitle: PreviewData.nowPlayingTitle,
         artistNames: PreviewData.nowPlayingArtist,
         isPlaying: false,
-        repeatMode: .album,
+        repeatMode: .context,
         queueIsActive: true,
         queueItems: PreviewData.queueItems,
     )
@@ -460,7 +460,7 @@ private struct NowPlayingBarPreview: View {
         artistNames: PreviewData.nowPlayingArtist,
         isPlaying: true,
         isLoading: true,
-        repeatMode: .none,
+        repeatMode: .off,
         queueIsActive: true,
         queueItems: PreviewData.queueItems,
     )
@@ -472,7 +472,7 @@ private struct NowPlayingBarPreview: View {
         trackTitle: nil,
         artistNames: nil,
         isPlaying: false,
-        repeatMode: .none,
+        repeatMode: .off,
         queueIsActive: false,
         queueItems: [],
     )

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -2360,7 +2360,7 @@ enum FfiEvent {
     MuteChanged {
         is_muted: bool,
     },
-    /// Repeat mode changed: `none` / `track` / `album`.
+    /// Repeat mode changed: `off` / `track` / `context`.
     RepeatModeChanged {
         mode: String,
     },
@@ -2572,9 +2572,9 @@ fn candidate_audio_paths(
 fn repeat_mode_name(mode: &bae_core::playback::RepeatMode) -> &'static str {
     use bae_core::playback::RepeatMode;
     match mode {
-        RepeatMode::Off => "none",
+        RepeatMode::Off => "off",
         RepeatMode::Track => "track",
-        RepeatMode::Context => "album",
+        RepeatMode::Context => "context",
     }
 }
 
@@ -2905,7 +2905,7 @@ pub unsafe extern "C" fn bae_get_volume(handle: *const BaeHandle) -> f32 {
     app.runtime.block_on(app.services.playback().get_volume())
 }
 
-/// Cycle the repeat mode (off → repeat-track → repeat-album → off). The new mode
+/// Cycle the repeat mode (off → repeat-context → repeat-track → off). The new mode
 /// arrives as a `RepeatModeChanged` event.
 ///
 /// # Safety

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -1402,7 +1402,7 @@ public sealed partial class MainWindow : Window
                 NpRepeat.Content = evt.Mode switch
                 {
                     "track" => "🔂",
-                    "album" => "🔁",
+                    "context" => "🔁",
                     _ => "↻",
                 };
                 break;

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -967,7 +967,7 @@ internal static class NativeBae
     [DllImport(Dll, EntryPoint = "bae_get_volume", CallingConvention = CallingConvention.Cdecl)]
     internal static extern float GetVolume(IntPtr handle);
 
-    /// <summary>Cycle repeat mode (off → track → album).</summary>
+    /// <summary>Cycle repeat mode (off → context → track).</summary>
     [DllImport(Dll, EntryPoint = "bae_cycle_repeat_mode", CallingConvention = CallingConvention.Cdecl)]
     internal static extern void CycleRepeatMode(IntPtr handle);
 


### PR DESCRIPTION
bae-core's `RepeatMode` shipped as `Off/Track/Context`, but the bridge enum and the four UIs still spoke the old `None/Track/Album` vocabulary, mapped onto the new core variants at the boundary. This renames the user-facing vocabulary to match, so the bridge `BridgeRepeatMode` mirrors the core enum 1:1 instead of translating stale names — and the windows-ffi wire string (`"off"/"track"/"context"`) and every UI's glyph/label follow.

The bridge enum is a mandated uniffi/FFI mirror, not a duplicate type, so it keeps its own declaration; `to_core`/`from_core` simply become identity maps. Windows consumes the repeat mode as a wire string rather than the enum, so its mapping moves in `MainWindow.xaml.cs` (and `"off"` falls through to the existing neutral glyph). Three stale cycle-order comments (claiming `off → track → album`) are corrected to the real `off → context → track`.

This is the first of three bridge slices for the queue redesign; the entry-id and two-section-queue changes follow separately.

## Test plan
- [x] `cargo build` + `cargo clippy --all-targets` (bae-bridge, bae-windows-ffi) — clean
- [x] macOS pre-commit (xcodegen + xcodebuild + periphery) — passed
- [ ] CI: iOS / Android / Windows build (the generated enums carry the new variant names; each UI's switch/when updated to match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F