### PR TITLE
Library shuffle, via a ContextSource enum

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -33,6 +33,7 @@ import uniffi.bae_bridge.AppHandle
 import uniffi.bae_bridge.BridgeLoadingTrackInfo
 import uniffi.bae_bridge.BridgePlaybackContext
 import uniffi.bae_bridge.BridgePlaybackPauseReason
+import uniffi.bae_bridge.BridgePlaybackSourceKind
 import uniffi.bae_bridge.BridgeQueueEntry
 import uniffi.bae_bridge.BridgeRepeatMode
 import uniffi.bae_bridge.BridgeSidePausePrompt
@@ -77,6 +78,7 @@ data class QueueItem(
  *  plus whether it was ordered by shuffle (the UI shows a shuffle indicator when
  *  so). Rendered as a section distinct from the manual lane. */
 data class QueueContext(
+    val kind: BridgePlaybackSourceKind,
     val shuffled: Boolean,
     val upcoming: List<QueueItem>,
 )
@@ -489,6 +491,10 @@ class BaeCorePlayer(
     private var contextShuffled: Boolean = false
     private var hasContext: Boolean = false
 
+    /** What the context plays from (release vs library), null when no context.
+     *  Read only inside the `hasContext` branch of `publish`, where it is set. */
+    private var contextKind: BridgePlaybackSourceKind? = null
+
     /** Authoritative now-playing metadata from the latest Playing/Paused payload. */
     private var currentMeta: Meta? = null
 
@@ -744,6 +750,7 @@ class BaeCorePlayer(
             manualEntries = manualMetas
             contextEntries = contextMetas
             contextShuffled = context?.shuffled == true
+            contextKind = context?.kind
             hasContext = context != null
             entries = manualMetas + contextMetas
             this@BaeCorePlayer.hasNext = hasNext
@@ -778,6 +785,7 @@ class BaeCorePlayer(
                 context =
                     if (hasContext) {
                         QueueContext(
+                            kind = requireNotNull(contextKind) { "a context has a source kind" },
                             shuffled = contextShuffled,
                             upcoming = contextEntries.mapNotNull { it.toQueueItem() },
                         )

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -246,16 +247,14 @@ private fun LibraryBrowser(
 ) {
     var searchQuery by remember { mutableStateOf("") }
     var searchOpen by remember { mutableStateOf(false) }
-    var sortCriterion by remember {
-        mutableStateOf(BridgeSortCriterion(BridgeSortField.DATE_ADDED, BridgeSortDirection.DESCENDING))
-    }
+    var sortCriterion by
+        remember { mutableStateOf(BridgeSortCriterion(BridgeSortField.DATE_ADDED, BridgeSortDirection.DESCENDING)) }
     val generation by session.libraryStore.generation.collectAsState()
     val syncing by session.configStore.syncing.collectAsState()
     val syncError by session.configStore.syncError.collectAsState()
     val appError by session.configStore.error.collectAsState()
-    val appContext = LocalContext.current
     val gridState = rememberLazyGridState()
-    val page = rememberLibraryPage(session, generation, sortCriterion, appContext, gridState)
+    val page = rememberLibraryPage(session, generation, sortCriterion, LocalContext.current, gridState)
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (searchOpen) {
@@ -270,6 +269,13 @@ private fun LibraryBrowser(
         } else {
             LibraryTopBar(
                 onOpenSearch = { searchOpen = true },
+                onShuffleLibrary = {
+                    try {
+                        session.appHandle.playLibraryShuffled()
+                    } catch (e: Exception) {
+                        logger.error("playLibraryShuffled failed", e)
+                    }
+                },
                 sortCriterion = sortCriterion,
                 onSortChange = { sortCriterion = it },
                 onSettings = onSettings,
@@ -388,6 +394,7 @@ private fun LibraryErrorBanner(
 @Composable
 private fun LibraryTopBar(
     onOpenSearch: () -> Unit,
+    onShuffleLibrary: () -> Unit,
     sortCriterion: BridgeSortCriterion,
     onSortChange: (BridgeSortCriterion) -> Unit,
     onSettings: () -> Unit,
@@ -401,6 +408,12 @@ private fun LibraryTopBar(
             Spacer(modifier = Modifier.weight(1f))
             IconButton(onClick = onOpenSearch) {
                 Icon(imageVector = Icons.Filled.Search, contentDescription = stringResource(R.string.search))
+            }
+            IconButton(onClick = onShuffleLibrary) {
+                Icon(
+                    imageVector = Icons.Filled.Shuffle,
+                    contentDescription = stringResource(R.string.shuffle_library),
+                )
             }
             SortMenu(criterion = sortCriterion, onChange = onSortChange)
             IconButton(onClick = onSettings) {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/QueueScreen.kt
@@ -47,6 +47,7 @@ import fm.bae.app.playback.QueueItem
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
+import uniffi.bae_bridge.BridgePlaybackSourceKind
 
 private const val TAG = "bae.QueueScreen"
 private val logger = BaeLogger(TAG)
@@ -108,6 +109,10 @@ internal class QueueOrder {
     val manual = mutableStateListOf<QueueItem>()
     val context = mutableStateListOf<QueueItem>()
     var contextShuffled by mutableStateOf(false)
+
+    /** What the context plays from (release vs library), labelling its section,
+     *  or null when nothing is playing from a context. */
+    var contextKind by mutableStateOf<BridgePlaybackSourceKind?>(null)
 
     val isEmpty: Boolean
         get() = manual.isEmpty() && context.isEmpty()
@@ -178,11 +183,13 @@ internal fun rememberReorderableQueue(
             when (val context = queue.context) {
                 null -> {
                     order.contextShuffled = false
+                    order.contextKind = null
                 }
 
                 else -> {
                     order.context.addAll(context.upcoming)
                     order.contextShuffled = context.shuffled
+                    order.contextKind = context.kind
                 }
             }
         }
@@ -224,9 +231,14 @@ internal fun LazyListScope.queueContent(
 
     if (order.context.isNotEmpty()) {
         item(key = "ctxhdr") {
+            val labelRes =
+                when (order.contextKind) {
+                    BridgePlaybackSourceKind.LIBRARY -> R.string.queue_section_your_library
+                    BridgePlaybackSourceKind.RELEASE, null -> R.string.queue_section_playing_from
+                }
             ContextSectionLabel(
                 session = session,
-                text = stringResource(R.string.queue_section_playing_from),
+                text = stringResource(labelRes),
                 shuffled = order.contextShuffled,
             )
         }

--- a/bae-android/app/src/main/res/values-ar/strings.xml
+++ b/bae-android/app/src/main/res/values-ar/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">قيد التشغيل الآن</string>
     <string name="queue_section_up_next">التالي</string>
     <string name="queue_section_playing_from">يُشغّل من</string>
+    <string name="queue_section_your_library">مكتبتك</string>
+    <string name="shuffle_library">تشغيل المكتبة عشوائيًا</string>
     <string name="queue_nothing_up_next">لا شيء تاليًا</string>
     <string name="queue_empty">قائمة الانتظار فارغة</string>
     <string name="queue_remove">إزالة من قائمة الانتظار</string>

--- a/bae-android/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/bae-android/app/src/main/res/values-b+pt+BR/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Tocando agora</string>
     <string name="queue_section_up_next">A seguir</string>
     <string name="queue_section_playing_from">Tocando de</string>
+    <string name="queue_section_your_library">Sua biblioteca</string>
+    <string name="shuffle_library">Embaralhar biblioteca</string>
     <string name="queue_nothing_up_next">Nada a seguir</string>
     <string name="queue_empty">A fila está vazia</string>
     <string name="queue_remove">Remover da fila</string>

--- a/bae-android/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/bae-android/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">正在播放</string>
     <string name="queue_section_up_next">接下来</string>
     <string name="queue_section_playing_from">来自</string>
+    <string name="queue_section_your_library">你的音乐库</string>
+    <string name="shuffle_library">随机播放音乐库</string>
     <string name="queue_nothing_up_next">没有接下来的内容</string>
     <string name="queue_empty">队列为空</string>
     <string name="queue_remove">从队列移除</string>

--- a/bae-android/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/bae-android/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">正在播放</string>
     <string name="queue_section_up_next">接下來</string>
     <string name="queue_section_playing_from">來自</string>
+    <string name="queue_section_your_library">你的資料庫</string>
+    <string name="shuffle_library">隨機播放資料庫</string>
     <string name="queue_nothing_up_next">接下來沒有內容</string>
     <string name="queue_empty">佇列是空的</string>
     <string name="queue_remove">從佇列移除</string>

--- a/bae-android/app/src/main/res/values-bg/strings.xml
+++ b/bae-android/app/src/main/res/values-bg/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Текущо възпроизвеждане</string>
     <string name="queue_section_up_next">Следва</string>
     <string name="queue_section_playing_from">Възпроизвежда се от</string>
+    <string name="queue_section_your_library">Вашата библиотека</string>
+    <string name="shuffle_library">Разбъркване на библиотеката</string>
     <string name="queue_nothing_up_next">Няма следващо</string>
     <string name="queue_empty">Опашката е празна</string>
     <string name="queue_remove">Премахване от опашката</string>

--- a/bae-android/app/src/main/res/values-bn/strings.xml
+++ b/bae-android/app/src/main/res/values-bn/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">এখন চলছে</string>
     <string name="queue_section_up_next">পরবর্তী</string>
     <string name="queue_section_playing_from">যা থেকে চলছে</string>
+    <string name="queue_section_your_library">আপনার লাইব্রেরি</string>
+    <string name="shuffle_library">লাইব্রেরি শাফল করুন</string>
     <string name="queue_nothing_up_next">পরবর্তী কিছু নেই</string>
     <string name="queue_empty">সারি খালি</string>
     <string name="queue_remove">সারি থেকে সরান</string>

--- a/bae-android/app/src/main/res/values-cs/strings.xml
+++ b/bae-android/app/src/main/res/values-cs/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Právě hraje</string>
     <string name="queue_section_up_next">Další v pořadí</string>
     <string name="queue_section_playing_from">Přehrává se z</string>
+    <string name="queue_section_your_library">Vaše knihovna</string>
+    <string name="shuffle_library">Náhodně přehrát knihovnu</string>
     <string name="queue_nothing_up_next">Nic dalšího v pořadí</string>
     <string name="queue_empty">Fronta je prázdná</string>
     <string name="queue_remove">Odebrat z fronty</string>

--- a/bae-android/app/src/main/res/values-de/strings.xml
+++ b/bae-android/app/src/main/res/values-de/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Aktuelle Wiedergabe</string>
     <string name="queue_section_up_next">Als Nächstes</string>
     <string name="queue_section_playing_from">Wird abgespielt aus</string>
+    <string name="queue_section_your_library">Deine Mediathek</string>
+    <string name="shuffle_library">Mediathek zufällig wiedergeben</string>
     <string name="queue_nothing_up_next">Nichts als Nächstes</string>
     <string name="queue_empty">Warteschlange ist leer</string>
     <string name="queue_remove">Aus Warteschlange entfernen</string>

--- a/bae-android/app/src/main/res/values-es/strings.xml
+++ b/bae-android/app/src/main/res/values-es/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">En reproducción</string>
     <string name="queue_section_up_next">A continuación</string>
     <string name="queue_section_playing_from">Reproduciendo desde</string>
+    <string name="queue_section_your_library">Tu biblioteca</string>
+    <string name="shuffle_library">Reproducir biblioteca al azar</string>
     <string name="queue_nothing_up_next">Nada a continuación</string>
     <string name="queue_empty">La cola está vacía</string>
     <string name="queue_remove">Quitar de la cola</string>

--- a/bae-android/app/src/main/res/values-fr/strings.xml
+++ b/bae-android/app/src/main/res/values-fr/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Lecture en cours</string>
     <string name="queue_section_up_next">À suivre</string>
     <string name="queue_section_playing_from">Lecture depuis</string>
+    <string name="queue_section_your_library">Votre bibliothèque</string>
+    <string name="shuffle_library">Lecture aléatoire de la bibliothèque</string>
     <string name="queue_nothing_up_next">Rien à suivre</string>
     <string name="queue_empty">La file est vide</string>
     <string name="queue_remove">Retirer de la file</string>

--- a/bae-android/app/src/main/res/values-gu/strings.xml
+++ b/bae-android/app/src/main/res/values-gu/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">હમણાં વગડે છે</string>
     <string name="queue_section_up_next">આગળ</string>
     <string name="queue_section_playing_from">આમાંથી વાગે છે</string>
+    <string name="queue_section_your_library">તમારી લાઇબ્રેરી</string>
+    <string name="shuffle_library">લાઇબ્રેરી શફલ કરો</string>
     <string name="queue_nothing_up_next">આગળ કશું નથી</string>
     <string name="queue_empty">કતાર ખાલી છે</string>
     <string name="queue_remove">કતારમાંથી કાઢો</string>

--- a/bae-android/app/src/main/res/values-he/strings.xml
+++ b/bae-android/app/src/main/res/values-he/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">מתנגן כעת</string>
     <string name="queue_section_up_next">הבא בתור</string>
     <string name="queue_section_playing_from">מנגן מתוך</string>
+    <string name="queue_section_your_library">הספרייה שלך</string>
+    <string name="shuffle_library">ערבוב הספרייה</string>
     <string name="queue_nothing_up_next">אין דבר בהמשך</string>
     <string name="queue_empty">התור ריק</string>
     <string name="queue_remove">הסר מהתור</string>

--- a/bae-android/app/src/main/res/values-hi/strings.xml
+++ b/bae-android/app/src/main/res/values-hi/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">अभी चल रहा है</string>
     <string name="queue_section_up_next">अगला</string>
     <string name="queue_section_playing_from">यहाँ से चल रहा है</string>
+    <string name="queue_section_your_library">आपकी लाइब्रेरी</string>
+    <string name="shuffle_library">लाइब्रेरी शफ़ल करें</string>
     <string name="queue_nothing_up_next">अगला कुछ नहीं</string>
     <string name="queue_empty">कतार खाली है</string>
     <string name="queue_remove">कतार से हटाएँ</string>

--- a/bae-android/app/src/main/res/values-hr/strings.xml
+++ b/bae-android/app/src/main/res/values-hr/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Trenutno svira</string>
     <string name="queue_section_up_next">Sljedeće na redu</string>
     <string name="queue_section_playing_from">Reproducira se iz</string>
+    <string name="queue_section_your_library">Vaša biblioteka</string>
+    <string name="shuffle_library">Nasumično reproduciraj biblioteku</string>
     <string name="queue_nothing_up_next">Ništa nije na redu</string>
     <string name="queue_empty">Red je prazan</string>
     <string name="queue_remove">Ukloni iz reda</string>

--- a/bae-android/app/src/main/res/values-it/strings.xml
+++ b/bae-android/app/src/main/res/values-it/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">In riproduzione</string>
     <string name="queue_section_up_next">A seguire</string>
     <string name="queue_section_playing_from">In riproduzione da</string>
+    <string name="queue_section_your_library">La tua libreria</string>
+    <string name="shuffle_library">Riproduci libreria in ordine casuale</string>
     <string name="queue_nothing_up_next">Niente a seguire</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>

--- a/bae-android/app/src/main/res/values-ja/strings.xml
+++ b/bae-android/app/src/main/res/values-ja/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">再生中</string>
     <string name="queue_section_up_next">次に再生</string>
     <string name="queue_section_playing_from">再生元</string>
+    <string name="queue_section_your_library">ライブラリ</string>
+    <string name="shuffle_library">ライブラリをシャッフル</string>
     <string name="queue_nothing_up_next">次の項目はありません</string>
     <string name="queue_empty">キューは空です</string>
     <string name="queue_remove">キューから削除</string>

--- a/bae-android/app/src/main/res/values-kn/strings.xml
+++ b/bae-android/app/src/main/res/values-kn/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">ಈಗ ಪ್ಲೇ ಆಗುತ್ತಿದೆ</string>
     <string name="queue_section_up_next">ಮುಂದಿನದು</string>
     <string name="queue_section_playing_from">ಇದರಿಂದ ಪ್ಲೇ ಆಗುತ್ತಿದೆ</string>
+    <string name="queue_section_your_library">ನಿಮ್ಮ ಲೈಬ್ರರಿ</string>
+    <string name="shuffle_library">ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ</string>
     <string name="queue_nothing_up_next">ಮುಂದೆ ಏನೂ ಇಲ್ಲ</string>
     <string name="queue_empty">ಸರತಿ ಖಾಲಿ</string>
     <string name="queue_remove">ಸರತಿಯಿಂದ ತೆಗೆದುಹಾಕಿ</string>

--- a/bae-android/app/src/main/res/values-ko/strings.xml
+++ b/bae-android/app/src/main/res/values-ko/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">지금 재생 중</string>
     <string name="queue_section_up_next">다음 재생</string>
     <string name="queue_section_playing_from">재생 위치</string>
+    <string name="queue_section_your_library">보관함</string>
+    <string name="shuffle_library">라이브러리 셔플</string>
     <string name="queue_nothing_up_next">다음 항목 없음</string>
     <string name="queue_empty">대기열이 비어 있습니다</string>
     <string name="queue_remove">대기열에서 제거</string>

--- a/bae-android/app/src/main/res/values-ml/strings.xml
+++ b/bae-android/app/src/main/res/values-ml/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു</string>
     <string name="queue_section_up_next">അടുത്തത്</string>
     <string name="queue_section_playing_from">ഇതിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു</string>
+    <string name="queue_section_your_library">നിങ്ങളുടെ ലൈബ്രറി</string>
+    <string name="shuffle_library">ലൈബ്രറി ഷഫിൾ ചെയ്യുക</string>
     <string name="queue_nothing_up_next">അടുത്തത് ഒന്നുമില്ല</string>
     <string name="queue_empty">ക്യൂ ശൂന്യം</string>
     <string name="queue_remove">ക്യൂയിൽ നിന്ന് നീക്കുക</string>

--- a/bae-android/app/src/main/res/values-mr/strings.xml
+++ b/bae-android/app/src/main/res/values-mr/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">आता प्ले होत आहे</string>
     <string name="queue_section_up_next">पुढचे</string>
     <string name="queue_section_playing_from">येथून वाजत आहे</string>
+    <string name="queue_section_your_library">तुमची लायब्ररी</string>
+    <string name="shuffle_library">लायब्ररी शफल करा</string>
     <string name="queue_nothing_up_next">पुढे काही नाही</string>
     <string name="queue_empty">रांग रिकामी आहे</string>
     <string name="queue_remove">रांगेतून काढा</string>

--- a/bae-android/app/src/main/res/values-nl/strings.xml
+++ b/bae-android/app/src/main/res/values-nl/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Speelt nu</string>
     <string name="queue_section_up_next">Volgende</string>
     <string name="queue_section_playing_from">Afspelen vanuit</string>
+    <string name="queue_section_your_library">Je bibliotheek</string>
+    <string name="shuffle_library">Bibliotheek shufflen</string>
     <string name="queue_nothing_up_next">Niets hierna</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>

--- a/bae-android/app/src/main/res/values-pa/strings.xml
+++ b/bae-android/app/src/main/res/values-pa/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ</string>
     <string name="queue_section_up_next">ਅਗਲਾ</string>
     <string name="queue_section_playing_from">ਇੱਥੋਂ ਚੱਲ ਰਿਹਾ ਹੈ</string>
+    <string name="queue_section_your_library">ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ</string>
+    <string name="shuffle_library">ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ</string>
     <string name="queue_nothing_up_next">ਅੱਗੇ ਕੁਝ ਨਹੀਂ</string>
     <string name="queue_empty">ਕਤਾਰ ਖਾਲੀ ਹੈ</string>
     <string name="queue_remove">ਕਤਾਰ ਤੋਂ ਹਟਾਓ</string>

--- a/bae-android/app/src/main/res/values-pl/strings.xml
+++ b/bae-android/app/src/main/res/values-pl/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Teraz odtwarzane</string>
     <string name="queue_section_up_next">Następne w kolejce</string>
     <string name="queue_section_playing_from">Odtwarzanie z</string>
+    <string name="queue_section_your_library">Twoja biblioteka</string>
+    <string name="shuffle_library">Odtwarzaj bibliotekę losowo</string>
     <string name="queue_nothing_up_next">Brak następnych pozycji</string>
     <string name="queue_empty">Kolejka jest pusta</string>
     <string name="queue_remove">Usuń z kolejki</string>

--- a/bae-android/app/src/main/res/values-ta/strings.xml
+++ b/bae-android/app/src/main/res/values-ta/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">இப்போது ஒலிக்கிறது</string>
     <string name="queue_section_up_next">அடுத்தது</string>
     <string name="queue_section_playing_from">இதிலிருந்து இயக்குகிறது</string>
+    <string name="queue_section_your_library">உங்கள் நூலகம்</string>
+    <string name="shuffle_library">நூலகத்தை கலைத்து இயக்கு</string>
     <string name="queue_nothing_up_next">அடுத்தது எதுவும் இல்லை</string>
     <string name="queue_empty">வரிசை காலி</string>
     <string name="queue_remove">வரிசையிலிருந்து அகற்று</string>

--- a/bae-android/app/src/main/res/values-te/strings.xml
+++ b/bae-android/app/src/main/res/values-te/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">ఇప్పుడు ప్లే అవుతోంది</string>
     <string name="queue_section_up_next">తదుపరి</string>
     <string name="queue_section_playing_from">దీని నుండి ప్లే అవుతోంది</string>
+    <string name="queue_section_your_library">మీ లైబ్రరీ</string>
+    <string name="shuffle_library">లైబ్రరీని షఫుల్ చేయి</string>
     <string name="queue_nothing_up_next">తదుపరి ఏమీ లేదు</string>
     <string name="queue_empty">క్యూ ఖాళీగా ఉంది</string>
     <string name="queue_remove">క్యూ నుండి తీసివేయి</string>

--- a/bae-android/app/src/main/res/values-th/strings.xml
+++ b/bae-android/app/src/main/res/values-th/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">กำลังเล่น</string>
     <string name="queue_section_up_next">ถัดไป</string>
     <string name="queue_section_playing_from">กำลังเล่นจาก</string>
+    <string name="queue_section_your_library">คลังของคุณ</string>
+    <string name="shuffle_library">สุ่มเล่นคลังเพลง</string>
     <string name="queue_nothing_up_next">ไม่มีรายการถัดไป</string>
     <string name="queue_empty">คิวว่าง</string>
     <string name="queue_remove">นำออกจากคิว</string>

--- a/bae-android/app/src/main/res/values-tr/strings.xml
+++ b/bae-android/app/src/main/res/values-tr/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Çalıyor</string>
     <string name="queue_section_up_next">Sıradaki</string>
     <string name="queue_section_playing_from">Şuradan çalınıyor</string>
+    <string name="queue_section_your_library">Kitaplığınız</string>
+    <string name="shuffle_library">Kitaplığı karıştır</string>
     <string name="queue_nothing_up_next">Sırada bir şey yok</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>

--- a/bae-android/app/src/main/res/values-uk/strings.xml
+++ b/bae-android/app/src/main/res/values-uk/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Зараз відтворюється</string>
     <string name="queue_section_up_next">Далі в черзі</string>
     <string name="queue_section_playing_from">Відтворюється з</string>
+    <string name="queue_section_your_library">Ваша фонотека</string>
+    <string name="shuffle_library">Перемішати фонотеку</string>
     <string name="queue_nothing_up_next">Далі нічого немає</string>
     <string name="queue_empty">Черга порожня</string>
     <string name="queue_remove">Вилучити з черги</string>

--- a/bae-android/app/src/main/res/values-ur/strings.xml
+++ b/bae-android/app/src/main/res/values-ur/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">اب چل رہا ہے</string>
     <string name="queue_section_up_next">اگلا</string>
     <string name="queue_section_playing_from">یہاں سے چل رہا ہے</string>
+    <string name="queue_section_your_library">آپ کی لائبریری</string>
+    <string name="shuffle_library">لائبریری کو شفل کریں</string>
     <string name="queue_nothing_up_next">آگے کچھ نہیں</string>
     <string name="queue_empty">قطار خالی ہے</string>
     <string name="queue_remove">قطار سے ہٹائیں</string>

--- a/bae-android/app/src/main/res/values-vi/strings.xml
+++ b/bae-android/app/src/main/res/values-vi/strings.xml
@@ -40,6 +40,8 @@
     <string name="queue_section_now_playing">Đang phát</string>
     <string name="queue_section_up_next">Tiếp theo</string>
     <string name="queue_section_playing_from">Đang phát từ</string>
+    <string name="queue_section_your_library">Thư viện của bạn</string>
+    <string name="shuffle_library">Phát ngẫu nhiên thư viện</string>
     <string name="queue_nothing_up_next">Không có mục tiếp theo</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>

--- a/bae-android/app/src/main/res/values/strings.xml
+++ b/bae-android/app/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@
     <string name="queue_section_now_playing">Now Playing</string>
     <string name="queue_section_up_next">Up Next</string>
     <string name="queue_section_playing_from">Playing From</string>
+    <string name="queue_section_your_library">Your Library</string>
+    <string name="shuffle_library">Shuffle Library</string>
     <string name="queue_nothing_up_next">Nothing up next</string>
     <string name="queue_empty">Queue is empty</string>
     <string name="queue_remove">Remove from queue</string>

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -266,6 +266,10 @@ impl AppHandle {
         );
     }
 
+    pub fn play_library_shuffled(&self) {
+        self.app_services.playback().play_library_shuffled();
+    }
+
     pub fn pause(&self) {
         self.app_services.playback().pause();
     }
@@ -1543,6 +1547,7 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             Some(BridgeUiEvent::QueueUpdated {
                 manual: manual.into_iter().map(to_entry).collect(),
                 context: context.map(|c| BridgePlaybackContext {
+                    kind: BridgePlaybackSourceKind::from_core(&c.source),
                     shuffled: c.shuffled,
                     upcoming: c.upcoming.into_iter().map(to_entry).collect(),
                 }),

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1968,12 +1968,33 @@ pub struct BridgeQueueEntry {
     pub cover_image_id: Option<String>,
 }
 
-/// The context lane (the release being played from), carried by `QueueUpdated`
+/// Which kind of source the context plays from, so the UI labels the section
+/// (a release's "Playing From" vs the whole library). The discriminant of
+/// `bae_core::playback::ContextSource`; the release id stays in core (the UI
+/// labels by kind, not by id here). FFI mirror of the core enum's variants.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum BridgePlaybackSourceKind {
+    Release,
+    Library,
+}
+
+impl BridgePlaybackSourceKind {
+    pub(crate) fn from_core(source: &bae_core::playback::ContextSource) -> Self {
+        match source {
+            bae_core::playback::ContextSource::Release(_) => Self::Release,
+            bae_core::playback::ContextSource::Library => Self::Library,
+        }
+    }
+}
+
+/// The context lane (what the queue is playing from), carried by `QueueUpdated`
 /// alongside the manual lane so each UI renders the two as distinct sections:
-/// its not-yet-played tail, plus whether it was ordered by shuffle (the UI shows
-/// a shuffle indicator when so).
+/// its kind (release vs library, for the section label), its not-yet-played tail,
+/// plus whether it was ordered by shuffle (the UI shows a shuffle indicator when
+/// so).
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgePlaybackContext {
+    pub kind: BridgePlaybackSourceKind,
     pub shuffled: bool,
     pub upcoming: Vec<BridgeQueueEntry>,
 }

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -1490,6 +1490,23 @@ impl Database {
             .await
     }
 
+    /// Every track id in the library, in a deterministic base order (the same
+    /// order across calls so a shuffle seed permutes a stable list). Ordered to
+    /// match the per-release order — by release, then side, track number, id — so
+    /// the library and a single release agree on what "source order" means.
+    pub async fn get_all_track_ids(&self) -> Result<Vec<String>, DbError> {
+        self.inner
+            .coven_db
+            .call(move |conn| {
+                let mut stmt = conn
+                    .prepare("SELECT id FROM tracks ORDER BY release_id, side, track_number, id")?;
+                let rows = stmt.query_map([], |row| row.get::<_, String>("id"))?;
+                rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+                    .map_err(DbError::from)
+            })
+            .await
+    }
+
     /// Return the subset of `track_ids` that exist in the tracks table.
     /// Ordering of returned IDs is unspecified; callers that need a
     /// specific order must re-derive it.

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -304,7 +304,9 @@ pub struct DbReleaseLocalCopy {
 /// the DB client destructures this on save and reassembles it on load.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DbPlaybackContext {
-    /// The release being played from.
+    /// What the context plays from, encoded for the flat column: a release id, or
+    /// the library sentinel. See `source_to_str`/`source_from_str` in
+    /// `playback::persisted`.
     pub source: String,
     /// The `u64` shuffle seed reinterpreted as `i64` (SQLite's integer type) so
     /// the high bit round-trips. `None` = sequential (source) order.

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -3758,6 +3758,12 @@ impl LibraryManager {
     pub async fn get_track_ids(&self, release_id: &str) -> Result<Vec<String>, LibraryError> {
         Ok(self.database.get_track_ids_for_release(release_id).await?)
     }
+    /// Every track id in the library, in a deterministic base order. Used to
+    /// materialize a `ContextSource::Library` context (shuffle library, and the
+    /// `Context`-repeat re-derive of a library context).
+    pub async fn get_all_track_ids(&self) -> Result<Vec<String>, LibraryError> {
+        Ok(self.database.get_all_track_ids().await?)
+    }
     /// Return the play context for a track: its release id, the release's full
     /// track order, and the track's index within it. Used by the playback
     /// service to build the queue around a freshly selected track without
@@ -9019,5 +9025,104 @@ mod tests {
             ),
             "the drop guard must emit ReleaseTransferEnded for the aborted release, got {event:?}"
         );
+    }
+
+    /// Seed an album with two releases, each holding two tracks with explicit
+    /// side/track-number so the library order is deterministic. Track ids are
+    /// chosen so the `(release_id, side, track_number, id)` order is unambiguous.
+    async fn seed_two_release_library(manager: &LibraryManager) -> (String, String) {
+        use crate::db::DbTrack;
+        let mut album = create_test_album();
+        album.id = "alb-1".to_string();
+        let mut rel1 = create_test_release(&album.id);
+        rel1.id = "rel-1".to_string();
+        let mut rel2 = create_test_release(&album.id);
+        rel2.id = "rel-2".to_string();
+        manager.database.insert_album(&album).await.unwrap();
+        manager.database.insert_release(&rel1).await.unwrap();
+        manager.database.insert_release(&rel2).await.unwrap();
+
+        let track = |release_id: &str, id: &str, side: i32, number: i32| {
+            let t = DbTrack {
+                side,
+                ..DbTrack::new_test(release_id, id, "Track Title", Some(number))
+            };
+            let database = &manager.database;
+            async move { database.insert_track(&t).await.unwrap() }
+        };
+        // rel-1: side 1 then side 2; rel-2: two side-1 tracks.
+        track("rel-1", "r1-t1", 1, 1).await;
+        track("rel-1", "r1-t2", 2, 1).await;
+        track("rel-2", "r2-t1", 1, 1).await;
+        track("rel-2", "r2-t2", 1, 2).await;
+        (rel1.id, rel2.id)
+    }
+
+    /// `get_all_track_ids` returns every library track in the deterministic base
+    /// order — by release, then side, track number, id — so a shuffle seed
+    /// permutes a stable list.
+    #[tokio::test]
+    async fn test_get_all_track_ids_returns_library_in_base_order() {
+        let (manager, _temp_dir) = setup_test_manager().await;
+        seed_two_release_library(&manager).await;
+        let all = manager.get_all_track_ids().await.unwrap();
+        assert_eq!(all, vec!["r1-t1", "r1-t2", "r2-t1", "r2-t2"]);
+    }
+
+    /// The two track-id queries the service's source dispatcher routes between:
+    /// a release's own ordered tracks (`get_track_ids`) vs the whole library
+    /// (`get_all_track_ids`). The library is the union of the releases, so a
+    /// release's tracks are a strict subset of it.
+    #[tokio::test]
+    async fn test_release_and_library_track_id_queries_return_their_sets() {
+        let (manager, _temp_dir) = setup_test_manager().await;
+        let (rel1, _rel2) = seed_two_release_library(&manager).await;
+        let release_tracks = manager.get_track_ids(&rel1).await.unwrap();
+        assert_eq!(release_tracks, vec!["r1-t1", "r1-t2"]);
+        let library_tracks = manager.get_all_track_ids().await.unwrap();
+        assert_eq!(library_tracks, vec!["r1-t1", "r1-t2", "r2-t1", "r2-t2"]);
+        assert!(release_tracks.iter().all(|t| library_tracks.contains(t)));
+    }
+
+    /// A `playback_state` row carrying a library source survives save → load: the
+    /// `source` column stores the library sentinel and reads back unchanged, and a
+    /// release row stores/reads its id. (Decoding the sentinel back to the source
+    /// enum is covered in `playback::persisted`.)
+    #[tokio::test]
+    async fn test_playback_state_source_column_round_trips_both_kinds() {
+        use crate::db::{DbPlaybackContext, DbPlaybackState};
+        use crate::playback::source_to_str;
+        use crate::playback::ContextSource;
+        let (manager, _temp_dir) = setup_test_manager().await;
+
+        for source in [
+            ContextSource::Library,
+            ContextSource::Release("rel-1".to_string()),
+        ] {
+            let row = DbPlaybackState {
+                context: Some(DbPlaybackContext {
+                    source: source_to_str(&source),
+                    shuffle_seed: Some(11),
+                    cursor: 0,
+                }),
+                manual: "[]".to_string(),
+                repeat: "off".to_string(),
+                current_track_id: None,
+                position_ms: None,
+                volume: 1.0,
+                is_muted: false,
+            };
+            manager.save_playback_state(&row).await.unwrap();
+            let loaded = manager
+                .load_playback_state()
+                .await
+                .unwrap()
+                .expect("a saved row loads");
+            assert_eq!(
+                loaded.context.unwrap().source,
+                source_to_str(&source),
+                "the source column round-trips for {source:?}"
+            );
+        }
     }
 }

--- a/bae-core/src/playback/context.rs
+++ b/bae-core/src/playback/context.rs
@@ -1,5 +1,17 @@
 use crate::playback::queue::QueueEntry;
 
+/// What the queue is playing from: a single release (its track order), or the
+/// whole library. A `Release` carries the id its tracks are fetched by; `Library`
+/// has no id — its tracks are every track in the library. The service dispatches
+/// the track re-fetch on this (release → `get_track_ids`, library →
+/// `get_all_track_ids`) and persistence encodes it in the resume cache's `source`
+/// column.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextSource {
+    Release(String),
+    Library,
+}
+
 /// How the context's track order was derived, kept so `Context` repeat can
 /// re-derive it: `Sequential` replays the source order; `Shuffled` re-permutes
 /// with a fresh seed each loop.
@@ -19,17 +31,19 @@ pub enum ContextStart {
     Shuffled { seed: u64 },
 }
 
-/// The thing playback is "playing from": a release's track order, traversed by a
+/// The thing playback is "playing from": a source's track order, traversed by a
 /// cursor.
 ///
 /// The tracks are held as per-instance [`QueueEntry`]s so the cursor walks
 /// forward (advance) and backward (Previous) over stable row ids, and `Context`
-/// repeat loops the stored order without re-fetching it. A release is small, so
-/// the whole order is held expanded.
+/// repeat loops the stored order without re-fetching it. The whole order is held
+/// expanded — a release is small, and the library materializes to cheap track-id
+/// strings.
 pub struct PlaybackContext {
-    /// The release this order came from. Read by persistence to re-fetch the
-    /// tracks and re-materialize the order on restart.
-    pub source: String,
+    /// What this order came from (a release, or the whole library). Read by
+    /// persistence and the shuffle/repeat re-derive to re-fetch the tracks and
+    /// re-materialize the order.
+    pub source: ContextSource,
     /// The release's tracks in play order, each with a stable per-instance id.
     pub entries: Vec<QueueEntry>,
     /// Index into `entries` of the context track currently playing.

--- a/bae-core/src/playback/mod.rs
+++ b/bae-core/src/playback/mod.rs
@@ -22,10 +22,10 @@ pub use audio_output::{wait_for_samples, CaptureAudioOutput};
 pub use audio_output::{
     AudioError, AudioOutput, AudioState, AudioStream, CompletionEvent, PositionEvent,
 };
-pub use context::{ContextStart, Traversal};
+pub use context::{ContextSource, ContextStart, Traversal};
 pub use decoded_pcm::DecodedPcm;
 pub use error::PlaybackError;
-pub use persisted::{repeat_to_str, PersistedPlayback};
+pub use persisted::{repeat_to_str, source_to_str, PersistedPlayback};
 pub use progress::{PlaybackProgress, PreviewState};
 pub use queue::{
     ContextProjection, ContextSnapshot, NextEntry, PlaybackQueue, PreviousAction, QueueEntry,
@@ -37,7 +37,7 @@ pub use service::{
     PlaybackState, PlaybackTrackInfo, PlaybackTrackSide, PositionDisplay,
     SIDE_PAUSE_CASSETTE_MESSAGE_KEY, SIDE_PAUSE_TITLE_KEY, SIDE_PAUSE_VINYL_MESSAGE_KEY,
 };
-pub use source::{PlaybackSource, TrackCrossing, TrackFmt};
+pub use source::{TrackCrossing, TrackFmt};
 pub use sparse_buffer::SharedSparseBuffer;
 pub use track_stream::{create_track_stream_pair, TrackSink, TrackStream};
 

--- a/bae-core/src/playback/persisted.rs
+++ b/bae-core/src/playback/persisted.rs
@@ -8,7 +8,7 @@
 
 use tracing::warn;
 
-use super::{ContextSnapshot, QueueSnapshot, RepeatMode, Traversal};
+use super::{ContextSnapshot, ContextSource, QueueSnapshot, RepeatMode, Traversal};
 use crate::db::DbPlaybackState;
 
 /// The validated device-local resume cache: a queue snapshot plus the live
@@ -67,7 +67,7 @@ impl PersistedPlayback {
                     None => Traversal::Sequential,
                 };
                 Some(ContextSnapshot {
-                    source: ctx.source,
+                    source: source_from_str(ctx.source),
                     traversal,
                     cursor,
                 })
@@ -100,6 +100,32 @@ impl PersistedPlayback {
             volume: row.volume,
             is_muted: row.is_muted,
         })
+    }
+}
+
+/// The `playback_state.source` value standing for a library context. A release
+/// `source` is a UUID, which can never equal this literal, so the two are
+/// unambiguous in the column.
+const LIBRARY_SOURCE: &str = "library";
+
+/// Encode a [`ContextSource`] for the `playback_state.source` column: a release
+/// stores its id, the library the `LIBRARY_SOURCE` sentinel. A present context
+/// always has a `source`; "no context" is the NULL column, handled one level up.
+pub fn source_to_str(source: &ContextSource) -> String {
+    match source {
+        ContextSource::Release(id) => id.clone(),
+        ContextSource::Library => LIBRARY_SOURCE.to_string(),
+    }
+}
+
+/// Decode the `playback_state.source` column back to a [`ContextSource`]: the
+/// sentinel is the library, anything else is a release id. Total — every stored
+/// string maps to a source, so a present context never discards the cache here.
+fn source_from_str(source: String) -> ContextSource {
+    if source == LIBRARY_SOURCE {
+        ContextSource::Library
+    } else {
+        ContextSource::Release(source)
     }
 }
 
@@ -150,7 +176,7 @@ mod tests {
     fn valid_row_round_trips() {
         let parsed = PersistedPlayback::from_row(valid_row()).expect("a valid row parses");
         let context = parsed.queue.context.expect("the context survives");
-        assert_eq!(context.source, "rel-A");
+        assert_eq!(context.source, ContextSource::Release("rel-A".into()));
         assert_eq!(context.cursor, 2);
         assert!(matches!(
             context.traversal,
@@ -177,6 +203,36 @@ mod tests {
         let parsed = PersistedPlayback::from_row(row).expect("a valid row parses");
         let context = parsed.queue.context.expect("the context survives");
         assert!(matches!(context.traversal, Traversal::Sequential));
+    }
+
+    /// A row whose `source` is the library sentinel decodes back to the library
+    /// source — the resume cache for "shuffle library" survives a restart.
+    #[test]
+    fn library_source_row_round_trips() {
+        let row = DbPlaybackState {
+            context: Some(DbPlaybackContext {
+                source: source_to_str(&ContextSource::Library),
+                shuffle_seed: Some(7),
+                cursor: 0,
+            }),
+            ..valid_row()
+        };
+        let parsed = PersistedPlayback::from_row(row).expect("a valid row parses");
+        let context = parsed.queue.context.expect("the context survives");
+        assert_eq!(context.source, ContextSource::Library);
+    }
+
+    /// Both source kinds survive the `playback_state.source` encode/decode: a
+    /// release id is its own string, the library is the sentinel, and neither is
+    /// mistaken for the other (a release id is a UUID, never the sentinel).
+    #[test]
+    fn source_encoding_round_trips() {
+        for source in [
+            ContextSource::Release("550e8400-e29b-41d4-a716-446655440000".into()),
+            ContextSource::Library,
+        ] {
+            assert_eq!(source_from_str(source_to_str(&source)), source);
+        }
     }
 
     #[test]

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -4,7 +4,9 @@ use tracing::warn;
 
 use super::RepeatMode;
 use crate::id_provider::IdRef;
-use crate::playback::context::{shuffled_traversal, ContextStart, PlaybackContext, Traversal};
+use crate::playback::context::{
+    shuffled_traversal, ContextSource, ContextStart, PlaybackContext, Traversal,
+};
 
 /// Per-instance identity for an enqueued track. Distinct from `track_id`: the
 /// same track enqueued twice yields two entries with two ids, each removable,
@@ -20,11 +22,13 @@ pub struct QueueEntry {
     pub track_id: String,
 }
 
-/// The context lane projected for the UI: its not-yet-played tail and whether
-/// the release was ordered by shuffle (which the UI surfaces as an indicator).
-/// Kept distinct from the manual lane so the two render as separate sections.
+/// The context lane projected for the UI: what it plays from (so the UI labels
+/// the section — a release vs the library), its not-yet-played tail, and whether
+/// it was ordered by shuffle (which the UI surfaces as an indicator). Kept
+/// distinct from the manual lane so the two render as separate sections.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextProjection {
+    pub source: ContextSource,
     pub shuffled: bool,
     pub upcoming: Vec<QueueEntry>,
 }
@@ -54,11 +58,11 @@ enum EntryLocation {
     Context(usize),
 }
 
-/// The persistable view of a playing context (its release and how it's ordered),
-/// without the per-instance entry ids — those are local UI identity, re-minted on
-/// restore. Re-materialized from `source` + `traversal` on load.
+/// The persistable view of a playing context (what it plays from and how it's
+/// ordered), without the per-instance entry ids — those are local UI identity,
+/// re-minted on restore. Re-materialized from `source` + `traversal` on load.
 pub struct ContextSnapshot {
-    pub source: String,
+    pub source: ContextSource,
     pub traversal: Traversal,
     pub cursor: usize,
 }
@@ -170,7 +174,7 @@ impl PlaybackQueue {
 
     // -- Context ---------------------------------------------------------------
 
-    /// Order a release's source tracks under a traversal and mint a fresh
+    /// Order a source's tracks under a traversal and mint a fresh
     /// per-instance id per track: a shuffled traversal re-permutes `tracks` from
     /// its seed (the same seed yields the same order, so a restored shuffle
     /// reproduces what was played); a sequential one keeps source order. Shared
@@ -187,14 +191,14 @@ impl PlaybackQueue {
         tracks.into_iter().map(|t| self.mint(t)).collect()
     }
 
-    /// Build a `PlaybackContext` from a release's tracks under a traversal,
-    /// pairing the materialized order with `cursor`. The caller passes a non-empty
-    /// release and an in-range `cursor` (`play_release` validates its index;
+    /// Build a `PlaybackContext` from a source's tracks under a traversal,
+    /// pairing the materialized order with `cursor`. The caller passes non-empty
+    /// `tracks` and an in-range `cursor` (`play_release` validates its index;
     /// `restore` validates the saved cursor against the re-fetched tracks), so the
     /// context is non-empty with a valid cursor.
     fn build_context(
         &self,
-        source: String,
+        source: ContextSource,
         tracks: Vec<String>,
         cursor: usize,
         traversal: Traversal,
@@ -212,14 +216,14 @@ impl PlaybackQueue {
         }
     }
 
-    /// Make a release's tracks the playing context: build their order under
+    /// Make a source's tracks the playing context: build their order under
     /// `start`, set the cursor, and make the cursor entry current. Clears the
     /// manual lane (a fresh playback session). Returns the track to play. The
-    /// caller passes a non-empty release (and an in-range `Index`); the context
-    /// is therefore non-empty with a valid cursor.
+    /// caller passes a non-empty `track_ids` (and an in-range `Index`); the
+    /// context is therefore non-empty with a valid cursor.
     pub fn play_release(
         &mut self,
-        release_id: String,
+        source: ContextSource,
         track_ids: Vec<String>,
         start: ContextStart,
     ) -> String {
@@ -228,7 +232,7 @@ impl PlaybackQueue {
             ContextStart::Index(index) => (index, Traversal::Sequential),
             ContextStart::Shuffled { seed } => (0, Traversal::Shuffled { seed }),
         };
-        let context = self.build_context(release_id, track_ids, cursor, traversal);
+        let context = self.build_context(source, track_ids, cursor, traversal);
         let track = context.current().track_id.clone();
         self.current = Some(context.current().clone());
         self.context = Some(context);
@@ -614,12 +618,13 @@ impl PlaybackQueue {
         self.manual.iter().cloned().collect()
     }
 
-    /// The context's projection — its not-yet-played tail and whether it was
-    /// ordered by shuffle — or `None` when nothing is playing from a release.
+    /// The context's projection — what it plays from, its not-yet-played tail,
+    /// and whether it was ordered by shuffle — or `None` when nothing is playing.
     /// The two lanes are kept separate (not flattened) so each UI renders the
     /// manual lane and the context as distinct sections.
     pub fn context_projection(&self) -> Option<ContextProjection> {
         self.context.as_ref().map(|ctx| ContextProjection {
+            source: ctx.source.clone(),
             shuffled: matches!(ctx.traversal, Traversal::Shuffled { .. }),
             upcoming: ctx.upcoming().to_vec(),
         })
@@ -685,11 +690,11 @@ impl PlaybackQueue {
         self.current.as_ref().map(|e| e.track_id.as_str())
     }
 
-    /// The source release id of the playing context, or `None` when nothing is
-    /// playing from a release. The shuffle toggle reads this to re-fetch the
-    /// context's source tracks before re-materializing the order.
-    pub fn context_source(&self) -> Option<&str> {
-        self.context.as_ref().map(|ctx| ctx.source.as_str())
+    /// What the playing context plays from (a release or the library), or `None`
+    /// when nothing is playing. The shuffle toggle and `Context` repeat read this
+    /// to re-fetch the context's source tracks before re-materializing the order.
+    pub fn context_source(&self) -> Option<&ContextSource> {
+        self.context.as_ref().map(|ctx| &ctx.source)
     }
 
     /// The whole context order (including the tracks behind the cursor) as track
@@ -734,6 +739,11 @@ mod tests {
 
     fn rel(tracks: &[&str]) -> Vec<String> {
         tracks.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// A release source for the given id, the common `play_release` source.
+    fn rel_src(id: &str) -> ContextSource {
+        ContextSource::Release(id.to_string())
     }
 
     // -- manual lane -----------------------------------------------------------
@@ -843,7 +853,7 @@ mod tests {
     fn test_clear_empties_manual_keeps_context() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(0),
         );
@@ -878,7 +888,7 @@ mod tests {
     fn test_play_release_sets_current_and_upcoming() {
         let mut q = queue();
         let first = q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(0),
         );
@@ -891,7 +901,7 @@ mod tests {
     fn test_play_release_start_index() {
         let mut q = queue();
         let first = q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(1),
         );
@@ -903,7 +913,7 @@ mod tests {
     fn test_play_release_shuffled_keeps_all_tracks() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4"]),
             ContextStart::Shuffled { seed: 7 },
         );
@@ -917,7 +927,7 @@ mod tests {
         let order = |seed| {
             let mut q = queue();
             q.play_release(
-                "r1".into(),
+                rel_src("r1"),
                 rel(&["t1", "t2", "t3", "t4", "t5"]),
                 ContextStart::Shuffled { seed },
             );
@@ -934,7 +944,7 @@ mod tests {
     fn test_context_repeat_shuffled_loops_a_re_derived_order() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4", "t5"]),
             ContextStart::Shuffled { seed: 1 },
         );
@@ -960,13 +970,63 @@ mod tests {
         );
     }
 
+    /// A `Library` source is the same construct as a release: its tracks
+    /// materialize into the context under the seed, keeping every track, and the
+    /// snapshot reports the `Library` source.
+    #[test]
+    fn test_library_source_context_materializes_all_tracks() {
+        let mut q = queue();
+        q.play_release(
+            ContextSource::Library,
+            rel(&["t1", "t2", "t3", "t4", "t5"]),
+            ContextStart::Shuffled { seed: 3 },
+        );
+        let mut all = full_order(&q);
+        all.sort();
+        assert_eq!(all, vec!["t1", "t2", "t3", "t4", "t5"]);
+        assert_eq!(q.snapshot().context.unwrap().source, ContextSource::Library);
+    }
+
+    /// `Context` repeat on a `Library` context loops a freshly re-derived order
+    /// of the same library tracks each pass — the queue re-permutes its held
+    /// entries in place, identical to a release context (the source enum only
+    /// labels where the tracks came from).
+    #[test]
+    fn test_context_repeat_on_library_re_derives_a_fresh_order() {
+        let mut q = queue();
+        q.play_release(
+            ContextSource::Library,
+            rel(&["t1", "t2", "t3", "t4", "t5"]),
+            ContextStart::Shuffled { seed: 9 },
+        );
+        q.set_repeat_mode(RepeatMode::Context);
+        let first_pass = full_order(&q);
+        for _ in 0..first_pass.len() - 1 {
+            q.next_entry();
+        }
+        match q.next_entry() {
+            NextEntry::Play(_) => {}
+            other => panic!("expected a looped Play, got {other:?}"),
+        }
+        let second_pass = full_order(&q);
+
+        let (mut a, mut b) = (first_pass.clone(), second_pass.clone());
+        a.sort();
+        b.sort();
+        assert_eq!(a, b, "the loop replays exactly the library tracks");
+        assert_ne!(
+            first_pass, second_pass,
+            "but in a freshly re-derived order each pass"
+        );
+    }
+
     // -- shuffle toggle --------------------------------------------------------
 
     #[test]
     fn test_set_shuffle_on_keeps_current_track_with_cursor_on_it() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4", "t5"]),
             ContextStart::Index(2),
         );
@@ -992,7 +1052,7 @@ mod tests {
     fn test_set_shuffle_off_restores_source_order_from_current() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4", "t5"]),
             ContextStart::Index(2),
         );
@@ -1024,7 +1084,7 @@ mod tests {
         let order = |seed| {
             let mut q = queue();
             q.play_release(
-                "r1".into(),
+                rel_src("r1"),
                 rel(&["t1", "t2", "t3", "t4", "t5"]),
                 ContextStart::Index(0),
             );
@@ -1040,12 +1100,15 @@ mod tests {
     fn test_snapshot_restore_sequential_context() {
         let mut q = queue();
         q.play_release(
-            "rel-A".into(),
+            rel_src("rel-A"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(1),
         );
         let snap = q.snapshot();
-        assert_eq!(snap.context.as_ref().unwrap().source, "rel-A");
+        assert_eq!(
+            snap.context.as_ref().unwrap().source,
+            ContextSource::Release("rel-A".into())
+        );
         assert_eq!(snap.current_track_id.as_deref(), Some("t2"));
 
         let mut restored = queue();
@@ -1062,7 +1125,7 @@ mod tests {
     fn test_snapshot_restore_shuffled_keeps_cursor_on_same_track() {
         let mut q = queue();
         q.play_release(
-            "rel-A".into(),
+            rel_src("rel-A"),
             rel(&["t1", "t2", "t3", "t4", "t5"]),
             ContextStart::Shuffled { seed: 99 },
         );
@@ -1096,7 +1159,7 @@ mod tests {
     #[test]
     fn test_manual_drains_before_context() {
         let mut q = queue();
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.add_to_queue(rel(&["m1"]));
         // current = t1; next drains manual (m1) before advancing the context.
         assert!(matches!(q.next_entry(), NextEntry::Play(t) if t == "m1"));
@@ -1108,7 +1171,7 @@ mod tests {
     fn test_context_advances_by_cursor() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(0),
         );
@@ -1122,7 +1185,7 @@ mod tests {
         // The queue holds the context order, so looping reuses it: the queue has
         // no library access, so it structurally cannot re-fetch.
         let mut q = queue();
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.set_repeat_mode(RepeatMode::Context);
         assert!(matches!(q.next_entry(), NextEntry::Play(t) if t == "t2"));
         // Exhausted under Context repeat → loop from the start of the same order.
@@ -1133,7 +1196,7 @@ mod tests {
     #[test]
     fn test_repeat_track_pins_current() {
         let mut q = queue();
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.set_repeat_mode(RepeatMode::Track);
         assert!(matches!(q.next_entry(), NextEntry::RepeatCurrent(t) if t == "t1"));
     }
@@ -1142,7 +1205,7 @@ mod tests {
     fn test_previous_steps_cursor_back_multiple() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(0),
         );
@@ -1160,7 +1223,7 @@ mod tests {
     #[test]
     fn test_previous_past_3s_restarts() {
         let mut q = queue();
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(1));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(1));
         assert!(matches!(
             q.previous_action(5000),
             PreviousAction::RestartCurrent
@@ -1171,7 +1234,7 @@ mod tests {
     fn test_skip_to_context_tail_moves_cursor() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4"]),
             ContextStart::Index(0),
         );
@@ -1186,7 +1249,7 @@ mod tests {
     fn test_remove_context_tail_entry() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(0),
         );
@@ -1200,7 +1263,7 @@ mod tests {
     fn test_reorder_context_tail_keeps_cursor() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4"]),
             ContextStart::Index(0),
         );
@@ -1220,7 +1283,7 @@ mod tests {
     #[test]
     fn test_reorder_cross_lane_is_noop() {
         let mut q = queue();
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(0));
         q.add_to_queue(rel(&["m1"]));
         let manual_id = manual_ids(&q)[0].clone();
         let context_id = q
@@ -1262,7 +1325,7 @@ mod tests {
     fn test_remove_by_ids_clears_manual_and_context() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "dup", "t3"]),
             ContextStart::Index(0),
         );
@@ -1277,7 +1340,7 @@ mod tests {
     fn test_remove_by_ids_keeps_cursor_on_same_track() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["gone", "t2", "t3"]),
             ContextStart::Index(1),
         );
@@ -1291,7 +1354,7 @@ mod tests {
     #[test]
     fn test_remove_by_ids_clears_current_when_deleted() {
         let mut q = queue();
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(0));
         let ids: HashSet<String> = ["t1"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
         assert_eq!(q.current_track_id(), None);
@@ -1301,7 +1364,7 @@ mod tests {
     fn test_remove_by_ids_deleting_current_last_entry_keeps_cursor_valid() {
         let mut q = queue();
         // current = t2 at the last position (cursor == len-1).
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(1));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(1));
         let ids: HashSet<String> = ["t2"].iter().map(|s| s.to_string()).collect();
         q.remove_by_ids(&ids);
         assert_eq!(
@@ -1337,7 +1400,7 @@ mod tests {
     fn test_projection_keeps_manual_and_context_separate() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3"]),
             ContextStart::Index(0),
         );
@@ -1371,7 +1434,7 @@ mod tests {
     fn test_projection_context_carries_shuffled_flag() {
         let mut q = queue();
         q.play_release(
-            "r1".into(),
+            rel_src("r1"),
             rel(&["t1", "t2", "t3", "t4"]),
             ContextStart::Shuffled { seed: 7 },
         );
@@ -1397,7 +1460,7 @@ mod tests {
         let mut q = queue();
         assert!(!q.has_upcoming());
         assert!(!q.has_previous());
-        q.play_release("r1".into(), rel(&["t1", "t2"]), ContextStart::Index(0));
+        q.play_release(rel_src("r1"), rel(&["t1", "t2"]), ContextStart::Index(0));
         assert!(q.has_upcoming());
         assert!(!q.has_previous());
         q.next_entry(); // → t2

--- a/bae-core/src/playback/service.rs
+++ b/bae-core/src/playback/service.rs
@@ -23,8 +23,8 @@
 
 use super::RepeatMode;
 use super::{
-    repeat_to_str, ContextStart, NextEntry, PersistedPlayback, PlaybackQueue, PreviousAction,
-    QueueEntryId, QueueSnapshot, Traversal,
+    repeat_to_str, source_to_str, ContextSource, ContextStart, NextEntry, PersistedPlayback,
+    PlaybackQueue, PreviousAction, QueueEntryId, QueueSnapshot, Traversal,
 };
 use crate::audio_codec::StreamingDecodeError;
 use crate::db::{DbPlaybackContext, DbPlaybackState};
@@ -39,7 +39,10 @@ use crate::playback::error::PlaybackError;
 use crate::playback::progress::emit_progress;
 use crate::playback::progress::PreviewState;
 use crate::playback::progress::{PlaybackProgress, PlaybackProgressHandle};
-use crate::playback::source::{PlaybackSource, TrackCrossing, TrackFmt};
+// The `source` module is imported by path so the audio sample feed reads
+// `source::PlaybackSource` — distinct from the queue's `ContextSource`.
+use crate::playback::source;
+use crate::playback::source::{TrackCrossing, TrackFmt};
 use crate::playback::sparse_buffer::{create_sparse_buffer, SharedSparseBuffer};
 use crate::playback::{create_track_stream_pair, TrackStream};
 use crate::util::format::PhysicalSideMedium;
@@ -139,6 +142,9 @@ pub enum PlaybackCommand {
         start_track_index: Option<usize>,
         shuffle: bool,
     },
+    /// Play the whole library in a freshly seeded shuffle. An empty library is a
+    /// no-op (logged); the seed is minted in the handler.
+    PlayLibraryShuffled,
     Pause,
     Resume,
     Stop,
@@ -294,6 +300,9 @@ impl PlaybackHandle {
                 shuffle,
             },
         );
+    }
+    pub fn play_library_shuffled(&self) {
+        dispatch_command(&self.command_tx, PlaybackCommand::PlayLibraryShuffled);
     }
     pub fn pause(&self) {
         dispatch_command(&self.command_tx, PlaybackCommand::Pause);
@@ -617,7 +626,7 @@ pub struct PlaybackService {
     /// Current playing source. A `PlaybackSource` wraps the current track and an
     /// optional pre-staged next track so the audio callback can advance across a
     /// track boundary without rebuilding the stream.
-    current_playback_source: Option<Arc<Mutex<PlaybackSource>>>,
+    current_playback_source: Option<Arc<Mutex<source::PlaybackSource>>>,
     /// JoinHandle for the current decoder thread (needed for seek cancellation)
     current_decoder_handle: Option<std::thread::JoinHandle<()>>,
     /// Listener task handles for the current track (position ticks + completion)
@@ -644,7 +653,7 @@ pub struct PlaybackService {
     /// Streaming source for preview (to cancel on stop). Wrapped in a
     /// single-track `PlaybackSource` (preview never chains) to share the audio
     /// output's stream interface.
-    preview_playback_source: Option<Arc<Mutex<PlaybackSource>>>,
+    preview_playback_source: Option<Arc<Mutex<source::PlaybackSource>>>,
     /// Path of the file currently being previewed
     preview_path: Option<String>,
     /// Whether the main player was playing before preview started (to resume on stop)
@@ -764,7 +773,7 @@ fn spawn_sync_to_async_bridge<T: Send + 'static>(
 
 async fn setup_audio_stream(
     audio_output: &mut dyn AudioOutput,
-    source: Arc<Mutex<PlaybackSource>>,
+    source: Arc<Mutex<source::PlaybackSource>>,
     position_update_interval_ms: u32,
 ) -> Result<StreamSetup, PlaybackError> {
     let (source_sample_rate, source_channels) = {
@@ -978,7 +987,7 @@ impl PlaybackService {
     /// filling the buffer. After this, the buffer is ready for a new decoder
     /// to read from position 0.
     async fn teardown_decoder_for_seek(
-        source: &mut Option<Arc<Mutex<PlaybackSource>>>,
+        source: &mut Option<Arc<Mutex<source::PlaybackSource>>>,
         buffer: &SharedSparseBuffer,
         cancel_token: &Arc<std::sync::atomic::AtomicBool>,
         decoder_handle: &mut Option<std::thread::JoinHandle<()>>,
@@ -1045,7 +1054,7 @@ impl PlaybackService {
 
         // Wrap the track source in a PlaybackSource so the audio callback can
         // advance to a pre-staged next track without rebuilding the stream.
-        let gapless = Arc::new(Mutex::new(PlaybackSource::new(
+        let gapless = Arc::new(Mutex::new(source::PlaybackSource::new(
             source,
             fmt,
             self.boundary_tx.clone(),
@@ -1406,24 +1415,25 @@ impl PlaybackService {
 
         // -- All fallible work first; the queue is untouched until it succeeds. --
 
-        // Re-materialize the context from its source release's current tracks
-        // (deleted tracks fall out of `get_track_ids`). A fetch error abandons the
-        // restore; an empty result means the source release is gone; a result
-        // shorter than the saved cursor means the release shrank below where we
-        // were playing. Either way we drop the context and restore the manual
-        // lane only, so `build_context` only ever sees an in-range cursor.
+        // Re-materialize the context from its source's current tracks (deleted
+        // tracks fall out of the re-fetch). A fetch error abandons the restore; an
+        // empty result means the source is gone (the release was deleted, or the
+        // library is now empty); a result shorter than the saved cursor means the
+        // source shrank below where we were playing. Either way we drop the context
+        // and restore the manual lane only, so `build_context` only ever sees an
+        // in-range cursor.
         let (context, context_tracks) = match &parsed.queue.context {
-            Some(cs) => match self.library_manager.get_track_ids(&cs.source).await {
+            Some(cs) => match self.fetch_source_tracks(&cs.source).await {
                 Ok(tracks) if tracks.is_empty() => {
                     debug!(
-                        "resume context release {} is gone; restoring the manual lane only",
+                        "resume context source {:?} is gone; restoring the manual lane only",
                         cs.source
                     );
                     (None, Vec::new())
                 }
                 Ok(tracks) if cs.cursor >= tracks.len() => {
                     warn!(
-                        "saved cursor {} is past the {} current tracks of {}; \
+                        "saved cursor {} is past the {} current tracks of {:?}; \
                          restoring the manual lane only",
                         cs.cursor,
                         tracks.len(),
@@ -1434,7 +1444,7 @@ impl PlaybackService {
                 Ok(tracks) => (parsed.queue.context, tracks),
                 Err(e) => {
                     warn!(
-                        "couldn't load the resume context tracks for {}: {e}; starting fresh",
+                        "couldn't load the resume context tracks for {:?}: {e}; starting fresh",
                         cs.source
                     );
                     return;
@@ -1552,6 +1562,21 @@ impl PlaybackService {
     ///
     /// The write is logged-best-effort, not propagated as fatal: a failed
     /// resume-cache write only costs the resume point; playback is unaffected.
+    /// Fetch a context's tracks in source order for the source it plays from:
+    /// a release's ordered track ids, or every library track. The one place the
+    /// service re-derives a context's tracks (the shuffle toggle, restore, and
+    /// any future `Context`-repeat re-fetch dispatch here so the two sources stay
+    /// in lockstep).
+    async fn fetch_source_tracks(
+        &self,
+        source: &ContextSource,
+    ) -> Result<Vec<String>, crate::library::LibraryError> {
+        match source {
+            ContextSource::Release(id) => self.library_manager.get_track_ids(id).await,
+            ContextSource::Library => self.library_manager.get_all_track_ids().await,
+        }
+    }
+
     /// The log is the never-mask escape hatch — a write failure is recorded, not
     /// conflated with "nothing was playing".
     async fn persist_playback_state(&self) {
@@ -1564,7 +1589,7 @@ impl PlaybackService {
         }
         let snap = self.playback_queue.snapshot();
         let context = snap.context.map(|ctx| DbPlaybackContext {
-            source: ctx.source,
+            source: source_to_str(&ctx.source),
             shuffle_seed: match ctx.traversal {
                 Traversal::Shuffled { seed } => Some(seed as i64),
                 Traversal::Sequential => None,
@@ -1616,7 +1641,7 @@ impl PlaybackService {
                     match self.library_manager.get_play_context(&track_id).await {
                         Ok(context) => {
                             self.playback_queue.play_release(
-                                context.release_id,
+                                ContextSource::Release(context.release_id),
                                 context.track_ids,
                                 ContextStart::Index(context.index),
                             );
@@ -1671,9 +1696,38 @@ impl PlaybackService {
                         };
                         ContextStart::Index(index)
                     };
-                    let first_track = self
-                        .playback_queue
-                        .play_release(release_id, track_ids, start);
+                    let first_track = self.playback_queue.play_release(
+                        ContextSource::Release(release_id),
+                        track_ids,
+                        start,
+                    );
+                    self.pending_side_pause = None;
+                    self.emit_queue_update();
+                    self.play_track(&first_track, false, false).await;
+                }
+                PlaybackCommand::PlayLibraryShuffled => {
+                    let track_ids = match self.fetch_source_tracks(&ContextSource::Library).await {
+                        Ok(ids) => ids,
+                        Err(e) => {
+                            error!("PlayLibraryShuffled: couldn't load library tracks: {e}");
+                            continue;
+                        }
+                    };
+                    if track_ids.is_empty() {
+                        warn!("PlayLibraryShuffled: the library has no tracks; nothing to play");
+                        continue;
+                    }
+                    self.stop_preview_without_resume();
+                    self.main_was_playing_before_preview = false;
+                    // A fresh seed minted at the command boundary so the shuffled
+                    // order is reproducible and `Context` repeat can re-derive it.
+                    let first_track = self.playback_queue.play_release(
+                        ContextSource::Library,
+                        track_ids,
+                        ContextStart::Shuffled {
+                            seed: rand::random(),
+                        },
+                    );
                     self.pending_side_pause = None;
                     self.emit_queue_update();
                     self.play_track(&first_track, false, false).await;
@@ -1988,12 +2042,8 @@ impl PlaybackService {
                     self.persist_playback_state().await;
                 }
                 PlaybackCommand::SetShuffle(on) => {
-                    match self
-                        .playback_queue
-                        .context_source()
-                        .map(|s| s.to_string())
-                    {
-                        Some(source) => match self.library_manager.get_track_ids(&source).await {
+                    match self.playback_queue.context_source().cloned() {
+                        Some(source) => match self.fetch_source_tracks(&source).await {
                             Ok(source_tracks) => {
                                 // A fresh seed minted here at the command boundary so
                                 // a shuffled order is reproducible and `Context`
@@ -2005,7 +2055,7 @@ impl PlaybackService {
                                 self.persist_playback_state().await;
                             }
                             Err(e) => warn!(
-                                "SetShuffle: couldn't fetch source tracks for {source}: {e}; \
+                                "SetShuffle: couldn't fetch source tracks for {source:?}: {e}; \
                                  leaving the queue unchanged"
                             ),
                         },
@@ -2829,7 +2879,7 @@ impl PlaybackService {
             replay_gain_linear: 1.0,
         };
         let (preview_boundary_tx, _preview_boundary_rx) = tokio_mpsc::unbounded_channel();
-        let source = Arc::new(Mutex::new(PlaybackSource::new(
+        let source = Arc::new(Mutex::new(source::PlaybackSource::new(
             source,
             preview_fmt,
             preview_boundary_tx,

--- a/bae-core/src/queue.rs
+++ b/bae-core/src/queue.rs
@@ -18,14 +18,15 @@ pub struct QueueItem {
     pub cover_image_id: Option<String>,
 }
 
-/// The context lane resolved for display: the not-yet-played tail of the
-/// release being played from, plus whether it was ordered by shuffle (which the
-/// UI surfaces as an indicator). The display-ready counterpart of
-/// [`crate::playback::ContextProjection`], with each entry resolved to a
-/// [`QueueItem`]. Carried separately from the manual lane so each UI renders the
-/// two as distinct sections.
+/// The context lane resolved for display: what it plays from (so the UI labels
+/// the section — a release vs the library), the not-yet-played tail, and whether
+/// it was ordered by shuffle (which the UI surfaces as an indicator). The
+/// display-ready counterpart of [`crate::playback::ContextProjection`], with each
+/// entry resolved to a [`QueueItem`]. Carried separately from the manual lane so
+/// each UI renders the two as distinct sections.
 #[derive(Debug, Clone)]
 pub struct ResolvedContext {
+    pub source: crate::playback::ContextSource,
     pub shuffled: bool,
     pub upcoming: Vec<QueueItem>,
 }

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -186,6 +186,7 @@ impl UiEventBus {
                                 bus.emit(UiBusEvent::QueueUpdated {
                                     manual: manual_items,
                                     context: context.map(|c| crate::queue::ResolvedContext {
+                                        source: c.source,
                                         shuffled: c.shuffled,
                                         upcoming: context_items,
                                     }),

--- a/bae-ios/bae/bae/Localizable.xcstrings
+++ b/bae-ios/bae/bae/Localizable.xcstrings
@@ -15775,6 +15775,388 @@
           }
         }
       }
+    },
+    "Shuffle Library": {
+      "comment": "Library view: shuffle the whole library into a fresh session",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffle Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir biblioteca al azar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture aléatoire de la bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mediathek zufällig wiedergeben"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Embaralhar biblioteca"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリをシャッフル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随机播放音乐库"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل المكتبة عشوائيًا"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערבוב הספרייה"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемішати фонотеку"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разбъркване на библиотеката"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzaj bibliotekę losowo"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Náhodně přehrát knihovnu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nasumično reproduciraj biblioteku"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이브러리 셔플"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隨機播放資料庫"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduci libreria in ordine casuale"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kitaplığı karıştır"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phát ngẫu nhiên thư viện"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibliotheek shufflen"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइब्रेरी शफ़ल करें"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লাইব্রেরি শাফল করুন"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நூலகத்தை கலைத்து இயக்கு"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "లైబ్రరీని షఫుల్ చేయి"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लायब्ररी शफल करा"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائبریری کو شفل کریں"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "લાઇબ્રેરી શફલ કરો"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ലൈബ്രറി ഷഫിൾ ചെയ്യുക"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สุ่มเล่นคลังเพลง"
+          }
+        }
+      }
+    },
+    "Your Library": {
+      "comment": "Queue panel: context section header when playing the whole library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu biblioteca"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votre bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deine Mediathek"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua biblioteca"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的音乐库"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مكتبتك"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הספרייה שלך"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваша фонотека"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вашата библиотека"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twoja biblioteka"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaše knihovna"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaša biblioteka"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보관함"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的資料庫"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tua libreria"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kitaplığınız"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thư viện của bạn"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je bibliotheek"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी लाइब्रेरी"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আপনার লাইব্রেরি"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உங்கள் நூலகம்"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "మీ లైబ్రరీ"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "तुमची लायब्ररी"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کی لائبریری"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "તમારી લાઇબ્રેરી"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ನಿಮ್ಮ ಲೈಬ್ರರಿ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "നിങ്ങളുടെ ലൈബ്രറി"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลังของคุณ"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
+++ b/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
@@ -202,7 +202,11 @@ struct ExpandedNowPlayingView: View {
                     onSkipped: {}
                 )
             } header: {
-                playingFromHeader(shuffled: context.shuffled, queue: queue)
+                playingFromHeader(
+                    kind: context.kind,
+                    shuffled: context.shuffled,
+                    queue: queue
+                )
             }
         }
     }

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -17,6 +17,8 @@ struct LibraryView: View {
     private var configStore
     @Environment(Sync.self)
     private var sync
+    @Environment(Playback.self)
+    private var playback
 
     @State
     private var showSettings = false
@@ -56,6 +58,14 @@ struct LibraryView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     sortMenu
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        playback.playLibraryShuffled()
+                    } label: {
+                        Image(systemName: "shuffle")
+                    }
+                    .accessibilityLabel(Text("Shuffle Library"))
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Text(

--- a/bae-ios/bae/bae/Views/QueueView.swift
+++ b/bae-ios/bae/bae/Views/QueueView.swift
@@ -122,21 +122,30 @@ struct QueueView: View {
                     onSkipped: { dismiss() }
                 )
             } header: {
-                playingFromHeader(shuffled: context.shuffled, queue: queue)
+                playingFromHeader(
+                    kind: context.kind,
+                    shuffled: context.shuffled,
+                    queue: queue
+                )
             }
         }
     }
 }
 
-/// The "Playing From" context-section header with its shuffle toggle — shared by
-/// the queue sheet and the expanded player's embedded queue so the control can't
-/// drift. The toggle is tinted when on; tapping it flips the context's order
-/// while the current track keeps playing.
+/// The context-section header with its shuffle toggle — shared by the queue
+/// sheet and the expanded player's embedded queue so the control can't drift.
+/// The title names what's playing — a release ("Playing From") vs the whole
+/// library — by `kind`. The toggle is tinted when on; tapping it flips the
+/// context's order while the current track keeps playing.
 @MainActor
 @ViewBuilder
-func playingFromHeader(shuffled: Bool, queue: Queue) -> some View {
+func playingFromHeader(
+    kind: BridgePlaybackSourceKind,
+    shuffled: Bool,
+    queue: Queue
+) -> some View {
     HStack(spacing: 6) {
-        Text("Playing From")
+        Text(contextSectionTitle(kind))
         Spacer()
         Button {
             queue.setShuffle(!shuffled)
@@ -148,6 +157,18 @@ func playingFromHeader(shuffled: Bool, queue: Queue) -> some View {
         .accessibilityLabel(
             shuffled ? Text("Turn off shuffle") : Text("Shuffle")
         )
+    }
+}
+
+/// The context section's title, by what it plays from: a release keeps the
+/// "Playing From" label; the library names itself. Resolving a localized key by
+/// the source kind is the UI's locale-rendering job.
+func contextSectionTitle(_ kind: BridgePlaybackSourceKind) -> LocalizedStringKey {
+    switch kind {
+    case .release:
+        return "Playing From"
+    case .library:
+        return "Your Library"
     }
 }
 

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -79594,6 +79594,388 @@
           }
         }
       }
+    },
+    "Shuffle Library": {
+      "comment": "Library view: shuffle the whole library into a fresh session",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffle Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir biblioteca al azar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture aléatoire de la bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mediathek zufällig wiedergeben"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Embaralhar biblioteca"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリをシャッフル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随机播放音乐库"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل المكتبة عشوائيًا"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערבוב הספרייה"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемішати фонотеку"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разбъркване на библиотеката"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzaj bibliotekę losowo"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Náhodně přehrát knihovnu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nasumično reproduciraj biblioteku"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이브러리 셔플"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隨機播放資料庫"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduci libreria in ordine casuale"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kitaplığı karıştır"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phát ngẫu nhiên thư viện"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibliotheek shufflen"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइब्रेरी शफ़ल करें"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লাইব্রেরি শাফল করুন"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நூலகத்தை கலைத்து இயக்கு"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "లైబ్రరీని షఫుల్ చేయి"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लायब्ररी शफल करा"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائبریری کو شفل کریں"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "લાઇબ્રેરી શફલ કરો"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ലൈബ്രറി ഷഫിൾ ചെയ്യുക"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สุ่มเล่นคลังเพลง"
+          }
+        }
+      }
+    },
+    "Your Library": {
+      "comment": "Queue panel: context section header when playing the whole library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu biblioteca"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votre bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deine Mediathek"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua biblioteca"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的音乐库"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مكتبتك"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הספרייה שלך"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваша фонотека"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вашата библиотека"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twoja biblioteka"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaše knihovna"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaša biblioteka"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보관함"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的資料庫"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tua libreria"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kitaplığınız"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thư viện của bạn"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je bibliotheek"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी लाइब्रेरी"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আপনার লাইব্রেরি"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உங்கள் நூலகம்"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "మీ లైబ్రరీ"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "तुमची लायब्ररी"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کی لائبریری"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "તમારી લાઇબ્રેરી"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ನಿಮ್ಮ ಲೈಬ್ರರಿ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "നിങ്ങളുടെ ലൈബ്രറി"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลังของคุณ"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-macos/bae/bae/Services/Playback.swift
+++ b/bae-macos/bae/bae/Services/Playback.swift
@@ -18,6 +18,9 @@ final class Playback: Sendable, Observable {
         @Sendable (
             _ releaseId: String, _ startTrackIndex: UInt32?, _ shuffle: Bool
         ) -> Void
+    /// Play the whole library in a freshly seeded shuffle. An empty library is a
+    /// no-op (logged in core).
+    let playLibraryShuffled: @Sendable () -> Void
 
     init(
         togglePlayPause: @escaping @Sendable () -> Void = {},
@@ -33,7 +36,8 @@ final class Playback: Sendable, Observable {
             _,
             _,
             _ in
-        }
+        },
+        playLibraryShuffled: @escaping @Sendable () -> Void = {}
     ) {
         self.togglePlayPause = togglePlayPause
         self.pause = pause
@@ -45,6 +49,7 @@ final class Playback: Sendable, Observable {
         self.toggleMute = toggleMute
         self.cycleRepeatMode = cycleRepeatMode
         self.playRelease = playRelease
+        self.playLibraryShuffled = playLibraryShuffled
     }
 
     convenience init(handle: any AppHandleProtocol) {
@@ -64,7 +69,8 @@ final class Playback: Sendable, Observable {
                     startTrackIndex: $1,
                     shuffle: $2
                 )
-            }
+            },
+            playLibraryShuffled: { handle.playLibraryShuffled() }
         )
     }
 

--- a/bae-macos/bae/bae/Services/Store/QueueItem.swift
+++ b/bae-macos/bae/bae/Services/Store/QueueItem.swift
@@ -24,19 +24,27 @@ struct QueueItem: Identifiable, Equatable {
     }
 }
 
-/// The context lane (the release being played from): its not-yet-played tail,
-/// plus whether it was ordered by shuffle (rendered as a shuffle indicator).
-/// Shown as its own section, distinct from the manual "Up Next" lane.
+/// The context lane (what the queue is playing from): its kind (a release vs the
+/// whole library, which the section header labels), its not-yet-played tail, plus
+/// whether it was ordered by shuffle (rendered as a shuffle indicator). Shown as
+/// its own section, distinct from the manual "Up Next" lane.
 struct QueuePlaybackContext: Equatable {
+    let kind: BridgePlaybackSourceKind
     let shuffled: Bool
     let upcoming: [QueueItem]
 
     init(bridge: BridgePlaybackContext) {
+        kind = bridge.kind
         shuffled = bridge.shuffled
         upcoming = bridge.upcoming.map(QueueItem.init(bridge:))
     }
 
-    init(shuffled: Bool, upcoming: [QueueItem]) {
+    init(
+        kind: BridgePlaybackSourceKind,
+        shuffled: Bool,
+        upcoming: [QueueItem]
+    ) {
+        self.kind = kind
         self.shuffled = shuffled
         self.upcoming = upcoming
     }

--- a/bae-macos/bae/bae/Views/AlbumGridView.swift
+++ b/bae-macos/bae/bae/Views/AlbumGridView.swift
@@ -18,6 +18,8 @@ struct AlbumGridView<ExpansionContent: View>: View {
     let onPlay: (String) -> Void
     let onAddToQueue: (String) -> Void
     let onAddNext: (String) -> Void
+    /// Shuffle the whole library into a fresh playback session.
+    let onShuffleLibrary: () -> Void
     let headerTitle: String
     @ViewBuilder
     let expansionContent: (_ albumId: String) -> ExpansionContent
@@ -212,6 +214,11 @@ struct AlbumGridView<ExpansionContent: View>: View {
             Text(headerTitle)
                 .font(.system(size: 36, weight: .bold))
             Spacer()
+            Button(action: onShuffleLibrary) {
+                Label("Shuffle Library", systemImage: "shuffle")
+            }
+            .buttonStyle(.borderless)
+            .help("Shuffle Library")
             sortControls
         }
     }
@@ -486,6 +493,7 @@ private class MenuItem: NSMenuItem {
                 onPlay: { _ in },
                 onAddToQueue: { _ in },
                 onAddNext: { _ in },
+                onShuffleLibrary: {},
                 headerTitle: "Library",
             ) { albumId in
                 AlbumDetailView(albumId: albumId)

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -44,6 +44,7 @@ struct LibraryView: View {
                         onAddNext: { releaseId in
                             queue.addReleaseNext(releaseId)
                         },
+                        onShuffleLibrary: { playback.playLibraryShuffled() },
                         headerTitle: String(localized: "Library"),
                     ) { albumId in
                         AlbumDetailView(albumId: albumId)

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -449,6 +449,7 @@ private struct NowPlayingBarPreview: View {
         queueIsActive: true,
         queueManual: Array(PreviewData.queueItems.prefix(2)),
         queueContext: QueuePlaybackContext(
+            kind: .release,
             shuffled: false,
             upcoming: Array(PreviewData.queueItems.suffix(3))
         ),
@@ -465,6 +466,7 @@ private struct NowPlayingBarPreview: View {
         queueIsActive: true,
         queueManual: Array(PreviewData.queueItems.prefix(2)),
         queueContext: QueuePlaybackContext(
+            kind: .release,
             shuffled: true,
             upcoming: Array(PreviewData.queueItems.suffix(3))
         ),

--- a/bae-macos/bae/bae/Views/QueueView.swift
+++ b/bae-macos/bae/bae/Views/QueueView.swift
@@ -90,7 +90,7 @@ struct QueueView: View {
 
                         if let context, !context.upcoming.isEmpty {
                             QueueSection(
-                                title: String(localized: "Playing From"),
+                                title: Self.contextSectionTitle(context.kind),
                                 shuffled: context.shuffled,
                                 items: context.upcoming,
                                 acceptsExternalDrops: false,
@@ -109,6 +109,21 @@ struct QueueView: View {
             }
         }
         .background(Theme.surface)
+    }
+
+    /// The context section's title, by what it plays from: a release keeps the
+    /// "Playing From" label; the library names itself. Resolving a localized key
+    /// by the source kind is the UI's locale-rendering job — the kind crosses the
+    /// bridge as an enum, the prose stays here.
+    private static func contextSectionTitle(_ kind: BridgePlaybackSourceKind)
+        -> String
+    {
+        switch kind {
+        case .release:
+            return String(localized: "Playing From")
+        case .library:
+            return String(localized: "Your Library")
+        }
     }
 
     // MARK: - Header
@@ -558,6 +573,7 @@ extension QueueView {
         nowPlayingArtist: PreviewData.nowPlayingArtist,
         manual: Array(PreviewData.queueItems.prefix(2)),
         context: QueuePlaybackContext(
+            kind: .release,
             shuffled: true,
             upcoming: Array(PreviewData.queueItems.suffix(3))
         )

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -2274,12 +2274,14 @@ struct FfiQueueItem {
     cover_image_id: Option<String>,
 }
 
-/// The context lane (the release being played from), carried by `QueueUpdated`
-/// alongside the manual lane so the UI renders the two as distinct sections:
-/// its not-yet-played tail, plus whether it was ordered by shuffle (the UI shows
-/// a shuffle indicator when so).
+/// The context lane (what the queue is playing from), carried by `QueueUpdated`
+/// alongside the manual lane so the UI renders the two as distinct sections: its
+/// kind (`release` / `library`, for the section label), its not-yet-played tail,
+/// plus whether it was ordered by shuffle (the UI shows a shuffle indicator when
+/// so).
 #[derive(Serialize)]
 struct FfiPlaybackContext {
+    kind: String,
     shuffled: bool,
     upcoming: Vec<FfiQueueItem>,
 }
@@ -2621,6 +2623,16 @@ fn repeat_mode_name(mode: &bae_core::playback::RepeatMode) -> &'static str {
     }
 }
 
+/// The wire name for a playback source kind — which the UI labels the context
+/// section by (a release vs the whole library).
+fn source_kind_name(source: &bae_core::playback::ContextSource) -> &'static str {
+    use bae_core::playback::ContextSource;
+    match source {
+        ContextSource::Release(_) => "release",
+        ContextSource::Library => "library",
+    }
+}
+
 /// Map a core `UiBusEvent` to the subset the WinUI app handles, or `None`.
 fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
     Some(match event {
@@ -2716,6 +2728,7 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             FfiEvent::QueueUpdated {
                 manual: manual.iter().map(to_item).collect(),
                 context: context.as_ref().map(|c| FfiPlaybackContext {
+                    kind: source_kind_name(&c.source).to_string(),
                     shuffled: c.shuffled,
                     upcoming: c.upcoming.iter().map(to_item).collect(),
                 }),
@@ -2896,6 +2909,18 @@ pub unsafe extern "C" fn bae_play_release(
         .services
         .playback()
         .play_release(release_id, start, shuffle);
+}
+
+/// Play the whole library in a freshly seeded shuffle. An empty library is a
+/// no-op (logged in core).
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn bae_play_library_shuffled(handle: *const BaeHandle) {
+    if let Some(handle) = handle.as_ref() {
+        handle.0.services.playback().play_library_shuffled();
+    }
 }
 
 /// Toggle play/pause.

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -34,6 +34,7 @@
                 <TextBlock x:Name="SyncIndicator" VerticalAlignment="Center"
                            Foreground="Gray" TextWrapping="NoWrap" />
                 <ComboBox x:Name="SortBox" SelectionChanged="OnSortChanged" VerticalAlignment="Center" />
+                <Button x:Uid="ShuffleLibraryButton" Content="shuffle library" Click="OnShuffleLibraryClick" />
                 <Button x:Uid="LibrariesButton" Content="libraries" Click="OnLibrariesClick" />
                 <Button x:Uid="CloseLibraryButton" Content="close" Click="OnCloseLibraryClick" ToolTipService.ToolTip="close library">
                     <Button.KeyboardAccelerators>

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -396,6 +396,14 @@ public sealed partial class MainWindow : Window
     // new one. Restore-from-code lives only in the first-run flow. Once a library
     // is open the first-run flow never shows, so this is the only way to reach
     // other libraries or create another.
+    private void OnShuffleLibraryClick(object sender, RoutedEventArgs e)
+    {
+        if (_handle != IntPtr.Zero)
+        {
+            NativeBae.PlayLibraryShuffled(_handle);
+        }
+    }
+
     private async void OnLibrariesClick(object sender, RoutedEventArgs e)
     {
         var libraries = LoadLibraries();
@@ -2617,7 +2625,12 @@ public sealed partial class MainWindow : Window
 
         if (_queueContext is { Upcoming.Count: > 0 } ctx)
         {
-            content.Children.Add(ContextSectionLabel(Loc.Chrome("queue.section.playing_from"), ctx.Shuffled));
+            // The context section names what's playing — a release ("Playing From")
+            // vs the whole library — by the source kind the wire shape carries.
+            var labelKey = ctx.Kind == "library"
+                ? "queue.section.your_library"
+                : "queue.section.playing_from";
+            content.Children.Add(ContextSectionLabel(Loc.Chrome(labelKey), ctx.Shuffled));
             content.Children.Add(BuildQueueLaneList(ctx.Upcoming));
         }
 

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -956,6 +956,11 @@ internal static class NativeBae
         long startTrackIndex,
         [MarshalAs(UnmanagedType.I1)] bool shuffle);
 
+    /// <summary>Play the whole library in a freshly seeded shuffle. An empty
+    /// library is a no-op.</summary>
+    [DllImport(Dll, EntryPoint = "bae_play_library_shuffled", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void PlayLibraryShuffled(IntPtr handle);
+
     /// <summary>Toggle play/pause.</summary>
     [DllImport(Dll, EntryPoint = "bae_play_pause", CallingConvention = CallingConvention.Cdecl)]
     internal static extern void PlayPause(IntPtr handle);

--- a/bae-windows/QueueItem.cs
+++ b/bae-windows/QueueItem.cs
@@ -22,12 +22,15 @@ public sealed class QueueItem
     public override string ToString() => $"{Title} — {Artist} · {DurationLabel}".Trim();
 }
 
-/// <summary>The context lane (the release being played from), from the
-/// <c>QueueUpdated</c> event JSON: its not-yet-played tail, plus whether it was
-/// ordered by shuffle (the queue dialog shows a shuffle indicator when so).
-/// Rendered as its own section, distinct from the manual "Up Next" lane.</summary>
+/// <summary>The context lane (what the queue is playing from), from the
+/// <c>QueueUpdated</c> event JSON: its kind (<c>release</c> / <c>library</c>, for
+/// the section label), its not-yet-played tail, plus whether it was ordered by
+/// shuffle (the queue dialog shows a shuffle indicator when so). Rendered as its
+/// own section, distinct from the manual "Up Next" lane.</summary>
 public sealed class PlaybackContext
 {
+    /// <summary>The source kind wire name: <c>"release"</c> or <c>"library"</c>.</summary>
+    public string Kind { get; set; } = string.Empty;
     public bool Shuffled { get; set; }
     public List<QueueItem> Upcoming { get; set; } = new();
 }

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>بحث</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>المكتبات</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>تشغيل المكتبة عشوائيًا</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>إغلاق</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>إغلاق المكتبة</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>استيراد</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>قائمة الانتظار</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>التالي</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>يُشغّل من</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>مكتبتك</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>إيقاف التشغيل العشوائي</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>تشغيل عشوائي</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>رمز الاستعادة</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>търсене</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>библиотеки</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>разбъркване на библиотеката</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>затваряне</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>затваряне на библиотеката</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>внасяне</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>опашка</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Следва</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Възпроизвежда се от</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Вашата библиотека</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>изключване на разбъркването</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>разбъркване</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>код за възстановяване</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>লাইব্রেরি শাফল করুন</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close লাইব্রেরি</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>পরবর্তী</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>যা থেকে চলছে</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>আপনার লাইব্রেরি</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>hledat</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>knihovny</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>náhodně přehrát knihovnu</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>zavřít</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>zavřít knihovnu</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>fronta</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Další v pořadí</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Přehrává se z</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Vaše knihovna</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>vypnout náhodné přehrávání</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>náhodně</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>kód pro obnovení</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>suchen</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>Bibliotheken</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>Mediathek zufällig wiedergeben</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>schließen</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Bibliothek schließen</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importieren</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>Warteschlange</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Als Nächstes</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Wird abgespielt aus</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Deine Mediathek</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>Zufallswiedergabe ausschalten</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>Zufallswiedergabe</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>Wiederherstellungscode</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>shuffle library</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -155,6 +156,7 @@
   <data name="queue.clear" xml:space="preserve"><value>clear queue</value></data>
   <data name="queue.remove_item" xml:space="preserve"><value>Remove from queue</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Playing From</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Your Library</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Up Next</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>buscar</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliotecas</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>reproducir biblioteca al azar</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>cerrar</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>cerrar biblioteca</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importar</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>cola</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>A continuación</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Reproduciendo desde</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Tu biblioteca</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>desactivar aleatorio</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>aleatorio</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>código de restauración</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>rechercher</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliothèques</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>lecture aléatoire de la bibliothèque</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>fermer</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>fermer la bibliothèque</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importer</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>file</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>À suivre</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Lecture depuis</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Votre bibliothèque</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>désactiver la lecture aléatoire</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>lecture aléatoire</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>code de restauration</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>લાઇબ્રેરી શફલ કરો</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close લાઇબ્રેરી</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>આગળ</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>આમાંથી વાગે છે</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>તમારી લાઇબ્રેરી</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>חיפוש</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ספריות</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ערבוב הספרייה</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>סגור</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>סגור ספרייה</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>ייבוא</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>תור</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>הבא בתור</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>מנגן מתוך</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>הספרייה שלך</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>כבה ערבוב</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>ערבב</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>קוד שחזור</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>लाइब्रेरी शफ़ल करें</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close लाइब्रेरी</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>अगला</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>यहाँ से चल रहा है</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>आपकी लाइब्रेरी</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>pretraživanje</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>fonoteke</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>nasumično reproduciraj biblioteku</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>zatvori</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>zatvori fonoteku</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>uvoz</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>red</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Sljedeće na redu</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Reproducira se iz</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Vaša biblioteka</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>isključi naizmjenično</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>naizmjenično</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>kod za vraćanje</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>riproduci libreria in ordine casuale</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close Libreria</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>A seguire</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>In riproduzione da</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>La tua libreria</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>検索</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ライブラリ</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ライブラリをシャッフル</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>閉じる</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>ライブラリを閉じる</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>取り込む</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>キュー</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>次に再生</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>再生元</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>ライブラリ</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>シャッフルをオフにする</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>シャッフル</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>復元コード</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close ಲೈಬ್ರರಿ</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>ಮುಂದಿನದು</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>ಇದರಿಂದ ಪ್ಲೇ ಆಗುತ್ತಿದೆ</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>ನಿಮ್ಮ ಲೈಬ್ರರಿ</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>검색</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>라이브러리</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>라이브러리 셔플</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>닫기</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>라이브러리 닫기</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>가져오기</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>대기열</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>다음 재생</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>재생 위치</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>보관함</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>셔플 끄기</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>셔플</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>복원 코드</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ലൈബ്രറി ഷഫിൾ ചെയ്യുക</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close ലൈബ്രറി</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>അടുത്തത്</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>ഇതിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>നിങ്ങളുടെ ലൈബ്രറി</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>लायब्ररी शफल करा</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close लायब्ररी</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>पुढचे</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>येथून वाजत आहे</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>तुमची लायब्ररी</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>bibliotheek shufflen</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close Bibliotheek</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Volgende</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Afspelen vanuit</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Je bibliotheek</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close ਲਾਇਬ੍ਰੇਰੀ</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>ਅਗਲਾ</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>ਇੱਥੋਂ ਚੱਲ ਰਿਹਾ ਹੈ</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>szukaj</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>biblioteki</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>odtwarzaj bibliotekę losowo</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>zamknij</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>zamknij bibliotekę</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importuj</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>kolejka</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Następne w kolejce</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Odtwarzanie z</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Twoja biblioteka</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>wyłącz odtwarzanie losowe</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>losowo</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>kod przywracania</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>buscar</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliotecas</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>embaralhar biblioteca</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>fechar</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>fechar biblioteca</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importar</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>fila</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>A seguir</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Tocando de</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Sua biblioteca</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>desativar aleatório</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>aleatório</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>código de restauração</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>நூலகத்தை கலைத்து இயக்கு</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close நூலகம்</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>அடுத்தது</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>இதிலிருந்து இயக்குகிறது</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>உங்கள் நூலகம்</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>లైబ్రరీని షఫుల్ చేయి</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close లైబ్రరీ</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>తదుపరి</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>దీని నుండి ప్లే అవుతోంది</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>మీ లైబ్రరీ</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>สุ่มเล่นคลังเพลง</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close ไลบรารี</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>ถัดไป</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>กำลังเล่นจาก</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>คลังของคุณ</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>kitaplığı karıştır</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close Kitaplık</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Sıradaki</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Şuradan çalınıyor</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Kitaplığınız</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>пошук</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>бібліотеки</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>перемішати фонотеку</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>закрити</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>закрити бібліотеку</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>імпорт</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>черга</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Далі в черзі</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Відтворюється з</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Ваша фонотека</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>вимкнути перемішування</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>перемішати</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>код відновлення</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>لائبریری کو شفل کریں</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close لائبریری</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>اگلا</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>یہاں سے چل رہا ہے</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>آپ کی لائبریری</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>phát ngẫu nhiên thư viện</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close Thư viện</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>Tiếp theo</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>Đang phát từ</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>Thư viện của bạn</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>搜索</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>库</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>随机播放音乐库</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>关闭</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>关闭库</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>导入</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>队列</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>接下来</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>来自</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>你的音乐库</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>关闭随机播放</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>随机播放</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>恢复代码</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -4,6 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
+  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>隨機播放資料庫</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close 資料庫</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>
@@ -119,6 +120,7 @@
   <data name="queue.title" xml:space="preserve"><value>queue</value></data>
   <data name="queue.section.up_next" xml:space="preserve"><value>接下來</value></data>
   <data name="queue.section.playing_from" xml:space="preserve"><value>來自</value></data>
+  <data name="queue.section.your_library" xml:space="preserve"><value>你的資料庫</value></data>
   <data name="queue.shuffle.off" xml:space="preserve"><value>turn off shuffle</value></data>
   <data name="queue.shuffle.on" xml:space="preserve"><value>shuffle</value></data>
   <data name="restore.code_placeholder" xml:space="preserve"><value>restore code</value></data>


### PR DESCRIPTION
Generalizes a playing context's source into `ContextSource { Release(id), Library }` so the seeded-shuffle construct that shuffles a release can shuffle the whole library. `PlayLibraryShuffled` materializes every track id in a deterministic base order and plays it shuffled (empty library is a logged no-op). The service re-fetches a context's tracks through one `fetch_source_tracks` dispatcher, shared by the shuffle/repeat re-derive and resume. The device-local `playback_state` row encodes the source as a release id or a `library` sentinel (a UUID release id can't collide with it). The bridge gains a `kind` on the playback context and a `play_library_shuffled` action; each UI gets a Shuffle Library entry and labels the context header by kind.

The new enum is `ContextSource`, not `PlaybackSource`, to avoid colliding with the unrelated audio sample-feed type of that name in `playback::source`.

## Test plan
- 817 bae-core lib tests pass (library-shuffle materialization, fetch_source_tracks destinations, playback_state Library + Release round-trips, get_all_track_ids ordering)
- workspace clippy -D warnings, cargo fmt, chrome-string orphan gate (0), swift-format + SwiftLint (macOS+iOS), ktlint
- macOS xcodebuild + periphery via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)