### PR TITLE
Drop the dead bae-side cloud-outbox read/drain mirrors

### DIFF
--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -3017,12 +3017,14 @@ impl Database {
 
     // ---- Cloud outbox ----
 
-    /// Add an upload entry to the cloud outbox. coven encrypts the blob with the
-    /// library master key (`BlobScope::Master`) at drain, long after this enqueue
-    /// site is gone. `retain_pinned` is the transient pin choice: when set, coven
-    /// populates `storage/pinned/<id>` from the plaintext on a successful upload so
-    /// the blob is kept local and budget-exempt; when unset it populates nothing
-    /// (the evictable cache fills on a later read-miss).
+    /// Seed an upload entry in coven's cloud outbox. Production never enqueues
+    /// uploads this way — coven's `make_remote` owns that — so this exists only
+    /// to exercise the outbox-snapshot / drain machinery in tests. coven encrypts
+    /// the blob with the library master key (`BlobScope::Master`) at drain;
+    /// `retain_pinned` is the transient pin choice (populate `storage/pinned/<id>`
+    /// from the plaintext on success, else fill the evictable cache on a later
+    /// read-miss).
+    #[cfg(any(test, feature = "test-utils"))]
     pub async fn add_cloud_outbox_upload(
         &self,
         file_id: &str,
@@ -3056,17 +3058,9 @@ impl Database {
     // The cloud_outbox table is coven's; bae drives the queue through coven's
     // Database API instead of hand-writing its SQL. The only direct read of the
     // shared table is `outbox_items` below, which joins it against bae's own
-    // domain tables (no coven API can express that).
-
-    /// Pending upload entries, oldest first.
-    pub async fn get_pending_cloud_uploads(&self) -> Result<Vec<coven::db::OutboxEntry>, DbError> {
-        self.inner.coven_db.get_pending_cloud_uploads().await
-    }
-
-    /// Pending delete entries, oldest first.
-    pub async fn get_pending_cloud_deletes(&self) -> Result<Vec<coven::db::OutboxEntry>, DbError> {
-        self.inner.coven_db.get_pending_cloud_deletes().await
-    }
+    // domain tables (no coven API can express that). Reading the raw pending
+    // queue (uploads/deletes) goes through `coven_db()` directly — bae keeps no
+    // wrapper, since coven owns the drain.
 
     /// Remove a cloud outbox entry by id.
     pub async fn remove_cloud_outbox_entry(&self, id: i64) -> Result<(), DbError> {
@@ -3082,19 +3076,6 @@ impl Database {
         self.inner
             .coven_db
             .remove_cloud_outbox_uploads_for_key(cloud_key)
-            .await
-    }
-
-    /// Record a failed upload attempt; the entry stays queued for retry.
-    pub async fn record_cloud_upload_failure(
-        &self,
-        id: i64,
-        error: &str,
-        attempted_at: &str,
-    ) -> Result<(), DbError> {
-        self.inner
-            .coven_db
-            .record_cloud_upload_failure(id, error, attempted_at)
             .await
     }
 

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -1187,10 +1187,10 @@ impl ImportService {
     /// DbFile + audio-format records, reference the files in place, finalize
     /// atomically as a LOCAL release (playable immediately), emit events.
     /// No bytes move here. If `storage_mode` is `Remote`, the release then
-    /// transitions to the cloud via `enqueue_remote_uploads` (the same flow the
+    /// transitions to the cloud via `coven_make_remote` (the same flow the
     /// "Manage" action runs), carrying `pin` as the upload's retain-pinned intent;
-    /// the observer flips `remote` true and deletes the in-place source once the
-    /// last upload lands. `pin` is ignored for an `Local` import.
+    /// coven flips `remote` true and deletes the in-place source once the last
+    /// upload lands. `pin` is ignored for an `Local` import.
     ///
     /// All DB writes happen in one atomic transaction at the end. DbTracks —
     /// including their populated `duration_ms` — live inside `tracks_to_files`.
@@ -1247,9 +1247,9 @@ impl ImportService {
         // Every import lands LOCAL: reference the files in place and record
         // their common-ancestor folder as the release's local source. No bytes
         // move here in any mode. A Remote import then transitions to the cloud
-        // (`enqueue_remote_uploads`, below), flipping `remote` true once the
-        // upload lands; until then it is a valid, playable local release, so
-        // another device never sees a release before its audio is in the cloud.
+        // (`coven_make_remote`, below); coven flips `remote` true once the upload
+        // lands; until then it is a valid, playable local release, so another
+        // device never sees a release before its audio is in the cloud.
         let local_root = {
             let mut ancestor: Option<&Path> = None;
             for file in discovered_files.iter() {

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -53,7 +53,6 @@ use crate::storage::cloud::CloudHome;
 use crate::storage::local::cleanup::{append_pending_deletions, PendingDeletion};
 use crate::storage::local::ReleaseStorageImpl;
 use crate::sync::sync_manager::{build_sync_manager, S3ConfigData, SyncManager};
-use coven::db::OutboxEntry;
 /// Comma-join artist names for display.
 pub(crate) fn join_artist_names(artists: &[DbArtist]) -> String {
     artists
@@ -2083,8 +2082,10 @@ impl LibraryManager {
 
     /// Build a `ReleaseUploadObserver` over this manager's shared outbox/throughput/
     /// event state — the same observer `build_sync_manager` wires into the live sync
-    /// loop. The single place that wiring lives outside the loop builder, shared by
-    /// the by-hand upload drain and the test-only make-Local driver.
+    /// loop. Production builds its observer inside the loop builder; this helper
+    /// exists only for the test drivers (the by-hand upload drain and the make-Local
+    /// driver) that run a transition without a live loop.
+    #[cfg(any(test, feature = "test-utils"))]
     fn build_upload_observer(&self) -> crate::sync::upload_observer::ReleaseUploadObserver {
         crate::sync::upload_observer::ReleaseUploadObserver::new(
             Arc::new(self.database.clone()),
@@ -2459,10 +2460,6 @@ impl LibraryManager {
         .map_err(|e| LibraryError::Storage(format!("cloud key for cover {release_id}: {e}")))
     }
 
-    pub async fn get_pending_cloud_uploads(&self) -> Result<Vec<OutboxEntry>, LibraryError> {
-        Ok(self.database.get_pending_cloud_uploads().await?)
-    }
-
     /// Retry failed uploads now: clear their backoff so the next cycle picks
     /// them up immediately, then kick the sync loop.
     pub async fn retry_outbox_now(&self) -> Result<(), LibraryError> {
@@ -2528,10 +2525,11 @@ impl LibraryManager {
         self.sync_paused.load(std::sync::atomic::Ordering::SeqCst)
     }
 
-    pub async fn get_pending_cloud_deletes(&self) -> Result<Vec<OutboxEntry>, LibraryError> {
-        Ok(self.database.get_pending_cloud_deletes().await?)
-    }
-
+    /// Drive coven's upload drain once against an injected cloud home, for tests
+    /// that have no live sync loop. A test seam over coven's real
+    /// `drain_uploads` (with bae's observer/cipher wiring) — production drains
+    /// from the sync loop — so it stays out of release builds.
+    #[cfg(any(test, feature = "test-utils"))]
     pub async fn process_cloud_uploads_with(
         &self,
         cloud_home: &dyn CloudHome,
@@ -5812,7 +5810,12 @@ mod tests {
 
         // delete_release awaits the deletion queueing, so by now the remote
         // blob's cloud-outbox tombstone is enqueued.
-        let deletes = manager.get_pending_cloud_deletes().await.unwrap();
+        let deletes = manager
+            .database
+            .coven_db()
+            .get_pending_cloud_deletes()
+            .await
+            .unwrap();
         assert_eq!(
             deletes.len(),
             1,
@@ -5877,7 +5880,12 @@ mod tests {
             None,
         )
         .unwrap();
-        let deletes = manager.database.get_pending_cloud_deletes().await.unwrap();
+        let deletes = manager
+            .database
+            .coven_db()
+            .get_pending_cloud_deletes()
+            .await
+            .unwrap();
         assert!(
             deletes.iter().any(|d| d.cloud_key == cloud_key),
             "cover blob delete must be enqueued"
@@ -5927,7 +5935,12 @@ mod tests {
             None,
         )
         .unwrap();
-        let deletes = manager.database.get_pending_cloud_deletes().await.unwrap();
+        let deletes = manager
+            .database
+            .coven_db()
+            .get_pending_cloud_deletes()
+            .await
+            .unwrap();
         assert!(deletes.iter().any(|d| d.cloud_key == cloud_key));
     }
 
@@ -7291,6 +7304,7 @@ mod tests {
         // A recorded failure: failed with the stored error + attempt.
         manager
             .database
+            .coven_db()
             .record_cloud_upload_failure(item_id, "boom", "2024-06-01T00:00:00Z")
             .await
             .unwrap();
@@ -7305,7 +7319,12 @@ mod tests {
 
         // Reset backoff clears the timestamp but keeps the failure record.
         manager.database.reset_cloud_outbox_backoff().await.unwrap();
-        let uploads = manager.database.get_pending_cloud_uploads().await.unwrap();
+        let uploads = manager
+            .database
+            .coven_db()
+            .get_pending_cloud_uploads()
+            .await
+            .unwrap();
         assert_eq!(uploads[0].attempt_count, 1);
         assert!(uploads[0].last_attempt_at.is_none());
         assert_eq!(uploads[0].last_error.as_deref(), Some("boom"));

--- a/bae-core/tests/test_outbox.rs
+++ b/bae-core/tests/test_outbox.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "test-utils")]
 //! Integration tests for bae's cloud-outbox DB wrappers (`db/client.rs`): the
-//! enqueue/read/remove pass-throughs over coven's `cloud_outbox`, plus the
-//! `BlobScope::Master` default bae stamps at enqueue. The drains themselves
+//! delete enqueue and the remove/cancel seam bae keeps over coven's
+//! `cloud_outbox`, plus the `BlobScope::Master` default bae stamps when it seeds
+//! an upload. Pending-queue reads go through `coven_db()` directly (coven owns
+//! the queue; bae keeps no read wrapper). The drains themselves
 //! (`coven::blob::upload::drain_uploads`, the tombstone delete path) are coven's
 //! and covered by coven's own blob tests.
 
@@ -44,7 +46,7 @@ async fn test_add_and_get_pending_uploads_fifo() {
         .await
         .unwrap();
 
-    let uploads = db.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert_eq!(uploads.len(), 3);
     assert_eq!(upload_file_id(&uploads[0]), "file-aaa");
     assert_eq!(upload_file_id(&uploads[1]), "file-bbb");
@@ -66,7 +68,7 @@ async fn test_outbox_upload_round_trips_master_scope() {
         .await
         .unwrap();
 
-    let uploads = db.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert_eq!(uploads.len(), 1);
     let OutboxOperation::Upload { scope, .. } = &uploads[0].operation else {
         panic!("expected an upload operation");
@@ -80,7 +82,7 @@ async fn test_outbox_upload_round_trips_master_scope() {
     db.add_cloud_outbox_delete("storage/aa/bb/file-k")
         .await
         .unwrap();
-    let deletes = db.get_pending_cloud_deletes().await.unwrap();
+    let deletes = db.coven_db().get_pending_cloud_deletes().await.unwrap();
     assert_eq!(deletes.len(), 1);
     assert!(
         matches!(deletes[0].operation, OutboxOperation::Delete),
@@ -99,7 +101,7 @@ async fn test_add_and_get_pending_deletes() {
         .await
         .unwrap();
 
-    let deletes = db.get_pending_cloud_deletes().await.unwrap();
+    let deletes = db.coven_db().get_pending_cloud_deletes().await.unwrap();
     assert_eq!(deletes.len(), 2);
     assert_eq!(deletes[0].cloud_key, "storage/aa/bb/file-aaa");
     assert!(matches!(
@@ -121,13 +123,13 @@ async fn test_remove_outbox_entry() {
         .await
         .unwrap();
 
-    let uploads = db.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert_eq!(uploads.len(), 1);
     let id = uploads[0].id;
 
     db.remove_cloud_outbox_entry(id).await.unwrap();
 
-    let uploads = db.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert!(uploads.is_empty());
 }
 
@@ -146,7 +148,7 @@ async fn test_remove_uploads_for_key() {
         .await
         .unwrap();
 
-    let uploads = db.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert_eq!(uploads.len(), 1);
     assert_eq!(upload_file_id(&uploads[0]), "file-bbb");
 }
@@ -164,6 +166,6 @@ async fn test_insert_or_ignore_idempotency() {
         .await
         .unwrap();
 
-    let uploads = db.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert_eq!(uploads.len(), 1, "duplicate insert should be ignored");
 }

--- a/bae-core/tests/test_storage_state_machine.rs
+++ b/bae-core/tests/test_storage_state_machine.rs
@@ -357,7 +357,11 @@ async fn test_manage_refused_when_sync_not_running() {
         "make-Remote must fail when the upload pipeline isn't running, got {result:?}"
     );
     assert!(
-        mgr.get_pending_cloud_uploads().await.unwrap().is_empty(),
+        db.coven_db()
+            .get_pending_cloud_uploads()
+            .await
+            .unwrap()
+            .is_empty(),
         "no upload may be enqueued when the pipeline can't drain it"
     );
     assert_eq!(
@@ -387,7 +391,7 @@ async fn test_manage_cloud_only_uploads_from_source_then_completes() {
     mgr.make_remote_for_test(&release_id, false).await.unwrap();
 
     // Outbox uploads read from the originals (source_path = Some).
-    let uploads = mgr.get_pending_cloud_uploads().await.unwrap();
+    let uploads = db.coven_db().get_pending_cloud_uploads().await.unwrap();
     assert_eq!(uploads.len(), files.len());
     assert!(uploads.iter().all(|u| matches!(
         &u.operation,
@@ -489,7 +493,11 @@ async fn test_manage_truncated_source_aborts_before_enqueue() {
     assert!(result.is_err(), "truncated source must abort make-Remote");
 
     assert!(
-        mgr.get_pending_cloud_uploads().await.unwrap().is_empty(),
+        db.coven_db()
+            .get_pending_cloud_uploads()
+            .await
+            .unwrap()
+            .is_empty(),
         "no upload may be enqueued when a source is truncated"
     );
     for (name, _) in &files {
@@ -551,7 +559,7 @@ async fn test_unmanage_from_remote_reads_through_cache_then_queues_deletes() {
             "external ref points at the new path"
         );
     }
-    let deletes = mgr.get_pending_cloud_deletes().await.unwrap();
+    let deletes = db.coven_db().get_pending_cloud_deletes().await.unwrap();
     assert_eq!(deletes.len(), files.len());
 }
 
@@ -585,7 +593,12 @@ async fn test_unmanage_from_remote_missing_blob_is_hard_error() {
         .await;
     assert!(result.is_err(), "missing blob must be a hard error");
 
-    assert!(mgr.get_pending_cloud_deletes().await.unwrap().is_empty());
+    assert!(db
+        .coven_db()
+        .get_pending_cloud_deletes()
+        .await
+        .unwrap()
+        .is_empty());
     assert_eq!(
         storage(&mgr, &release_id).await,
         (ReleaseStorageState::Remote, false)

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -536,7 +536,12 @@ async fn test_make_local_cancelled_rolls_back_and_stays_remote() {
         storage(&mgr, &release_id).await,
         (ReleaseStorageState::Remote, false)
     );
-    assert!(mgr.get_pending_cloud_deletes().await.unwrap().is_empty());
+    assert!(db
+        .coven_db()
+        .get_pending_cloud_deletes()
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 /// A make-Local whose destination can't be written (the path is a file) fails,
@@ -575,7 +580,12 @@ async fn test_make_local_abort_on_dest_failure_queues_no_deletes() {
         storage(&mgr, &release_id).await,
         (ReleaseStorageState::Remote, false)
     );
-    assert!(mgr.get_pending_cloud_deletes().await.unwrap().is_empty());
+    assert!(db
+        .coven_db()
+        .get_pending_cloud_deletes()
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the `created_at` fix (#156). The blob-lifecycle rewire handed coven the `cloud_outbox` table and the upload drain, but left behind a cluster of bae-side outbox wrappers with no remaining production callers — they're what make it *look* like bae still runs its own outbox alongside coven's.

The pure coven pass-throughs go entirely: `get_pending_cloud_uploads`, `get_pending_cloud_deletes`, and `record_cloud_upload_failure` on both `Database` and `LibraryManager` were one-line forwarders to the identical coven method, adding nothing over `coven_db()`. Their only callers were tests, which now read coven's queue through `coven_db()` directly.

The genuine test seams stay but move out of release builds. `process_cloud_uploads_with` drives coven's real `drain_uploads` with bae's observer/cipher wiring for tests that have no live sync loop; `add_cloud_outbox_upload` seeds a queue row; `build_upload_observer` (orphaned in non-test builds once the drain driver was gated) builds the observer those drivers need. All three are now `#[cfg(any(test, feature = "test-utils"))]` — the same shape `make_remote_for_test`/`make_local_for_test` already use. Production builds its observer inside the sync-loop builder and never enqueues uploads through bae.

What stays live is the host seam bae genuinely still owns: the delete enqueue, plus the cancel and retry the Storage Manager drives. The snapshot projection (`outbox_items` + `build_outbox_snapshot`) also stays — that's bae's UI view of coven's queue joined to bae's albums, which coven can't produce. Also corrects two import comments that named the long-removed `enqueue_remote_uploads` and repeated the pre-rewire "observer flips remote" model (coven flips the gate now).

## Test plan
- [x] `cargo clippy --lib` and `--tests` (bae-core) clean — confirms no production caller of the deleted/gated methods
- [x] `test_outbox`, `test_transfer`, `test_storage_state_machine` green (callers repointed to `coven_db()`)
- [x] outbox snapshot + manager unit tests green