### PR TITLE
Read/write cloud_outbox.created_at as coven's HLC stamp

### DIFF
--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -3030,7 +3030,7 @@ impl Database {
         source_path: Option<&str>,
         retain_pinned: bool,
     ) -> Result<(), DbError> {
-        let created_at = self.inner.clock.now().to_rfc3339();
+        let created_at = self.register_stamp();
         self.inner
             .coven_db
             .enqueue_upload(
@@ -3046,7 +3046,7 @@ impl Database {
 
     /// Add a delete entry to the cloud outbox.
     pub async fn add_cloud_outbox_delete(&self, cloud_key: &str) -> Result<(), DbError> {
-        let created_at = self.inner.clock.now().to_rfc3339();
+        let created_at = self.register_stamp();
         self.inner
             .coven_db
             .enqueue_delete(cloud_key, &created_at)
@@ -3123,20 +3123,24 @@ impl Database {
                          ORDER BY co.id",
                 )?;
                 let rows = stmt.query_map([], |row| {
-                    // The queue row stores `created_at` as RFC 3339 text; the UI
-                    // needs an instant, so parse it to epoch millis here. bae
-                    // writes valid RFC 3339 at enqueue, so a parse failure is a
-                    // corrupt value — surface it as a column-conversion error
-                    // rather than masking it. The index is `created_at`'s
-                    // position in the SELECT (`co.id`=0, …, `co.created_at`=4) so
-                    // the diagnostic names the right column.
+                    // coven writes `created_at` as its HLC stamp
+                    // (`millis-counter-device`, the same format `make_remote`
+                    // enqueues with and `register_stamp` mints); the UI needs an
+                    // instant for the "queued N ago" label, so take the stamp's
+                    // physical millis. A value that isn't a coven stamp is corrupt
+                    // — surface it as a column-conversion error rather than masking
+                    // it. The index is `created_at`'s position in the SELECT
+                    // (`co.id`=0, …, `co.created_at`=4) so the diagnostic names the
+                    // right column.
                     let created_at_raw = row.get::<_, String>("created_at")?;
-                    let created_at = crate::config::rfc3339_to_epoch_millis(&created_at_raw)
-                        .map_err(|e| {
+                    let created_at = coven::sync::hlc::Timestamp::parse(&created_at_raw)
+                        .map(|t| t.millis as i64)
+                        .ok_or_else(|| {
                             coven::rusqlite::Error::FromSqlConversionFailure(
                                 4,
                                 coven::rusqlite::types::Type::Text,
-                                Box::new(e),
+                                format!("created_at {created_at_raw:?} is not a coven HLC stamp")
+                                    .into(),
                             )
                         })?;
                     Ok(DbOutboxRow {

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -240,6 +240,45 @@ async fn expect_release_updated(
 }
 
 // ---------------------------------------------------------------------------
+// The make-Remote enqueue is visible in the outbox snapshot before the drain
+// ---------------------------------------------------------------------------
+
+/// A Managed import lands Unmanaged-and-uploading: the make-Remote uploads are
+/// enqueued through coven, and the Storage Manager / import-progress UI reads
+/// them from `outbox_snapshot`. Assert they are visible the instant make-Remote
+/// returns — before any byte drains — so the upload shows up immediately rather
+/// than only after it finishes.
+#[tokio::test]
+async fn make_remote_uploads_are_visible_in_snapshot_before_drain() {
+    tracing_init();
+    let tmp = TempDir::new().unwrap();
+    let (db, mgr, _cloud, _enc) = setup_with_cloud(&tmp).await;
+    let source = tmp.path().join("src");
+    let (_album_id, release_id, named) = create_local_release(
+        &db,
+        &mgr,
+        &source,
+        &[("01.flac", b"aaaaaaaa"), ("02.flac", b"bbbbbbbbbbbb")],
+    )
+    .await;
+
+    // Enqueue make-Remote through the real coven path; do NOT drain.
+    mgr.make_remote_for_test(&release_id, false).await.unwrap();
+
+    let snap = mgr.outbox_snapshot().await.unwrap();
+    assert_eq!(
+        snap.total.queued,
+        named.len() as u32,
+        "every file is queued in the snapshot immediately after make-Remote"
+    );
+    let per = snap
+        .per_release
+        .get(&release_id)
+        .expect("the uploading release is present in per_release");
+    assert_eq!(per.queued, named.len() as u32);
+}
+
+// ---------------------------------------------------------------------------
 // Host-provided cover blob via coven's local store
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
When the blob-lifecycle rewire moved upload-enqueue into coven's `make_remote`, coven began writing `cloud_outbox.created_at` as its HLC stamp (`millis-counter-device`). bae's `outbox_items` reader was never updated to match — it still parsed the column as RFC 3339. So for any Managed (Remote) import, the very first upload row coven enqueued made `build_outbox_snapshot` throw a column-conversion error. The upload observer swallows that error (warn + emit nothing), so the Storage Manager and the import-confirmation progress bar stayed blank for the entire upload, even though the bytes were uploading fine. The release itself imported and played normally; only the upload's visibility was gone.

The column is coven's, and every coven enqueue site (`make_remote`, `make_local`, `cancel_make_remote`) stamps it with `hlc.now().to_string()`. So the right shape is one coven-owned format for the whole column: read it with coven's `Timestamp::parse` (its physical `millis` is exactly the instant the "queued N ago" label needs), and write bae's own rows (the live delete-enqueue, and the test upload helper) through `register_stamp` — coven's shared `UpdatedAtStamper`, the same `hlc.now()` coven enqueues with. No RFC 3339 assumption, no tolerating two formats.

The regression was untested because no test asserted the snapshot reflects a queued upload between enqueue and drain — the existing transfer tests jump straight to draining. The new test drives the real coven `make_remote` enqueue and asserts the snapshot shows the queued uploads before any byte moves; it failed on the parse error before this change.

This is bae-core only, so it fixes every platform that reads the snapshot (macOS, Windows FFI) at once.

## Test plan
- [x] `make_remote_uploads_are_visible_in_snapshot_before_drain` (new) — fails before, passes after
- [x] `cargo test -p bae-core --features test-utils --test test_transfer --test test_storage_state_machine` green
- [x] outbox unit tests + `test_outbox` integration tests green