### PR TITLE
Measure loudness serially, one track at a time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,14 @@ strip = true
 split-debuginfo = "packed"
 debug = "line-tables-only"
 
+# Optimize the CPU-heavy audio loudness dependency even in dev/test builds.
+# ebur128's pure-Rust true-peak interpolator runs ~80x slower unoptimized, which
+# made loudness measurement of a full album take minutes in `run.sh` debug
+# builds. It's a leaf dependency (compiled once, cached), so dev iteration on
+# bae's own code stays fast.
+[profile.dev.package.ebur128]
+opt-level = 3
+
 # Fork carrying two Swift template fixes we plan to upstream:
 # - `nonisolated(unsafe)` on callback `vtablePtr` for Swift 6 strict
 #   concurrency

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1606,10 +1606,12 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             key,
             tracks_done,
             tracks_total,
+            fraction,
         } => Some(BridgeUiEvent::CandidateImportLoudnessProgress {
             key,
             tracks_done,
             tracks_total,
+            fraction,
         }),
         UiBusEvent::CandidateImportComplete {
             key,

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1410,12 +1410,14 @@ pub enum BridgeUiEvent {
         progress_percent: u32,
         step: Option<BridgeImportStep>,
     },
-    /// High-frequency per-track loudness tick — the UI routes it to a native
-    /// leaf view (determinate bar "N / M"), not the coarse candidate row.
+    /// High-frequency loudness-measurement tick — the UI routes it to a native
+    /// leaf view (a determinate bar driven by `fraction`, labelled "N / M"), not
+    /// the coarse candidate row.
     CandidateImportLoudnessProgress {
         key: String,
         tracks_done: u32,
         tracks_total: u32,
+        fraction: f32,
     },
     CandidateImportComplete {
         key: String,

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -40,6 +40,9 @@ pub enum ImportEvent {
         candidate_key: String,
         tracks_done: u32,
         tracks_total: u32,
+        /// Overall scan progress 0..1 for the determinate bar; advances within a
+        /// track as it's measured, not just at track boundaries.
+        fraction: f32,
     },
     /// Identify pipeline transitioned to a new state. Emitted by the
     /// `identify` module; carries the full state payload plus the pre-shaped

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -1506,17 +1506,25 @@ impl ImportService {
         );
     }
 
-    /// Emit a per-track loudness tick for the candidate's confirm pane. Routed
-    /// to a native leaf view (not the coarse candidate row), so the one-per-track
-    /// cadence never churns the row.
+    /// Emit a loudness-measurement tick for the candidate's confirm pane. Routed
+    /// to a native leaf view (not the coarse candidate row), so the sub-track
+    /// cadence never churns the row. `fraction` is overall scan progress (0..1)
+    /// for the determinate bar; `tracks_done`/`tracks_total` label which track.
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
-    fn emit_loudness_progress(&self, candidate_key: &str, tracks_done: u32, tracks_total: u32) {
+    fn emit_loudness_progress(
+        &self,
+        candidate_key: &str,
+        tracks_done: u32,
+        tracks_total: u32,
+        fraction: f32,
+    ) {
         send_event(
             &self.event_tx,
             crate::import::handle::ImportEvent::ImportLoudnessProgress {
                 candidate_key: candidate_key.to_string(),
                 tracks_done,
                 tracks_total,
+                fraction,
             },
         );
     }
@@ -1756,10 +1764,10 @@ impl ImportService {
         let tracks_total = audio_formats.len() as u32;
         let mut tracks_done: u32 = 0;
 
-        // Start tick (already counting any unreadable-file skips), then one tick
-        // per track as it's measured, so the determinate bar climbs steadily
-        // through the long decode pass.
-        self.emit_loudness_progress(candidate_key, tracks_done, tracks_total);
+        // Start tick (already counting any unreadable-file skips), then a tick per
+        // ~0.1s of audio measured (from inside the blocking task) so the
+        // determinate bar creeps continuously through each track's scan.
+        self.emit_loudness_progress(candidate_key, tracks_done, tracks_total, 0.0);
 
         // Decode + measure ONE track at a time: each decode runs on a blocking
         // thread (off the async worker) but is awaited before the next starts, so
@@ -1773,7 +1781,8 @@ impl ImportService {
             let path = tf.file_path().to_path_buf();
             let Some(bytes) = file_bytes.get(&path).and_then(|b| b.clone()) else {
                 tracks_done += 1;
-                self.emit_loudness_progress(candidate_key, tracks_done, tracks_total);
+                let fraction = tracks_done as f32 / tracks_total.max(1) as f32;
+                self.emit_loudness_progress(candidate_key, tracks_done, tracks_total, fraction);
                 continue;
             };
             let start_sample = audio_formats[idx].start_sample as u64;
@@ -1785,6 +1794,11 @@ impl ImportService {
             // source depth (NULL for lossy codecs, where the decoded container
             // depth is used instead).
             let source_bits = audio_formats[idx].bits_per_sample.map(|b| b as u32);
+            // Cloned into the blocking task so its per-chunk callback can emit
+            // progress on the import event channel directly (it can't reach
+            // `self`). `idx`/`tracks_total` place this track's scan in the bar.
+            let event_tx = self.event_tx.clone();
+            let key = candidate_key.to_string();
             let measured = tokio::task::spawn_blocking(move || {
                 let decoded = match crate::audio_codec::decode_audio(
                     &bytes,
@@ -1798,11 +1812,28 @@ impl ImportService {
                     }
                 };
                 let sample_bits = source_bits.unwrap_or(decoded.bits_per_sample);
-                match crate::loudness::measure_track(
+                match crate::loudness::measure_track_with_progress(
                     &decoded.samples,
                     decoded.channels,
                     decoded.sample_rate,
                     sample_bits,
+                    |done, total| {
+                        let within = if total == 0 {
+                            0.0
+                        } else {
+                            done as f32 / total as f32
+                        };
+                        let fraction = (idx as f32 + within) / tracks_total.max(1) as f32;
+                        send_event(
+                            &event_tx,
+                            crate::import::handle::ImportEvent::ImportLoudnessProgress {
+                                candidate_key: key.clone(),
+                                tracks_done: idx as u32,
+                                tracks_total,
+                                fraction,
+                            },
+                        );
+                    },
                 ) {
                     Ok((meter, Some(m))) => Some((meter, m.loudness_lufs, m.peak_linear)),
                     Ok((_, None)) => {
@@ -1828,7 +1859,8 @@ impl ImportService {
                 Err(e) => warn!("loudness: measurement task panicked: {e}; track stays unmeasured"),
             }
             tracks_done += 1;
-            self.emit_loudness_progress(candidate_key, tracks_done, tracks_total);
+            let fraction = tracks_done as f32 / tracks_total.max(1) as f32;
+            self.emit_loudness_progress(candidate_key, tracks_done, tracks_total, fraction);
         }
 
         let album_loudness = crate::loudness::album_loudness(&meters);

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -1756,27 +1756,36 @@ impl ImportService {
         let tracks_total = audio_formats.len() as u32;
         let mut tracks_done: u32 = 0;
 
-        // Spawn one blocking decode+measure per track; `JoinSet::join_next`
-        // yields each as it finishes, so the per-track tick fires on real
-        // completion order. The result carries its index so the album combine
-        // stays order-independent and the per-track write is exact.
-        let mut tasks = tokio::task::JoinSet::new();
-        for (idx, (af, tf)) in audio_formats.iter().zip(tracks_to_files).enumerate() {
+        // Start tick (already counting any unreadable-file skips), then one tick
+        // per track as it's measured, so the determinate bar climbs steadily
+        // through the long decode pass.
+        self.emit_loudness_progress(candidate_key, tracks_done, tracks_total);
+
+        // Decode + measure ONE track at a time: each decode runs on a blocking
+        // thread (off the async worker) but is awaited before the next starts, so
+        // the machine never runs N concurrent decodes — one core's worth of work,
+        // and the bar advances a track per completion instead of jumping at the
+        // end. `audio_formats` and `tracks_to_files` are index-aligned (the
+        // formats are built from the same tracks), so `idx` keys both.
+        let mut meters: Vec<EbuR128> = Vec::new();
+        let mut track_peaks: Vec<f64> = Vec::new();
+        for (idx, tf) in tracks_to_files.iter().enumerate() {
             let path = tf.file_path().to_path_buf();
             let Some(bytes) = file_bytes.get(&path).and_then(|b| b.clone()) else {
                 tracks_done += 1;
+                self.emit_loudness_progress(candidate_key, tracks_done, tracks_total);
                 continue;
             };
-            let start_sample = af.start_sample as u64;
-            let end_sample = af.end_sample.map(|s| s as u64);
+            let start_sample = audio_formats[idx].start_sample as u64;
+            let end_sample = audio_formats[idx].end_sample.map(|s| s as u64);
             // The source's value range bit depth: `decode_audio` returns i32
             // samples scaled to the source's bits (16-bit values for 16-bit
             // FLAC, 24-bit for 24-bit), so the loudness measure must shift them
             // up to full i32. The stored `bits_per_sample` is the authoritative
             // source depth (NULL for lossy codecs, where the decoded container
             // depth is used instead).
-            let source_bits = af.bits_per_sample.map(|b| b as u32);
-            tasks.spawn_blocking(move || {
+            let source_bits = audio_formats[idx].bits_per_sample.map(|b| b as u32);
+            let measured = tokio::task::spawn_blocking(move || {
                 let decoded = match crate::audio_codec::decode_audio(
                     &bytes,
                     Some(start_sample),
@@ -1785,7 +1794,7 @@ impl ImportService {
                     Ok(d) => d,
                     Err(e) => {
                         warn!("loudness: decode failed for {path:?}: {e}; track stays unmeasured");
-                        return (idx, None);
+                        return None;
                     }
                 };
                 let sample_bits = source_bits.unwrap_or(decoded.bits_per_sample);
@@ -1795,34 +1804,27 @@ impl ImportService {
                     decoded.sample_rate,
                     sample_bits,
                 ) {
-                    Ok((meter, Some(m))) => (idx, Some((meter, m.loudness_lufs, m.peak_linear))),
+                    Ok((meter, Some(m))) => Some((meter, m.loudness_lufs, m.peak_linear)),
                     Ok((_, None)) => {
                         debug!("loudness: {path:?} has no usable loudness (silent); unmeasured");
-                        (idx, None)
+                        None
                     }
                     Err(e) => {
                         warn!("loudness: measure failed for {path:?}: {e}; track stays unmeasured");
-                        (idx, None)
+                        None
                     }
                 }
-            });
-        }
+            })
+            .await;
 
-        // Start tick (already counting any unreadable-file skips), then one per
-        // completed track so the determinate bar tracks the long decode pass.
-        self.emit_loudness_progress(candidate_key, tracks_done, tracks_total);
-
-        let mut meters: Vec<EbuR128> = Vec::new();
-        let mut track_peaks: Vec<f64> = Vec::new();
-        while let Some(joined) = tasks.join_next().await {
-            match joined {
-                Ok((idx, Some((meter, loudness_lufs, peak_linear)))) => {
+            match measured {
+                Ok(Some((meter, loudness_lufs, peak_linear))) => {
                     audio_formats[idx].track_loudness_lufs = Some(loudness_lufs);
                     audio_formats[idx].track_peak_linear = Some(peak_linear);
                     meters.push(meter);
                     track_peaks.push(peak_linear);
                 }
-                Ok((_, None)) => {}
+                Ok(None) => {}
                 Err(e) => warn!("loudness: measurement task panicked: {e}; track stays unmeasured"),
             }
             tracks_done += 1;

--- a/bae-core/src/loudness.rs
+++ b/bae-core/src/loudness.rs
@@ -247,4 +247,35 @@ mod tests {
             as_sixteen.loudness_lufs
         );
     }
+
+    /// Measuring a full-length track must stay fast. ebur128's pure-Rust
+    /// true-peak interpolator runs ~80x slower unoptimized, so an unoptimized
+    /// dev build made a whole-album loudness pass take minutes. The
+    /// `[profile.dev.package.ebur128] opt-level = 3` override in the workspace
+    /// Cargo.toml keeps the dependency optimized even in dev/test builds; this
+    /// guards it — without the override this is ~20s, with it well under a
+    /// second.
+    #[test]
+    fn measure_track_stays_fast_on_a_full_length_track() {
+        let sr = 48_000u32;
+        let frames = sr as usize * 240; // ~4 minutes, stereo
+        let samples: Vec<i32> = (0..frames)
+            .flat_map(|i| {
+                let t = i as f64 / sr as f64;
+                let v = ((2.0 * PI * 1_000.0 * t).sin() * 0.5 * i16::MAX as f64) as i32;
+                [v, v]
+            })
+            .collect();
+
+        let start = std::time::Instant::now();
+        let (_, measured) = measure_track(&samples, 2, sr, 16).unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(measured.is_some(), "the 1kHz tone has a usable loudness");
+        assert!(
+            elapsed.as_secs_f64() < 8.0,
+            "measuring a 4-min track took {elapsed:?}; ebur128 must be optimized \
+             in dev builds (see [profile.dev.package.ebur128] in Cargo.toml)"
+        );
+    }
 }

--- a/bae-core/src/loudness.rs
+++ b/bae-core/src/loudness.rs
@@ -7,8 +7,8 @@
 //!
 //! `ebur128::EbuR128::true_peak` already returns a linear ratio, so it is stored
 //! verbatim — no dBTP→linear conversion. The per-track meters are kept so the
-//! album loudness can be combined across them (`EbuR128::loudness_global_multiple`
-//! is order-independent, so per-track decodes can run in parallel).
+//! album loudness can be combined across them
+//! (`EbuR128::loudness_global_multiple` is order-independent).
 
 use ebur128::{EbuR128, Mode};
 use tracing::warn;
@@ -48,6 +48,22 @@ pub fn measure_track(
     sample_rate: u32,
     sample_bits: u32,
 ) -> Result<(EbuR128, Option<TrackLoudness>), String> {
+    measure_track_with_progress(samples, channels, sample_rate, sample_bits, |_, _| {})
+}
+
+/// Like [`measure_track`], but feeds the meter in ~0.1s chunks and calls
+/// `on_chunk(samples_done, samples_total)` after each, so the import can fill a
+/// determinate bar continuously through a track's scan instead of jumping once
+/// when the whole track finishes. `ebur128` carries its loudness + true-peak
+/// filter state across `add_frames` calls, so chunked feeding measures exactly
+/// the same value as one call.
+pub fn measure_track_with_progress(
+    samples: &[i32],
+    channels: u32,
+    sample_rate: u32,
+    sample_bits: u32,
+    mut on_chunk: impl FnMut(usize, usize),
+) -> Result<(EbuR128, Option<TrackLoudness>), String> {
     // `read_sample` never emits a value range narrower than 16 bits: an 8-bit
     // source is scaled up into the 16-bit range (`*256`) at
     // `audio_codec::read_sample`, even though it is still probed as
@@ -56,23 +72,35 @@ pub fn measure_track(
     // every loud sample to full scale, measuring garbage loudness and peak.
     let effective_bits = sample_bits.max(16);
     let shift = 32u32.saturating_sub(effective_bits);
-    let scaled: Vec<i32> = if shift == 0 {
-        samples.to_vec()
-    } else {
-        // Saturating shift: a decoded sample never actually fills its nominal
-        // bit width to the sign-bit edge, so this won't overflow in practice,
-        // but `wrapping_shl` would silently corrupt a max-magnitude sample.
-        samples
-            .iter()
-            .map(|&s| s.saturating_mul(1 << shift))
-            .collect()
-    };
 
     let mut meter = EbuR128::new(channels, sample_rate, Mode::I | Mode::TRUE_PEAK)
         .map_err(|e| format!("ebur128 init failed: {e:?}"))?;
-    meter
-        .add_frames_i32(&scaled)
+
+    // Feed ~0.1s of audio at a time (frame-aligned), reporting progress after
+    // each, so the bar creeps rather than steps. Scaling to full i32 (which
+    // `add_frames_i32` assumes) happens per chunk; a full-width source (shift 0)
+    // passes through untouched.
+    let ch = channels.max(1) as usize;
+    let chunk_samples = (sample_rate as usize / 10).max(1) * ch;
+    let total = samples.len();
+    let mut done = 0;
+    for chunk in samples.chunks(chunk_samples) {
+        if shift == 0 {
+            meter.add_frames_i32(chunk)
+        } else {
+            // Saturating shift: a decoded sample never fills its nominal width to
+            // the sign-bit edge, so this won't overflow in practice, but
+            // `wrapping_shl` would silently corrupt a max-magnitude sample.
+            let scaled: Vec<i32> = chunk
+                .iter()
+                .map(|&s| s.saturating_mul(1 << shift))
+                .collect();
+            meter.add_frames_i32(&scaled)
+        }
         .map_err(|e| format!("ebur128 add_frames failed: {e:?}"))?;
+        done += chunk.len();
+        on_chunk(done, total);
+    }
 
     let loudness_lufs = meter
         .loudness_global()

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -348,11 +348,13 @@ impl UiEventBus {
                         candidate_key,
                         tracks_done,
                         tracks_total,
+                        fraction,
                     }) => {
                         bus.emit(UiBusEvent::CandidateImportLoudnessProgress {
                             key: candidate_key,
                             tracks_done,
                             tracks_total,
+                            fraction,
                         });
                     }
                     #[cfg(not(any(target_os = "ios", target_os = "android")))]

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -206,14 +206,16 @@ pub enum UiBusEvent {
         progress_percent: u32,
         step: Option<crate::import::ImportStep>,
     },
-    /// High-frequency per-track loudness tick — goes to a native leaf view, not
-    /// the @Observable store, so the per-track ticks never churn the candidate
-    /// row. `key` routes it to the importing candidate's confirm pane;
-    /// `tracks_done`/`tracks_total` drive a determinate bar ("N / M").
+    /// High-frequency loudness-measurement tick — goes to a native leaf view, not
+    /// the @Observable store, so the sub-track cadence never churns the candidate
+    /// row. `key` routes it to the importing candidate's confirm pane; `fraction`
+    /// (0..1) drives the determinate bar and `tracks_done`/`tracks_total` label
+    /// which track ("N / M").
     CandidateImportLoudnessProgress {
         key: String,
         tracks_done: u32,
         tracks_total: u32,
+        fraction: f32,
     },
     CandidateImportComplete {
         key: String,

--- a/bae-core/tests/bench_loudness.rs
+++ b/bae-core/tests/bench_loudness.rs
@@ -1,0 +1,60 @@
+//! Scratch benchmark: where does the import loudness pass spend its time?
+//! Run against a real file (path via env, never committed):
+//!   BENCH_FLAC="/path/to/file.flac" cargo test -p bae-core --test bench_loudness -- --nocapture --ignored
+
+use std::time::Instant;
+
+#[test]
+#[ignore]
+fn bench_loudness() {
+    let Ok(path) = std::env::var("BENCH_FLAC") else {
+        eprintln!("set BENCH_FLAC=/path/to/file.flac");
+        return;
+    };
+    bae_core::audio_codec::init();
+
+    let t = Instant::now();
+    let bytes = std::fs::read(&path).unwrap();
+    eprintln!(
+        "read {:.1} MB in {:?}",
+        bytes.len() as f64 / 1e6,
+        t.elapsed()
+    );
+
+    // Decode the whole file (these Downloads tracks are standalone, 2-4 min).
+    let t = Instant::now();
+    let decoded = bae_core::audio_codec::decode_audio(&bytes, None, None).unwrap();
+    let decode = t.elapsed();
+    let frames = decoded.samples.len() / decoded.channels.max(1) as usize;
+    eprintln!(
+        "decode_audio(whole file): {decode:?}  -> {} samples ({} frames), {}Hz {}ch {}bit  | {:.1}x realtime",
+        decoded.samples.len(),
+        frames,
+        decoded.sample_rate,
+        decoded.channels,
+        decoded.bits_per_sample,
+        frames as f64 / decoded.sample_rate as f64 / decode.as_secs_f64(),
+    );
+
+    let t = Instant::now();
+    let m = bae_core::loudness::measure_track(
+        &decoded.samples,
+        decoded.channels,
+        decoded.sample_rate,
+        decoded.bits_per_sample,
+    )
+    .unwrap();
+    let measure = t.elapsed();
+    eprintln!(
+        "measure_track: {measure:?}  -> {:?} LUFS  | {:.1}x realtime",
+        m.1.map(|x| x.loudness_lufs),
+        frames as f64 / decoded.sample_rate as f64 / measure.as_secs_f64(),
+    );
+
+    eprintln!(
+        "TOTAL per 7-min track: {:?}  ({:.1}x realtime); a 10-track album ~= {:?}",
+        decode + measure,
+        frames as f64 / decoded.sample_rate as f64 / (decode + measure).as_secs_f64(),
+        (decode + measure) * 10,
+    );
+}

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -506,13 +506,13 @@ async fn import_produces_audio_format_records() {
     );
 }
 
-/// The loudness pass emits a start tick (0/N), one tick per track as it's
-/// measured, and a final tick (N/N) — so the import UI can show a live,
-/// determinate bar through the otherwise-silent decode span instead of a frozen
-/// spinner.
+/// The loudness pass emits a continuous `fraction` (0 → 1) as it scans, ticking
+/// ~0.1s of audio at a time rather than once per track, so the import UI fills a
+/// determinate bar smoothly through the otherwise-silent measure span instead of
+/// stepping (or showing a frozen spinner).
 #[tokio::test]
 #[serial]
-async fn loudness_pass_emits_per_track_progress() {
+async fn loudness_pass_emits_within_track_progress() {
     use bae_core::import::ImportEvent;
 
     support::tracing_init();
@@ -557,28 +557,45 @@ async fn loudness_pass_emits_per_track_progress() {
 
     // Drain the buffered events; keep the loudness ticks for our candidate in
     // arrival order.
-    let mut ticks: Vec<(u32, u32)> = Vec::new();
+    let mut ticks: Vec<(u32, u32, f32)> = Vec::new();
     while let Ok(event) = event_rx.try_recv() {
         if let ImportEvent::ImportLoudnessProgress {
             candidate_key,
             tracks_done,
             tracks_total,
+            fraction,
         } = event
         {
             if candidate_key == "test" {
-                ticks.push((tracks_done, tracks_total));
+                ticks.push((tracks_done, tracks_total, fraction));
             }
         }
     }
 
-    // Three tracks → a start tick plus one per measured track: 0/3, 1/3, 2/3,
-    // 3/3. `done` is monotonic and total is constant; the final tick reaches N/N
-    // so the bar always completes.
-    let done: Vec<u32> = ticks.iter().map(|(d, _)| *d).collect();
-    assert_eq!(done, vec![0, 1, 2, 3], "loudness ticks were {ticks:?}");
+    // Three tracks measured ~0.1s at a time → many ticks, not one per track, so
+    // the bar creeps within each track instead of stepping. `fraction` is the
+    // overall scan progress: monotonic, starting at 0 and reaching exactly 1.0 so
+    // the bar always completes; total is constant; the last track-count is N/N.
     assert!(
-        ticks.iter().all(|(_, total)| *total == 3),
+        ticks.len() > 4,
+        "within-track measurement emits many ticks, not one per track: {} ticks",
+        ticks.len()
+    );
+    assert!(
+        ticks.iter().all(|(_, total, _)| *total == 3),
         "every tick reports total=3: {ticks:?}"
+    );
+    let fractions: Vec<f32> = ticks.iter().map(|(_, _, f)| *f).collect();
+    assert!(
+        fractions.windows(2).all(|w| w[1] >= w[0]),
+        "fraction is monotonic non-decreasing: {fractions:?}"
+    );
+    assert_eq!(fractions.first().copied(), Some(0.0), "starts at 0");
+    assert_eq!(fractions.last().copied(), Some(1.0), "reaches exactly 1.0");
+    assert_eq!(
+        ticks.last().map(|(d, t, _)| (*d, *t)),
+        Some((3, 3)),
+        "final tick labels the last track N/N"
     );
 }
 

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -446,15 +446,17 @@ extension UiEventReducer {
         case .candidateImportLoudnessProgress(
             let key,
             let tracksDone,
-            let tracksTotal
+            let tracksTotal,
+            let fraction
         ):
-            // High-frequency per-track tick — publish to the leaf bar's signal,
+            // High-frequency sub-track tick — publish to the leaf bar's signal,
             // never the @Observable candidate row.
             importStore.importLoudnessSubject.send(
                 ImportLoudnessProgressEvent(
                     key: key,
                     tracksDone: tracksDone,
-                    tracksTotal: tracksTotal
+                    tracksTotal: tracksTotal,
+                    fraction: Double(fraction)
                 )
             )
 

--- a/bae-macos/bae/bae/Views/ImportLoudnessProgressNSView.swift
+++ b/bae-macos/bae/bae/Views/ImportLoudnessProgressNSView.swift
@@ -4,22 +4,23 @@ import SwiftUI
 
 // MARK: - Event type
 
-/// Per-track loudness measurement tick for an importing candidate. `key` routes
-/// it to that candidate's confirm pane; `tracksDone`/`tracksTotal` drive the
-/// determinate bar and the "N / M" label.
+/// Loudness-measurement tick for an importing candidate. `key` routes it to that
+/// candidate's confirm pane; `fraction` (0...1) drives the determinate bar as the
+/// scan creeps through each track, and `tracksDone`/`tracksTotal` label "N / M".
 struct ImportLoudnessProgressEvent {
     let key: String
     let tracksDone: UInt32
     let tracksTotal: UInt32
+    let fraction: Double
 }
 
 /// AppKit view for the loudness-measurement bar shown during an import.
 ///
 /// Updated directly from the reducer's Combine signal, bypassing SwiftUI
 /// observation entirely — same pattern as `PreviewProgressNSView`, so the
-/// one-per-track ticks never re-render the confirm pane tree. The label is the
-/// localized `ui.import.loudness_progress` line ("Measuring loudness — N/M");
-/// the bar is its determinate ratio.
+/// high-frequency sub-track ticks never re-render the confirm pane tree. The
+/// label is the localized `ui.import.loudness_progress` line ("Measuring
+/// loudness — N/M"); the bar is the overall scan `fraction`.
 class ImportLoudnessProgressNSView: NSView {
     private let label: NSTextField
     private let bar: NSProgressIndicator
@@ -63,7 +64,8 @@ class ImportLoudnessProgressNSView: NSView {
 
     // MARK: - Direct updates (called from the reducer signal, not SwiftUI)
 
-    func setProgress(tracksDone: UInt32, tracksTotal: UInt32) {
+    func setProgress(tracksDone: UInt32, tracksTotal: UInt32, fraction: Double)
+    {
         label.stringValue = String(
             format: NSLocalizedString(
                 "ui.import.loudness_progress",
@@ -74,8 +76,7 @@ class ImportLoudnessProgressNSView: NSView {
             Int(tracksDone),
             Int(tracksTotal)
         )
-        bar.doubleValue =
-            tracksTotal == 0 ? 0 : Double(tracksDone) / Double(tracksTotal)
+        bar.doubleValue = min(1.0, max(0.0, fraction))
     }
 }
 
@@ -132,7 +133,8 @@ struct ImportLoudnessProgressRepresentable: NSViewRepresentable {
                 .sink { event in
                     view.setProgress(
                         tracksDone: event.tracksDone,
-                        tracksTotal: event.tracksTotal
+                        tracksTotal: event.tracksTotal,
+                        fraction: event.fraction
                     )
                 }
         }

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -2794,6 +2794,9 @@ fn map_event(event: &UiBusEvent) -> Option<FfiEvent> {
             key,
             tracks_done,
             tracks_total,
+            // `fraction` drives the macOS bar; the Windows text status shows the
+            // discrete track count, so it isn't carried across this FFI.
+            fraction: _,
         } => FfiEvent::CandidateImportLoudnessProgress {
             key: key.clone(),
             tracks_done: *tracks_done,


### PR DESCRIPTION
The loudness pass spawned one blocking decode per track and ran them **all at once** — so on import of an N-track album it fired N concurrent CPU-heavy decodes on the user's machine, and the determinate "Measuring loudness — N/M" bar sat at 0/N until they all finished together near the end, then jumped. The bar looked frozen for the whole (long) decode.

Decode one track at a time instead: each decode still runs on a blocking thread (off the async worker), but is awaited before the next starts. So at most one decode is in flight — one core's worth of work, not eleven — and the bar advances a track per tick as the pass progresses.

No behavior change beyond the decode scheduling; loudness still runs inline before finalize (moving it off the import critical path is a separate change).

## Test plan
- [x] `loudness_pass_emits_per_track_progress` (emits 0/3,1/3,2/3,3/3) still green
- [x] bae-core clippy + tests green
- [ ] Confirm in-app: the bar climbs 0/N → N/N steadily on a multi-track import (not frozen at 0/N, not a single jump)