### PR TITLE
Scrub leaked personal paths and real-sounding names from test fixtures

### DIFF
--- a/bae-core/src/diagnostics.rs
+++ b/bae-core/src/diagnostics.rs
@@ -889,11 +889,11 @@ mod tests {
             ("operation".to_string(), "scan".to_string()),
             (
                 "path".to_string(),
-                "/Users/person/Music/file.flac".to_string(),
+                "/tmp/import_source/file.flac".to_string(),
             ),
             (
                 "status".to_string(),
-                "stored at /Users/person/Music/file.flac".to_string(),
+                "stored at /tmp/import_source/file.flac".to_string(),
             ),
             (
                 "error_code".to_string(),
@@ -1022,7 +1022,7 @@ mod tests {
                 tracing::warn!(
                     target: "scan",
                     operation = "import",
-                    path = "/Users/person/Music/file.flac",
+                    path = "/tmp/import_source/file.flac",
                     "release {} failed",
                     "123e4567-e89b-12d3-a456-426614174000"
                 );

--- a/bae-core/src/import/folder_registry.rs
+++ b/bae-core/src/import/folder_registry.rs
@@ -190,7 +190,7 @@ mod tests {
             .add(&library_dir, "/Volumes/Music/New Rips".to_string())
             .unwrap());
         assert!(registry
-            .add(&library_dir, "/Users/sam/Downloads/Bandcamp".to_string())
+            .add(&library_dir, "/music/library/incoming".to_string())
             .unwrap());
         // A duplicate add is a no-op.
         assert!(!registry
@@ -208,8 +208,8 @@ mod tests {
                     name: "New Rips".to_string(),
                 },
                 WatchedFolder {
-                    path: "/Users/sam/Downloads/Bandcamp".to_string(),
-                    name: "Bandcamp".to_string(),
+                    path: "/music/library/incoming".to_string(),
+                    name: "incoming".to_string(),
                 },
             ]
         );

--- a/bae-core/src/import/folder_scanner/tests.rs
+++ b/bae-core/src/import/folder_scanner/tests.rs
@@ -223,7 +223,7 @@ fn content_hash_is_location_independent_and_size_sensitive() {
     // The same relative structure under two different parent folders hashes
     // identically — the fingerprint follows the rip, not where it sits.
     let a = make("/Volumes/Music/Release", 2000);
-    let b = make("/Users/sam/Downloads/Release", 2000);
+    let b = make("/tmp/import_source/Release", 2000);
     assert_eq!(a.content_hash(), b.content_hash());
 
     // A single differing file size flips the hash.

--- a/bae-core/tests/test_import_operations.rs
+++ b/bae-core/tests/test_import_operations.rs
@@ -49,9 +49,9 @@ async fn test_insert_and_get_import() {
 
     let import = DbImport::new(
         "test-import-1",
-        "Neon Dreams",
-        "The Wanderers",
-        "/music/wanderers/neon-dreams",
+        "Album Title",
+        "Artist Name",
+        "/music/library/album-title",
         chrono::Utc::now(),
     );
 
@@ -62,9 +62,9 @@ async fn test_insert_and_get_import() {
 
     let retrieved = retrieved.unwrap();
     assert_eq!(retrieved.id, "test-import-1");
-    assert_eq!(retrieved.album_title, "Neon Dreams");
-    assert_eq!(retrieved.artist_name, "The Wanderers");
-    assert_eq!(retrieved.folder_path, "/music/wanderers/neon-dreams");
+    assert_eq!(retrieved.album_title, "Album Title");
+    assert_eq!(retrieved.artist_name, "Artist Name");
+    assert_eq!(retrieved.folder_path, "/music/library/album-title");
     assert_eq!(retrieved.status, ImportOperationStatus::Importing);
     assert!(retrieved.release_id.is_none());
     assert!(retrieved.error_message.is_none());
@@ -80,9 +80,9 @@ async fn test_import_lifecycle_success() {
     // Create import record (starts at Importing since all validation already passed)
     let import = DbImport::new(
         "lifecycle-import",
-        "Midnight Echo",
-        "Solar Flare",
-        "/music/solar-flare/midnight-echo",
+        "Album Title",
+        "Artist Name",
+        "/music/library/album-title",
         chrono::Utc::now(),
     );
     db.insert_import(&import).await.unwrap();
@@ -232,9 +232,9 @@ async fn test_no_import_record_when_validation_fails() {
     // Successful import: validation passed, so insert_import is called
     let successful_import = DbImport::new(
         "success-import",
-        "Midnight Echo",
-        "Solar Flare",
-        "/music/solar-flare/midnight-echo",
+        "Album Title",
+        "Artist Name",
+        "/music/library/album-title",
         chrono::Utc::now(),
     );
     db.insert_import(&successful_import).await.unwrap();


### PR DESCRIPTION
A repo audit turned up test fixtures carrying personal-looking absolute filesystem paths (`/Users/person/…`, `/Users/sam/Downloads/…`) and real-sounding artist/album names embedded in import-test fixtures. None are production code — every hit is inside a `#[cfg(test)]` module or a `tests/` file — and none of the values are load-bearing beyond being distinct strings, so they're replaced with neutral placeholders that keep the same coverage (distinct parents preserved where a test relies on them, redaction-regex match preserved where a test asserts on it).

One fixture was deliberately left as-is: a UTF-16 EAC rip-log under `bae-core/tests/fixtures/` whose `C:\Users\TestUser\…` content is already fully synthetic placeholders — a UTF-16 edit would risk corrupting the fixture for no real scrubbing benefit.

## Test plan
- [x] `cargo test -p bae-core --features test-utils -- --test-threads=1`: 980 passed, identical before and after.
- [x] fmt clean.