### PR TITLE
Queue: render the two real lanes as distinct sections

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
@@ -139,7 +139,8 @@ object UiEventReducer {
 
             is BridgeUiEvent.QueueUpdated -> {
                 player.onQueueUpdated(
-                    items = event.items,
+                    manual = event.manual,
+                    context = event.context,
                     hasNext = event.hasNext,
                     hasPrevious = event.hasPrevious,
                 )

--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.withContext
 import uniffi.bae_bridge.AppHandle
 import uniffi.bae_bridge.BridgeLoadingTrackInfo
 import uniffi.bae_bridge.BridgePlaybackPauseReason
+import uniffi.bae_bridge.BridgePlaybackContext
 import uniffi.bae_bridge.BridgeQueueEntry
 import uniffi.bae_bridge.BridgeRepeatMode
 import uniffi.bae_bridge.BridgeSidePausePrompt
@@ -72,6 +73,26 @@ data class QueueItem(
     val coverPath: String?,
 )
 
+/** The context lane (the release being played from): its not-yet-played tail,
+ *  plus whether it was ordered by shuffle (the UI shows a shuffle indicator when
+ *  so). Rendered as a section distinct from the manual lane. */
+data class QueueContext(
+    val shuffled: Boolean,
+    val upcoming: List<QueueItem>,
+)
+
+/** The queue's two lanes the [fm.bae.app.ui.QueueScreen] renders as distinct
+ *  sections: the manual lane ("Up Next") and the [context] (or null when nothing
+ *  plays from a release). Kept separate, not flattened. */
+data class QueueProjection(
+    val manual: List<QueueItem>,
+    val context: QueueContext?,
+) {
+    companion object {
+        val EMPTY = QueueProjection(manual = emptyList(), context = null)
+    }
+}
+
 /**
  * The playback-state intake [BaeCorePlayer] exposes to [fm.bae.app.data.UiEventReducer].
  * The reducer depends on this contract, not the concrete player (which needs a
@@ -98,7 +119,8 @@ interface PlaybackEventSink {
     fun onRepeatModeChanged(mode: BridgeRepeatMode)
 
     fun onQueueUpdated(
-        items: List<BridgeQueueEntry>,
+        manual: List<BridgeQueueEntry>,
+        context: BridgePlaybackContext?,
         hasNext: Boolean,
         hasPrevious: Boolean,
     )
@@ -454,8 +476,18 @@ class BaeCorePlayer(
     private var transport: Transport = Transport.IDLE
     private var playWhenReady: Boolean = false
 
-    /** The queue, hydrated from the latest `QueueUpdated` event. */
+    /** The flat up-next playlist (manual lane then the context tail), hydrated
+     *  from the latest `QueueUpdated` event. This is the linear order the Media3
+     *  session and skip-by-index need; the in-app two-section projection reads
+     *  [manualEntries] / [contextEntries] separately. */
     private var entries: List<Meta> = emptyList()
+
+    /** The manual lane and the context tail, kept separate for the in-app
+     *  two-section projection (`publish` builds `_queue` from these). */
+    private var manualEntries: List<Meta> = emptyList()
+    private var contextEntries: List<Meta> = emptyList()
+    private var contextShuffled: Boolean = false
+    private var hasContext: Boolean = false
 
     /** Authoritative now-playing metadata from the latest Playing/Paused payload. */
     private var currentMeta: Meta? = null
@@ -490,12 +522,13 @@ class BaeCorePlayer(
     private val _position = MutableStateFlow(PlaybackPosition(0.0, "", ""))
     val position: StateFlow<PlaybackPosition> = _position.asStateFlow()
 
-    // The up-next queue projection the in-app QueueScreen renders, derived in
-    // publish() from the same `entries` the Media3 State is built from so the
-    // two can't drift. (The currently-playing track is not in this list — it
-    // rides `nowPlaying` — matching core's queue, which holds only what's next.)
-    private val _queue = MutableStateFlow<List<QueueItem>>(emptyList())
-    val queue: StateFlow<List<QueueItem>> = _queue.asStateFlow()
+    // The two-lane queue projection the in-app QueueScreen renders as distinct
+    // sections, derived in publish() from the same lanes the flat Media3 `entries`
+    // are built from so the two can't drift. (The currently-playing track is not
+    // in this projection — it rides `nowPlaying` — matching core's queue, which
+    // holds only what's next.)
+    private val _queue = MutableStateFlow(QueueProjection.EMPTY)
+    val queue: StateFlow<QueueProjection> = _queue.asStateFlow()
 
     // Repeat mode for the in-app now-playing control. Driven by core's
     // RepeatModeChanged (the same event that sets the Media3 `repeatMode`), so
@@ -682,18 +715,29 @@ class BaeCorePlayer(
 
     /**
      * Hydrate the playlist from a `QueueUpdated` event. The core resolves each
-     * item's metadata before emitting, so map the items straight to entries off
+     * item's metadata before emitting, so map both lanes straight to entries off
      * the main thread (cover ids resolve to local file paths via the image
      * resolver, which stats the disk), then re-anchor on the application looper.
+     * The flat [entries] (manual lane then the context tail) drives the Media3
+     * session and skip-by-index; the two lanes are also kept apart for the
+     * in-app two-section projection.
      */
     override fun onQueueUpdated(
-        items: List<BridgeQueueEntry>,
+        manual: List<BridgeQueueEntry>,
+        context: BridgePlaybackContext?,
         hasNext: Boolean,
         hasPrevious: Boolean,
     ) {
         scope.launch {
-            val hydrated = withContext(Dispatchers.IO) { items.map { it.toEntry() } }
-            entries = hydrated
+            val (manualMetas, contextMetas) =
+                withContext(Dispatchers.IO) {
+                    manual.map { it.toEntry() } to (context?.upcoming?.map { it.toEntry() } ?: emptyList())
+                }
+            manualEntries = manualMetas
+            contextEntries = contextMetas
+            contextShuffled = context?.shuffled ?: false
+            hasContext = context != null
+            entries = manualMetas + contextMetas
             this@BaeCorePlayer.hasNext = hasNext
             this@BaeCorePlayer.hasPrevious = hasPrevious
             publish()
@@ -720,7 +764,19 @@ class BaeCorePlayer(
                 elapsedLabel = elapsedLabel,
                 remainingLabel = remainingLabel,
             )
-        _queue.value = entries.mapNotNull { it.toQueueItem() }
+        _queue.value =
+            QueueProjection(
+                manual = manualEntries.mapNotNull { it.toQueueItem() },
+                context =
+                    if (hasContext) {
+                        QueueContext(
+                            shuffled = contextShuffled,
+                            upcoming = contextEntries.mapNotNull { it.toQueueItem() },
+                        )
+                    } else {
+                        null
+                    },
+            )
     }
 
     private fun Meta.toQueueItem(): QueueItem? {

--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -31,8 +31,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.bae_bridge.AppHandle
 import uniffi.bae_bridge.BridgeLoadingTrackInfo
-import uniffi.bae_bridge.BridgePlaybackPauseReason
 import uniffi.bae_bridge.BridgePlaybackContext
+import uniffi.bae_bridge.BridgePlaybackPauseReason
 import uniffi.bae_bridge.BridgeQueueEntry
 import uniffi.bae_bridge.BridgeRepeatMode
 import uniffi.bae_bridge.BridgeSidePausePrompt

--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -729,13 +729,21 @@ class BaeCorePlayer(
         hasPrevious: Boolean,
     ) {
         scope.launch {
+            // No context (nothing playing from a release) resolves to an empty
+            // context lane with no shuffle — a normal state, named here rather
+            // than defaulted around the absent value.
             val (manualMetas, contextMetas) =
                 withContext(Dispatchers.IO) {
-                    manual.map { it.toEntry() } to (context?.upcoming?.map { it.toEntry() } ?: emptyList())
+                    val resolvedContext =
+                        when (context) {
+                            null -> emptyList()
+                            else -> context.upcoming.map { it.toEntry() }
+                        }
+                    manual.map { it.toEntry() } to resolvedContext
                 }
             manualEntries = manualMetas
             contextEntries = contextMetas
-            contextShuffled = context?.shuffled ?: false
+            contextShuffled = context?.shuffled == true
             hasContext = context != null
             entries = manualMetas + contextMetas
             this@BaeCorePlayer.hasNext = hasNext

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -28,7 +29,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,7 +79,9 @@ fun QueueScreen(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
-        item(key = "header") { QueueHeader(session = session, isQueueEmpty = order.isEmpty()) }
+        // Clear empties only the manual lane (the context survives), so it
+        // disables on an empty manual lane regardless of the context.
+        item(key = "header") { QueueHeader(session = session, isClearDisabled = order.manual.isEmpty()) }
         nowPlaying?.let { np ->
             item(key = "nowplaying") {
                 SectionLabel(stringResource(R.string.queue_section_now_playing))
@@ -94,36 +99,63 @@ fun QueueScreen(
 }
 
 /**
- * The optimistic queue order plus its reorderable list state, shared by the queue
- * sheet and the expanded player's embedded queue so the conventions stay in one
- * place. The order is seeded from the authoritative flow but NOT while a drag is
- * in progress — re-seeding mid-drag would clobber the optimistic move and snap
- * the row back. A drop maps the dragged/target entry ids to positions and calls
- * core's reorder with the entry id of the row the moved item now precedes.
+ * The optimistic order of one lane (the manual "Up Next" lane or the context),
+ * mutated in place on a drag. Each lane reorders independently — entry ids are
+ * unique across both, and core no-ops a cross-lane move — so the two are held
+ * apart and a drop is resolved within its own lane.
+ */
+internal class QueueOrder {
+    val manual = mutableStateListOf<QueueItem>()
+    val context = mutableStateListOf<QueueItem>()
+    var contextShuffled by mutableStateOf(false)
+
+    val isEmpty: Boolean
+        get() = manual.isEmpty() && context.isEmpty()
+
+    /** The lane (manual or context) holding the entry id, or null if neither. */
+    fun laneOf(entryId: String): SnapshotStateList<QueueItem>? =
+        when {
+            manual.any { it.entryId == entryId } -> manual
+            context.any { it.entryId == entryId } -> context
+            else -> null
+        }
+}
+
+/**
+ * The optimistic two-lane queue order plus its reorderable list state, shared by
+ * the queue sheet and the expanded player's embedded queue so the conventions
+ * stay in one place. The order is seeded from the authoritative flow but NOT while
+ * a drag is in progress — re-seeding mid-drag would clobber the optimistic move
+ * and snap the row back. A drop maps the dragged/target entry ids to positions
+ * WITHIN one lane and calls core's reorder with the entry id of the row the moved
+ * item now precedes; a cross-lane drag is ignored (core no-ops it).
  */
 @Composable
 internal fun rememberReorderableQueue(
     session: OpenLibrary,
     listState: LazyListState,
-): Pair<SnapshotStateList<QueueItem>, ReorderableLazyListState> {
+): Pair<QueueOrder, ReorderableLazyListState> {
     val queue by session.playback.queue.collectAsState()
-    val order = remember { mutableStateListOf<QueueItem>() }
+    val order = remember { QueueOrder() }
     val reorderState =
         rememberReorderableLazyListState(listState) { from, to ->
-            // Map the dragged/target keys (entry ids) back to positions in
-            // `order` (offset-free: the non-row header items never match a row
-            // key).
-            val fromPos = order.indexOfFirst { it.entryId == from.key }
-            val toPos = order.indexOfFirst { it.entryId == to.key }
-            if (fromPos < 0 || toPos < 0) {
-                logger.debug("reorder: drag key not a queue row (from=${from.key}, to=${to.key}); ignoring")
+            // Resolve both keys to their lane; a reorder stays within one lane
+            // (the section headers never match a row key, so they're skipped).
+            val lane = order.laneOf(from.key as? String ?: "")
+            if (lane == null || lane !== order.laneOf(to.key as? String ?: "")) {
+                logger.debug("reorder: drag spans lanes or key not a row (from=${from.key}, to=${to.key}); ignoring")
                 return@rememberReorderableLazyListState
             }
-            val moved = order.removeAt(fromPos)
-            order.add(toPos, moved)
-            // The moved entry lands before whatever now follows it in the
-            // optimistic order; a null `before` (it's now last) means the end.
-            val beforeEntryId = order.getOrNull(toPos + 1)?.entryId
+            val fromPos = lane.indexOfFirst { it.entryId == from.key }
+            val toPos = lane.indexOfFirst { it.entryId == to.key }
+            if (fromPos < 0 || toPos < 0) {
+                return@rememberReorderableLazyListState
+            }
+            val moved = lane.removeAt(fromPos)
+            lane.add(toPos, moved)
+            // The moved entry lands before whatever now follows it in the lane;
+            // a null `before` (it's now last) means the lane's end.
+            val beforeEntryId = lane.getOrNull(toPos + 1)?.entryId
             try {
                 session.appHandle.reorderEntry(moved.entryId, beforeEntryId)
             } catch (e: Exception) {
@@ -133,28 +165,33 @@ internal fun rememberReorderableQueue(
 
     LaunchedEffect(queue, reorderState.isAnyItemDragging) {
         if (!reorderState.isAnyItemDragging) {
-            order.clear()
-            order.addAll(queue)
+            order.manual.clear()
+            order.manual.addAll(queue.manual)
+            order.context.clear()
+            order.context.addAll(queue.context?.upcoming ?: emptyList())
+            order.contextShuffled = queue.context?.shuffled ?: false
         }
     }
     return order to reorderState
 }
 
-// The "Up Next" list (header + reorderable rows, or an empty message) — shared by
-// the queue sheet and the expanded player's embedded queue so the reorder / skip /
-// remove index conventions stay in one place. The caller owns the now-playing
-// header above this (the sheet shows a Now Playing row; the player shows the full
-// transport), passing `hasNowPlaying` only to word the empty state. `onSkipped`
-// runs after a tap-to-skip — the sheet passes its dismiss; the embedded player
-// passes `null` because it stays put on skip.
+// The two-section queue (manual "Up Next" lane + the context section, or an empty
+// message) — shared by the queue sheet and the expanded player's embedded queue so
+// the reorder / skip / remove conventions stay in one place. The caller owns the
+// now-playing header above this (the sheet shows a Now Playing row; the player
+// shows the full transport), passing `hasNowPlaying` only to word the empty state.
+// `onSkipped` runs after a tap-to-skip — the sheet passes its dismiss; the embedded
+// player passes `null` because it stays put on skip.
 internal fun LazyListScope.queueContent(
     session: OpenLibrary,
-    order: List<QueueItem>,
+    order: QueueOrder,
     reorderState: ReorderableLazyListState,
     hasNowPlaying: Boolean,
     onSkipped: (() -> Unit)?,
 ) {
-    if (order.isEmpty()) {
+    // Only show the empty message when nothing follows at all; with a context
+    // present, the "Playing From" section below carries the queue.
+    if (order.isEmpty) {
         item(key = "empty") {
             Text(
                 text = stringResource(if (hasNowPlaying) R.string.queue_nothing_up_next else R.string.queue_empty),
@@ -162,31 +199,55 @@ internal fun LazyListScope.queueContent(
                 modifier = Modifier.fillMaxWidth().padding(32.dp),
             )
         }
-    } else {
+        return
+    }
+
+    if (order.manual.isNotEmpty()) {
         item(key = "uphdr") { SectionLabel(stringResource(R.string.queue_section_up_next)) }
-        itemsIndexed(order, key = { _, item -> item.entryId }) { _, item ->
-            ReorderableItem(reorderState, key = item.entryId) { isDragging ->
-                Surface(tonalElevation = if (isDragging) 4.dp else 0.dp, color = MaterialTheme.colorScheme.surface) {
-                    QueueRow(
-                        item = item,
-                        dragHandleModifier = Modifier.draggableHandle(),
-                        onClick = {
-                            try {
-                                session.appHandle.skipToEntry(item.entryId)
-                                onSkipped?.invoke()
-                            } catch (e: Exception) {
-                                logger.error("skipToEntry ${item.entryId} failed", e)
-                            }
-                        },
-                        onRemove = {
-                            try {
-                                session.appHandle.removeEntry(item.entryId)
-                            } catch (e: Exception) {
-                                logger.error("removeEntry ${item.entryId} failed", e)
-                            }
-                        },
-                    )
-                }
+        queueRows(session, order.manual, reorderState, onSkipped)
+    }
+
+    if (order.context.isNotEmpty()) {
+        item(key = "ctxhdr") {
+            ContextSectionLabel(
+                text = stringResource(R.string.queue_section_playing_from),
+                shuffled = order.contextShuffled,
+            )
+        }
+        queueRows(session, order.context, reorderState, onSkipped)
+    }
+}
+
+// One lane's reorderable rows. Entry ids key the rows (unique across both lanes),
+// so skip/remove/reorder target one instance.
+private fun LazyListScope.queueRows(
+    session: OpenLibrary,
+    items: List<QueueItem>,
+    reorderState: ReorderableLazyListState,
+    onSkipped: (() -> Unit)?,
+) {
+    itemsIndexed(items, key = { _, item -> item.entryId }) { _, item ->
+        ReorderableItem(reorderState, key = item.entryId) { isDragging ->
+            Surface(tonalElevation = if (isDragging) 4.dp else 0.dp, color = MaterialTheme.colorScheme.surface) {
+                QueueRow(
+                    item = item,
+                    dragHandleModifier = Modifier.draggableHandle(),
+                    onClick = {
+                        try {
+                            session.appHandle.skipToEntry(item.entryId)
+                            onSkipped?.invoke()
+                        } catch (e: Exception) {
+                            logger.error("skipToEntry ${item.entryId} failed", e)
+                        }
+                    },
+                    onRemove = {
+                        try {
+                            session.appHandle.removeEntry(item.entryId)
+                        } catch (e: Exception) {
+                            logger.error("removeEntry ${item.entryId} failed", e)
+                        }
+                    },
+                )
             }
         }
     }
@@ -195,7 +256,7 @@ internal fun LazyListScope.queueContent(
 @Composable
 private fun QueueHeader(
     session: OpenLibrary,
-    isQueueEmpty: Boolean,
+    isClearDisabled: Boolean,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
@@ -215,7 +276,7 @@ private fun QueueHeader(
                     logger.error("clearQueue failed", e)
                 }
             },
-            enabled = !isQueueEmpty,
+            enabled = !isClearDisabled,
         ) {
             Text(stringResource(R.string.queue_clear))
         }
@@ -234,6 +295,35 @@ private fun SectionLabel(text: String) {
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 4.dp),
     )
+}
+
+// The context section's label, with a shuffle indicator when the release was
+// ordered by shuffle.
+@Composable
+private fun ContextSectionLabel(
+    text: String,
+    shuffled: Boolean,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (shuffled) {
+            Spacer(modifier = Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.Filled.Shuffle,
+                contentDescription = stringResource(R.string.queue_shuffled),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
 }
 
 @Composable

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -149,6 +149,10 @@ internal fun rememberReorderableQueue(
             val fromPos = lane.indexOfFirst { it.entryId == from.key }
             val toPos = lane.indexOfFirst { it.entryId == to.key }
             if (fromPos < 0 || toPos < 0) {
+                // The lane held both keys a moment ago (laneOf matched); failing to
+                // resolve them to positions now is an unexpected race, not a normal
+                // skip — surface it before bailing rather than dropping it silently.
+                logger.warning("reorder: key not found in lane (from=${from.key}, to=${to.key}); ignoring")
                 return@rememberReorderableLazyListState
             }
             val moved = lane.removeAt(fromPos)
@@ -168,8 +172,16 @@ internal fun rememberReorderableQueue(
             order.manual.clear()
             order.manual.addAll(queue.manual)
             order.context.clear()
-            order.context.addAll(queue.context?.upcoming ?: emptyList())
-            order.contextShuffled = queue.context?.shuffled ?: false
+            // No context (nothing playing from a release) seeds an empty context
+            // lane with no shuffle — a normal state, named here rather than
+            // defaulted around the absent value.
+            when (val context = queue.context) {
+                null -> order.contextShuffled = false
+                else -> {
+                    order.context.addAll(context.upcoming)
+                    order.contextShuffled = context.shuffled
+                }
+            }
         }
     }
     return order to reorderState

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -176,7 +176,10 @@ internal fun rememberReorderableQueue(
             // lane with no shuffle — a normal state, named here rather than
             // defaulted around the absent value.
             when (val context = queue.context) {
-                null -> order.contextShuffled = false
+                null -> {
+                    order.contextShuffled = false
+                }
+
                 else -> {
                     order.context.addAll(context.upcoming)
                     order.contextShuffled = context.shuffled

--- a/bae-android/app/src/main/res/values-ar/strings.xml
+++ b/bae-android/app/src/main/res/values-ar/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">مسح</string>
     <string name="queue_section_now_playing">قيد التشغيل الآن</string>
     <string name="queue_section_up_next">التالي</string>
+    <string name="queue_section_playing_from">يُشغّل من</string>
     <string name="queue_nothing_up_next">لا شيء تاليًا</string>
     <string name="queue_empty">قائمة الانتظار فارغة</string>
     <string name="queue_remove">إزالة من قائمة الانتظار</string>
     <string name="queue_drag_to_reorder">اسحب لإعادة الترتيب</string>
+    <string name="queue_shuffled">تم الخلط</string>
     <string name="search_failed">فشل البحث</string>
     <string name="search_no_results">لا توجد نتائج لـ ”%1$s“</string>
     <string name="search_section_albums">الألبومات</string>

--- a/bae-android/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/bae-android/app/src/main/res/values-b+pt+BR/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Limpar</string>
     <string name="queue_section_now_playing">Tocando agora</string>
     <string name="queue_section_up_next">A seguir</string>
+    <string name="queue_section_playing_from">Tocando de</string>
     <string name="queue_nothing_up_next">Nada a seguir</string>
     <string name="queue_empty">A fila está vazia</string>
     <string name="queue_remove">Remover da fila</string>
     <string name="queue_drag_to_reorder">Arraste para reordenar</string>
+    <string name="queue_shuffled">Aleatório</string>
     <string name="search_failed">Falha na busca</string>
     <string name="search_no_results">Nenhum resultado para “%1$s”</string>
     <string name="search_section_albums">Álbuns</string>

--- a/bae-android/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/bae-android/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">清空</string>
     <string name="queue_section_now_playing">正在播放</string>
     <string name="queue_section_up_next">接下来</string>
+    <string name="queue_section_playing_from">来自</string>
     <string name="queue_nothing_up_next">没有接下来的内容</string>
     <string name="queue_empty">队列为空</string>
     <string name="queue_remove">从队列移除</string>
     <string name="queue_drag_to_reorder">拖动以重新排序</string>
+    <string name="queue_shuffled">已随机</string>
     <string name="search_failed">搜索失败</string>
     <string name="search_no_results">没有“%1$s”的结果</string>
     <string name="search_section_albums">专辑</string>

--- a/bae-android/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/bae-android/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">清除</string>
     <string name="queue_section_now_playing">正在播放</string>
     <string name="queue_section_up_next">接下來</string>
+    <string name="queue_section_playing_from">來自</string>
     <string name="queue_nothing_up_next">接下來沒有內容</string>
     <string name="queue_empty">佇列是空的</string>
     <string name="queue_remove">從佇列移除</string>
     <string name="queue_drag_to_reorder">拖曳以重新排序</string>
+    <string name="queue_shuffled">已隨機</string>
     <string name="search_failed">搜尋 · 錯誤</string>
     <string name="search_no_results">沒有結果: “%1$s”</string>
     <string name="search_section_albums">專輯</string>

--- a/bae-android/app/src/main/res/values-bg/strings.xml
+++ b/bae-android/app/src/main/res/values-bg/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Изчистване</string>
     <string name="queue_section_now_playing">Текущо възпроизвеждане</string>
     <string name="queue_section_up_next">Следва</string>
+    <string name="queue_section_playing_from">Възпроизвежда се от</string>
     <string name="queue_nothing_up_next">Няма следващо</string>
     <string name="queue_empty">Опашката е празна</string>
     <string name="queue_remove">Премахване от опашката</string>
     <string name="queue_drag_to_reorder">Плъзнете за пренареждане</string>
+    <string name="queue_shuffled">Разбъркано</string>
     <string name="search_failed">Търсенето не бе успешно</string>
     <string name="search_no_results">Няма резултати за „%1$s“</string>
     <string name="search_section_albums">Албуми</string>

--- a/bae-android/app/src/main/res/values-bn/strings.xml
+++ b/bae-android/app/src/main/res/values-bn/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">মুছুন</string>
     <string name="queue_section_now_playing">এখন চলছে</string>
     <string name="queue_section_up_next">পরবর্তী</string>
+    <string name="queue_section_playing_from">যা থেকে চলছে</string>
     <string name="queue_nothing_up_next">পরবর্তী কিছু নেই</string>
     <string name="queue_empty">সারি খালি</string>
     <string name="queue_remove">সারি থেকে সরান</string>
     <string name="queue_drag_to_reorder">নতুন ক্রমে আনতে টানুন</string>
+    <string name="queue_shuffled">শাফল করা</string>
     <string name="search_failed">খুঁজুন · ত্রুটি</string>
     <string name="search_no_results">কোনো ফল নেই: “%1$s”</string>
     <string name="search_section_albums">অ্যালবাম</string>

--- a/bae-android/app/src/main/res/values-cs/strings.xml
+++ b/bae-android/app/src/main/res/values-cs/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Vymazat</string>
     <string name="queue_section_now_playing">Právě hraje</string>
     <string name="queue_section_up_next">Další v pořadí</string>
+    <string name="queue_section_playing_from">Přehrává se z</string>
     <string name="queue_nothing_up_next">Nic dalšího v pořadí</string>
     <string name="queue_empty">Fronta je prázdná</string>
     <string name="queue_remove">Odebrat z fronty</string>
     <string name="queue_drag_to_reorder">Tažením změníte pořadí</string>
+    <string name="queue_shuffled">Zamícháno</string>
     <string name="search_failed">Vyhledávání selhalo</string>
     <string name="search_no_results">Žádné výsledky pro „%1$s“</string>
     <string name="search_section_albums">Alba</string>

--- a/bae-android/app/src/main/res/values-de/strings.xml
+++ b/bae-android/app/src/main/res/values-de/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Leeren</string>
     <string name="queue_section_now_playing">Aktuelle Wiedergabe</string>
     <string name="queue_section_up_next">Als Nächstes</string>
+    <string name="queue_section_playing_from">Wird abgespielt aus</string>
     <string name="queue_nothing_up_next">Nichts als Nächstes</string>
     <string name="queue_empty">Warteschlange ist leer</string>
     <string name="queue_remove">Aus Warteschlange entfernen</string>
     <string name="queue_drag_to_reorder">Zum Umsortieren ziehen</string>
+    <string name="queue_shuffled">Zufällig</string>
     <string name="search_failed">Suche fehlgeschlagen</string>
     <string name="search_no_results">Keine Ergebnisse für „%1$s“</string>
     <string name="search_section_albums">Alben</string>

--- a/bae-android/app/src/main/res/values-es/strings.xml
+++ b/bae-android/app/src/main/res/values-es/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Vaciar</string>
     <string name="queue_section_now_playing">En reproducción</string>
     <string name="queue_section_up_next">A continuación</string>
+    <string name="queue_section_playing_from">Reproduciendo desde</string>
     <string name="queue_nothing_up_next">Nada a continuación</string>
     <string name="queue_empty">La cola está vacía</string>
     <string name="queue_remove">Quitar de la cola</string>
     <string name="queue_drag_to_reorder">Arrastra para reordenar</string>
+    <string name="queue_shuffled">Aleatorio</string>
     <string name="search_failed">Error en la búsqueda</string>
     <string name="search_no_results">Sin resultados para «%1$s»</string>
     <string name="search_section_albums">Álbumes</string>

--- a/bae-android/app/src/main/res/values-fr/strings.xml
+++ b/bae-android/app/src/main/res/values-fr/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Vider</string>
     <string name="queue_section_now_playing">Lecture en cours</string>
     <string name="queue_section_up_next">À suivre</string>
+    <string name="queue_section_playing_from">Lecture depuis</string>
     <string name="queue_nothing_up_next">Rien à suivre</string>
     <string name="queue_empty">La file est vide</string>
     <string name="queue_remove">Retirer de la file</string>
     <string name="queue_drag_to_reorder">Glisser pour réorganiser</string>
+    <string name="queue_shuffled">Aléatoire</string>
     <string name="search_failed">Échec de la recherche</string>
     <string name="search_no_results">Aucun résultat pour « %1$s »</string>
     <string name="search_section_albums">Albums</string>

--- a/bae-android/app/src/main/res/values-gu/strings.xml
+++ b/bae-android/app/src/main/res/values-gu/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">સાફ કરો</string>
     <string name="queue_section_now_playing">હમણાં વગડે છે</string>
     <string name="queue_section_up_next">આગળ</string>
+    <string name="queue_section_playing_from">આમાંથી વાગે છે</string>
     <string name="queue_nothing_up_next">આગળ કશું નથી</string>
     <string name="queue_empty">કતાર ખાલી છે</string>
     <string name="queue_remove">કતારમાંથી કાઢો</string>
     <string name="queue_drag_to_reorder">ક્રમ બદલવા ખેંચો</string>
+    <string name="queue_shuffled">શફલ કરેલું</string>
     <string name="search_failed">શોધો · ભૂલ</string>
     <string name="search_no_results">કોઈ પરિણામ નથી: “%1$s”</string>
     <string name="search_section_albums">એલ્બમ</string>

--- a/bae-android/app/src/main/res/values-he/strings.xml
+++ b/bae-android/app/src/main/res/values-he/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">נקה</string>
     <string name="queue_section_now_playing">מתנגן כעת</string>
     <string name="queue_section_up_next">הבא בתור</string>
+    <string name="queue_section_playing_from">מנגן מתוך</string>
     <string name="queue_nothing_up_next">אין דבר בהמשך</string>
     <string name="queue_empty">התור ריק</string>
     <string name="queue_remove">הסר מהתור</string>
     <string name="queue_drag_to_reorder">גררו לסידור מחדש</string>
+    <string name="queue_shuffled">אקראי</string>
     <string name="search_failed">החיפוש נכשל</string>
     <string name="search_no_results">אין תוצאות עבור ”%1$s“</string>
     <string name="search_section_albums">אלבומים</string>

--- a/bae-android/app/src/main/res/values-hi/strings.xml
+++ b/bae-android/app/src/main/res/values-hi/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">साफ़ करें</string>
     <string name="queue_section_now_playing">अभी चल रहा है</string>
     <string name="queue_section_up_next">अगला</string>
+    <string name="queue_section_playing_from">यहाँ से चल रहा है</string>
     <string name="queue_nothing_up_next">अगला कुछ नहीं</string>
     <string name="queue_empty">कतार खाली है</string>
     <string name="queue_remove">कतार से हटाएँ</string>
     <string name="queue_drag_to_reorder">क्रम बदलने के लिए खींचें</string>
+    <string name="queue_shuffled">शफ़ल किया गया</string>
     <string name="search_failed">खोजें · त्रुटि</string>
     <string name="search_no_results">कोई परिणाम नहीं: “%1$s”</string>
     <string name="search_section_albums">एल्बम</string>

--- a/bae-android/app/src/main/res/values-hr/strings.xml
+++ b/bae-android/app/src/main/res/values-hr/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Očisti</string>
     <string name="queue_section_now_playing">Trenutno svira</string>
     <string name="queue_section_up_next">Sljedeće na redu</string>
+    <string name="queue_section_playing_from">Reproducira se iz</string>
     <string name="queue_nothing_up_next">Ništa nije na redu</string>
     <string name="queue_empty">Red je prazan</string>
     <string name="queue_remove">Ukloni iz reda</string>
     <string name="queue_drag_to_reorder">Povucite za promjenu redoslijeda</string>
+    <string name="queue_shuffled">Izmiješano</string>
     <string name="search_failed">Pretraživanje nije uspjelo</string>
     <string name="search_no_results">Nema rezultata za „%1$s”</string>
     <string name="search_section_albums">Albumi</string>

--- a/bae-android/app/src/main/res/values-it/strings.xml
+++ b/bae-android/app/src/main/res/values-it/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Clear</string>
     <string name="queue_section_now_playing">In riproduzione</string>
     <string name="queue_section_up_next">A seguire</string>
+    <string name="queue_section_playing_from">In riproduzione da</string>
     <string name="queue_nothing_up_next">Niente a seguire</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>
     <string name="queue_drag_to_reorder">Trascina per riordinare</string>
+    <string name="queue_shuffled">Casuale</string>
     <string name="search_failed">Cerca · Errore</string>
     <string name="search_no_results">Nessun risultato: “%1$s”</string>
     <string name="search_section_albums">Album</string>

--- a/bae-android/app/src/main/res/values-ja/strings.xml
+++ b/bae-android/app/src/main/res/values-ja/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">クリア</string>
     <string name="queue_section_now_playing">再生中</string>
     <string name="queue_section_up_next">次に再生</string>
+    <string name="queue_section_playing_from">再生元</string>
     <string name="queue_nothing_up_next">次の項目はありません</string>
     <string name="queue_empty">キューは空です</string>
     <string name="queue_remove">キューから削除</string>
     <string name="queue_drag_to_reorder">ドラッグで並べ替え</string>
+    <string name="queue_shuffled">シャッフル</string>
     <string name="search_failed">検索に失敗しました</string>
     <string name="search_no_results">「%1$s」の結果なし</string>
     <string name="search_section_albums">アルバム</string>

--- a/bae-android/app/src/main/res/values-kn/strings.xml
+++ b/bae-android/app/src/main/res/values-kn/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">ತೆರವುಗೊಳಿಸಿ</string>
     <string name="queue_section_now_playing">ಈಗ ಪ್ಲೇ ಆಗುತ್ತಿದೆ</string>
     <string name="queue_section_up_next">ಮುಂದಿನದು</string>
+    <string name="queue_section_playing_from">ಇದರಿಂದ ಪ್ಲೇ ಆಗುತ್ತಿದೆ</string>
     <string name="queue_nothing_up_next">ಮುಂದೆ ಏನೂ ಇಲ್ಲ</string>
     <string name="queue_empty">ಸರತಿ ಖಾಲಿ</string>
     <string name="queue_remove">ಸರತಿಯಿಂದ ತೆಗೆದುಹಾಕಿ</string>
     <string name="queue_drag_to_reorder">ಕ್ರಮ ಬದಲಿಸಲು ಎಳೆದುಹಾಕಿ</string>
+    <string name="queue_shuffled">ಶಫಲ್ ಮಾಡಲಾಗಿದೆ</string>
     <string name="search_failed">ಹುಡುಕಿ · ದೋಷ</string>
     <string name="search_no_results">ಫಲಿತಾಂಶಗಳಿಲ್ಲ: “%1$s”</string>
     <string name="search_section_albums">ಆಲ್ಬಮ್‌ಗಳು</string>

--- a/bae-android/app/src/main/res/values-ko/strings.xml
+++ b/bae-android/app/src/main/res/values-ko/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">지우기</string>
     <string name="queue_section_now_playing">지금 재생 중</string>
     <string name="queue_section_up_next">다음 재생</string>
+    <string name="queue_section_playing_from">재생 위치</string>
     <string name="queue_nothing_up_next">다음 항목 없음</string>
     <string name="queue_empty">대기열이 비어 있습니다</string>
     <string name="queue_remove">대기열에서 제거</string>
     <string name="queue_drag_to_reorder">끌어서 순서 변경</string>
+    <string name="queue_shuffled">셔플됨</string>
     <string name="search_failed">검색 실패</string>
     <string name="search_no_results">“%1$s”에 대한 결과 없음</string>
     <string name="search_section_albums">앨범</string>

--- a/bae-android/app/src/main/res/values-ml/strings.xml
+++ b/bae-android/app/src/main/res/values-ml/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">മായ്ക്കുക</string>
     <string name="queue_section_now_playing">ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു</string>
     <string name="queue_section_up_next">അടുത്തത്</string>
+    <string name="queue_section_playing_from">ഇതിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു</string>
     <string name="queue_nothing_up_next">അടുത്തത് ഒന്നുമില്ല</string>
     <string name="queue_empty">ക്യൂ ശൂന്യം</string>
     <string name="queue_remove">ക്യൂയിൽ നിന്ന് നീക്കുക</string>
     <string name="queue_drag_to_reorder">ക്രമം മാറ്റാൻ വലിക്കുക</string>
+    <string name="queue_shuffled">ഷഫിൾ ചെയ്തു</string>
     <string name="search_failed">തിരയുക · പിശക്</string>
     <string name="search_no_results">ഫലങ്ങളില്ല: “%1$s”</string>
     <string name="search_section_albums">ആൽബങ്ങൾ</string>

--- a/bae-android/app/src/main/res/values-mr/strings.xml
+++ b/bae-android/app/src/main/res/values-mr/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">साफ करा</string>
     <string name="queue_section_now_playing">आता प्ले होत आहे</string>
     <string name="queue_section_up_next">पुढचे</string>
+    <string name="queue_section_playing_from">येथून वाजत आहे</string>
     <string name="queue_nothing_up_next">पुढे काही नाही</string>
     <string name="queue_empty">रांग रिकामी आहे</string>
     <string name="queue_remove">रांगेतून काढा</string>
     <string name="queue_drag_to_reorder">क्रम बदलण्यासाठी ओढा</string>
+    <string name="queue_shuffled">शफल केले</string>
     <string name="search_failed">शोधा · त्रुटी</string>
     <string name="search_no_results">निकाल नाहीत: “%1$s”</string>
     <string name="search_section_albums">अल्बम</string>

--- a/bae-android/app/src/main/res/values-nl/strings.xml
+++ b/bae-android/app/src/main/res/values-nl/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Clear</string>
     <string name="queue_section_now_playing">Speelt nu</string>
     <string name="queue_section_up_next">Volgende</string>
+    <string name="queue_section_playing_from">Afspelen vanuit</string>
     <string name="queue_nothing_up_next">Niets hierna</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>
     <string name="queue_drag_to_reorder">Sleep om te herschikken</string>
+    <string name="queue_shuffled">Geschud</string>
     <string name="search_failed">Zoeken · Fout</string>
     <string name="search_no_results">Geen resultaten: “%1$s”</string>
     <string name="search_section_albums">Albums</string>

--- a/bae-android/app/src/main/res/values-pa/strings.xml
+++ b/bae-android/app/src/main/res/values-pa/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">ਸਾਫ਼ ਕਰੋ</string>
     <string name="queue_section_now_playing">ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ</string>
     <string name="queue_section_up_next">ਅਗਲਾ</string>
+    <string name="queue_section_playing_from">ਇੱਥੋਂ ਚੱਲ ਰਿਹਾ ਹੈ</string>
     <string name="queue_nothing_up_next">ਅੱਗੇ ਕੁਝ ਨਹੀਂ</string>
     <string name="queue_empty">ਕਤਾਰ ਖਾਲੀ ਹੈ</string>
     <string name="queue_remove">ਕਤਾਰ ਤੋਂ ਹਟਾਓ</string>
     <string name="queue_drag_to_reorder">ਕ੍ਰਮ ਬਦਲਣ ਲਈ ਘਸੀਟੋ</string>
+    <string name="queue_shuffled">ਸ਼ਫਲ ਕੀਤਾ</string>
     <string name="search_failed">ਖੋਜੋ · ਗਲਤੀ</string>
     <string name="search_no_results">ਕੋਈ ਨਤੀਜਾ ਨਹੀਂ: “%1$s”</string>
     <string name="search_section_albums">ਐਲਬਮ</string>

--- a/bae-android/app/src/main/res/values-pl/strings.xml
+++ b/bae-android/app/src/main/res/values-pl/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Wyczyść</string>
     <string name="queue_section_now_playing">Teraz odtwarzane</string>
     <string name="queue_section_up_next">Następne w kolejce</string>
+    <string name="queue_section_playing_from">Odtwarzanie z</string>
     <string name="queue_nothing_up_next">Brak następnych pozycji</string>
     <string name="queue_empty">Kolejka jest pusta</string>
     <string name="queue_remove">Usuń z kolejki</string>
     <string name="queue_drag_to_reorder">Przeciągnij, aby zmienić kolejność</string>
+    <string name="queue_shuffled">Losowo</string>
     <string name="search_failed">Wyszukiwanie nie powiodło się</string>
     <string name="search_no_results">Brak wyników dla „%1$s”</string>
     <string name="search_section_albums">Albumy</string>

--- a/bae-android/app/src/main/res/values-ta/strings.xml
+++ b/bae-android/app/src/main/res/values-ta/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">அழி</string>
     <string name="queue_section_now_playing">இப்போது ஒலிக்கிறது</string>
     <string name="queue_section_up_next">அடுத்தது</string>
+    <string name="queue_section_playing_from">இதிலிருந்து இயக்குகிறது</string>
     <string name="queue_nothing_up_next">அடுத்தது எதுவும் இல்லை</string>
     <string name="queue_empty">வரிசை காலி</string>
     <string name="queue_remove">வரிசையிலிருந்து அகற்று</string>
     <string name="queue_drag_to_reorder">வரிசை மாற்ற இழுக்கவும்</string>
+    <string name="queue_shuffled">கலைக்கப்பட்டது</string>
     <string name="search_failed">தேடு · பிழை</string>
     <string name="search_no_results">முடிவுகள் இல்லை: “%1$s”</string>
     <string name="search_section_albums">ஆல்பங்கள்</string>

--- a/bae-android/app/src/main/res/values-te/strings.xml
+++ b/bae-android/app/src/main/res/values-te/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">తొలగించు</string>
     <string name="queue_section_now_playing">ఇప్పుడు ప్లే అవుతోంది</string>
     <string name="queue_section_up_next">తదుపరి</string>
+    <string name="queue_section_playing_from">దీని నుండి ప్లే అవుతోంది</string>
     <string name="queue_nothing_up_next">తదుపరి ఏమీ లేదు</string>
     <string name="queue_empty">క్యూ ఖాళీగా ఉంది</string>
     <string name="queue_remove">క్యూ నుండి తీసివేయి</string>
     <string name="queue_drag_to_reorder">క్రమం మార్చడానికి లాగండి</string>
+    <string name="queue_shuffled">షఫుల్ చేయబడింది</string>
     <string name="search_failed">వెతుకు · లోపం</string>
     <string name="search_no_results">ఫలితాలు లేవు: “%1$s”</string>
     <string name="search_section_albums">ఆల్బమ్‌లు</string>

--- a/bae-android/app/src/main/res/values-th/strings.xml
+++ b/bae-android/app/src/main/res/values-th/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">ล้าง</string>
     <string name="queue_section_now_playing">กำลังเล่น</string>
     <string name="queue_section_up_next">ถัดไป</string>
+    <string name="queue_section_playing_from">กำลังเล่นจาก</string>
     <string name="queue_nothing_up_next">ไม่มีรายการถัดไป</string>
     <string name="queue_empty">คิวว่าง</string>
     <string name="queue_remove">นำออกจากคิว</string>
     <string name="queue_drag_to_reorder">ลากเพื่อจัดลำดับใหม่</string>
+    <string name="queue_shuffled">สุ่ม</string>
     <string name="search_failed">ค้นหา · ข้อผิดพลาด</string>
     <string name="search_no_results">ไม่มีผลลัพธ์: “%1$s”</string>
     <string name="search_section_albums">อัลบั้ม</string>

--- a/bae-android/app/src/main/res/values-tr/strings.xml
+++ b/bae-android/app/src/main/res/values-tr/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Clear</string>
     <string name="queue_section_now_playing">Çalıyor</string>
     <string name="queue_section_up_next">Sıradaki</string>
+    <string name="queue_section_playing_from">Şuradan çalınıyor</string>
     <string name="queue_nothing_up_next">Sırada bir şey yok</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>
     <string name="queue_drag_to_reorder">Yeniden sıralamak için sürükle</string>
+    <string name="queue_shuffled">Karışık</string>
     <string name="search_failed">Ara · Hata</string>
     <string name="search_no_results">Sonuç yok: “%1$s”</string>
     <string name="search_section_albums">Albümler</string>

--- a/bae-android/app/src/main/res/values-uk/strings.xml
+++ b/bae-android/app/src/main/res/values-uk/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Очистити</string>
     <string name="queue_section_now_playing">Зараз відтворюється</string>
     <string name="queue_section_up_next">Далі в черзі</string>
+    <string name="queue_section_playing_from">Відтворюється з</string>
     <string name="queue_nothing_up_next">Далі нічого немає</string>
     <string name="queue_empty">Черга порожня</string>
     <string name="queue_remove">Вилучити з черги</string>
     <string name="queue_drag_to_reorder">Перетягніть, щоб змінити порядок</string>
+    <string name="queue_shuffled">Перемішано</string>
     <string name="search_failed">Не вдалося виконати пошук</string>
     <string name="search_no_results">Немає результатів для «%1$s»</string>
     <string name="search_section_albums">Альбоми</string>

--- a/bae-android/app/src/main/res/values-ur/strings.xml
+++ b/bae-android/app/src/main/res/values-ur/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">صاف کریں</string>
     <string name="queue_section_now_playing">اب چل رہا ہے</string>
     <string name="queue_section_up_next">اگلا</string>
+    <string name="queue_section_playing_from">یہاں سے چل رہا ہے</string>
     <string name="queue_nothing_up_next">آگے کچھ نہیں</string>
     <string name="queue_empty">قطار خالی ہے</string>
     <string name="queue_remove">قطار سے ہٹائیں</string>
     <string name="queue_drag_to_reorder">ترتیب بدلنے کے لیے گھسیٹیں</string>
+    <string name="queue_shuffled">شفل شدہ</string>
     <string name="search_failed">تلاش · خرابی</string>
     <string name="search_no_results">کوئی نتیجہ نہیں: “%1$s”</string>
     <string name="search_section_albums">البمز</string>

--- a/bae-android/app/src/main/res/values-vi/strings.xml
+++ b/bae-android/app/src/main/res/values-vi/strings.xml
@@ -39,10 +39,12 @@
     <string name="queue_clear">Clear</string>
     <string name="queue_section_now_playing">Đang phát</string>
     <string name="queue_section_up_next">Tiếp theo</string>
+    <string name="queue_section_playing_from">Đang phát từ</string>
     <string name="queue_nothing_up_next">Không có mục tiếp theo</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>
     <string name="queue_drag_to_reorder">Kéo để sắp xếp lại</string>
+    <string name="queue_shuffled">Đã trộn</string>
     <string name="search_failed">Tìm kiếm · Lỗi</string>
     <string name="search_no_results">Không có kết quả: “%1$s”</string>
     <string name="search_section_albums">Album</string>

--- a/bae-android/app/src/main/res/values/strings.xml
+++ b/bae-android/app/src/main/res/values/strings.xml
@@ -60,10 +60,12 @@
     <string name="queue_clear">Clear</string>
     <string name="queue_section_now_playing">Now Playing</string>
     <string name="queue_section_up_next">Up Next</string>
+    <string name="queue_section_playing_from">Playing From</string>
     <string name="queue_nothing_up_next">Nothing up next</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>
     <string name="queue_drag_to_reorder">Drag to reorder</string>
+    <string name="queue_shuffled">Shuffled</string>
 
     <!-- Search results -->
     <string name="search_failed">Search failed</string>

--- a/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import uniffi.bae_bridge.BridgeException
 import uniffi.bae_bridge.BridgeLoadingTrackInfo
+import uniffi.bae_bridge.BridgePlaybackContext
 import uniffi.bae_bridge.BridgePlaybackErrorReason
 import uniffi.bae_bridge.BridgeQueueEntry
 import uniffi.bae_bridge.BridgeRepeatMode
@@ -42,7 +43,8 @@ class UiEventReducerTest {
             override fun onRepeatModeChanged(mode: BridgeRepeatMode) {}
 
             override fun onQueueUpdated(
-                items: List<BridgeQueueEntry>,
+                manual: List<BridgeQueueEntry>,
+                context: BridgePlaybackContext?,
                 hasNext: Boolean,
                 hasPrevious: Boolean,
             ) {}

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1522,25 +1522,30 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             mode: BridgeRepeatMode::from_core(mode),
         }),
         UiBusEvent::QueueUpdated {
-            items,
+            manual,
+            context,
             has_next,
             has_previous,
-        } => Some(BridgeUiEvent::QueueUpdated {
-            items: items
-                .into_iter()
-                .map(|i| BridgeQueueEntry {
-                    entry_id: i.entry_id,
-                    track_id: i.track_id,
-                    title: i.title,
-                    artist_names: i.artist_names,
-                    duration_ms: i.duration_ms,
-                    album_title: i.album_title,
-                    cover_image_id: i.cover_image_id,
-                })
-                .collect(),
-            has_next,
-            has_previous,
-        }),
+        } => {
+            let to_entry = |i: bae_core::queue::QueueItem| BridgeQueueEntry {
+                entry_id: i.entry_id,
+                track_id: i.track_id,
+                title: i.title,
+                artist_names: i.artist_names,
+                duration_ms: i.duration_ms,
+                album_title: i.album_title,
+                cover_image_id: i.cover_image_id,
+            };
+            Some(BridgeUiEvent::QueueUpdated {
+                manual: manual.into_iter().map(to_entry).collect(),
+                context: context.map(|c| BridgePlaybackContext {
+                    shuffled: c.shuffled,
+                    upcoming: c.upcoming.into_iter().map(to_entry).collect(),
+                }),
+                has_next,
+                has_previous,
+            })
+        }
         UiBusEvent::QueueItemsAdded { count } => Some(BridgeUiEvent::QueueItemsAdded { count }),
 
         // ── Preview ────────────────────────────────────────────────

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1349,7 +1349,8 @@ pub enum BridgeUiEvent {
         mode: BridgeRepeatMode,
     },
     QueueUpdated {
-        items: Vec<BridgeQueueEntry>,
+        manual: Vec<BridgeQueueEntry>,
+        context: Option<BridgePlaybackContext>,
         has_next: bool,
         has_previous: bool,
     },
@@ -1965,6 +1966,16 @@ pub struct BridgeQueueEntry {
     pub duration_ms: Option<i64>,
     pub album_title: String,
     pub cover_image_id: Option<String>,
+}
+
+/// The context lane (the release being played from), carried by `QueueUpdated`
+/// alongside the manual lane so each UI renders the two as distinct sections:
+/// its not-yet-played tail, plus whether it was ordered by shuffle (the UI shows
+/// a shuffle indicator when so).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgePlaybackContext {
+    pub shuffled: bool,
+    pub upcoming: Vec<BridgeQueueEntry>,
 }
 
 #[derive(Debug, Clone, uniffi::Enum)]

--- a/bae-core/src/playback/mod.rs
+++ b/bae-core/src/playback/mod.rs
@@ -28,8 +28,8 @@ pub use error::PlaybackError;
 pub use persisted::{repeat_to_str, PersistedPlayback};
 pub use progress::{PlaybackProgress, PreviewState};
 pub use queue::{
-    ContextSnapshot, NextEntry, PlaybackQueue, PreviousAction, QueueEntry, QueueEntryId,
-    QueueSnapshot,
+    ContextProjection, ContextSnapshot, NextEntry, PlaybackQueue, PreviousAction, QueueEntry,
+    QueueEntryId, QueueSnapshot,
 };
 pub use repeat_mode::RepeatMode;
 pub use service::{

--- a/bae-core/src/playback/progress/mod.rs
+++ b/bae-core/src/playback/progress/mod.rs
@@ -37,10 +37,14 @@ pub enum PlaybackProgress {
         track_id: String,
         progress: f64,
     },
-    /// Queue was updated — contains current queue state as per-instance entries
-    /// (id + track id), in order.
+    /// Queue was updated — the two lanes kept separate: the manual lane ("Up
+    /// Next") in order, and the context (the release being played from) as its
+    /// not-yet-played tail plus its shuffled flag, or `None` when nothing plays
+    /// from a release. Each entry is a per-instance id + track id; the event bus
+    /// resolves them to display items.
     QueueUpdated {
-        entries: Vec<crate::playback::QueueEntry>,
+        manual: Vec<crate::playback::QueueEntry>,
+        context: Option<crate::playback::ContextProjection>,
         has_next: bool,
         has_previous: bool,
     },

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -20,6 +20,15 @@ pub struct QueueEntry {
     pub track_id: String,
 }
 
+/// The context lane projected for the UI: its not-yet-played tail and whether
+/// the release was ordered by shuffle (which the UI surfaces as an indicator).
+/// Kept distinct from the manual lane so the two render as separate sections.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextProjection {
+    pub shuffled: bool,
+    pub upcoming: Vec<QueueEntry>,
+}
+
 /// What to do when advancing to the next track.
 #[derive(Debug)]
 pub enum NextEntry {
@@ -546,8 +555,28 @@ impl PlaybackQueue {
 
     // -- Projection / accessors ------------------------------------------------
 
-    /// The flat upcoming list the UI renders: the manual lane, then the
-    /// not-yet-played tail of the context.
+    /// The manual lane ("Up Next") in order — the explicitly enqueued entries,
+    /// which drain before the context.
+    pub fn manual_entries(&self) -> Vec<QueueEntry> {
+        self.manual.iter().cloned().collect()
+    }
+
+    /// The context's projection — its not-yet-played tail and whether it was
+    /// ordered by shuffle — or `None` when nothing is playing from a release.
+    /// The two lanes are kept separate (not flattened) so each UI renders the
+    /// manual lane and the context as distinct sections.
+    pub fn context_projection(&self) -> Option<ContextProjection> {
+        self.context.as_ref().map(|ctx| ContextProjection {
+            shuffled: matches!(ctx.traversal, Traversal::Shuffled { .. }),
+            upcoming: ctx.upcoming().to_vec(),
+        })
+    }
+
+    /// The flat play order from the current track onward: the manual lane, then
+    /// the not-yet-played tail of the context. Used where a single linear order
+    /// is the right shape (the unit tests' play-order assertions, the platform
+    /// media-session playlist) — not the two-section UI projection, which reads
+    /// `manual_entries` and `context_projection` separately.
     pub fn upcoming(&self) -> Vec<QueueEntry> {
         let mut out: Vec<QueueEntry> = self.manual.iter().cloned().collect();
         if let Some(ctx) = self.context.as_ref() {
@@ -1153,6 +1182,69 @@ mod tests {
             vec!["a", "b"],
             "front must not consume"
         );
+    }
+
+    /// The projection keeps the two lanes separate: the manual lane is its own
+    /// list, the context is its not-yet-played tail, and no manual entry leaks
+    /// into the context list (or vice versa). A sequential context is not
+    /// shuffled.
+    #[test]
+    fn test_projection_keeps_manual_and_context_separate() {
+        let mut q = queue();
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3"]),
+            ContextStart::Index(0),
+        );
+        q.add_to_queue(rel(&["m1", "m2"]));
+
+        let manual: Vec<String> = q.manual_entries().into_iter().map(|e| e.track_id).collect();
+        assert_eq!(manual, vec!["m1", "m2"], "the manual lane is its own list");
+
+        let ctx = q.context_projection().expect("a release is playing");
+        let context_tracks: Vec<String> = ctx.upcoming.into_iter().map(|e| e.track_id).collect();
+        assert_eq!(
+            context_tracks,
+            vec!["t2", "t3"],
+            "the context is only the not-yet-played tail"
+        );
+        assert!(!ctx.shuffled, "a sequential context is not shuffled");
+
+        // The lanes don't bleed into each other.
+        assert!(
+            !context_tracks.iter().any(|t| t == "m1" || t == "m2"),
+            "manual entries are not mixed into the context list"
+        );
+        assert!(
+            !manual.iter().any(|t| t == "t2" || t == "t3"),
+            "context entries are not mixed into the manual list"
+        );
+    }
+
+    /// A shuffled context carries its `shuffled` flag through the projection.
+    #[test]
+    fn test_projection_context_carries_shuffled_flag() {
+        let mut q = queue();
+        q.play_release(
+            "r1".into(),
+            rel(&["t1", "t2", "t3", "t4"]),
+            ContextStart::Shuffled { seed: 7 },
+        );
+        let ctx = q.context_projection().expect("a release is playing");
+        assert!(ctx.shuffled, "a shuffled context reports shuffled");
+    }
+
+    /// No context → no projection; the manual lane still projects on its own.
+    #[test]
+    fn test_projection_no_context_is_none() {
+        let mut q = queue();
+        q.add_to_queue(rel(&["m1", "m2"]));
+        assert!(
+            q.context_projection().is_none(),
+            "nothing is playing from a release"
+        );
+        let manual: Vec<String> = q.manual_entries().into_iter().map(|e| e.track_id).collect();
+        assert_eq!(manual, vec!["m1", "m2"]);
     }
 
     #[test]

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -3377,7 +3377,8 @@ impl PlaybackService {
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::QueueUpdated {
-                entries: self.playback_queue.upcoming(),
+                manual: self.playback_queue.manual_entries(),
+                context: self.playback_queue.context_projection(),
                 has_next,
                 has_previous,
             },

--- a/bae-core/src/queue.rs
+++ b/bae-core/src/queue.rs
@@ -17,3 +17,15 @@ pub struct QueueItem {
     pub album_title: String,
     pub cover_image_id: Option<String>,
 }
+
+/// The context lane resolved for display: the not-yet-played tail of the
+/// release being played from, plus whether it was ordered by shuffle (which the
+/// UI surfaces as an indicator). The display-ready counterpart of
+/// [`crate::playback::ContextProjection`], with each entry resolved to a
+/// [`QueueItem`]. Carried separately from the manual lane so each UI renders the
+/// two as distinct sections.
+#[derive(Debug, Clone)]
+pub struct ResolvedContext {
+    pub shuffled: bool,
+    pub upcoming: Vec<QueueItem>,
+}

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -151,20 +151,39 @@ impl UiEventBus {
                         });
                     }
                     PlaybackProgress::QueueUpdated {
-                        entries,
+                        manual,
+                        context,
                         has_next,
                         has_previous,
                     } => {
-                        // Resolve the queue's entries to display-ready items in
-                        // core so the event payload is fully populated, each row
-                        // carrying its per-instance entry id. Consumers then map
-                        // it directly instead of each re-querying the DB (the
-                        // macOS reducer used to; Windows didn't, so its queue
-                        // rows rendered blank).
-                        match lm.get_queue_items(&entries).await {
+                        // Resolve both lanes to display-ready items in core so the
+                        // event payload is fully populated, each row carrying its
+                        // per-instance entry id. Consumers map it straight through
+                        // instead of each re-querying the DB. Resolve manual and
+                        // the context tail in ONE query (so a single failure path
+                        // covers both), then split the resolved rows back into the
+                        // two lanes by entry id — not by length, since resolution
+                        // drops any entry whose track has no metadata, which would
+                        // otherwise shift the lane boundary.
+                        let context_entries =
+                            context.as_ref().map(|c| c.upcoming.clone()).unwrap_or_default();
+                        let combined: Vec<_> =
+                            manual.iter().chain(context_entries.iter()).cloned().collect();
+                        match lm.get_queue_items(&combined).await {
                             Ok(items) => {
+                                let context_ids: std::collections::HashSet<&str> = context_entries
+                                    .iter()
+                                    .map(|e| e.id.0.as_str())
+                                    .collect();
+                                let (context_items, manual_items): (Vec<_>, Vec<_>) = items
+                                    .into_iter()
+                                    .partition(|i| context_ids.contains(i.entry_id.as_str()));
                                 bus.emit(UiBusEvent::QueueUpdated {
-                                    items,
+                                    manual: manual_items,
+                                    context: context.map(|c| crate::queue::ResolvedContext {
+                                        shuffled: c.shuffled,
+                                        upcoming: context_items,
+                                    }),
                                     has_next,
                                     has_previous,
                                 });
@@ -172,7 +191,7 @@ impl UiEventBus {
                             Err(e) => {
                                 tracing::warn!(
                                     "skipping QueueUpdated: failed to resolve {} queue entry(ies): {e}",
-                                    entries.len()
+                                    combined.len()
                                 );
                             }
                         }

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -165,8 +165,13 @@ impl UiEventBus {
                         // two lanes by entry id — not by length, since resolution
                         // drops any entry whose track has no metadata, which would
                         // otherwise shift the lane boundary.
-                        let context_entries =
-                            context.as_ref().map(|c| c.upcoming.clone()).unwrap_or_default();
+                        // No context (nothing playing from a release) yields no
+                        // context entries — a normal domain state, expressed by
+                        // iterating the Option rather than defaulting an absence.
+                        let context_entries: Vec<_> = context
+                            .iter()
+                            .flat_map(|c| c.upcoming.iter().cloned())
+                            .collect();
                         let combined: Vec<_> =
                             manual.iter().chain(context_entries.iter()).cloned().collect();
                         match lm.get_queue_items(&combined).await {

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -147,8 +147,13 @@ pub enum UiBusEvent {
     RepeatModeChanged {
         mode: crate::playback::RepeatMode,
     },
+    /// The queue's two lanes, kept separate so each UI renders them as distinct
+    /// sections: the manual lane ("Up Next") in order, and the context (the
+    /// release being played from) as its not-yet-played tail plus its shuffled
+    /// flag, or `None` when nothing plays from a release.
     QueueUpdated {
-        items: Vec<crate::queue::QueueItem>,
+        manual: Vec<crate::queue::QueueItem>,
+        context: Option<crate::queue::ResolvedContext>,
         has_next: bool,
         has_previous: bool,
     },

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -228,9 +228,14 @@ impl PlaybackTestFixture {
         while Instant::now() < deadline {
             match timeout(Duration::from_millis(100), self.progress_rx.recv()).await {
                 Ok(Some(PlaybackProgress::QueueUpdated {
-                    entries: latest, ..
+                    manual, context, ..
                 })) => {
-                    entries = latest;
+                    // The mutation targets entries in either lane, so flatten the
+                    // two lanes into one play-order list for id lookup.
+                    entries = manual;
+                    if let Some(ctx) = context {
+                        entries.extend(ctx.upcoming);
+                    }
                 }
                 Ok(Some(PlaybackProgress::StateChanged {
                     state: PlaybackState::Playing { .. },
@@ -4163,11 +4168,12 @@ async fn test_restore_drops_context_when_cursor_past_shrunk_tracks() {
     while Instant::now() < deadline {
         match timeout(Duration::from_millis(100), progress_rx.recv()).await {
             Ok(Some(PlaybackProgress::QueueUpdated {
-                entries,
+                manual,
+                context,
                 has_previous,
                 ..
             })) => {
-                queue_update = Some((entries, has_previous));
+                queue_update = Some((manual, context, has_previous));
                 break;
             }
             Ok(Some(_)) => continue,
@@ -4175,12 +4181,16 @@ async fn test_restore_drops_context_when_cursor_past_shrunk_tracks() {
         }
     }
 
-    let (entries, has_previous) = queue_update.expect("restore emits a queue update");
-    let queued: Vec<&str> = entries.iter().map(|e| e.track_id.as_str()).collect();
+    let (manual, context, has_previous) = queue_update.expect("restore emits a queue update");
     assert!(
         !has_previous,
         "the context was dropped, so nothing sits before the cursor"
     );
+    assert!(
+        context.is_none(),
+        "the cursor was past the release, so the context is dropped entirely: {context:?}"
+    );
+    let queued: Vec<&str> = manual.iter().map(|e| e.track_id.as_str()).collect();
     assert!(
         queued.contains(&manual_track_id.as_str()),
         "the manual lane survives the restore: {queued:?}"

--- a/bae-ios/bae/bae/Localizable.xcstrings
+++ b/bae-ios/bae/bae/Localizable.xcstrings
@@ -8744,6 +8744,197 @@
         }
       }
     },
+    "Playing From": {
+      "comment": "Queue panel: context (release being played from) section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playing From"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciendo desde"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture depuis"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird abgespielt aus"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocando de"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再生元"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来自"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يُشغّل من"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מנגן מתוך"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відтворюється з"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Възпроизвежда се от"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzanie z"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přehrává se z"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducira se iz"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재생 위치"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來自"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In riproduzione da"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şuradan çalınıyor"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang phát từ"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afspelen vanuit"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यहाँ से चल रहा है"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যা থেকে চলছে"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இதிலிருந்து இயக்குகிறது"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "దీని నుండి ప్లే అవుతోంది"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "येथून वाजत आहे"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یہاں سے چل رہا ہے"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "આમાંથી વાગે છે"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಇದರಿಂದ ಪ್ಲೇ ಆಗುತ್ತಿದೆ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ഇതിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਇੱਥੋਂ ਚੱਲ ਰਿਹਾ ਹੈ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเล่นจาก"
+          }
+        }
+      }
+    },
     "Previous track": {
       "localizations": {
         "en": {
@@ -11394,6 +11585,197 @@
           "stringUnit": {
             "state": "translated",
             "value": "ਸ਼ਫਲ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สุ่ม"
+          }
+        }
+      }
+    },
+    "Shuffled": {
+      "comment": "Queue panel: shuffle indicator accessibility label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aleatorio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aléatoire"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zufällig"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aleatório"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャッフル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已随机"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم الخلط"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אקראי"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемішано"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разбъркано"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Losowo"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zamícháno"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izmiješano"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔플됨"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已隨機"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Casuale"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karışık"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã trộn"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschud"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "शफ़ल किया गया"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শাফল করা"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைக்கப்பட்டது"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "షఫుల్ చేయబడింది"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "शफल केले"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شفل شدہ"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "શફલ કરેલું"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಶಫಲ್ ಮಾಡಲಾಗಿದೆ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ഷഫിൾ ചെയ്തു"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਸ਼ਫਲ ਕੀਤਾ"
           }
         },
         "th": {

--- a/bae-ios/bae/bae/UiEventReducer.swift
+++ b/bae-ios/bae/bae/UiEventReducer.swift
@@ -298,8 +298,9 @@ enum UiEventReducer {
         case .muteChanged(let isMuted):
             playbackStore.isMuted = isMuted
 
-        case .queueUpdated(let items, let hasNext, let hasPrevious):
-            playbackStore.queueItems = items.map(QueueItem.init(bridge:))
+        case .queueUpdated(let manual, let playbackContext, let hasNext, let hasPrevious):
+            playbackStore.manualQueue = manual.map(QueueItem.init(bridge:))
+            playbackStore.queueContext = playbackContext.map(QueuePlaybackContext.init(bridge:))
             context.mediaControlService.updateCommandAvailability(
                 hasNext: hasNext,
                 hasPrevious: hasPrevious

--- a/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
+++ b/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
@@ -183,14 +183,32 @@ struct ExpandedNowPlayingView: View {
     // above. The section is dropped when empty so no bare "Up Next" header shows.
     @ViewBuilder
     private var upNext: some View {
-        if !playbackStore.queueItems.isEmpty {
+        if !playbackStore.manualQueue.isEmpty {
             Section("Up Next") {
                 upNextRows(
-                    items: playbackStore.queueItems,
+                    items: playbackStore.manualQueue,
                     queue: queue,
                     isEditing: false,
                     onSkipped: {}
                 )
+            }
+        }
+        if let context = playbackStore.queueContext, !context.upcoming.isEmpty {
+            Section {
+                upNextRows(
+                    items: context.upcoming,
+                    queue: queue,
+                    isEditing: false,
+                    onSkipped: {}
+                )
+            } header: {
+                HStack(spacing: 6) {
+                    Text("Playing From")
+                    if context.shuffled {
+                        Image(systemName: "shuffle")
+                            .accessibilityLabel(Text("Shuffled"))
+                    }
+                }
             }
         }
     }

--- a/bae-ios/bae/bae/Views/QueueView.swift
+++ b/bae-ios/bae/bae/Views/QueueView.swift
@@ -43,10 +43,11 @@ struct QueueView: View {
                 }
 
                 upNext
+                playingFrom
             }
             .listStyle(.plain)
             .environment(\.editMode, $editMode)
-            .onChange(of: playbackStore.queueItems.isEmpty) { _, isEmpty in
+            .onChange(of: playbackStore.manualQueue.isEmpty) { _, isEmpty in
                 if isEmpty { editMode = .inactive }
             }
             .background(Theme.background)
@@ -54,8 +55,11 @@ struct QueueView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
+                    // Clear empties only the manual lane; the context (the release
+                    // being played from) survives, so it disables on an empty
+                    // manual lane regardless of the context.
                     Button("Clear") { queue.clearQueue() }
-                        .disabled(playbackStore.queueItems.isEmpty)
+                        .disabled(playbackStore.manualQueue.isEmpty)
                 }
                 // EditButton toggles the list into edit mode, which is what
                 // surfaces the drag-to-reorder handles (and the delete control)
@@ -72,16 +76,21 @@ struct QueueView: View {
 
     @ViewBuilder
     private var upNext: some View {
-        if playbackStore.queueItems.isEmpty {
-            Section {
-                Text(
-                    playbackStore.nowPlaying.track == nil
-                        ? String(localized: "Queue is empty")
-                        : String(localized: "Nothing up next")
-                )
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.vertical, 24)
+        if playbackStore.manualQueue.isEmpty {
+            // Only show the empty message when nothing follows at all — no manual
+            // lane and no context section below. With a context present, the
+            // "Playing From" section carries the queue, so no message is needed.
+            if playbackStore.queueContext == nil {
+                Section {
+                    Text(
+                        playbackStore.nowPlaying.track == nil
+                            ? String(localized: "Queue is empty")
+                            : String(localized: "Nothing up next")
+                    )
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
+                }
             }
         }
         else {
@@ -89,11 +98,36 @@ struct QueueView: View {
                 // Edit mode surfaces reorder handles here; a row tap is gated to
                 // skip only when not editing, and skipping dismisses the sheet.
                 upNextRows(
-                    items: playbackStore.queueItems,
+                    items: playbackStore.manualQueue,
                     queue: queue,
                     isEditing: editMode.isEditing,
                     onSkipped: { dismiss() }
                 )
+            }
+        }
+    }
+
+    // The context (the release being played from): its not-yet-played tail, with
+    // a shuffle indicator in the header when the order is shuffled. The rows skip/
+    // remove/reorder by entry id, the same as the manual lane.
+    @ViewBuilder
+    private var playingFrom: some View {
+        if let context = playbackStore.queueContext, !context.upcoming.isEmpty {
+            Section {
+                upNextRows(
+                    items: context.upcoming,
+                    queue: queue,
+                    isEditing: editMode.isEditing,
+                    onSkipped: { dismiss() }
+                )
+            } header: {
+                HStack(spacing: 6) {
+                    Text("Playing From")
+                    if context.shuffled {
+                        Image(systemName: "shuffle")
+                            .accessibilityLabel(Text("Shuffled"))
+                    }
+                }
             }
         }
     }

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -48108,6 +48108,197 @@
         }
       }
     },
+    "Playing From": {
+      "comment": "Queue panel: context (release being played from) section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playing From"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciendo desde"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture depuis"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird abgespielt aus"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocando de"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再生元"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来自"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يُشغّل من"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מנגן מתוך"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відтворюється з"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Възпроизвежда се от"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzanie z"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přehrává se z"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducira se iz"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재생 위치"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來自"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In riproduzione da"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şuradan çalınıyor"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang phát từ"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afspelen vanuit"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यहाँ से चल रहा है"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "যা থেকে চলছে"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "இதிலிருந்து இயக்குகிறது"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "దీని నుండి ప్లే అవుతోంది"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "येथून वाजत आहे"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یہاں سے چل رہا ہے"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "આમાંથી વાગે છે"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಇದರಿಂದ ಪ್ಲೇ ಆಗುತ್ತಿದೆ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ഇതിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਇੱਥੋਂ ਚੱਲ ਰਿਹਾ ਹੈ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเล่นจาก"
+          }
+        }
+      }
+    },
     "Previous Library": {
       "comment": "File menu: switch to the previous library",
       "localizations": {
@@ -63003,6 +63194,197 @@
         }
       }
     },
+    "Shuffled": {
+      "comment": "Queue panel: shuffle indicator accessibility label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aleatorio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aléatoire"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zufällig"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aleatório"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャッフル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已随机"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم الخلط"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אקראי"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемішано"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разбъркано"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Losowo"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zamícháno"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izmiješano"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔플됨"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已隨機"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Casuale"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karışık"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã trộn"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschud"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "शफ़ल किया गया"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শাফল করা"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைக்கப்பட்டது"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "షఫుల్ చేయబడింది"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "शफल केले"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شفل شدہ"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "શફલ કરેલું"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಶಫಲ್ ಮಾಡಲಾಗಿದೆ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ഷഫിൾ ചെയ്തു"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਸ਼ਫਲ ਕੀਤਾ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สุ่ม"
+          }
+        }
+      }
+    },
     "Signals": {
       "comment": "Import signals toolbar: header label",
       "localizations": {
@@ -71841,6 +72223,197 @@
           "stringUnit": {
             "state": "translated",
             "value": "เปิดเสียง"
+          }
+        }
+      }
+    },
+    "Up Next": {
+      "comment": "Queue panel: manual lane section header",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up Next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A continuación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À suivre"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als Nächstes"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A seguir"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次に再生"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接下来"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التالي"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הבא בתור"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Далі в черзі"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следва"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następne w kolejce"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Další v pořadí"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sljedeće na redu"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 재생"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接下來"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A seguire"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sıradaki"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp theo"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volgende"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अगला"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "পরবর্তী"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "அடுத்தது"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "తదుపరి"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पुढचे"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگلا"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "આગળ"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಮುಂದಿನದು"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "അടുത്തത്"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਅਗਲਾ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ถัดไป"
           }
         }
       }

--- a/bae-macos/bae/bae/Services/PlaybackStore.swift
+++ b/bae-macos/bae/bae/Services/PlaybackStore.swift
@@ -5,10 +5,10 @@ import os.log
 private let logger = Logger.bae("PlaybackStore")
 
 /// Mirror of core's playback state. The reducer is the sole writer:
-/// `nowPlaying`, `volume`, `isMuted`, `repeatMode`, and `queueItems` are
-/// all driven by `BridgeUiEvent` deliveries. Views read fields at the
-/// leaf and never write back — they invoke `appHandle` actions instead,
-/// and the resulting events flow back through the reducer.
+/// `nowPlaying`, `volume`, `isMuted`, `repeatMode`, `manualQueue`, and
+/// `queueContext` are all driven by `BridgeUiEvent` deliveries. Views read
+/// fields at the leaf and never write back — they invoke `appHandle` actions
+/// instead, and the resulting events flow back through the reducer.
 @Observable
 class PlaybackStore {
     var nowPlaying: NowPlaying = .stopped
@@ -16,7 +16,11 @@ class PlaybackStore {
     var volume: Float = 1.0
     var isMuted: Bool = false
     var repeatMode: RepeatMode = .off
-    var queueItems: [QueueItem] = []
+    /// The manual lane ("Up Next") — explicitly enqueued tracks, drained first.
+    var manualQueue: [QueueItem] = []
+    /// The context (the release being played from), or `nil` when nothing plays
+    /// from a release. Rendered as a section distinct from `manualQueue`.
+    var queueContext: QueuePlaybackContext?
 
     /// Current playback position. Updates at display rate during playback —
     /// far too frequent for `@Observable`; published as a Combine signal so

--- a/bae-macos/bae/bae/Services/Store/QueueItem.swift
+++ b/bae-macos/bae/bae/Services/Store/QueueItem.swift
@@ -23,3 +23,21 @@ struct QueueItem: Identifiable, Equatable {
         coverImageId = bridge.coverImageId
     }
 }
+
+/// The context lane (the release being played from): its not-yet-played tail,
+/// plus whether it was ordered by shuffle (rendered as a shuffle indicator).
+/// Shown as its own section, distinct from the manual "Up Next" lane.
+struct QueuePlaybackContext: Equatable {
+    let shuffled: Bool
+    let upcoming: [QueueItem]
+
+    init(bridge: BridgePlaybackContext) {
+        shuffled = bridge.shuffled
+        upcoming = bridge.upcoming.map(QueueItem.init(bridge:))
+    }
+
+    init(shuffled: Bool, upcoming: [QueueItem]) {
+        self.shuffled = shuffled
+        self.upcoming = upcoming
+    }
+}

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -329,10 +329,20 @@ enum UiEventReducer {
         case .repeatModeChanged(let mode):
             playbackStore.repeatMode = RepeatMode(bridge: mode)
 
-        case .queueUpdated(let items, let hasNext, let hasPrevious):
-            // The event carries display-ready items (core resolves them before
-            // emitting), so map them straight through — no DB re-query here.
-            playbackStore.queueItems = items.map(QueueItem.init(bridge:))
+        case .queueUpdated(
+            let manual,
+            let playbackContext,
+            let hasNext,
+            let hasPrevious
+        ):
+            // The event carries display-ready items in two lanes (core resolves
+            // them before emitting), so map them straight through — no DB
+            // re-query here. The manual lane and the context render as distinct
+            // sections.
+            playbackStore.manualQueue = manual.map(QueueItem.init(bridge:))
+            playbackStore.queueContext = playbackContext.map(
+                QueuePlaybackContext.init(bridge:)
+            )
             context.appService.mediaControlService.updateCommandAvailability(
                 hasNext: hasNext,
                 hasPrevious: hasPrevious

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -48,7 +48,8 @@ struct NowPlayingBarContainer: View {
             queueNowPlayingTitle: track?.trackTitle,
             queueNowPlayingArtist: track?.artistNames,
             queueNowPlayingPath: coverPath,
-            queueItems: playbackStore.queueItems,
+            queueManual: playbackStore.manualQueue,
+            queueContext: playbackStore.queueContext,
             resolveQueueImagePath: { $0.flatMap(mediaPaths.imagePathIfExists) },
             onPlayPause: { playback.togglePlayPause() },
             onNext: { playback.nextTrack() },
@@ -111,7 +112,8 @@ struct NowPlayingBar: View {
     let queueNowPlayingTitle: String?
     let queueNowPlayingArtist: String?
     let queueNowPlayingPath: String?
-    let queueItems: [QueueItem]
+    let queueManual: [QueueItem]
+    let queueContext: QueuePlaybackContext?
     let resolveQueueImagePath: (String?) -> String?
     let onPlayPause: () -> Void
     let onNext: () -> Void
@@ -280,7 +282,8 @@ struct NowPlayingBar: View {
                     nowPlayingTitle: queueNowPlayingTitle,
                     nowPlayingArtist: queueNowPlayingArtist,
                     nowPlayingPath: queueNowPlayingPath,
-                    items: queueItems,
+                    manual: queueManual,
+                    context: queueContext,
                     resolveImagePath: resolveQueueImagePath,
                     onClose: { showQueue = false },
                     onClear: { onQueueClear() },
@@ -384,7 +387,8 @@ private struct NowPlayingBarPreview: View {
     var isLoading: Bool = false
     let repeatMode: RepeatMode
     let queueIsActive: Bool
-    let queueItems: [QueueItem]
+    var queueManual: [QueueItem] = []
+    var queueContext: QueuePlaybackContext?
 
     @State
     private var showQueue = false
@@ -409,7 +413,8 @@ private struct NowPlayingBarPreview: View {
             queueNowPlayingTitle: trackTitle,
             queueNowPlayingArtist: artistNames,
             queueNowPlayingPath: nil,
-            queueItems: queueItems,
+            queueManual: queueManual,
+            queueContext: queueContext,
             resolveQueueImagePath: { _ in nil },
             onPlayPause: {},
             onNext: {},
@@ -438,7 +443,11 @@ private struct NowPlayingBarPreview: View {
         isPlaying: true,
         repeatMode: .off,
         queueIsActive: true,
-        queueItems: PreviewData.queueItems,
+        queueManual: Array(PreviewData.queueItems.prefix(2)),
+        queueContext: QueuePlaybackContext(
+            shuffled: false,
+            upcoming: Array(PreviewData.queueItems.suffix(3))
+        ),
     )
     .environment(MediaPaths.stub)
 }
@@ -450,7 +459,11 @@ private struct NowPlayingBarPreview: View {
         isPlaying: false,
         repeatMode: .context,
         queueIsActive: true,
-        queueItems: PreviewData.queueItems,
+        queueManual: Array(PreviewData.queueItems.prefix(2)),
+        queueContext: QueuePlaybackContext(
+            shuffled: true,
+            upcoming: Array(PreviewData.queueItems.suffix(3))
+        ),
     )
     .environment(MediaPaths.stub)
 }
@@ -463,7 +476,8 @@ private struct NowPlayingBarPreview: View {
         isLoading: true,
         repeatMode: .off,
         queueIsActive: true,
-        queueItems: PreviewData.queueItems,
+        queueManual: PreviewData.queueItems,
+        queueContext: nil,
     )
     .environment(MediaPaths.stub)
 }
@@ -475,7 +489,6 @@ private struct NowPlayingBarPreview: View {
         isPlaying: false,
         repeatMode: .off,
         queueIsActive: false,
-        queueItems: [],
     )
     .environment(MediaPaths.stub)
 }

--- a/bae-macos/bae/bae/Views/QueueView.swift
+++ b/bae-macos/bae/bae/Views/QueueView.swift
@@ -29,7 +29,14 @@ struct QueueView: View {
     private var draggedEntryId: String?
 
     private var isEmpty: Bool {
-        manual.isEmpty && (context?.upcoming.isEmpty ?? true)
+        // No context (nothing playing from a release) contributes no rows — a
+        // normal state, named here rather than folded into a default.
+        switch context {
+        case .none:
+            return manual.isEmpty
+        case .some(let context):
+            return manual.isEmpty && context.upcoming.isEmpty
+        }
     }
 
     var body: some View {
@@ -192,9 +199,11 @@ private struct QueueSection: View {
                 index,
                 item in
                 VStack(spacing: 0) {
-                    if dropInsertIndex == index {
-                        insertionLine
-                    }
+                    // Kept in the tree and toggled by opacity so showing the drop
+                    // line doesn't change a row's size and re-lay-out the lane.
+                    insertionLine
+                        .opacity(dropInsertIndex == index ? 1 : 0)
+                        .allowsHitTesting(false)
                     queueItemRow(item, index: index)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
@@ -214,9 +223,11 @@ private struct QueueSection: View {
                     )
                 )
             }
-            if dropInsertIndex == items.count {
-                insertionLine
-            }
+            // The trailing drop line (insert at the lane's end) stays in the tree
+            // and toggles by opacity, matching the per-row lines above.
+            insertionLine
+                .opacity(dropInsertIndex == items.count ? 1 : 0)
+                .allowsHitTesting(false)
 
             // Trailing drop zone for appending — only the manual lane appends
             // external tracks; the context still accepts a reorder-to-end here.
@@ -270,17 +281,22 @@ private struct QueueSection: View {
                     .frame(width: 40, height: 40)
                     .clipShape(RoundedRectangle(cornerRadius: 3))
 
-                if hoveredIndex == index {
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(.black.opacity(0.5))
-                        .frame(width: 40, height: 40)
-                    Button(action: { onSkipTo(item.id) }) {
-                        Image(systemName: "play.fill")
-                            .font(.caption)
-                            .foregroundColor(.white)
-                    }
-                    .buttonStyle(.plain)
+                // The hover play overlay stays in the tree and toggles by
+                // opacity/hit-testing so revealing it on hover doesn't resize the
+                // row and re-lay-out the whole lane.
+                let isHovered = hoveredIndex == index
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.black.opacity(0.5))
+                    .frame(width: 40, height: 40)
+                    .opacity(isHovered ? 1 : 0)
+                Button(action: { onSkipTo(item.id) }) {
+                    Image(systemName: "play.fill")
+                        .font(.caption)
+                        .foregroundColor(.white)
                 }
+                .buttonStyle(.plain)
+                .opacity(isHovered ? 1 : 0)
+                .allowsHitTesting(isHovered)
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -295,7 +311,16 @@ private struct QueueSection: View {
 
             Spacer()
 
-            if hoveredIndex == index {
+            // Hover swaps the duration for a remove button. Both stay in the tree
+            // and toggle by opacity/hit-testing so the swap doesn't resize the row
+            // and re-lay-out the lane. (The trailing slot is the wider of the two,
+            // so neither toggle changes the row's intrinsic width.)
+            let isHovered = hoveredIndex == index
+            ZStack(alignment: .trailing) {
+                Text(item.durationLabel)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .opacity(isHovered ? 0 : 1)
                 Button(action: { onRemove(item.id) }) {
                     Image(systemName: "xmark")
                         .font(.caption)
@@ -303,11 +328,8 @@ private struct QueueSection: View {
                 }
                 .buttonStyle(.plain)
                 .help("Remove from queue")
-            }
-            else if !item.durationLabel.isEmpty {
-                Text(item.durationLabel)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                .opacity(isHovered ? 1 : 0)
+                .allowsHitTesting(isHovered)
             }
         }
         .contentShape(Rectangle())

--- a/bae-macos/bae/bae/Views/QueueView.swift
+++ b/bae-macos/bae/bae/Views/QueueView.swift
@@ -274,30 +274,35 @@ private struct QueueSection: View {
             .padding(.horizontal, 8)
     }
 
+    // The hover play overlay stays in the tree and toggles by opacity/hit-testing
+    // so revealing it on hover doesn't resize the row and re-lay-out the lane.
+    private func queueItemArtWithHover(_ item: QueueItem, index: Int)
+        -> some View
+    {
+        let isHovered = hoveredIndex == index
+        return ZStack {
+            queueItemArt(path: resolveImagePath(item.coverImageId))
+                .frame(width: 40, height: 40)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.black.opacity(0.5))
+                .frame(width: 40, height: 40)
+                .opacity(isHovered ? 1 : 0)
+            Button(action: { onSkipTo(item.id) }) {
+                Image(systemName: "play.fill")
+                    .font(.caption)
+                    .foregroundColor(.white)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovered ? 1 : 0)
+            .allowsHitTesting(isHovered)
+        }
+    }
+
     private func queueItemRow(_ item: QueueItem, index: Int) -> some View {
         HStack(spacing: 10) {
-            ZStack {
-                queueItemArt(path: resolveImagePath(item.coverImageId))
-                    .frame(width: 40, height: 40)
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
-
-                // The hover play overlay stays in the tree and toggles by
-                // opacity/hit-testing so revealing it on hover doesn't resize the
-                // row and re-lay-out the whole lane.
-                let isHovered = hoveredIndex == index
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(.black.opacity(0.5))
-                    .frame(width: 40, height: 40)
-                    .opacity(isHovered ? 1 : 0)
-                Button(action: { onSkipTo(item.id) }) {
-                    Image(systemName: "play.fill")
-                        .font(.caption)
-                        .foregroundColor(.white)
-                }
-                .buttonStyle(.plain)
-                .opacity(isHovered ? 1 : 0)
-                .allowsHitTesting(isHovered)
-            }
+            queueItemArtWithHover(item, index: index)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)

--- a/bae-macos/bae/bae/Views/QueueView.swift
+++ b/bae-macos/bae/bae/Views/QueueView.swift
@@ -6,23 +6,31 @@ struct QueueView: View {
     let nowPlayingTitle: String?
     let nowPlayingArtist: String?
     let nowPlayingPath: String?
-    let items: [QueueItem]
+    /// The manual lane ("Up Next"): explicitly enqueued tracks, drained first.
+    let manual: [QueueItem]
+    /// The context (the release being played from), or `nil` when nothing plays
+    /// from a release. Rendered as a section distinct from the manual lane.
+    let context: QueuePlaybackContext?
     let resolveImagePath: (String?) -> String?
     let onClose: () -> Void
     let onClear: () -> Void
     let onSkipTo: (String) -> Void
     let onRemove: (String) -> Void
     /// Move the entry `entryId` to sit before `beforeEntryId`; `nil` moves it
-    /// to the end of the queue.
+    /// to the end of its lane.
     let onReorder: (_ entryId: String, _ beforeEntryId: String?) -> Void
     let onInsertTracks: ([String], Int) -> Void
 
-    @State
-    private var hoveredIndex: Int?
+    // A drag can start in either section; the dragged entry id is shared so the
+    // source row dims wherever it lives. Hover and drop-insertion are positional,
+    // so each QueueSection owns its own — a row index in one lane must not light
+    // up the same index in the other.
     @State
     private var draggedEntryId: String?
-    @State
-    private var dropInsertIndex: Int?
+
+    private var isEmpty: Bool {
+        manual.isEmpty && (context?.upcoming.isEmpty ?? true)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -34,7 +42,7 @@ struct QueueView: View {
                 Divider()
             }
 
-            if items.isEmpty {
+            if isEmpty {
                 ContentUnavailableView(
                     "Queue is empty",
                     systemImage: "list.bullet",
@@ -52,66 +60,43 @@ struct QueueView: View {
             else {
                 ScrollView {
                     VStack(spacing: 0) {
-                        ForEach(Array(items.enumerated()), id: \.element.id) {
-                            index,
-                            item in
-                            VStack(spacing: 0) {
-                                // Insertion line above this row
-                                if dropInsertIndex == index {
-                                    insertionLine
-                                }
-                                queueItemRow(item, index: index)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 4)
-                                    .opacity(
-                                        draggedEntryId == item.id ? 0.3 : 1.0
-                                    )
-                                Divider().padding(.leading, 62)
-                            }
-                            .onDrop(
-                                of: [UTType.plainText],
-                                delegate: QueueDropDelegate(
-                                    targetIndex: index,
-                                    items: items,
-                                    draggedEntryId: $draggedEntryId,
-                                    dropInsertIndex: $dropInsertIndex,
-                                    onReorder: onReorder,
-                                    onInsertTracks: onInsertTracks,
-                                )
-                            )
-                        }
-                        // Insertion line at the very end
-                        if dropInsertIndex == items.count {
-                            insertionLine
-                        }
+                        // The manual lane drains first, so it is shown first. It
+                        // accepts external track drops (Play Next / Add to Queue
+                        // land here); the context section, being the release's own
+                        // order, takes reorder/remove/skip only.
+                        QueueSection(
+                            title: String(localized: "Up Next"),
+                            shuffled: false,
+                            items: manual,
+                            acceptsExternalDrops: true,
+                            resolveImagePath: resolveImagePath,
+                            draggedEntryId: $draggedEntryId,
+                            onSkipTo: onSkipTo,
+                            onRemove: onRemove,
+                            onReorder: onReorder,
+                            onInsertTracks: onInsertTracks,
+                        )
 
-                        // Drop zone at the end of the list for appending
-                        Color.clear
-                            .frame(height: 40)
-                            .onDrop(
-                                of: [UTType.plainText],
-                                delegate: QueueDropDelegate(
-                                    targetIndex: items.count,
-                                    items: items,
-                                    draggedEntryId: $draggedEntryId,
-                                    dropInsertIndex: $dropInsertIndex,
-                                    onReorder: onReorder,
-                                    onInsertTracks: onInsertTracks,
-                                )
+                        if let context, !context.upcoming.isEmpty {
+                            QueueSection(
+                                title: String(localized: "Playing From"),
+                                shuffled: context.shuffled,
+                                items: context.upcoming,
+                                acceptsExternalDrops: false,
+                                resolveImagePath: resolveImagePath,
+                                draggedEntryId: $draggedEntryId,
+                                onSkipTo: onSkipTo,
+                                onRemove: onRemove,
+                                onReorder: onReorder,
+                                onInsertTracks: onInsertTracks,
                             )
+                        }
                     }
                 }
                 .background(Theme.background)
             }
         }
         .background(Theme.surface)
-    }
-
-    private var insertionLine: some View {
-        Rectangle()
-            .fill(Color.accentColor)
-            .frame(height: 2)
-            .padding(.horizontal, 8)
     }
 
     // MARK: - Header
@@ -121,10 +106,13 @@ struct QueueView: View {
             Text("Queue")
                 .font(.headline)
             Spacer()
+            // Clear empties only the manual lane; the context (the release being
+            // played from) survives, so the control disables on an empty manual
+            // lane regardless of the context.
             Button("Clear") { onClear() }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
-                .disabled(items.isEmpty)
+                .disabled(manual.isEmpty)
             Button(action: onClose) {
                 Image(systemName: "xmark")
                     .foregroundStyle(.secondary)
@@ -169,8 +157,111 @@ struct QueueView: View {
     private var nowPlayingArt: some View {
         ImageView(localPath: nowPlayingPath, pointSize: 48)
     }
+}
 
-    // MARK: - Queue Items
+// MARK: - Section
+
+/// One lane of the queue (the manual "Up Next" lane or the context), rendered as
+/// a labelled section of reorderable rows. Reorder/remove/skip operate by entry
+/// id within this lane's `items`; only the manual lane sets `acceptsExternalDrops`
+/// (external track drops land in the manual lane, never the release's own order).
+/// Hover and drop-insertion are positional, so each section owns its own state.
+private struct QueueSection: View {
+    let title: String
+    let shuffled: Bool
+    let items: [QueueItem]
+    let acceptsExternalDrops: Bool
+    let resolveImagePath: (String?) -> String?
+    @Binding
+    var draggedEntryId: String?
+    let onSkipTo: (String) -> Void
+    let onRemove: (String) -> Void
+    let onReorder: (_ entryId: String, _ beforeEntryId: String?) -> Void
+    let onInsertTracks: ([String], Int) -> Void
+
+    @State
+    private var hoveredIndex: Int?
+    @State
+    private var dropInsertIndex: Int?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            sectionHeader
+
+            ForEach(Array(items.enumerated()), id: \.element.id) {
+                index,
+                item in
+                VStack(spacing: 0) {
+                    if dropInsertIndex == index {
+                        insertionLine
+                    }
+                    queueItemRow(item, index: index)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .opacity(draggedEntryId == item.id ? 0.3 : 1.0)
+                    Divider().padding(.leading, 62)
+                }
+                .onDrop(
+                    of: [UTType.plainText],
+                    delegate: QueueDropDelegate(
+                        targetIndex: index,
+                        items: items,
+                        acceptsExternalDrops: acceptsExternalDrops,
+                        draggedEntryId: $draggedEntryId,
+                        dropInsertIndex: $dropInsertIndex,
+                        onReorder: onReorder,
+                        onInsertTracks: onInsertTracks,
+                    )
+                )
+            }
+            if dropInsertIndex == items.count {
+                insertionLine
+            }
+
+            // Trailing drop zone for appending — only the manual lane appends
+            // external tracks; the context still accepts a reorder-to-end here.
+            Color.clear
+                .frame(height: acceptsExternalDrops ? 40 : 12)
+                .onDrop(
+                    of: [UTType.plainText],
+                    delegate: QueueDropDelegate(
+                        targetIndex: items.count,
+                        items: items,
+                        acceptsExternalDrops: acceptsExternalDrops,
+                        draggedEntryId: $draggedEntryId,
+                        dropInsertIndex: $dropInsertIndex,
+                        onReorder: onReorder,
+                        onInsertTracks: onInsertTracks,
+                    )
+                )
+        }
+    }
+
+    private var sectionHeader: some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            if shuffled {
+                Image(systemName: "shuffle")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(Text("Shuffled"))
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+    }
+
+    private var insertionLine: some View {
+        Rectangle()
+            .fill(Color.accentColor)
+            .frame(height: 2)
+            .padding(.horizontal, 8)
+    }
 
     private func queueItemRow(_ item: QueueItem, index: Int) -> some View {
         HStack(spacing: 10) {
@@ -247,6 +338,10 @@ struct QueueView: View {
 private struct QueueDropDelegate: DropDelegate {
     let targetIndex: Int
     let items: [QueueItem]
+    /// Whether external (non-row) track drops are accepted into this lane. The
+    /// manual lane inserts them; the context lane ignores them (you can't add a
+    /// track into the release's own order) and only handles internal reorders.
+    let acceptsExternalDrops: Bool
     @Binding
     var draggedEntryId: String?
     @Binding
@@ -255,7 +350,10 @@ private struct QueueDropDelegate: DropDelegate {
     let onReorder: (_ entryId: String, _ beforeEntryId: String?) -> Void
     let onInsertTracks: ([String], Int) -> Void
 
-    /// Whether this is an internal reorder (dragged from within the queue).
+    /// Whether this is an internal reorder within this lane (the dragged entry is
+    /// one of this lane's rows). A drag from the other lane is neither an internal
+    /// reorder here nor a valid external track drop, so it is rejected (cross-lane
+    /// reorder is a core no-op anyway).
     private var isInternalDrag: Bool {
         guard let draggedId = draggedEntryId else {
             return false
@@ -267,7 +365,7 @@ private struct QueueDropDelegate: DropDelegate {
         if let draggedId = draggedEntryId,
             let fromIndex = items.firstIndex(where: { $0.id == draggedId })
         {
-            // Internal reorder: show insertion line relative to source
+            // Internal reorder: show insertion line relative to source.
             if targetIndex > fromIndex {
                 dropInsertIndex = targetIndex + 1
             }
@@ -278,14 +376,19 @@ private struct QueueDropDelegate: DropDelegate {
                 dropInsertIndex = nil
             }
         }
-        else {
-            // External drop: show insertion line at target position
+        else if acceptsExternalDrops {
+            // External drop into the manual lane: insertion line at the target.
             dropInsertIndex = targetIndex
         }
     }
 
     func dropUpdated(info _: DropInfo) -> DropProposal? {
-        DropProposal(operation: isInternalDrag ? .move : .copy)
+        if isInternalDrag {
+            return DropProposal(operation: .move)
+        }
+        return DropProposal(
+            operation: acceptsExternalDrops ? .copy : .forbidden
+        )
     }
 
     func performDrop(info: DropInfo) -> Bool {
@@ -294,7 +397,7 @@ private struct QueueDropDelegate: DropDelegate {
         {
             // Internal reorder. `toIndex` is the gap the entry lands in; the
             // entry it lands before is whatever currently sits at that gap
-            // (nil past the end = move to the queue's end).
+            // (nil past the end = move to the lane's end).
             let toIndex =
                 targetIndex > fromIndex ? targetIndex + 1 : targetIndex
             if toIndex != fromIndex {
@@ -307,7 +410,13 @@ private struct QueueDropDelegate: DropDelegate {
             return true
         }
 
-        // External drop: load string IDs from the pasteboard
+        // External drop: rejected unless this lane accepts external tracks.
+        guard acceptsExternalDrops else {
+            dropInsertIndex = nil
+            return false
+        }
+
+        // Load string IDs from the pasteboard.
         let providers = info.itemProviders(for: [UTType.plainText])
         guard !providers.isEmpty else {
             dropInsertIndex = nil
@@ -351,11 +460,13 @@ private struct QueueDropDelegate: DropDelegate {
     }
 
     func validateDrop(info: DropInfo) -> Bool {
-        // Accept both internal drags and external drops with plain text
-        if draggedEntryId != nil {
+        // Accept internal drags from this lane; accept external plain-text drops
+        // only when this lane takes them.
+        if isInternalDrag {
             return true
         }
-        return info.hasItemsConforming(to: [UTType.plainText])
+        return acceptsExternalDrops
+            && info.hasItemsConforming(to: [UTType.plainText])
     }
 }
 
@@ -367,14 +478,16 @@ extension QueueView {
         isActive: Bool,
         nowPlayingTitle: String?,
         nowPlayingArtist: String?,
-        items: [QueueItem]
+        manual: [QueueItem],
+        context: QueuePlaybackContext?
     ) -> QueueView {
         QueueView(
             isActive: isActive,
             nowPlayingTitle: nowPlayingTitle,
             nowPlayingArtist: nowPlayingArtist,
             nowPlayingPath: nil,
-            items: items,
+            manual: manual,
+            context: context,
             resolveImagePath: { _ in nil },
             onClose: {},
             onClear: {},
@@ -393,7 +506,11 @@ extension QueueView {
         isActive: true,
         nowPlayingTitle: PreviewData.nowPlayingTitle,
         nowPlayingArtist: PreviewData.nowPlayingArtist,
-        items: PreviewData.queueItems
+        manual: Array(PreviewData.queueItems.prefix(2)),
+        context: QueuePlaybackContext(
+            shuffled: true,
+            upcoming: Array(PreviewData.queueItems.suffix(3))
+        )
     )
     .frame(width: 350, height: 500)
     .environment(MediaPaths.stub)
@@ -404,7 +521,8 @@ extension QueueView {
         isActive: false,
         nowPlayingTitle: nil,
         nowPlayingArtist: nil,
-        items: []
+        manual: [],
+        context: nil
     )
     .frame(width: 350, height: 400)
     .environment(MediaPaths.stub)

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -2274,6 +2274,16 @@ struct FfiQueueItem {
     cover_image_id: Option<String>,
 }
 
+/// The context lane (the release being played from), carried by `QueueUpdated`
+/// alongside the manual lane so the UI renders the two as distinct sections:
+/// its not-yet-played tail, plus whether it was ordered by shuffle (the UI shows
+/// a shuffle indicator when so).
+#[derive(Serialize)]
+struct FfiPlaybackContext {
+    shuffled: bool,
+    upcoming: Vec<FfiQueueItem>,
+}
+
 /// One signals-toolbar badge (carried by `CandidateIdentifyState`). A flat,
 /// pre-shaped mirror of `bae_core::identify::ToolbarSignal`: the UI renders it
 /// directly. `kind`/`role`/`origin` are the snake_case wire names; `state` is a
@@ -2376,7 +2386,8 @@ enum FfiEvent {
     /// The library changed (album/release add/update/remove) — reload views.
     LibraryChanged,
     QueueUpdated {
-        items: Vec<FfiQueueItem>,
+        manual: Vec<FfiQueueItem>,
+        context: Option<FfiPlaybackContext>,
         has_next: bool,
         has_previous: bool,
     },
@@ -2689,24 +2700,29 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
         | UiBusEvent::ReleaseUpdated { .. }
         | UiBusEvent::ReleaseRemoved { .. } => FfiEvent::LibraryChanged,
         UiBusEvent::QueueUpdated {
-            items,
+            manual,
+            context,
             has_next,
             has_previous,
-        } => FfiEvent::QueueUpdated {
-            items: items
-                .iter()
-                .map(|item| FfiQueueItem {
-                    entry_id: item.entry_id.clone(),
-                    title: item.title.clone(),
-                    artist: item.artist_names.clone(),
-                    duration_ms: item.duration_ms,
-                    album_title: item.album_title.clone(),
-                    cover_image_id: item.cover_image_id.clone(),
-                })
-                .collect(),
-            has_next: *has_next,
-            has_previous: *has_previous,
-        },
+        } => {
+            let to_item = |item: &bae_core::queue::QueueItem| FfiQueueItem {
+                entry_id: item.entry_id.clone(),
+                title: item.title.clone(),
+                artist: item.artist_names.clone(),
+                duration_ms: item.duration_ms,
+                album_title: item.album_title.clone(),
+                cover_image_id: item.cover_image_id.clone(),
+            };
+            FfiEvent::QueueUpdated {
+                manual: manual.iter().map(to_item).collect(),
+                context: context.as_ref().map(|c| FfiPlaybackContext {
+                    shuffled: c.shuffled,
+                    upcoming: c.upcoming.iter().map(to_item).collect(),
+                }),
+                has_next: *has_next,
+                has_previous: *has_previous,
+            }
+        }
         UiBusEvent::VolumeChanged { volume } => FfiEvent::VolumeChanged { volume: *volume },
         UiBusEvent::MuteChanged { is_muted } => FfiEvent::MuteChanged {
             is_muted: *is_muted,

--- a/bae-windows/BaeEvent.cs
+++ b/bae-windows/BaeEvent.cs
@@ -46,7 +46,10 @@ public sealed class BaeEvent
     public float Volume { get; set; }
     public bool IsMuted { get; set; }
     public string? Mode { get; set; }
-    public List<QueueItem>? Items { get; set; }
+    // The queue's two lanes (QueueUpdated): the manual lane ("Up Next") and the
+    // context (the release being played from), rendered as distinct sections.
+    public List<QueueItem>? Manual { get; set; }
+    public PlaybackContext? Context { get; set; }
     public bool HasNext { get; set; }
     public bool HasPrevious { get; set; }
 

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -67,7 +67,11 @@ public sealed partial class MainWindow : Window
     private NativeBae.EventCallback? _eventCallback;
 
     // Latest queue snapshot from QueueUpdated; the queue dialog reads it on open.
-    private List<QueueItem> _queue = new();
+    // The two lanes are kept separate so the dialog renders them as distinct
+    // sections: the manual lane ("Up Next") and the context (the release being
+    // played from), or null when nothing plays from a release.
+    private List<QueueItem> _queueManual = new();
+    private PlaybackContext? _queueContext;
 
     // Holds the +N queue badge visible for ~1.4s after the last add; a fresh add
     // restarts it, replacing the count and resetting the timer.
@@ -353,7 +357,8 @@ public sealed partial class MainWindow : Window
         }
 
         _eventCallback = null;
-        _queue = new List<QueueItem>();
+        _queueManual = new List<QueueItem>();
+        _queueContext = null;
         // Scan candidates are per-library in-memory state; clear them on teardown
         // so the next library doesn't inherit the previous one's candidate list.
         _candidates.Clear();
@@ -1508,7 +1513,8 @@ public sealed partial class MainWindow : Window
                 _refreshSettings?.Invoke();
                 break;
             case "QueueUpdated":
-                _queue = evt.Items ?? new List<QueueItem>();
+                _queueManual = evt.Manual ?? new List<QueueItem>();
+                _queueContext = evt.Context;
                 NpPrev.IsEnabled = evt.HasPrevious;
                 NpNext.IsEnabled = evt.HasNext;
                 break;
@@ -2588,17 +2594,84 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        // A live copy so drag-reorder mutates it; the framework raises a Move on
-        // the collection, which we forward to the core as a queue reorder. Click
-        // (not selection) drives skip-to so a drag doesn't start playback.
-        var queueItems = new ObservableCollection<QueueItem>(_queue);
+        // Clear empties only the manual lane (the context survives), so it
+        // disables on an empty manual lane regardless of the context.
+        var clear = new Button
+        {
+            Content = Loc.Chrome("queue.clear"),
+            IsEnabled = _queueManual.Count > 0,
+        };
+        clear.Click += (_, _) => NativeBae.QueueClear(_handle);
+
+        var content = new StackPanel { Spacing = 8 };
+        content.Children.Add(clear);
+
+        // Two distinct sections: the manual lane ("Up Next"), then the context
+        // (the release being played from). Each is its own reorderable list —
+        // entry ids are unique across both and core no-ops a cross-lane move.
+        if (_queueManual.Count > 0)
+        {
+            content.Children.Add(QueueSectionLabel(Loc.Chrome("queue.section.up_next"), shuffled: false));
+            content.Children.Add(BuildQueueLaneList(_queueManual));
+        }
+
+        if (_queueContext is { Upcoming.Count: > 0 } ctx)
+        {
+            content.Children.Add(QueueSectionLabel(Loc.Chrome("queue.section.playing_from"), ctx.Shuffled));
+            content.Children.Add(BuildQueueLaneList(ctx.Upcoming));
+        }
+
+        var dialog = new ContentDialog
+        {
+            Title = Loc.Chrome("queue.title"),
+            Content = content,
+            CloseButtonText = Loc.Chrome("action.close"),
+            XamlRoot = Content.XamlRoot,
+        };
+        await dialog.ShowAsync();
+    }
+
+    // A section header for the queue dialog, with a shuffle glyph when the lane
+    // is shuffled (only the context lane ever is).
+    private static StackPanel QueueSectionLabel(string text, bool shuffled)
+    {
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+        };
+        row.Children.Add(new TextBlock
+        {
+            Text = text,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        if (shuffled)
+        {
+            // Segoe MDL2 Assets "Shuffle" glyph (U+E8B1).
+            var icon = new FontIcon
+            {
+                Glyph = "\uE8B1", // Segoe MDL2 Assets "Shuffle"
+                FontSize = 14,
+            };
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                icon, Loc.Chrome("queue.shuffled"));
+            row.Children.Add(icon);
+        }
+        return row;
+    }
+
+    // One lane's reorderable list: click skips, right-tap removes, drag reorders
+    // within the lane (the framework raises a Move, forwarded to core by entry id).
+    private ListView BuildQueueLaneList(IEnumerable<QueueItem> items)
+    {
+        var queueItems = new ObservableCollection<QueueItem>(items);
         queueItems.CollectionChanged += (_, args) =>
         {
             if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
             {
                 // The collection already reflects the move: the entry now sits at
                 // NewStartingIndex and lands before whatever follows it (null when
-                // it's now last = move to the end).
+                // it's now last = move to the lane's end).
                 var moved = queueItems[args.NewStartingIndex];
                 var beforeIndex = args.NewStartingIndex + 1;
                 var beforeEntryId = beforeIndex < queueItems.Count
@@ -2659,21 +2732,7 @@ public sealed partial class MainWindow : Window
             menu.ShowAt(element, new FlyoutShowOptions { Position = args.GetPosition(element) });
         };
 
-        var clear = new Button { Content = Loc.Chrome("queue.clear") };
-        clear.Click += (_, _) => NativeBae.QueueClear(_handle);
-
-        var content = new StackPanel { Spacing = 8 };
-        content.Children.Add(clear);
-        content.Children.Add(list);
-
-        var dialog = new ContentDialog
-        {
-            Title = Loc.Chrome("queue.title"),
-            Content = content,
-            CloseButtonText = Loc.Chrome("action.close"),
-            XamlRoot = Content.XamlRoot,
-        };
-        await dialog.ShowAsync();
+        return list;
     }
 
     private async System.Threading.Tasks.Task ShowSidePauseDialog(PlaybackPauseReason? reason)

--- a/bae-windows/QueueItem.cs
+++ b/bae-windows/QueueItem.cs
@@ -1,4 +1,6 @@
-﻿namespace Bae.Windows;
+﻿using System.Collections.Generic;
+
+namespace Bae.Windows;
 
 /// <summary>One track in the play queue, from the <c>QueueUpdated</c> event JSON.</summary>
 public sealed class QueueItem
@@ -18,4 +20,14 @@ public sealed class QueueItem
 
     /// <summary>The list row; used as the default item text.</summary>
     public override string ToString() => $"{Title} — {Artist} · {DurationLabel}".Trim();
+}
+
+/// <summary>The context lane (the release being played from), from the
+/// <c>QueueUpdated</c> event JSON: its not-yet-played tail, plus whether it was
+/// ordered by shuffle (the queue dialog shows a shuffle indicator when so).
+/// Rendered as its own section, distinct from the manual "Up Next" lane.</summary>
+public sealed class PlaybackContext
+{
+    public bool Shuffled { get; set; }
+    public List<QueueItem> Upcoming { get; set; } = new();
 }

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>مسح قائمة الانتظار</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>إزالة من قائمة الانتظار</value></data>
   <data name="queue.title" xml:space="preserve"><value>قائمة الانتظار</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>التالي</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>يُشغّل من</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>تم الخلط</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>رمز الاستعادة</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>استعادة</value></data>
   <data name="restore.failed" xml:space="preserve"><value>فشلت الاستعادة</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>изчистване на опашката</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Премахване от опашката</value></data>
   <data name="queue.title" xml:space="preserve"><value>опашка</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Следва</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Възпроизвежда се от</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Разбъркано</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>код за възстановяване</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>възстановяване</value></data>
   <data name="restore.failed" xml:space="preserve"><value>възстановяването не бе успешно</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>সারি থেকে সরান</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>পরবর্তী</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>যা থেকে চলছে</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>শাফল করা</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>vymazat frontu</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Odebrat z fronty</value></data>
   <data name="queue.title" xml:space="preserve"><value>fronta</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Další v pořadí</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Přehrává se z</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Zamícháno</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>kód pro obnovení</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>obnovit</value></data>
   <data name="restore.failed" xml:space="preserve"><value>obnovení selhalo</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>Warteschlange leeren</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Aus Warteschlange entfernen</value></data>
   <data name="queue.title" xml:space="preserve"><value>Warteschlange</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Als Nächstes</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Wird abgespielt aus</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Zufällig</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>Wiederherstellungscode</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>wiederherstellen</value></data>
   <data name="restore.failed" xml:space="preserve"><value>Wiederherstellung fehlgeschlagen</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -154,6 +154,9 @@
   <data name="outbox.retry_now" xml:space="preserve"><value>retry now</value></data>
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Playing From</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Up Next</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Shuffled</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>vaciar la cola</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Quitar de la cola</value></data>
   <data name="queue.title" xml:space="preserve"><value>cola</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>A continuación</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Reproduciendo desde</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Aleatorio</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>código de restauración</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restaurar</value></data>
   <data name="restore.failed" xml:space="preserve"><value>error al restaurar</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>vider la file</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Retirer de la file</value></data>
   <data name="queue.title" xml:space="preserve"><value>file</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>À suivre</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Lecture depuis</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Aléatoire</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>code de restauration</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restaurer</value></data>
   <data name="restore.failed" xml:space="preserve"><value>échec de la restauration</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>કતારમાંથી કાઢો</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>આગળ</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>આમાંથી વાગે છે</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>શફલ કરેલું</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>נקה תור</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>הסר מהתור</value></data>
   <data name="queue.title" xml:space="preserve"><value>תור</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>הבא בתור</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>מנגן מתוך</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>אקראי</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>קוד שחזור</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>שחזר</value></data>
   <data name="restore.failed" xml:space="preserve"><value>השחזור נכשל</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>कतार से हटाएँ</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>अगला</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>यहाँ से चल रहा है</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>शफ़ल किया गया</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>očisti red</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Ukloni iz reda</value></data>
   <data name="queue.title" xml:space="preserve"><value>red</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Sljedeće na redu</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Reproducira se iz</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Izmiješano</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>kod za vraćanje</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>vrati</value></data>
   <data name="restore.failed" xml:space="preserve"><value>vraćanje nije uspjelo</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>A seguire</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>In riproduzione da</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Casuale</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>キューをクリア</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>キューから削除</value></data>
   <data name="queue.title" xml:space="preserve"><value>キュー</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>次に再生</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>再生元</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>シャッフル</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>復元コード</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>復元</value></data>
   <data name="restore.failed" xml:space="preserve"><value>復元に失敗しました</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>ಸರತಿಯಿಂದ ತೆಗೆದುಹಾಕಿ</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>ಮುಂದಿನದು</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>ಇದರಿಂದ ಪ್ಲೇ ಆಗುತ್ತಿದೆ</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>ಶಫಲ್ ಮಾಡಲಾಗಿದೆ</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>대기열 지우기</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>대기열에서 제거</value></data>
   <data name="queue.title" xml:space="preserve"><value>대기열</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>다음 재생</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>재생 위치</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>셔플됨</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>복원 코드</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>복원</value></data>
   <data name="restore.failed" xml:space="preserve"><value>복원 실패</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>ക്യൂയിൽ നിന്ന് നീക്കുക</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>അടുത്തത്</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>ഇതിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>ഷഫിൾ ചെയ്തു</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>रांगेतून काढा</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>पुढचे</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>येथून वाजत आहे</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>शफल केले</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Volgende</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Afspelen vanuit</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Geschud</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>ਕਤਾਰ ਤੋਂ ਹਟਾਓ</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>ਅਗਲਾ</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>ਇੱਥੋਂ ਚੱਲ ਰਿਹਾ ਹੈ</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>ਸ਼ਫਲ ਕੀਤਾ</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>wyczyść kolejkę</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Usuń z kolejki</value></data>
   <data name="queue.title" xml:space="preserve"><value>kolejka</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Następne w kolejce</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Odtwarzanie z</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Losowo</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>kod przywracania</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>przywróć</value></data>
   <data name="restore.failed" xml:space="preserve"><value>przywracanie nie powiodło się</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>limpar fila</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remover da fila</value></data>
   <data name="queue.title" xml:space="preserve"><value>fila</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>A seguir</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Tocando de</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Aleatório</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>código de restauração</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restaurar</value></data>
   <data name="restore.failed" xml:space="preserve"><value>falha na restauração</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>வரிசையிலிருந்து அகற்று</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>அடுத்தது</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>இதிலிருந்து இயக்குகிறது</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>கலைக்கப்பட்டது</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>క్యూ నుండి తీసివేయి</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>తదుపరి</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>దీని నుండి ప్లే అవుతోంది</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>షఫుల్ చేయబడింది</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>นำออกจากคิว</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>ถัดไป</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>กำลังเล่นจาก</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>สุ่ม</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Sıradaki</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Şuradan çalınıyor</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Karışık</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>очистити чергу</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Вилучити з черги</value></data>
   <data name="queue.title" xml:space="preserve"><value>черга</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Далі в черзі</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Відтворюється з</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Перемішано</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>код відновлення</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>відновити</value></data>
   <data name="restore.failed" xml:space="preserve"><value>відновлення не вдалося</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>قطار سے ہٹائیں</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>اگلا</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>یہاں سے چل رہا ہے</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>شفل شدہ</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>Tiếp theo</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>Đang phát từ</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>Đã trộn</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>清空队列</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>从队列移除</value></data>
   <data name="queue.title" xml:space="preserve"><value>队列</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>接下来</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>来自</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>已随机</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>恢复代码</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>恢复</value></data>
   <data name="restore.failed" xml:space="preserve"><value>恢复失败</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -117,6 +117,9 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>從佇列移除</value></data>
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
+  <data name="queue.section.up_next" xml:space="preserve"><value>接下來</value></data>
+  <data name="queue.section.playing_from" xml:space="preserve"><value>來自</value></data>
+  <data name="queue.shuffled" xml:space="preserve"><value>已隨機</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>
   <data name="restore.confirm" xml:space="preserve"><value>restore</value></data>
   <data name="restore.failed" xml:space="preserve"><value>restore failed</value></data>

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,32 +1,20 @@
 #!/usr/bin/env bash
 # Locally reproduce all non-Windows CI checks before pushing.
 #
-# Usage: scripts/check.sh [--tests] [--no-ios] [--no-android]
+# Usage: scripts/check.sh
 #
-#   --tests       Run the full bae-core test suite (~5 min; skipped by default).
-#   --no-ios      Skip iOS bridge build and Swift checks.
-#   --no-android  Skip Android checks (also auto-skipped when ANDROID_NDK_HOME is unset).
+# Runs the same non-Windows gates as CI. Missing platform toolchains or lint
+# tools are failures.
 #
-# Not covered: bae-windows and bae-windows-ffi require the Windows toolchain
-# and can only be validated in CI.
+# Only Windows is excluded: bae-windows and bae-windows-ffi require the Windows
+# toolchain and can only be validated in CI.
 
 set -uo pipefail
 
-# ── Flags ─────────────────────────────────────────────────────────────────────
-RUN_TESTS=false
-RUN_IOS=true
-RUN_ANDROID=true
-IOS_SKIP_REASON=""
-ANDROID_SKIP_REASON=""
-
-for arg in "$@"; do
-  case "$arg" in
-    --tests)      RUN_TESTS=true ;;
-    --no-ios)     RUN_IOS=false; IOS_SKIP_REASON="--no-ios" ;;
-    --no-android) RUN_ANDROID=false; ANDROID_SKIP_REASON="--no-android" ;;
-    *) echo "Unknown option: $arg" >&2; exit 1 ;;
-  esac
-done
+if [[ $# -gt 0 ]]; then
+  echo "Usage: scripts/check.sh" >&2
+  exit 1
+fi
 
 # ── Environment ───────────────────────────────────────────────────────────────
 ROOT="$(git rev-parse --show-toplevel)"
@@ -38,22 +26,59 @@ if command -v brew &>/dev/null; then
   export LIBRARY_PATH="${BREW_PREFIX}/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
 fi
 
-# Auto-disable Android when NDK is unavailable.
-if [[ $RUN_ANDROID == true && -z "${ANDROID_NDK_HOME:-}" ]]; then
-  RUN_ANDROID=false
-  ANDROID_SKIP_REASON="ANDROID_NDK_HOME unset"
+export NDK_VERSION="${NDK_VERSION:-29.0.14206865}"
+
+if [[ -z "${ANDROID_HOME:-}" ]]; then
+  if [[ -n "${ANDROID_SDK_ROOT:-}" ]]; then
+    export ANDROID_HOME="$ANDROID_SDK_ROOT"
+  elif [[ -d "$HOME/Library/Android/sdk" ]]; then
+    export ANDROID_HOME="$HOME/Library/Android/sdk"
+  fi
 fi
 
-# Auto-disable iOS when ffmpeg-ios is absent.
-if [[ $RUN_IOS == true && ! -d "third_party/ffmpeg-ios" ]]; then
-  RUN_IOS=false
-  IOS_SKIP_REASON="third_party/ffmpeg-ios absent — run scripts/build-ffmpeg-ios.sh"
+if [[ -z "${ANDROID_HOME:-}" || ! -d "$ANDROID_HOME" ]]; then
+  echo "ANDROID_HOME is unset and no Android SDK was found at ~/Library/Android/sdk" >&2
+  exit 1
 fi
+
+if [[ -z "${ANDROID_NDK_HOME:-}" ]]; then
+  if [[ -d "$ANDROID_HOME/ndk/$NDK_VERSION" ]]; then
+    export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$NDK_VERSION"
+  else
+    echo "ANDROID_NDK_HOME is unset and $ANDROID_HOME/ndk/$NDK_VERSION does not exist" >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -d "$ANDROID_NDK_HOME" ]]; then
+  echo "ANDROID_NDK_HOME does not exist: $ANDROID_NDK_HOME" >&2
+  exit 1
+fi
+
+if [[ ! -d "third_party/ffmpeg-ios" ]]; then
+  echo "third_party/ffmpeg-ios is absent; run scripts/build-ffmpeg-ios.sh" >&2
+  exit 1
+fi
+
+require_free_kib() {
+  local path="$1"
+  local required_kib="$2"
+  local available_kib
+  available_kib="$(df -Pk "$path" | awk 'NR == 2 { print $4 }')"
+  if [[ -z "$available_kib" || "$available_kib" -lt "$required_kib" ]]; then
+    echo "$path has ${available_kib:-0} KiB free; scripts/check.sh requires ${required_kib} KiB" >&2
+    exit 1
+  fi
+}
+
+REQUIRED_CHECK_SPACE_KIB=$((40 * 1024 * 1024))
+require_free_kib "$ROOT" "$REQUIRED_CHECK_SPACE_KIB"
+require_free_kib "${TMPDIR:-/tmp}" "$REQUIRED_CHECK_SPACE_KIB"
 
 # ── Output helpers ────────────────────────────────────────────────────────────
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
+RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
 
-PASS=0; FAIL=0; SKIP=0
+PASS=0; FAIL=0
 FAILURES=()
 
 section() { echo -e "\n${BOLD}── $1 ──────────────────────────────────${NC}"; }
@@ -85,8 +110,6 @@ check() {
     return 1
   fi
 }
-
-skip() { echo -e "  ${YELLOW}–${NC} $1 ($2)"; SKIP=$((SKIP+1)); }
 
 # ── Helpers for complex multi-step commands ────────────────────────────────────
 
@@ -132,17 +155,8 @@ check "clippy (bae-core --features oauth-providers)" \
 check "clippy (bae-bridge --features oauth-providers,cloudkit)" \
   cargo clippy -p bae-bridge --features oauth-providers,cloudkit -- -D warnings
 
-if cargo machete --version &>/dev/null; then
-  check "cargo machete" cargo machete
-else
-  skip "cargo machete" "not installed — cargo binstall cargo-machete"
-fi
-
-if cargo deny --version &>/dev/null; then
-  check "cargo deny" cargo deny check
-else
-  skip "cargo deny" "not installed — cargo binstall cargo-deny"
-fi
+check "cargo machete" cargo machete
+check "cargo deny" cargo deny check
 
 check "cargo doc" env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 
@@ -155,151 +169,93 @@ check "cargo test (bae-bridge --lib)"  cargo test -p bae-bridge --lib
 # ── macOS ──────────────────────────────────────────────────────────────────────
 section "macOS"
 
-MACOS_BUILD_OK=false
-if check "bridge build" ./bae-bridge/build-macos.sh; then
+check "bridge build" ./bae-bridge/build-macos.sh
+check "copy macOS bridge binding" \
   cp bae-bridge/swift-bindings-macos/bae_bridge.swift bae-macos/bae/bae/bae_bridge.swift
-  check "xcodegen" bash -c 'cd bae-macos/bae && xcodegen'
-  MACOS_XCODE_OK=false
-  if check "xcodebuild" \
-      xcodebuild -project bae-macos/bae/bae.xcodeproj -scheme bae -configuration Debug \
-        CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
-        -derivedDataPath bae-macos/bae/.build/derivedData \
-        -scmProvider system -disablePackageRepositoryCache -skipPackageUpdates \
-        -disableAutomaticPackageResolution build; then
-    MACOS_BUILD_OK=true
-    MACOS_XCODE_OK=true
-  fi
-else
-  skip "xcodegen" "bridge build failed"
-  skip "xcodebuild" "bridge build failed"
-fi
+check "xcodegen" bash -c 'cd bae-macos/bae && xcodegen'
+check "xcodebuild" \
+  xcodebuild -project bae-macos/bae/bae.xcodeproj -scheme bae -configuration Debug \
+    CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
+    -derivedDataPath bae-macos/bae/.build/derivedData \
+    -scmProvider system -disablePackageRepositoryCache -skipPackageUpdates \
+    -disableAutomaticPackageResolution build
 
 check "swift-format lint" _swift_format_lint bae-macos/bae/bae
 
-if command -v swiftlint &>/dev/null; then
-  check "swiftlint" swiftlint lint --strict --config .swiftlint.yml bae-macos/bae/bae
-else
-  skip "swiftlint (macOS)" "not installed — brew install swiftlint"
-fi
+check "swiftlint" swiftlint lint --strict --config .swiftlint.yml bae-macos/bae/bae
 
-if command -v periphery &>/dev/null; then
-  if [[ ${MACOS_XCODE_OK:-false} == true ]]; then
-    check "periphery" bash -c '
-      cd bae-macos/bae && periphery scan --strict --skip-build \
-        --index-store-path .build/derivedData/Index.noindex/DataStore
-    '
-  else
-    skip "periphery (macOS)" "xcodebuild failed"
-  fi
-else
-  skip "periphery (macOS)" "not installed — brew install peripheryapp/periphery/periphery"
-fi
+check "periphery" bash -c '
+  cd bae-macos/bae && periphery scan --strict --skip-build \
+    --index-store-path .build/derivedData/Index.noindex/DataStore
+'
 
 # ── iOS ────────────────────────────────────────────────────────────────────────
 section "iOS"
 
-if [[ $RUN_IOS == false ]]; then
-  skip "iOS checks" "$IOS_SKIP_REASON"
-else
-  rustup target add aarch64-apple-ios 2>/dev/null || true
+rustup target add aarch64-apple-ios 2>/dev/null || true
 
-  check "clippy (iOS aarch64)"  _ios_clippy
+check "clippy (iOS aarch64)"  _ios_clippy
 
-  IOS_XCODE_OK=false
-  if check "bridge build" ./bae-bridge/build-ios.sh; then
-    check "xcodegen" bash -c 'cd bae-ios/bae && xcodegen'
-    if check "xcodebuild (iphonesimulator)" \
-        xcodebuild -project bae-ios/bae/bae.xcodeproj -scheme bae -configuration Debug \
-          CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
-          -sdk iphonesimulator -arch arm64 \
-          -derivedDataPath bae-ios/bae/.build/derivedData build; then
-      IOS_XCODE_OK=true
-    fi
-  else
-    skip "xcodegen (iOS)" "bridge build failed"
-    skip "xcodebuild (iOS)" "bridge build failed"
-  fi
+check "bridge build" ./bae-bridge/build-ios.sh
+check "xcodegen" bash -c 'cd bae-ios/bae && xcodegen'
+check "xcodebuild (iphonesimulator)" \
+  xcodebuild -project bae-ios/bae/bae.xcodeproj -scheme bae -configuration Debug \
+    CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
+    -sdk iphonesimulator -arch arm64 \
+    -derivedDataPath bae-ios/bae/.build/derivedData build
 
-  check "swift-format lint" _swift_format_lint bae-ios/bae/bae
-
-  if command -v swiftlint &>/dev/null; then
-    check "swiftlint" swiftlint lint --strict --config .swiftlint.yml bae-ios/bae/bae
-  else
-    skip "swiftlint (iOS)" "not installed — brew install swiftlint"
-  fi
-
-  if command -v periphery &>/dev/null; then
-    if [[ $IOS_XCODE_OK == true ]]; then
-      check "periphery" bash -c '
-        cd bae-ios/bae && periphery scan --strict --skip-build \
-          --index-store-path .build/derivedData/Index.noindex/DataStore
-      '
-    else
-      skip "periphery (iOS)" "xcodebuild failed"
-    fi
-  else
-    skip "periphery (iOS)" "not installed — brew install peripheryapp/periphery/periphery"
-  fi
-fi
+check "swift-format lint" _swift_format_lint bae-ios/bae/bae
+check "swiftlint" swiftlint lint --strict --config .swiftlint.yml bae-ios/bae/bae
+check "periphery" bash -c '
+  cd bae-ios/bae && periphery scan --strict --skip-build \
+    --index-store-path .build/derivedData/Index.noindex/DataStore
+'
 
 # ── Android ────────────────────────────────────────────────────────────────────
 section "Android"
 
-if [[ $RUN_ANDROID == false ]]; then
-  skip "Android checks" "$ANDROID_SKIP_REASON"
-else
-  rustup target add aarch64-linux-android 2>/dev/null || true
+rustup target add aarch64-linux-android 2>/dev/null || true
 
-  check "clippy (Android aarch64)" _android_clippy
+check "clippy (Android aarch64)" _android_clippy
 
-  ANDROID_BUILD_OK=false
-  if check "bridge build" ./bae-bridge/build-android.sh; then
-    ANDROID_BUILD_OK=true
-    check "Gradle unit tests" bash -c \
-      'cd bae-android && ./gradlew testFullDebugUnitTest --no-daemon'
-  else
-    skip "Gradle unit tests" "bridge build failed"
-  fi
+check "bridge build (Android full)" env BAE_BRIDGE_FEATURES=oauth-providers ./bae-bridge/build-android.sh
+check "Gradle unit tests (Android full)" bash -c \
+  'cd bae-android && ./gradlew testFullDebugUnitTest --no-daemon'
+check "ktlint" ktlint "bae-android/app/src/**/*.kt"
+check "detekt" detekt --input bae-android/app/src/main/java \
+  --config bae-android/detekt.yml --build-upon-default-config
+check "Android lint (full)" bash -c \
+  'cd bae-android && ./gradlew lintFullDebug --no-daemon'
+check "assemble debug APK (full)" bash -c \
+  'cd bae-android && ./gradlew assembleFullDebug --no-daemon'
 
-  if command -v ktlint &>/dev/null; then
-    check "ktlint" ktlint "bae-android/app/src/**/*.kt"
-  else
-    skip "ktlint" "not installed — brew install ktlint"
-  fi
-
-  if command -v detekt &>/dev/null; then
-    check "detekt" detekt --input bae-android/app/src/main/java \
-      --config bae-android/detekt.yml --build-upon-default-config
-  else
-    skip "detekt" "not installed — brew install detekt"
-  fi
-fi
+check "bridge build (Android baeium)" env BAE_BRIDGE_FEATURES= ./bae-bridge/build-android.sh
+check "Gradle unit tests (Android baeium)" bash -c \
+  'cd bae-android && ./gradlew testBaeiumDebugUnitTest --no-daemon'
+check "Android lint (baeium)" bash -c \
+  'cd bae-android && ./gradlew lintBaeiumDebug --no-daemon'
+check "assemble debug APK (baeium)" bash -c \
+  'cd bae-android && ./gradlew assembleBaeiumDebug --no-daemon'
 
 # ── GitHub Actions workflows ───────────────────────────────────────────────────
 section "Workflows"
 
-if command -v actionlint &>/dev/null; then
-  check "actionlint" env SHELLCHECK_OPTS="--severity=error" actionlint
-else
-  skip "actionlint" "not installed — brew install actionlint"
-fi
+check "actionlint" env SHELLCHECK_OPTS="--severity=error" actionlint
 
-# ── bae-core tests (opt-in, slow) ─────────────────────────────────────────────
-if [[ $RUN_TESTS == true ]]; then
-  section "bae-core tests"
-  check "cargo test (bae-core)" \
-    cargo test -p bae-core --features bae-core/test-utils \
-      -- --test-threads=1 --skip test_playback_cpu
-  check "cargo test (bae-core playback CPU, release)" \
-    cargo test -p bae-core --release --features bae-core/test-utils \
-      --test test_playback_cpu
-fi
+# ── bae-core tests ────────────────────────────────────────────────────────────
+section "bae-core tests"
+check "cargo test (bae-core)" \
+  cargo test -p bae-core --features bae-core/test-utils \
+    -- --test-threads=1 --skip test_playback_cpu
+check "cargo test (bae-core playback CPU, release)" \
+  cargo test -p bae-core --release --features bae-core/test-utils \
+    --test test_playback_cpu
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${BOLD}────────────────────────────────────────────────────────${NC}"
-printf "  ${GREEN}✓${NC} %d passed   ${RED}✗${NC} %d failed   ${YELLOW}–${NC} %d skipped\n" \
-  "$PASS" "$FAIL" "$SKIP"
+printf "  ${GREEN}✓${NC} %d passed   ${RED}✗${NC} %d failed\n" \
+  "$PASS" "$FAIL"
 
 if [[ $FAIL -gt 0 ]]; then
   echo -e "\n  ${RED}Failed:${NC}"


### PR DESCRIPTION
The queue emit flattened two genuinely different things into one list: the tracks you explicitly enqueued (Play Next / Add to Queue) and the release you're playing from. The core has held them as separate lanes since the manual/context split, but the projection collapsed them, so every UI showed a single undifferentiated "Up Next."

This stops flattening. `QueueUpdated` now carries `manual` (the manual lane) and `context: Option<{ shuffled, upcoming }>` (the release tail, when playing from one) through core → event bus → bridge → windows-ffi, and each UI renders two sections: "Up Next" and the context section (with a shuffle indicator when the release is shuffled). Row actions already operate by entry id across both lanes, so only the layout changes; "Clear" stays manual-lane-only — the context survives.

The event-bus hydration resolves both lanes in one lookup and partitions the result by entry id rather than length, so a dropped missing-metadata entry can't shift the manual/context boundary. The plan's `kind: Release/Library` field is deferred to the library-source PR (only `Release` exists today), and `shuffled` is read-only here — the shuffle toggle control is its own change.

## Test plan
- [x] `cargo test -p bae-core` (new projection tests assert the lanes stay separate + the context carries `shuffled`; queue + persistence green) and `cargo clippy --all-targets` (core/bridge/windows-ffi) clean
- [x] macOS pre-commit (xcodebuild + periphery) passed
- [ ] CI: iOS / Android build (two-section rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yo6tYWU3DPQMLoxj81p6F