### PR TITLE
Remove the pass-through coven facade modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ version = "0.1.0"
 dependencies = [
  "bae-core",
  "bae-loc",
+ "coven",
  "libsqlite3-sys",
  "serde_json",
  "thiserror 2.0.18",
@@ -788,6 +789,7 @@ version = "0.1.0"
 dependencies = [
  "bae-core",
  "bae-loc",
+ "coven",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ members = ["bae-bridge", "bae-core", "bae-loc", "bae-windows-ffi"]
 resolver = "2"
 
 [workspace.dependencies]
+# coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
+# every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
+# implements coven's CloudKitOps) resolves the same instance.
+coven = { git = "https://github.com/bae-fm/coven", rev = "20cc5d786e82321f4cda96d3decf79e006ee90a6" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-bridge/Cargo.toml
+++ b/bae-bridge/Cargo.toml
@@ -49,7 +49,7 @@ default = []
 # Enables the OAuth cloud-provider surface (sign-in + the desktop/host OAuth
 # flows) via bae-core/coven. Off by default → the baeium build; the bae
 # build turns it on.
-oauth-providers = ["bae-core/oauth-providers"]
+oauth-providers = ["bae-core/oauth-providers", "coven/oauth-providers"]
 cloudkit = []
 desktop = []
 

--- a/bae-bridge/Cargo.toml
+++ b/bae-bridge/Cargo.toml
@@ -20,6 +20,9 @@ path = "uniffi-bindgen.rs"
 
 [dependencies]
 bae-core = { path = "../bae-core" }
+# The CloudKit adapter implements coven's CloudKitOps, so it names coven types
+# directly (same pinned instance bae-core uses, via the workspace dep).
+coven = { workspace = true }
 uniffi = { version = "0.31", features = ["cli", "tokio"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = { workspace = true }

--- a/bae-bridge/src/cloudkit.rs
+++ b/bae-bridge/src/cloudkit.rs
@@ -21,39 +21,32 @@ struct CloudKitDriverAdapter {
     driver: Arc<dyn CloudKitDriver>,
 }
 
-impl bae_core::storage::cloud::CloudKitOps for CloudKitDriverAdapter {
-    fn write_record(
-        &self,
-        key: &str,
-        data: Vec<u8>,
-    ) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+impl coven::CloudKitOps for CloudKitDriverAdapter {
+    fn write_record(&self, key: &str, data: Vec<u8>) -> Result<(), coven::CloudHomeError> {
         self.driver
             .write_record(key.to_string(), data)
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn read_record(&self, key: &str) -> Result<Vec<u8>, bae_core::storage::cloud::CloudHomeError> {
+    fn read_record(&self, key: &str) -> Result<Vec<u8>, coven::CloudHomeError> {
         self.driver
             .read_record(key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn list_records(
-        &self,
-        prefix: &str,
-    ) -> Result<Vec<String>, bae_core::storage::cloud::CloudHomeError> {
+    fn list_records(&self, prefix: &str) -> Result<Vec<String>, coven::CloudHomeError> {
         self.driver
             .list_records(prefix.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn delete_record(&self, key: &str) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+    fn delete_record(&self, key: &str) -> Result<(), coven::CloudHomeError> {
         self.driver
             .delete_record(key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn record_exists(&self, key: &str) -> Result<bool, bae_core::storage::cloud::CloudHomeError> {
+    fn record_exists(&self, key: &str) -> Result<bool, coven::CloudHomeError> {
         self.driver
             .record_exists(key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
@@ -63,40 +56,29 @@ impl bae_core::storage::cloud::CloudKitOps for CloudKitDriverAdapter {
     // methods. bae uses a personal library on its own iCloud account, so all
     // three are unavailable; the Swift driver implements only the
     // private-database storage methods.
-    fn grant_access(
-        &self,
-        _email: &str,
-    ) -> Result<String, bae_core::storage::cloud::CloudHomeError> {
+    fn grant_access(&self, _email: &str) -> Result<String, coven::CloudHomeError> {
         Err(sharing_unsupported())
     }
 
-    fn revoke_access(
-        &self,
-        _user_record_id: &str,
-    ) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+    fn revoke_access(&self, _user_record_id: &str) -> Result<(), coven::CloudHomeError> {
         Err(sharing_unsupported())
     }
 
-    fn accept_share(
-        &self,
-        _share_url: &str,
-    ) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+    fn accept_share(&self, _share_url: &str) -> Result<(), coven::CloudHomeError> {
         Err(sharing_unsupported())
     }
 }
 
 /// The error coven's `CloudKitOps` sharing methods return on a personal library:
 /// bae has no library sharing, so grant/revoke/accept are unavailable.
-fn sharing_unsupported() -> bae_core::storage::cloud::CloudHomeError {
-    bae_core::storage::cloud::CloudHomeError::Storage(
-        "CloudKit library sharing is not supported".to_string(),
-    )
+fn sharing_unsupported() -> coven::CloudHomeError {
+    coven::CloudHomeError::Storage("CloudKit library sharing is not supported".to_string())
 }
 
-fn cloudkit_err_to_cloud_home_err(e: CloudKitError) -> bae_core::storage::cloud::CloudHomeError {
+fn cloudkit_err_to_cloud_home_err(e: CloudKitError) -> coven::CloudHomeError {
     match e {
-        CloudKitError::NotFound { msg } => bae_core::storage::cloud::CloudHomeError::NotFound(msg),
-        CloudKitError::Storage { msg } => bae_core::storage::cloud::CloudHomeError::Storage(msg),
+        CloudKitError::NotFound { msg } => coven::CloudHomeError::NotFound(msg),
+        CloudKitError::Storage { msg } => coven::CloudHomeError::Storage(msg),
     }
 }
 
@@ -112,7 +94,7 @@ pub fn set_cloudkit_driver(driver: Box<dyn CloudKitDriver>) {
 }
 
 /// Get a CloudKit ops adapter, if a driver has been registered.
-pub(crate) fn get_cloudkit_ops() -> Option<Arc<dyn bae_core::storage::cloud::CloudKitOps>> {
+pub(crate) fn get_cloudkit_ops() -> Option<Arc<dyn coven::CloudKitOps>> {
     let driver = CLOUDKIT_DRIVER
         .lock()
         .expect("CloudKit driver mutex poisoned")

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -3,7 +3,7 @@
 //! These run before an AppHandle exists (they create or configure the library
 //! that AppHandle will later open).
 
-fn parse_oauth_tokens(json: &str) -> Result<bae_core::oauth::OAuthTokens, BridgeError> {
+fn parse_oauth_tokens(json: &str) -> Result<coven::OAuthTokens, BridgeError> {
     serde_json::from_str(json)
         .map_err(|e| BridgeError::config(format!("Invalid OAuth token JSON: {e}")))
 }
@@ -98,7 +98,7 @@ use crate::types::{
 use crate::cloudkit::get_cloudkit_ops;
 
 #[cfg(not(feature = "cloudkit"))]
-fn get_cloudkit_ops() -> Option<std::sync::Arc<dyn bae_core::storage::cloud::CloudKitOps>> {
+fn get_cloudkit_ops() -> Option<std::sync::Arc<dyn coven::CloudKitOps>> {
     None
 }
 
@@ -113,8 +113,8 @@ fn restore_error_to_bridge(error: RestoreFromCodeError) -> BridgeError {
 
 async fn restore_from_code_config(
     code: String,
-    oauth_tokens: Option<bae_core::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn bae_core::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: Option<CancellationToken>,
 ) -> Result<Config, BridgeError> {
     match cancel {
@@ -198,7 +198,7 @@ pub fn discover_libraries() -> Result<Vec<BridgeLibrary>, BridgeError> {
 /// Create a new library. The library is set as the active library.
 #[uniffi::export]
 pub fn create_library(name: Option<String>) -> Result<BridgeLibrary, BridgeError> {
-    let ids = std::sync::Arc::new(bae_core::id_provider::UuidProvider);
+    let ids = std::sync::Arc::new(coven::UuidProvider);
     let config = match name {
         Some(n) => bae_core::library::create_library(n, ids.as_ref()),
         None => bae_core::library::create_library_default(ids.as_ref()),
@@ -351,8 +351,8 @@ pub fn restore_from_code(
 #[derive(uniffi::Object)]
 pub struct RestoreFromCodeOperation {
     code: String,
-    oauth_tokens: Option<bae_core::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn bae_core::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: CancellationToken,
     started: Mutex<bool>,
 }
@@ -459,8 +459,8 @@ fn join_error_to_bridge(error: JoinFromCodeError) -> BridgeError {
 
 async fn join_from_code_config(
     code: String,
-    oauth_tokens: Option<bae_core::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn bae_core::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: Option<CancellationToken>,
 ) -> Result<Config, BridgeError> {
     match cancel {
@@ -505,8 +505,8 @@ pub fn join_from_code(
 #[derive(uniffi::Object)]
 pub struct JoinFromCodeOperation {
     code: String,
-    oauth_tokens: Option<bae_core::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn bae_core::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: CancellationToken,
     started: Mutex<bool>,
 }
@@ -581,8 +581,8 @@ pub fn oauth_authorize(provider: BridgeCloudProvider) -> Result<String, BridgeEr
 
     let result = on_worker(move || async move {
         let core_provider = bridge_cloud_provider_to_core(provider);
-        let clock = std::sync::Arc::new(bae_core::clock::SystemClock);
-        let tokens = bae_core::oauth::authorize_provider(core_provider, cancel, clock.as_ref())
+        let clock = std::sync::Arc::new(coven::SystemClock);
+        let tokens = coven::authorize_provider(core_provider, cancel, clock.as_ref())
             .await
             .map_err(|e| BridgeError::config(format!("OAuth authorization failed: {e}")))?;
 
@@ -633,13 +633,13 @@ pub fn set_oauth_client_creds(creds_json: String) -> Result<(), BridgeError> {
             .map(str::to_string);
         creds.insert(
             provider,
-            bae_core::oauth::OAuthClientCreds {
+            coven::OAuthClientCreds {
                 client_id,
                 client_secret,
             },
         );
     }
-    bae_core::oauth::set_oauth_client_creds(creds);
+    coven::set_oauth_client_creds(creds);
     Ok(())
 }
 
@@ -656,7 +656,7 @@ pub fn oauth_begin(
     redirect_uri: String,
 ) -> Result<BridgeOAuthRequest, BridgeError> {
     let core_provider = bridge_cloud_provider_to_core(provider);
-    let req = bae_core::oauth::build_authorize_request_for_provider(core_provider, &redirect_uri)
+    let req = coven::build_authorize_request_for_provider(core_provider, &redirect_uri)
         .map_err(|e| BridgeError::config(format!("OAuth begin failed: {e}")))?;
     Ok(BridgeOAuthRequest {
         auth_url: req.auth_url,
@@ -677,8 +677,8 @@ pub fn oauth_complete(
 ) -> Result<String, BridgeError> {
     let core_provider = bridge_cloud_provider_to_core(provider);
     let tokens = on_worker(move || async move {
-        let clock = std::sync::Arc::new(bae_core::clock::SystemClock);
-        bae_core::oauth::exchange_code_for_provider(
+        let clock = std::sync::Arc::new(coven::SystemClock);
+        coven::exchange_code_for_provider(
             core_provider,
             &code,
             &verifier,

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -12,7 +12,7 @@ name = "bae_core"
 path = "src/lib.rs"
 
 [dependencies]
-coven = { git = "https://github.com/bae-fm/coven", rev = "20cc5d786e82321f4cda96d3decf79e006ee90a6" }
+coven = { workspace = true }
 reqwest = { workspace = true, features = ["form", "json", "query", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -109,7 +109,7 @@ ffmpeg-sys-next = { version = "8.0", default-features = false, features = ["avco
 tokio = { version = "1.0", features = ["test-util"] }
 serial_test = "3.4.0"
 # coven's deterministic clock/id fakes for bae's tests (off in production builds).
-coven = { git = "https://github.com/bae-fm/coven", rev = "20cc5d786e82321f4cda96d3decf79e006ee90a6", features = ["test-utils"] }
+coven = { workspace = true, features = ["test-utils"] }
 
 [[test]]
 name = "test_playback_behavior"

--- a/bae-core/examples/restore_code.rs
+++ b/bae-core/examples/restore_code.rs
@@ -10,7 +10,7 @@
 fn main() {
     bae_core::config::init_keyring();
 
-    let ids = bae_core::id_provider::UuidProvider;
+    let ids = coven::UuidProvider;
     let config = bae_core::config::Config::load(&ids);
     let dev_mode = bae_core::config::Config::is_dev_mode();
 

--- a/bae-core/src/app.rs
+++ b/bae-core/src/app.rs
@@ -10,14 +10,14 @@ use std::sync::Arc;
 
 use tracing::info;
 
-use crate::clock::{ClockRef, SystemClock};
 use crate::config::{Config, ConfigHandle};
 use crate::db::Database;
-use crate::id_provider::{IdRef, UuidProvider};
 use crate::keys::KeyService;
 use crate::library::AppServices;
 use crate::playback::PlaybackService;
 use crate::ui::UiEventBus;
+use coven::{ClockRef, SystemClock};
+use coven::{IdRef, UuidProvider};
 
 /// A fully constructed, running application: the tokio runtime that owns all
 /// background work, the composed service layer, and the UI event bus already
@@ -146,11 +146,9 @@ fn bootstrap_inner(
     // caller prompt the user to unlock.
     let pending_enc = if config.encryption_key_stored {
         match key_service.get_encryption_key() {
-            Ok(Some(key_hex)) => Some(
-                crate::encryption::EncryptionService::new(&key_hex).map_err(|e| {
-                    BootstrapError::Config(format!("Failed to initialize encryption: {e}"))
-                })?,
-            ),
+            Ok(Some(key_hex)) => Some(coven::EncryptionService::new(&key_hex).map_err(|e| {
+                BootstrapError::Config(format!("Failed to initialize encryption: {e}"))
+            })?),
             Ok(None) => {
                 tracing::warn!(
                     "encryption key marked stored but not found in keyring; deferring sync until unlocked"

--- a/bae-core/src/clock.rs
+++ b/bae-core/src/clock.rs
@@ -1,5 +1,0 @@
-//! Re-export of coven's clock. The clock primitive lives in coven now; this
-//! keeps bae's `crate::clock::…` call sites resolving unchanged.
-#[cfg(any(test, feature = "test-utils"))]
-pub use coven::FixedClock;
-pub use coven::{Clock, ClockRef, SystemClock};

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -1,4 +1,4 @@
-use crate::library_dir::LibraryDir;
+use coven::LibraryDir;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio::sync::watch;
@@ -416,7 +416,7 @@ impl std::ops::DerefMut for Config {
 }
 
 impl Config {
-    pub fn load(ids: &dyn crate::id_provider::IdProvider) -> Self {
+    pub fn load(ids: &dyn coven::IdProvider) -> Self {
         let dev_mode = std::env::var("BAE_DEV_MODE").is_ok() || {
             #[cfg(not(any(target_os = "ios", target_os = "android")))]
             {
@@ -436,7 +436,7 @@ impl Config {
         }
     }
 
-    fn from_env(ids: &dyn crate::id_provider::IdProvider) -> Self {
+    fn from_env(ids: &dyn coven::IdProvider) -> Self {
         // Use the same active-library pointer file as production mode
         let home_dir = dirs::home_dir().expect("Failed to get home directory");
         let bae_dir = home_dir.join(".bae");
@@ -459,7 +459,7 @@ impl Config {
             // `encryption_key_stored = true` with no fingerprint would let any
             // key later unlock the library (the fingerprint guard short-circuits
             // on None), so surface the parse failure loudly.
-            let fingerprint = crate::encryption::EncryptionService::new(key)
+            let fingerprint = coven::EncryptionService::new(key)
                 .expect("BAE_ENCRYPTION_KEY is malformed")
                 .fingerprint();
             config.encryption_key_stored = true;
@@ -506,16 +506,13 @@ impl Config {
         config
     }
 
-    fn from_config_file(ids: &dyn crate::id_provider::IdProvider) -> Self {
+    fn from_config_file(ids: &dyn coven::IdProvider) -> Self {
         let home_dir = dirs::home_dir().expect("Failed to get home directory");
         let bae_dir = home_dir.join(".bae");
         Self::load_from_bae_dir(&bae_dir, ids)
     }
 
-    fn load_from_bae_dir(
-        bae_dir: &std::path::Path,
-        ids: &dyn crate::id_provider::IdProvider,
-    ) -> Self {
+    fn load_from_bae_dir(bae_dir: &std::path::Path, ids: &dyn coven::IdProvider) -> Self {
         // Read active library UUID from pointer file
         let pointer_file = bae_dir.join("active-library");
         let active_id = read_active_library_id(bae_dir);
@@ -949,10 +946,8 @@ mod tests {
         config.save_to_config_yaml().unwrap();
         std::fs::write(bae_dir.join("active-library"), library_id).unwrap();
 
-        let loaded = Config::load_from_bae_dir(
-            bae_dir,
-            &crate::id_provider::SequentialIdProvider::new("device"),
-        );
+        let loaded =
+            Config::load_from_bae_dir(bae_dir, &coven::SequentialIdProvider::new("device"));
         assert_eq!(loaded.library_id, library_id);
         assert_eq!(&*loaded.library_dir, library_path.as_path());
     }
@@ -968,10 +963,8 @@ mod tests {
             .save_to_config_yaml()
             .unwrap();
 
-        let loaded = Config::load_from_bae_dir(
-            bae_dir,
-            &crate::id_provider::SequentialIdProvider::new("device"),
-        );
+        let loaded =
+            Config::load_from_bae_dir(bae_dir, &coven::SequentialIdProvider::new("device"));
         assert_eq!(loaded.library_id, "auto-lib");
     }
 
@@ -979,10 +972,7 @@ mod tests {
     #[should_panic(expected = "no libraries found")]
     fn load_from_bae_dir_panics_without_pointer_or_libraries() {
         let tmp = TempDir::new().unwrap();
-        Config::load_from_bae_dir(
-            tmp.path(),
-            &crate::id_provider::SequentialIdProvider::new("device"),
-        );
+        Config::load_from_bae_dir(tmp.path(), &coven::SequentialIdProvider::new("device"));
     }
 
     #[test]
@@ -991,10 +981,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // Pointer to a UUID that doesn't exist anywhere
         std::fs::write(tmp.path().join("active-library"), "nonexistent-uuid").unwrap();
-        Config::load_from_bae_dir(
-            tmp.path(),
-            &crate::id_provider::SequentialIdProvider::new("device"),
-        );
+        Config::load_from_bae_dir(tmp.path(), &coven::SequentialIdProvider::new("device"));
     }
 
     /// A library dir whose name isn't valid UTF-8 can't round-trip through the
@@ -1046,10 +1033,7 @@ mod tests {
         // Dir exists but no config.yaml — library is invisible to find_library_by_id
         std::fs::write(bae_dir.join("active-library"), "some-id").unwrap();
 
-        Config::load_from_bae_dir(
-            bae_dir,
-            &crate::id_provider::SequentialIdProvider::new("device"),
-        );
+        Config::load_from_bae_dir(bae_dir, &coven::SequentialIdProvider::new("device"));
     }
 
     #[test]
@@ -1063,10 +1047,7 @@ mod tests {
         std::fs::write(library_path.join("config.yaml"), "library_name: Test\n").unwrap();
         std::fs::write(bae_dir.join("active-library"), "some-id").unwrap();
 
-        Config::load_from_bae_dir(
-            bae_dir,
-            &crate::id_provider::SequentialIdProvider::new("device"),
-        );
+        Config::load_from_bae_dir(bae_dir, &coven::SequentialIdProvider::new("device"));
     }
 
     #[test]
@@ -1196,7 +1177,7 @@ mod tests {
             bae_dir,
             library_id.to_string(),
             "Test Library".to_string(),
-            &crate::id_provider::SequentialIdProvider::new("device"),
+            &coven::SequentialIdProvider::new("device"),
         )
         .unwrap();
 

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -1,10 +1,10 @@
-use crate::clock::ClockRef;
 use crate::db::models::*;
 use crate::playback::QueueEntry;
 use crate::queue::QueueItem;
 use crate::util::content_type::ContentType;
 use chrono::{DateTime, Utc};
 use coven::rusqlite::{params, Connection, OptionalExtension, Row};
+use coven::ClockRef;
 use coven::DbError;
 use coven::SyncedTable;
 use coven::UpdatedAtStamper;
@@ -3823,7 +3823,7 @@ mod readable_cloud_path_tests {
 #[cfg(test)]
 mod playback_state_load_tests {
     use super::*;
-    use crate::clock::SystemClock;
+    use coven::SystemClock;
 
     async fn empty_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/bae-core/src/encryption.rs
+++ b/bae-core/src/encryption.rs
@@ -1,6 +1,0 @@
-//! Re-export of coven's encryption service. The encryption primitives live in
-//! coven now; this keeps bae's `crate::encryption::…` call sites resolving
-//! unchanged. bae's old `derive_release_encryption(id)` is coven's generic
-//! `derive_scoped(id)` — call sites use the new name.
-// `CHUNK_SIZE` sizes bae's cloud streaming reads (see `playback::data_source`).
-pub use coven::{EncryptionError, EncryptionService, CHUNK_SIZE};

--- a/bae-core/src/id_provider.rs
+++ b/bae-core/src/id_provider.rs
@@ -1,5 +1,0 @@
-//! Re-export of coven's id provider. The id primitive lives in coven now; this
-//! keeps bae's `crate::id_provider::…` call sites resolving unchanged.
-#[cfg(any(test, feature = "test-utils"))]
-pub use coven::SequentialIdProvider;
-pub use coven::{IdProvider, IdRef, UuidProvider};

--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -263,9 +263,9 @@ mod tests {
         use crate::db::{Database, DbAlbum, DbArtist, DbFile, DbRelease, DbTrack};
         use crate::keys::KeyService;
         use crate::library::LibraryManager;
-        use crate::library_dir::LibraryDir;
         use crate::util::content_type::ContentType;
         use chrono::Utc;
+        use coven::LibraryDir;
         use std::sync::Arc;
         use uuid::Uuid;
 
@@ -295,7 +295,7 @@ mod tests {
 
         let database = Database::new_test(
             library_root.join("test.db").to_str().unwrap(),
-            Arc::new(crate::clock::SystemClock),
+            Arc::new(coven::SystemClock),
         )
         .await
         .unwrap();
@@ -327,8 +327,8 @@ mod tests {
             library_dir,
             config_handle,
             key_service,
-            Arc::new(crate::clock::SystemClock),
-            Arc::new(crate::id_provider::UuidProvider),
+            Arc::new(coven::SystemClock),
+            Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
 

--- a/bae-core/src/import/commit.rs
+++ b/bae-core/src/import/commit.rs
@@ -6,11 +6,11 @@
 
 use tracing::warn;
 
-use crate::clock::Clock;
 use crate::discogs::client::DiscogsError;
 use crate::discogs::DiscogsClient;
-use crate::id_provider::IdProvider;
 use crate::musicbrainz;
+use coven::Clock;
+use coven::IdProvider;
 
 use super::discogs_mapper;
 use super::types::MetadataSource;

--- a/bae-core/src/import/discogs_mapper.rs
+++ b/bae-core/src/import/discogs_mapper.rs
@@ -1,11 +1,11 @@
 use super::ParsedAlbum;
-use crate::clock::Clock;
 use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
 use crate::discogs::DiscogsRelease;
-use crate::id_provider::IdProvider;
 use crate::import::types::ReleaseIdentity;
 use crate::import::MetadataSource;
 use crate::musicbrainz::MbReleaseResponse;
+use coven::Clock;
+use coven::IdProvider;
 
 /// Map Discogs release metadata into database models including artist information.
 ///
@@ -372,9 +372,9 @@ fn extract_artist_name(title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::FixedClock;
     use crate::discogs::models::{DiscogsArtist, DiscogsTrack};
-    use crate::id_provider::SequentialIdProvider;
+    use coven::FixedClock;
+    use coven::SequentialIdProvider;
 
     /// Run the mapper with deterministic fakes. Exercises the real
     /// `map_discogs_to_db`; only the clock/id inputs are faked.

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -21,11 +21,11 @@
 //! rather than being defaulted.
 
 use super::ParsedAlbum;
-use crate::clock::Clock;
 use crate::db::ReleaseMetadataSource;
 use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
-use crate::id_provider::IdProvider;
 use crate::util::content_type::ContentType;
+use coven::Clock;
+use coven::IdProvider;
 use lofty::file::FileType;
 use lofty::prelude::*;
 use lofty::probe::Probe;
@@ -461,8 +461,8 @@ fn format_from_file_type(file_type: FileType) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::FixedClock;
-    use crate::id_provider::SequentialIdProvider;
+    use coven::FixedClock;
+    use coven::SequentialIdProvider;
     use lofty::config::WriteOptions;
     use lofty::tag::items::Timestamp;
     use lofty::tag::{Tag, TagType};

--- a/bae-core/src/import/folder_registry.rs
+++ b/bae-core/src/import/folder_registry.rs
@@ -6,7 +6,7 @@
 //! the import service loads the registry and scans each folder; the folders
 //! survive restart.
 
-use crate::library_dir::LibraryDir;
+use coven::LibraryDir;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing::{debug, warn};

--- a/bae-core/src/import/handle.rs
+++ b/bae-core/src/import/handle.rs
@@ -1096,7 +1096,7 @@ mod tests {
     use uuid::Uuid;
 
     fn test_config_and_keys(
-        library_dir: &crate::library_dir::LibraryDir,
+        library_dir: &coven::LibraryDir,
     ) -> (
         std::sync::Arc<crate::config::ConfigHandle>,
         crate::keys::KeyService,
@@ -1122,19 +1122,19 @@ mod tests {
         let db_path = temp_dir.path().join("test.db");
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(crate::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await
         .unwrap();
-        let library_dir = crate::library_dir::LibraryDir::new(temp_dir.path());
+        let library_dir = coven::LibraryDir::new(temp_dir.path());
         let (config_handle, key_service) = test_config_and_keys(&library_dir);
         let manager = LibraryManager::new(
             database,
             library_dir,
             config_handle,
             key_service,
-            std::sync::Arc::new(crate::clock::SystemClock),
-            std::sync::Arc::new(crate::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         (manager, temp_dir)

--- a/bae-core/src/import/musicbrainz_mapper.rs
+++ b/bae-core/src/import/musicbrainz_mapper.rs
@@ -15,12 +15,12 @@
 //! is resolved via MB's URL endpoint.
 
 use super::ParsedAlbum;
-use crate::clock::Clock;
 use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
-use crate::id_provider::IdProvider;
 use crate::import::types::ReleaseIdentity;
 use crate::import::MetadataSource;
 use crate::musicbrainz::{fetch_release_group_json, ExternalUrls, MbReleaseResponse};
+use coven::Clock;
+use coven::IdProvider;
 use tracing::warn;
 
 /// Extract the leading numeric Discogs release ID from a Discogs release URL.
@@ -357,11 +357,11 @@ pub fn map_mb_response_to_db(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::FixedClock;
-    use crate::id_provider::SequentialIdProvider;
     use crate::musicbrainz::{
         MbArtistCredit, MbArtistRef, MbMedium, MbRecording, MbReleaseResponse, MbTrack,
     };
+    use coven::FixedClock;
+    use coven::SequentialIdProvider;
 
     /// Run the mapper with deterministic fakes. Exercises the real
     /// `map_mb_response_to_db`; only the clock/id inputs are faked.

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -678,8 +678,8 @@ pub async fn prefetch_discogs_release(
 pub async fn commit_discogs_release(
     client: &DiscogsClient,
     release_id: &str,
-    clock: &dyn crate::clock::Clock,
-    ids: &dyn crate::id_provider::IdProvider,
+    clock: &dyn coven::Clock,
+    ids: &dyn coven::IdProvider,
 ) -> Result<crate::import::folder_scanner::PreparedRelease, String> {
     let (parsed, metadata_pairs) =
         crate::import::commit::fetch_and_map_discogs(client, release_id, clock, ids)

--- a/bae-core/src/import/service.rs
+++ b/bae-core/src/import/service.rs
@@ -1762,8 +1762,8 @@ impl ImportService {
     fn build_audio_formats(
         tracks_to_files: &[TrackFile],
         file_ids: &HashMap<PathBuf, String>,
-        clock: &dyn crate::clock::Clock,
-        ids: &dyn crate::id_provider::IdProvider,
+        clock: &dyn coven::Clock,
+        ids: &dyn coven::IdProvider,
     ) -> Result<Vec<crate::db::DbAudioFormat>, String> {
         let now = clock.now();
         let mut audio_formats = Vec::with_capacity(tracks_to_files.len());
@@ -2048,8 +2048,8 @@ fn apply_user_edit_to_seed(
     artists: &mut Vec<crate::db::DbArtist>,
     album_artists: &mut Vec<crate::db::DbAlbumArtist>,
     track_artists: &mut Vec<crate::db::DbTrackArtist>,
-    clock: &dyn crate::clock::Clock,
-    ids: &dyn crate::id_provider::IdProvider,
+    clock: &dyn coven::Clock,
+    ids: &dyn coven::IdProvider,
 ) -> Result<(), String> {
     use crate::db::{DbAlbumArtist, DbArtist, DbTrackArtist};
 
@@ -2265,8 +2265,8 @@ pub(crate) async fn prepare_release(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::FixedClock;
-    use crate::id_provider::SequentialIdProvider;
+    use coven::FixedClock;
+    use coven::SequentialIdProvider;
 
     #[test]
     fn affected_roots_maps_changed_paths_to_their_watched_roots() {

--- a/bae-core/src/keys.rs
+++ b/bae-core/src/keys.rs
@@ -10,9 +10,11 @@
 //! encryption-key/credentials env vars are.
 use tracing::{info, warn};
 
+pub use coven::{CloudHomeCredentials, KeyError, KeyService};
 // `read_keyring` / `keyring_service` back the bae-domain keyring credentials
-// below (Discogs key, encryption-key forget).
-pub use coven::{keyring_service, read_keyring, CloudHomeCredentials, KeyError, KeyService};
+// below (Discogs key, encryption-key forget); they're used only here, so they
+// stay a private import rather than re-exported `bae_core::keys` surface.
+use coven::{keyring_service, read_keyring};
 
 /// A namespaced keyring account, matching coven's own `base:library_id` scheme.
 fn account(ks: &KeyService, base: &str) -> String {

--- a/bae-core/src/keys.rs
+++ b/bae-core/src/keys.rs
@@ -12,9 +12,7 @@ use tracing::{info, warn};
 
 // `read_keyring` / `keyring_service` back the bae-domain keyring credentials
 // below (Discogs key, encryption-key forget).
-pub use coven::{
-    keyring_service, read_keyring, set_keyring_service, CloudHomeCredentials, KeyError, KeyService,
-};
+pub use coven::{keyring_service, read_keyring, CloudHomeCredentials, KeyError, KeyService};
 
 /// A namespaced keyring account, matching coven's own `base:library_id` scheme.
 fn account(ks: &KeyService, base: &str) -> String {

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -2,21 +2,17 @@ pub mod album_detail;
 pub mod ape;
 pub mod app;
 pub mod audio_codec;
-pub mod clock;
 #[doc(hidden)]
 pub mod config;
 pub mod cue_flac;
 pub mod db;
 pub mod diagnostics;
 pub mod discogs;
-pub mod encryption;
-pub mod id_provider;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub mod identify;
 pub mod import;
 pub mod keys;
 pub mod library;
-pub mod library_dir;
 pub mod library_name;
 // Loudness measurement uses `ebur128`, a desktop-only dependency (import decodes
 // audio only on these targets; playback derives the gain from the stored
@@ -25,7 +21,6 @@ pub mod library_name;
 pub mod loudness;
 pub mod musicbrainz;
 pub mod network;
-pub mod oauth;
 pub mod playback;
 pub mod queue;
 pub mod retry;

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -29,7 +29,6 @@ use crate::album_detail::{
     StorageFilter, StoragePage, StorageRow, StorageSort, StorageSortDirection, StorageSortField,
     TrackDetail, TrackGroup, TrackSearchResult,
 };
-use crate::clock::ClockRef;
 use crate::config::{CloudProvider, ConfigHandle};
 use crate::db::{
     Database, DbAlbum, DbAlbumArtist, DbAlbumSearchResult, DbAlbumSummary, DbArtist, DbAudioFormat,
@@ -39,20 +38,21 @@ use crate::db::{
     StorageFilter as DbStorageFilter, StorageSortCriterion as DbStorageSortCriterion,
     StorageSortField as DbStorageSortField,
 };
-use crate::encryption::EncryptionService;
-use crate::id_provider::IdRef;
 use crate::keys::BaeKeyServiceExt;
 use crate::keys::KeyService;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 use crate::library::export::ExportService;
-use crate::library_dir::LibraryDir;
 use crate::playback::QueueEntry;
 use crate::queue::QueueItem;
-use crate::storage::cloud::CloudHome;
 use crate::storage::local::cleanup::{append_pending_deletions, PendingDeletion};
 use crate::storage::local::ReleaseStorageImpl;
 use crate::sync::sync_manager::{S3ConfigData, SyncManager};
+use coven::ClockRef;
+use coven::CloudHome;
 use coven::CovenHandle;
+use coven::EncryptionService;
+use coven::IdRef;
+use coven::LibraryDir;
 /// Comma-join artist names for display.
 pub(crate) fn join_artist_names(artists: &[DbArtist]) -> String {
     artists
@@ -417,8 +417,8 @@ async fn project_musicbrainz_from_cache(
     database: &Database,
     release_id: &str,
     source_release_id: &str,
-    clock: &dyn crate::clock::Clock,
-    ids: &dyn crate::id_provider::IdProvider,
+    clock: &dyn coven::Clock,
+    ids: &dyn coven::IdProvider,
 ) -> Result<crate::import::ParsedAlbum, LibraryError> {
     let pairs = database.get_release_metadata_by_source(release_id).await?;
     let mb_json = pairs.get("musicbrainz").ok_or_else(|| {
@@ -470,8 +470,8 @@ async fn project_discogs_from_cache(
     database: &Database,
     release_id: &str,
     source_release_id: &str,
-    clock: &dyn crate::clock::Clock,
-    ids: &dyn crate::id_provider::IdProvider,
+    clock: &dyn coven::Clock,
+    ids: &dyn coven::IdProvider,
 ) -> Result<crate::import::ParsedAlbum, LibraryError> {
     let pairs = database.get_release_metadata_by_source(release_id).await?;
     let discogs_json = pairs.get("discogs").ok_or_else(|| {
@@ -606,7 +606,7 @@ pub enum LibraryError {
     #[error("Track mapping error: {0}")]
     TrackMapping(String),
     #[error("Encryption error: {0}")]
-    Encryption(#[from] crate::encryption::EncryptionError),
+    Encryption(#[from] coven::EncryptionError),
     #[error("Storage error: {0}")]
     Storage(String),
 }
@@ -5190,8 +5190,8 @@ impl LibraryManager {
 
     pub async fn save_s3_config(&self, data: S3ConfigData) -> Result<(), String> {
         use crate::keys::CloudHomeCredentials;
-        use crate::storage::cloud::CloudHome;
-        use crate::storage::cloud::S3CloudHome;
+        use coven::CloudHome;
+        use coven::S3CloudHome;
 
         // Probe the bucket with the proposed credentials *before* persisting
         // anything. A typo or a missing bucket would otherwise leave the UI
@@ -5242,7 +5242,7 @@ impl LibraryManager {
         provider: CloudProvider,
         storage: crate::config::HomeStorage,
     ) -> Result<(), String> {
-        use crate::storage::cloud as setup;
+        use coven::{sign_in_dropbox, sign_in_google_drive, sign_in_onedrive};
 
         // Hold the sender alive across the await so cancel.wait_for inside
         // oauth::authorize never fires (this fn doesn't surface a cancel
@@ -5257,7 +5257,7 @@ impl LibraryManager {
         match provider {
             CloudProvider::GoogleDrive => {
                 let folder_id =
-                    setup::sign_in_google_drive(&self.key_service, &library_name, cancel_rx, clock)
+                    sign_in_google_drive(&self.key_service, &library_name, cancel_rx, clock)
                         .await
                         .map_err(|e| e.to_string())?;
                 self.config_handle
@@ -5270,7 +5270,7 @@ impl LibraryManager {
             }
             CloudProvider::Dropbox => {
                 let folder_path =
-                    setup::sign_in_dropbox(&self.key_service, &library_name, cancel_rx, clock)
+                    sign_in_dropbox(&self.key_service, &library_name, cancel_rx, clock)
                         .await
                         .map_err(|e| e.to_string())?;
                 self.config_handle
@@ -5282,10 +5282,9 @@ impl LibraryManager {
                     .map_err(|e| e.to_string())?;
             }
             CloudProvider::OneDrive => {
-                let (drive_id, folder_id) =
-                    setup::sign_in_onedrive(&self.key_service, cancel_rx, clock)
-                        .await
-                        .map_err(|e| e.to_string())?;
+                let (drive_id, folder_id) = sign_in_onedrive(&self.key_service, cancel_rx, clock)
+                    .await
+                    .map_err(|e| e.to_string())?;
                 self.config_handle
                     .update(move |c| {
                         c.cloud_home.provider = Some(CloudProvider::OneDrive);
@@ -5449,10 +5448,10 @@ mod tests {
     use crate::config::Config;
     use crate::db::{DbAlbum, DbRelease};
     #[cfg(feature = "test-utils")]
-    use crate::storage::cloud::InMemoryCloudHome;
-    #[cfg(feature = "test-utils")]
     use crate::sync::CloudCipher;
     use chrono::Utc;
+    #[cfg(feature = "test-utils")]
+    use coven::InMemoryCloudHome;
     use tempfile::TempDir;
     use uuid::Uuid;
 
@@ -5469,12 +5468,9 @@ mod tests {
     async fn setup_test_manager_with_library_id(library_id: &str) -> (LibraryManager, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let database = Database::new_test(
-            db_path.to_str().unwrap(),
-            Arc::new(crate::clock::SystemClock),
-        )
-        .await
-        .unwrap();
+        let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
+            .await
+            .unwrap();
 
         // Insert the test artist that create_test_album() references
         let artist = DbArtist {
@@ -5502,8 +5498,8 @@ mod tests {
             library_dir,
             config_handle,
             key_service,
-            Arc::new(crate::clock::SystemClock),
-            Arc::new(crate::id_provider::UuidProvider),
+            Arc::new(coven::SystemClock),
+            Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         (manager, temp_dir)

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -20,9 +20,9 @@ pub use outbox_snapshot::{
 pub use upload_throughput::UploadThroughput;
 
 use crate::config::{Config, ConfigError, ConfigYaml};
-use crate::encryption::{EncryptionError, EncryptionService};
 use crate::keys::KeyService;
-use crate::library_dir::LibraryDir;
+use coven::LibraryDir;
+use coven::{EncryptionError, EncryptionService};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, warn};
@@ -49,16 +49,11 @@ fn restore_error(error: impl ToString) -> RestoreFromCodeError {
 ///
 /// Generates a UUID, optional random name, creates the directory, and
 /// writes the active-library marker.
-pub fn create_library_default(
-    ids: &dyn crate::id_provider::IdProvider,
-) -> Result<Config, ConfigError> {
+pub fn create_library_default(ids: &dyn coven::IdProvider) -> Result<Config, ConfigError> {
     create_library(crate::library_name::generate_library_name(), ids)
 }
 
-pub fn create_library(
-    name: String,
-    ids: &dyn crate::id_provider::IdProvider,
-) -> Result<Config, ConfigError> {
+pub fn create_library(name: String, ids: &dyn coven::IdProvider) -> Result<Config, ConfigError> {
     let home_dir = dirs::home_dir().ok_or_else(|| {
         ConfigError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -115,8 +110,8 @@ pub async fn restore_from_cloud(
         source,
         &keypair,
         &app_dir,
-        std::sync::Arc::new(crate::clock::SystemClock),
-        std::sync::Arc::new(crate::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         on_status,
     )
     .await
@@ -127,8 +122,8 @@ pub async fn restore_from_cloud(
 /// Restore a library from a restore code. Wraps coven's `restore_from_code`.
 pub async fn restore_from_code(
     code: &str,
-    oauth_tokens: Option<crate::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     on_status: impl Fn(&str),
 ) -> Result<Config, String> {
     restore_from_code_with_cancel(code, oauth_tokens, cloudkit_ops, None, on_status)
@@ -138,8 +133,8 @@ pub async fn restore_from_code(
 
 pub async fn restore_from_code_cancellable(
     code: &str,
-    oauth_tokens: Option<crate::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: CancellationToken,
     on_status: impl Fn(&str),
 ) -> Result<Config, RestoreFromCodeError> {
@@ -148,8 +143,8 @@ pub async fn restore_from_code_cancellable(
 
 async fn restore_from_code_with_cancel(
     code: &str,
-    oauth_tokens: Option<crate::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: Option<CancellationToken>,
     on_status: impl Fn(&str),
 ) -> Result<Config, RestoreFromCodeError> {
@@ -170,8 +165,8 @@ async fn restore_from_code_with_cancel(
         oauth_tokens,
         cloudkit_ops,
         &app_dir,
-        std::sync::Arc::new(crate::clock::SystemClock),
-        std::sync::Arc::new(crate::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         on_status,
     );
     let coven_config = if let Some((cancel, library_dir, library_dir_existed)) = cancel {
@@ -235,8 +230,8 @@ fn join_error(error: impl ToString) -> JoinFromCodeError {
 /// joining device authorizes its own cloud account), exactly as restore does.
 pub async fn join_from_code(
     code: &str,
-    oauth_tokens: Option<crate::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     on_status: impl Fn(&str),
 ) -> Result<Config, String> {
     join_from_code_with_cancel(code, oauth_tokens, cloudkit_ops, None, on_status)
@@ -246,8 +241,8 @@ pub async fn join_from_code(
 
 pub async fn join_from_code_cancellable(
     code: &str,
-    oauth_tokens: Option<crate::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: CancellationToken,
     on_status: impl Fn(&str),
 ) -> Result<Config, JoinFromCodeError> {
@@ -256,8 +251,8 @@ pub async fn join_from_code_cancellable(
 
 async fn join_from_code_with_cancel(
     code: &str,
-    oauth_tokens: Option<crate::oauth::OAuthTokens>,
-    cloudkit_ops: Option<Arc<dyn crate::storage::cloud::CloudKitOps>>,
+    oauth_tokens: Option<coven::OAuthTokens>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     cancel: Option<CancellationToken>,
     on_status: impl Fn(&str),
 ) -> Result<Config, JoinFromCodeError> {
@@ -278,8 +273,8 @@ async fn join_from_code_with_cancel(
         &synced_tables,
         oauth_tokens,
         cloudkit_ops,
-        std::sync::Arc::new(crate::clock::SystemClock),
-        std::sync::Arc::new(crate::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         on_status,
     );
     let coven_config = if let Some((cancel, library_dir, library_dir_existed)) = cancel {

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -345,12 +345,12 @@ pub(crate) async fn build_outbox_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::SystemClock;
     use crate::db::{
         Database, DbAlbum, DbArtist, DbFile, DbRelease, Pressing, ReleaseMetadataSource,
     };
     use crate::util::content_type::ContentType;
     use chrono::Utc;
+    use coven::SystemClock;
     use std::sync::Arc;
     use tempfile::TempDir;
 

--- a/bae-core/src/library_dir.rs
+++ b/bae-core/src/library_dir.rs
@@ -1,4 +1,0 @@
-//! Re-export of coven's library directory layout. The on-disk layout primitive
-//! lives in coven now; this keeps bae's `crate::library_dir::…` call sites
-//! resolving unchanged.
-pub use coven::LibraryDir;

--- a/bae-core/src/oauth.rs
+++ b/bae-core/src/oauth.rs
@@ -1,9 +1,0 @@
-//! Re-export of coven's OAuth helper. The OAuth flow lives in coven now; this
-//! keeps bae's `crate::oauth::…` call sites resolving unchanged. Provider client
-//! credentials are registered at startup via `coven::oauth::set_oauth_client_creds`.
-// `OAuthTokens`/`OAuthClientCreds` are the DTOs bae passes through setup/restore.
-#[cfg(feature = "oauth-providers")]
-pub use coven::{
-    authorize_provider, build_authorize_request_for_provider, exchange_code_for_provider,
-};
-pub use coven::{set_oauth_client_creds, OAuthClientCreds, OAuthTokens};

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -233,7 +233,7 @@ impl AudioDataReader for CovenBlobReader {
 // range read). A larger window means fewer such calls per second of playback, so
 // the per-call overhead stays well under the playback CPU budget; 4 MiB keeps the
 // readahead and per-track memory modest while cutting the call rate.
-const CLOUD_STREAM_READ_SIZE: u64 = crate::encryption::CHUNK_SIZE as u64 * 64;
+const CLOUD_STREAM_READ_SIZE: u64 = coven::CHUNK_SIZE as u64 * 64;
 
 /// The minimum the fill keeps buffered ahead of a reader, regardless of its
 /// track ceiling. A few windows so the decoder's ring can't underrun: it's the

--- a/bae-core/src/playback/queue.rs
+++ b/bae-core/src/playback/queue.rs
@@ -3,10 +3,10 @@ use std::collections::{HashSet, VecDeque};
 use tracing::warn;
 
 use super::RepeatMode;
-use crate::id_provider::IdRef;
 use crate::playback::context::{
     shuffled_traversal, ContextSource, ContextStart, PlaybackContext, Traversal,
 };
+use coven::IdRef;
 
 /// Per-instance identity for an enqueued track. Distinct from `track_id`: the
 /// same track enqueued twice yields two entries with two ids, each removable,
@@ -712,7 +712,7 @@ impl PlaybackQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::id_provider::SequentialIdProvider;
+    use coven::SequentialIdProvider;
     use std::sync::Arc;
 
     fn queue() -> PlaybackQueue {

--- a/bae-core/src/signals/service.rs
+++ b/bae-core/src/signals/service.rs
@@ -63,7 +63,7 @@ pub struct ExtractionServiceHandle {
 struct ExtractionServiceInner {
     runtime_handle: tokio::runtime::Handle,
     event_tx: broadcast::Sender<ImportEvent>,
-    clock: crate::clock::ClockRef,
+    clock: coven::ClockRef,
     analyzer: Mutex<Arc<dyn ArtworkAnalyzer>>,
     /// Resolves a release's library files for the `Release` re-identify path.
     library_manager: LibraryManager,
@@ -85,7 +85,7 @@ impl ExtractionService {
     pub fn start(
         runtime_handle: tokio::runtime::Handle,
         event_tx: broadcast::Sender<ImportEvent>,
-        clock: crate::clock::ClockRef,
+        clock: coven::ClockRef,
         library_manager: LibraryManager,
     ) -> ExtractionServiceHandle {
         ExtractionServiceHandle {
@@ -1092,14 +1092,14 @@ mod tests {
     /// must outlive the manager.
     async fn make_library_manager() -> (crate::library::LibraryManager, TempDir) {
         let tmp = TempDir::new().unwrap();
-        let clock: crate::clock::ClockRef = Arc::new(crate::clock::SystemClock);
+        let clock: coven::ClockRef = Arc::new(coven::SystemClock);
         let database = crate::db::Database::new_test(
             tmp.path().join("test.db").to_str().unwrap(),
             clock.clone(),
         )
         .await
         .unwrap();
-        let library_dir = crate::library_dir::LibraryDir::new(tmp.path());
+        let library_dir = coven::LibraryDir::new(tmp.path());
         // Unique id per test so keyring entries don't collide in the shared
         // process-global mock store (see `install_test_keyring`).
         let library_id = format!("test-{}", uuid::Uuid::new_v4());
@@ -1118,7 +1118,7 @@ mod tests {
             config_handle,
             key_service,
             clock,
-            Arc::new(crate::id_provider::UuidProvider),
+            Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         (manager, tmp)
@@ -1135,7 +1135,7 @@ mod tests {
         let handle = ExtractionService::start(
             tokio::runtime::Handle::current(),
             tx,
-            Arc::new(crate::clock::SystemClock),
+            Arc::new(coven::SystemClock),
             library_manager,
         );
         (handle, rx, lib_tmp)

--- a/bae-core/src/storage/mod.rs
+++ b/bae-core/src/storage/mod.rs
@@ -1,20 +1,7 @@
 //! bae's storage helpers around coven's cloud backends + encrypted layout. The
 //! locality-aware blob read/write, the pin/unpin queue, and the offline-home
-//! stub all live behind [`coven::CovenHandle`] now; what remains here is the
-//! cloud-provider setup re-export and the deferred local-cleanup manifest.
-pub mod cloud {
-    //! bae's view of coven's cloud backend surface, re-exported flat. coven owns
-    //! the providers and the `CloudHome` contract; bae implements `CloudHome` /
-    //! `CloudKitOps` against these and constructs `S3CloudHome` directly.
-    // The host implements `CloudHome`/`CloudKitOps` (whose `upload` method names
-    // `UploadProgress`) and constructs `S3CloudHome`.
-    #[cfg(any(test, feature = "test-utils"))]
-    pub use coven::InMemoryCloudHome;
-    #[cfg(feature = "oauth-providers")]
-    pub use coven::{sign_in_dropbox, sign_in_google_drive, sign_in_onedrive};
-    pub use coven::{
-        CloudHome, CloudHomeError, CloudHomeJoinInfo, CloudKitOps, S3CloudHome, UploadProgress,
-    };
-}
+//! stub all live behind [`coven::CovenHandle`] now; callers name coven's cloud
+//! types (`CloudHome`, `S3CloudHome`, …) directly. What remains here is the
+//! deferred local-cleanup manifest and the readable-path helper.
 pub mod local;
 pub mod readable_path;

--- a/bae-core/src/storage/mod.rs
+++ b/bae-core/src/storage/mod.rs
@@ -1,6 +1,6 @@
 //! bae's storage helpers around coven's cloud backends + encrypted layout. The
 //! locality-aware blob read/write, the pin/unpin queue, and the offline-home
-//! stub all live behind [`coven::CovenHandle`] now; callers name coven's cloud
+//! stub all live behind [`coven::CovenHandle`]; callers name coven's cloud
 //! types (`CloudHome`, `S3CloudHome`, …) directly. What remains here is the
 //! deferred local-cleanup manifest and the readable-path helper.
 pub mod local;

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -487,7 +487,7 @@ impl UiEventBus {
 mod tests {
     use super::*;
     use crate::config::{Config, ConfigHandle};
-    use crate::library_dir::LibraryDir;
+    use coven::LibraryDir;
     use std::time::Duration;
     use tempfile::TempDir;
 

--- a/bae-core/tests/alac_fixtures.rs
+++ b/bae-core/tests/alac_fixtures.rs
@@ -22,8 +22,8 @@ use bae_core::import::{
     IdentityChoice, ImportCommand, ImportService, MetadataRef, MetadataSource, StorageMode,
 };
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::util::content_type::ContentType;
+use coven::LibraryDir;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tracing::info;
@@ -90,7 +90,7 @@ async fn import_single_m4a_fixture(
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -101,8 +101,8 @@ async fn import_single_m4a_fixture(
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 
@@ -328,7 +328,7 @@ async fn import_cue_alac_pair() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -339,8 +339,8 @@ async fn import_cue_alac_pair() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 

--- a/bae-core/tests/support/mod.rs
+++ b/bae-core/tests/support/mod.rs
@@ -106,7 +106,7 @@ pub fn tracing_init() {
 /// HTTP work. (coven's KeyService reads the keyring, not env vars.)
 #[allow(dead_code)]
 pub fn test_config_and_keys(
-    library_dir: &bae_core::library_dir::LibraryDir,
+    library_dir: &coven::LibraryDir,
 ) -> (
     std::sync::Arc<bae_core::config::ConfigHandle>,
     bae_core::keys::KeyService,
@@ -142,8 +142,7 @@ pub fn setup_fresh_library(
     let tmp = tempfile::TempDir::new().unwrap();
     let library_id = uuid::Uuid::new_v4().to_string();
     let device_id = uuid::Uuid::new_v4().to_string();
-    let library_dir =
-        bae_core::library_dir::LibraryDir::new(tmp.path().join("libraries").join(&library_id));
+    let library_dir = coven::LibraryDir::new(tmp.path().join("libraries").join(&library_id));
     std::fs::create_dir_all(&*library_dir).expect("create library dir");
     let config = bae_core::config::Config::with_defaults(
         library_id.clone(),
@@ -158,7 +157,7 @@ pub fn setup_fresh_library(
     let database = runtime
         .block_on(bae_core::db::Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         ))
         .expect("create database");
 
@@ -180,8 +179,8 @@ pub fn setup_fresh_library(
         library_dir,
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         runtime.handle().clone(),
     );
 
@@ -355,15 +354,15 @@ impl MockCloudHome {
 }
 
 #[async_trait::async_trait]
-impl bae_core::storage::cloud::CloudHome for MockCloudHome {
+impl coven::CloudHome for MockCloudHome {
     async fn write(
         &self,
         key: &str,
         data: Vec<u8>,
-        progress: &bae_core::storage::cloud::UploadProgress<'_>,
-    ) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+        progress: &coven::UploadProgress<'_>,
+    ) -> Result<(), coven::CloudHomeError> {
         if self.fail_writes.load(std::sync::atomic::Ordering::SeqCst) {
-            return Err(bae_core::storage::cloud::CloudHomeError::Storage(
+            return Err(coven::CloudHomeError::Storage(
                 "mock write failure".to_string(),
             ));
         }
@@ -373,12 +372,15 @@ impl bae_core::storage::cloud::CloudHome for MockCloudHome {
         Ok(())
     }
 
-    async fn read(&self, key: &str) -> Result<Vec<u8>, bae_core::storage::cloud::CloudHomeError> {
+    async fn read(&self, key: &str) -> Result<Vec<u8>, coven::CloudHomeError> {
         self.full_reads
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        self.blobs.lock().unwrap().get(key).cloned().ok_or_else(|| {
-            bae_core::storage::cloud::CloudHomeError::Storage(format!("missing key {key}"))
-        })
+        self.blobs
+            .lock()
+            .unwrap()
+            .get(key)
+            .cloned()
+            .ok_or_else(|| coven::CloudHomeError::Storage(format!("missing key {key}")))
     }
 
     /// Serve `start..end` (inclusive..exclusive) of the stored blob. The first
@@ -388,7 +390,7 @@ impl bae_core::storage::cloud::CloudHome for MockCloudHome {
         key: &str,
         start: u64,
         end: u64,
-    ) -> Result<Vec<u8>, bae_core::storage::cloud::CloudHomeError> {
+    ) -> Result<Vec<u8>, coven::CloudHomeError> {
         if self
             .fail_next_range_reads
             .fetch_update(
@@ -398,19 +400,19 @@ impl bae_core::storage::cloud::CloudHome for MockCloudHome {
             )
             .is_ok()
         {
-            return Err(bae_core::storage::cloud::CloudHomeError::Storage(
+            return Err(coven::CloudHomeError::Storage(
                 "mock range read failure".to_string(),
             ));
         }
 
         let blobs = self.blobs.lock().unwrap();
-        let blob = blobs.get(key).ok_or_else(|| {
-            bae_core::storage::cloud::CloudHomeError::Storage(format!("missing key {key}"))
-        })?;
+        let blob = blobs
+            .get(key)
+            .ok_or_else(|| coven::CloudHomeError::Storage(format!("missing key {key}")))?;
         let start = usize::try_from(start).unwrap();
         let end = usize::try_from(end).unwrap();
         if start > end || end > blob.len() {
-            return Err(bae_core::storage::cloud::CloudHomeError::Storage(format!(
+            return Err(coven::CloudHomeError::Storage(format!(
                 "range {start}..{end} outside blob length {}",
                 blob.len()
             )));
@@ -418,34 +420,27 @@ impl bae_core::storage::cloud::CloudHome for MockCloudHome {
         Ok(blob[start..end].to_vec())
     }
 
-    async fn list(
-        &self,
-        _prefix: &str,
-    ) -> Result<Vec<String>, bae_core::storage::cloud::CloudHomeError> {
+    async fn list(&self, _prefix: &str) -> Result<Vec<String>, coven::CloudHomeError> {
         Ok(self.blobs.lock().unwrap().keys().cloned().collect())
     }
 
-    async fn delete(&self, key: &str) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+    async fn delete(&self, key: &str) -> Result<(), coven::CloudHomeError> {
         self.blobs.lock().unwrap().remove(key);
         Ok(())
     }
 
-    async fn exists(&self, key: &str) -> Result<bool, bae_core::storage::cloud::CloudHomeError> {
+    async fn exists(&self, key: &str) -> Result<bool, coven::CloudHomeError> {
         Ok(self.blobs.lock().unwrap().contains_key(key))
     }
 
     async fn grant_access(
         &self,
         _member_id: &str,
-    ) -> Result<bae_core::storage::cloud::CloudHomeJoinInfo, bae_core::storage::cloud::CloudHomeError>
-    {
+    ) -> Result<coven::CloudHomeJoinInfo, coven::CloudHomeError> {
         unimplemented!("grant_access not used by storage transition tests")
     }
 
-    async fn revoke_access(
-        &self,
-        _member_id: &str,
-    ) -> Result<(), bae_core::storage::cloud::CloudHomeError> {
+    async fn revoke_access(&self, _member_id: &str) -> Result<(), coven::CloudHomeError> {
         unimplemented!("revoke_access not used by storage transition tests")
     }
 }

--- a/bae-core/tests/test_album_sort.rs
+++ b/bae-core/tests/test_album_sort.rs
@@ -12,7 +12,7 @@ async fn setup_db() -> (Database, TempDir) {
     let db_path = temp_dir.path().join("test.db");
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_candidate_text_fixtures.rs
+++ b/bae-core/tests/test_candidate_text_fixtures.rs
@@ -239,14 +239,14 @@ fn materialize(fixture: &Fixture, tmp: &TempDir) -> (PathBuf, HashMap<PathBuf, V
 /// outlive the manager.
 async fn make_library_manager() -> (bae_core::library::LibraryManager, TempDir) {
     let tmp = TempDir::new().expect("library temp dir");
-    let clock: bae_core::clock::ClockRef = Arc::new(bae_core::clock::SystemClock);
+    let clock: coven::ClockRef = Arc::new(coven::SystemClock);
     let database = bae_core::db::Database::new_test(
         tmp.path().join("test.db").to_str().unwrap(),
         clock.clone(),
     )
     .await
     .unwrap();
-    let library_dir = bae_core::library_dir::LibraryDir::new(tmp.path());
+    let library_dir = coven::LibraryDir::new(tmp.path());
     // Unique id per test so keyring entries don't collide in the shared
     // process-global mock store (see `install_test_keyring`).
     let library_id = format!("test-{}", uuid::Uuid::new_v4());
@@ -265,7 +265,7 @@ async fn make_library_manager() -> (bae_core::library::LibraryManager, TempDir) 
         config_handle,
         key_service,
         clock,
-        Arc::new(bae_core::id_provider::UuidProvider),
+        Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     (manager, tmp)
@@ -281,7 +281,7 @@ async fn drive_fixture(
     let handle: ExtractionServiceHandle = ExtractionService::start(
         tokio::runtime::Handle::current(),
         tx,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
         library_manager,
     );
     let analyzer: Arc<dyn ArtworkAnalyzer> = Arc::new(FixtureAnalyzer::new(ocr_map));

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -16,9 +16,9 @@ use bae_core::import::{
     IdentityChoice, ImportCommand, ImportService, MetadataRef, MetadataSource, StorageMode,
 };
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::playback::{PlaybackProgress, PlaybackState};
 use bae_core::util::content_type::ContentType;
+use coven::LibraryDir;
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -125,7 +125,7 @@ async fn test_cue_ape_records_correct_durations() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -136,8 +136,8 @@ async fn test_cue_ape_records_correct_durations() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 
@@ -311,7 +311,7 @@ async fn test_cue_ape_records_track_timing() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -322,8 +322,8 @@ async fn test_cue_ape_records_track_timing() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 
@@ -434,7 +434,7 @@ impl CueApeTestFixture {
 
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await?;
         let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
@@ -444,8 +444,8 @@ impl CueApeTestFixture {
             library_dir.clone(),
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let runtime_handle = tokio::runtime::Handle::current();
@@ -1448,7 +1448,7 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -1459,8 +1459,8 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -18,9 +18,9 @@ use bae_core::import::{
     IdentityChoice, ImportCommand, ImportService, MetadataRef, MetadataSource, StorageMode,
 };
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::playback::{PlaybackProgress, PlaybackState};
 use bae_core::util::content_type::ContentType;
+use coven::LibraryDir;
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -409,7 +409,7 @@ async fn import_cue_flac_fixture(temp_root: &Path) -> (LibraryManager, String) {
     copy_cue_flac_fixture_with_seektable(&album_dir);
     let database = Database::new_test(
         db_dir.join("test.db").to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -420,8 +420,8 @@ async fn import_cue_flac_fixture(temp_root: &Path) -> (LibraryManager, String) {
         library_dir,
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let release_id_key = seed_discogs_test_release(create_test_discogs_release());
@@ -483,7 +483,7 @@ impl CueFlacCaptureFixture {
 
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await?;
         let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
@@ -493,8 +493,8 @@ impl CueFlacCaptureFixture {
             library_dir.clone(),
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let runtime_handle = tokio::runtime::Handle::current();

--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -3,8 +3,8 @@ mod support;
 use crate::support::{test_config_and_keys, tracing_init};
 use bae_core::db::{Database, DbAlbum, DbRelease, DbTrack, Pressing, ReleaseMetadataSource};
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use chrono::Utc;
+use coven::LibraryDir;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -15,7 +15,7 @@ async fn setup_test_environment() -> (LibraryManager, Database, TempDir) {
     let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("Failed to create database");
@@ -25,8 +25,8 @@ async fn setup_test_environment() -> (LibraryManager, Database, TempDir) {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     (library_manager, database, temp_dir)

--- a/bae-core/tests/test_export.rs
+++ b/bae-core/tests/test_export.rs
@@ -8,10 +8,10 @@
 mod support;
 
 use bae_core::db::Database;
-use bae_core::encryption::EncryptionService;
 use bae_core::import::{IdentityChoice, ImportCommand, StorageMode};
 use bae_core::library::{ExportFormat, LibraryManager};
-use bae_core::library_dir::LibraryDir;
+use coven::EncryptionService;
+use coven::LibraryDir;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -42,7 +42,7 @@ impl ExportFixture {
 
         let db = Database::new_test(
             db_dir.join("test.db").to_str().unwrap(),
-            Arc::new(bae_core::clock::SystemClock),
+            Arc::new(coven::SystemClock),
         )
         .await
         .unwrap();
@@ -53,8 +53,8 @@ impl ExportFixture {
             library_dir,
             config_handle,
             key_service,
-            Arc::new(bae_core::clock::SystemClock),
-            Arc::new(bae_core::id_provider::UuidProvider),
+            Arc::new(coven::SystemClock),
+            Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let cloud = Arc::new(MockCloudHome::new());

--- a/bae-core/tests/test_import_operations.rs
+++ b/bae-core/tests/test_import_operations.rs
@@ -34,7 +34,7 @@ async fn create_test_db() -> (Database, TempDir) {
     let db_path = temp_dir.path().join("test.db");
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -13,11 +13,11 @@ use bae_core::import::{
     PressingEdit, ReleaseUserEdit, ScanEvent, StorageMode, TrackUserEdit,
 };
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::musicbrainz::{
     ExternalUrls, MbArtistCredit, MbArtistRef, MbMedium, MbRecording, MbReleaseGroupRef,
     MbReleaseResponse, MbTrack,
 };
+use coven::LibraryDir;
 use serial_test::serial;
 use std::fs;
 use std::path::Path;
@@ -40,7 +40,7 @@ impl ImportFixture {
 
         let db = Database::new_test(
             db_dir.join("test.db").to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await
         .unwrap();
@@ -51,8 +51,8 @@ impl ImportFixture {
             library_dir.clone(),
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
 

--- a/bae-core/tests/test_library_events.rs
+++ b/bae-core/tests/test_library_events.rs
@@ -6,8 +6,8 @@ use bae_core::db::{
     Database, DbAlbum, DbAlbumArtist, DbRelease, DbTrack, Pressing, ReleaseMetadataSource,
 };
 use bae_core::library::{LibraryEvent, LibraryManager};
-use bae_core::library_dir::LibraryDir;
 use chrono::Utc;
+use coven::LibraryDir;
 use std::time::Duration;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -19,7 +19,7 @@ async fn setup() -> (LibraryManager, Database, TempDir) {
     let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("Failed to create database");
@@ -29,8 +29,8 @@ async fn setup() -> (LibraryManager, Database, TempDir) {
         library_dir,
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     (library_manager, database, temp_dir)

--- a/bae-core/tests/test_outbox.rs
+++ b/bae-core/tests/test_outbox.rs
@@ -15,7 +15,7 @@ async fn setup_db() -> (Database, TempDir) {
     let db_path = tmp.path().join("test.db");
     let db = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("create database");

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -6,14 +6,14 @@ use crate::support::{
 };
 use bae_core::db::Database;
 use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
-use bae_core::id_provider::{IdProvider, SequentialIdProvider};
 use bae_core::import::{IdentityChoice, ImportCommand, MetadataRef, MetadataSource, StorageMode};
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::playback::{
     PlaybackPauseReason, PlaybackProgress, PlaybackState, RepeatMode,
     SIDE_PAUSE_CASSETTE_MESSAGE_KEY, SIDE_PAUSE_VINYL_MESSAGE_KEY,
 };
+use coven::LibraryDir;
+use coven::{IdProvider, SequentialIdProvider};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -115,7 +115,7 @@ where
 
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await?;
     let database_arc = Arc::new(database.clone());
@@ -127,8 +127,8 @@ where
         library_dir,
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         runtime_handle.clone(),
     );
     configure(&library_manager)?;
@@ -703,7 +703,7 @@ impl CueFlacTestFixture {
 
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await?;
         let database_arc = Arc::new(database.clone());
@@ -714,8 +714,8 @@ impl CueFlacTestFixture {
             library_dir.clone(),
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let runtime_handle = tokio::runtime::Handle::current();
@@ -2925,7 +2925,7 @@ impl HighSampleRateTestFixture {
 
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await?;
         let database_arc = Arc::new(database.clone());
@@ -2936,8 +2936,8 @@ impl HighSampleRateTestFixture {
             library_dir.clone(),
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let runtime_handle = tokio::runtime::Handle::current();
@@ -3415,7 +3415,7 @@ async fn test_real_library_cpu_usage() {
     let bae_dir = dirs::home_dir().expect("home dir").join(".bae");
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("open db");
@@ -3426,8 +3426,8 @@ async fn test_real_library_cpu_usage() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 
@@ -3597,7 +3597,7 @@ async fn test_pause_seek_cue_flac() {
     let bae_dir = dirs::home_dir().expect("home dir").join(".bae");
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("open db");
@@ -3608,8 +3608,8 @@ async fn test_pause_seek_cue_flac() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 
@@ -3827,7 +3827,7 @@ async fn test_playing_seek_cue_flac() {
     let bae_dir = dirs::home_dir().expect("home dir").join(".bae");
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("open db");
@@ -3838,8 +3838,8 @@ async fn test_playing_seek_cue_flac() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
 
@@ -4007,7 +4007,7 @@ async fn test_restore_populates_last_position_display() {
     std::fs::create_dir_all(&album_dir).unwrap();
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -4019,8 +4019,8 @@ async fn test_restore_populates_last_position_display() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -4115,7 +4115,7 @@ async fn test_restore_drops_context_when_cursor_past_shrunk_tracks() {
     std::fs::create_dir_all(&album_dir).unwrap();
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -4127,8 +4127,8 @@ async fn test_restore_drops_context_when_cursor_past_shrunk_tracks() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -4242,7 +4242,7 @@ async fn test_play_persists_then_stop_clears_playback_state() {
     std::fs::create_dir_all(&album_dir).unwrap();
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -4254,8 +4254,8 @@ async fn test_play_persists_then_stop_clears_playback_state() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -4352,7 +4352,7 @@ async fn restore_test_library() -> RestoreTestLibrary {
     std::fs::create_dir_all(&album_dir).unwrap();
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -4364,8 +4364,8 @@ async fn restore_test_library() -> RestoreTestLibrary {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -4647,7 +4647,7 @@ impl CloudOnlyPlaybackFixture {
         std::fs::create_dir_all(&album_dir)?;
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await?;
         let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
@@ -4657,8 +4657,8 @@ impl CloudOnlyPlaybackFixture {
             library_dir,
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let master_key = [11u8; 32];
@@ -4666,9 +4666,9 @@ impl CloudOnlyPlaybackFixture {
         library_manager
             .connect_test_cloud_home(
                 cloud.clone(),
-                bae_core::sync::CloudCipher::Encrypted(
-                    bae_core::encryption::EncryptionService::new_with_key(&master_key),
-                ),
+                bae_core::sync::CloudCipher::Encrypted(coven::EncryptionService::new_with_key(
+                    &master_key,
+                )),
             )
             .await?;
 

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -30,8 +30,8 @@ use bae_core::db::Database;
 use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::import::{IdentityChoice, ImportCommand, MetadataRef, MetadataSource, StorageMode};
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::playback::{PlaybackProgress, PlaybackState};
+use coven::LibraryDir;
 use serial_test::serial;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -288,7 +288,7 @@ impl PlaybackTestFixture {
 
         let database = Database::new_test(
             db_path.to_str().unwrap(),
-            std::sync::Arc::new(bae_core::clock::SystemClock),
+            std::sync::Arc::new(coven::SystemClock),
         )
         .await?;
         let database_arc = Arc::new(database.clone());
@@ -299,8 +299,8 @@ impl PlaybackTestFixture {
             library_dir.clone(),
             config_handle,
             key_service,
-            std::sync::Arc::new(bae_core::clock::SystemClock),
-            std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+            std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
             tokio::runtime::Handle::current(),
         );
         let runtime_handle = tokio::runtime::Handle::current();

--- a/bae-core/tests/test_playback_state.rs
+++ b/bae-core/tests/test_playback_state.rs
@@ -9,7 +9,7 @@ async fn setup_db() -> (Database, TempDir) {
     let db_path = temp_dir.path().join("test.db");
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_reset_metadata.rs
+++ b/bae-core/tests/test_reset_metadata.rs
@@ -12,9 +12,9 @@ use bae_core::db::{
 };
 use bae_core::import::{MetadataSource, ReleaseIdentity};
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::util::content_type::ContentType;
 use chrono::Utc;
+use coven::LibraryDir;
 use std::path::PathBuf;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -26,7 +26,7 @@ async fn setup() -> (LibraryManager, Database, TempDir) {
     let library_dir = LibraryDir::new(temp_dir.path().to_path_buf());
     let database = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -36,8 +36,8 @@ async fn setup() -> (LibraryManager, Database, TempDir) {
         library_dir,
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     (library_manager, database, temp_dir)

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -14,8 +14,8 @@ use bae_core::import::{
     MetadataSource, StorageMode,
 };
 use bae_core::library::LibraryManager;
-use bae_core::library_dir::LibraryDir;
 use bae_core::util::content_type::ContentType;
+use coven::LibraryDir;
 use std::path::Path;
 use std::{fs, path::PathBuf};
 use tempfile::TempDir;
@@ -79,7 +79,7 @@ async fn test_local_import() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -90,8 +90,8 @@ async fn test_local_import() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -219,7 +219,7 @@ async fn test_local_delete_preserves_files() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("database");
@@ -230,8 +230,8 @@ async fn test_local_delete_preserves_files() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -338,7 +338,7 @@ async fn run_import_with_cover_test() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("Failed to create database");
@@ -349,8 +349,8 @@ async fn run_import_with_cover_test() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -654,7 +654,7 @@ async fn run_real_album_test(album_dir: PathBuf, discogs_release_id: String) {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("Failed to create database");
@@ -665,8 +665,8 @@ async fn run_real_album_test(album_dir: PathBuf, discogs_release_id: String) {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();
@@ -772,7 +772,7 @@ async fn test_local_import_not_in_temp_dir() {
     let db_file = db_dir.join("test.db");
     let database = Database::new_test(
         db_file.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .expect("create database");
@@ -783,8 +783,8 @@ async fn test_local_import_not_in_temp_dir() {
         library_dir.clone(),
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let runtime_handle = tokio::runtime::Handle::current();

--- a/bae-core/tests/test_storage_state_machine.rs
+++ b/bae-core/tests/test_storage_state_machine.rs
@@ -23,12 +23,12 @@ mod support;
 
 use bae_core::album_detail::ReleaseStorageState;
 use bae_core::db::{Database, DbAlbum, DbFile, DbRelease, Pressing, ReleaseMetadataSource};
-use bae_core::encryption::EncryptionService;
 use bae_core::library::{CancellationToken, LibraryManager};
-use bae_core::library_dir::LibraryDir;
 use bae_core::sync::CloudCipher;
 use bae_core::util::content_type::ContentType;
 use chrono::Utc;
+use coven::EncryptionService;
+use coven::LibraryDir;
 use std::sync::Arc;
 use support::MockCloudHome;
 use tempfile::TempDir;
@@ -72,7 +72,7 @@ async fn setup_manager(
     let db_path = tmp.path().join("test.db");
     let db = Database::new_test(
         db_path.to_str().unwrap(),
-        std::sync::Arc::new(bae_core::clock::SystemClock),
+        std::sync::Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -81,8 +81,8 @@ async fn setup_manager(
         library_dir,
         config_handle,
         key_service,
-        std::sync::Arc::new(bae_core::clock::SystemClock),
-        std::sync::Arc::new(bae_core::id_provider::UuidProvider),
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     let cloud = Arc::new(MockCloudHome::new());

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -13,15 +13,15 @@ mod support;
 
 use bae_core::album_detail::ReleaseStorageState;
 use bae_core::db::{Database, DbAlbum, DbFile, DbRelease, Pressing, ReleaseMetadataSource};
-use bae_core::encryption::EncryptionService;
 use bae_core::library::{CancellationToken, LibraryEvent, LibraryManager};
-use bae_core::library_dir::LibraryDir;
 use bae_core::storage::local::transfer::{
     read_release_file_bytes, TransferProgress, TransferService,
 };
 use bae_core::sync::CloudCipher;
 use bae_core::util::content_type::ContentType;
 use chrono::Utc;
+use coven::EncryptionService;
+use coven::LibraryDir;
 use std::path::Path;
 use std::sync::Arc;
 use support::MockCloudHome;
@@ -56,7 +56,7 @@ async fn setup(tmp: &TempDir) -> (Database, LibraryManager) {
     let (config_handle, key_service) = support::test_config_and_keys(&library_dir);
     let db = Database::new_test(
         tmp.path().join("test.db").to_str().unwrap(),
-        Arc::new(bae_core::clock::SystemClock),
+        Arc::new(coven::SystemClock),
     )
     .await
     .unwrap();
@@ -65,8 +65,8 @@ async fn setup(tmp: &TempDir) -> (Database, LibraryManager) {
         library_dir,
         config_handle,
         key_service,
-        Arc::new(bae_core::clock::SystemClock),
-        Arc::new(bae_core::id_provider::UuidProvider),
+        Arc::new(coven::SystemClock),
+        Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
     );
     (db, mgr)

--- a/bae-windows-ffi/Cargo.toml
+++ b/bae-windows-ffi/Cargo.toml
@@ -15,6 +15,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bae-core = { path = "../bae-core" }
+# The C-ABI surface names coven types directly (UuidProvider, SystemClock, the
+# OAuth DTOs) — same pinned instance bae-core uses, via the workspace dep.
+coven = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Complex results cross the C ABI as JSON; the C# side deserializes them.
@@ -34,4 +37,4 @@ bae-loc = { path = "../bae-loc" }
 # Enables the OAuth cloud-provider C-ABI surface (bae_oauth_authorize,
 # bae_sign_in_cloud, bae_set_oauth_client_creds) via bae-core/coven. Off by
 # default → the baeium build; the bae build turns it on.
-oauth-providers = ["bae-core/oauth-providers"]
+oauth-providers = ["bae-core/oauth-providers", "coven/oauth-providers"]

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn bae_set_oauth_client_creds(creds_json: *const c_char) -
             .map(str::to_string);
         creds.insert(
             provider,
-            bae_core::oauth::OAuthClientCreds {
+            coven::OAuthClientCreds {
                 client_id: client_id.to_string(),
                 client_secret,
             },
@@ -518,7 +518,7 @@ pub unsafe extern "C" fn bae_set_oauth_client_creds(creds_json: *const c_char) -
     if creds.is_empty() {
         return error_cstring("oauth creds json registered no providers");
     }
-    bae_core::oauth::set_oauth_client_creds(creds);
+    coven::set_oauth_client_creds(creds);
     std::ptr::null_mut()
 }
 
@@ -549,7 +549,7 @@ pub extern "C" fn bae_libraries() -> *mut c_char {
 /// or null on error. Free with [`bae_string_free`]. Requires [`bae_startup`].
 #[no_mangle]
 pub extern "C" fn bae_create_library() -> *mut c_char {
-    match bae_core::library::create_library_default(&bae_core::id_provider::UuidProvider) {
+    match bae_core::library::create_library_default(&coven::UuidProvider) {
         Ok(config) => error_cstring(&config.library_id),
         Err(e) => {
             tracing::error!("bae_create_library failed: {e}");
@@ -1032,12 +1032,8 @@ pub unsafe extern "C" fn bae_oauth_authorize(provider: *const c_char) -> *mut c_
     // abort the flow immediately. Windows exposes no cancel button yet — the
     // sender stays untouched (value never set true) until the flow returns.
     let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-    let clock = bae_core::clock::SystemClock;
-    let result = runtime.block_on(bae_core::oauth::authorize_provider(
-        core_provider,
-        cancel_rx,
-        &clock,
-    ));
+    let clock = coven::SystemClock;
+    let result = runtime.block_on(coven::authorize_provider(core_provider, cancel_rx, &clock));
     drop(cancel_tx);
     let out = match result {
         Ok(tokens) => match serde_json::to_string(&tokens) {
@@ -1080,7 +1076,7 @@ pub unsafe extern "C" fn bae_restore_from_code(
         });
     };
     let oauth_tokens = match cstr(oauth_token_json) {
-        Some(json) => match serde_json::from_str::<bae_core::oauth::OAuthTokens>(&json) {
+        Some(json) => match serde_json::from_str::<coven::OAuthTokens>(&json) {
             Ok(tokens) => Some(tokens),
             Err(e) => {
                 return json_cstring(&FfiRestoreResult {
@@ -1251,7 +1247,7 @@ pub unsafe extern "C" fn bae_join_from_code(
         });
     };
     let oauth_tokens = match cstr(oauth_token_json) {
-        Some(json) => match serde_json::from_str::<bae_core::oauth::OAuthTokens>(&json) {
+        Some(json) => match serde_json::from_str::<coven::OAuthTokens>(&json) {
             Ok(tokens) => Some(tokens),
             Err(e) => {
                 return json_cstring(&FfiRestoreResult {


### PR DESCRIPTION
Conforming bae to coven's sealed flat API (#165) left `crate::{clock, encryption, id_provider, library_dir, oauth}` and the `storage::cloud` submodule as thin re-exports of `coven::X` with nothing of their own. This removes them and points every caller at `coven::X` directly, so the indirection is gone and each use names its real source.

Killing `storage::cloud` surfaced that bae-bridge's CloudKit adapter and bae-windows-ffi's C ABI reach coven types (`CloudKitOps`, the OAuth DTOs, `UuidProvider`, `SystemClock`) *through* those facades, yet neither crate depended on coven. They now depend on it directly — bae-bridge implements a coven trait, so that edge is honest. coven becomes a workspace dependency so bae-core, bae-bridge, and bae-windows-ffi all resolve the one pinned instance (verified: a single coven builds, so the trait types unify).

`keys.rs` stays — it adds `BaeKeyServiceExt` (the Discogs/forget-key domain extension) — but drops the dead `set_keyring_service` re-export; its only caller already uses `coven::set_keyring_service`. `storage::local` keeps its `ReleaseStorageImpl` alias, which is a domain name rather than module indirection.

## Test plan
- `cargo clippy` across bae-core (lib + tests, default and oauth-providers), bae-bridge, bae-windows-ffi (oauth-providers) — clean under `-D warnings`.
- `cargo fmt --all` clean.
- Full bae-core test suite green (804 lib + all integration binaries).
- Pre-commit hook (incl. the bae-macos Swift build, since bae-bridge changed) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
