### PR TITLE
Adopt current coven: register bae's schema as migration #1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=ec4027e042d8b63697530095a3a2ab1891126ee4#ec4027e042d8b63697530095a3a2ab1891126ee4"
+source = "git+https://github.com/bae-fm/coven?rev=6d450fffd8bdad9dbd60e15743acfa47e376d3a3#6d450fffd8bdad9dbd60e15743acfa47e376d3a3"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "ec4027e042d8b63697530095a3a2ab1891126ee4" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "6d450fffd8bdad9dbd60e15743acfa47e376d3a3" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-core/src/db/client.rs
+++ b/bae-core/src/db/client.rs
@@ -381,10 +381,8 @@ impl Database {
             builder = builder.observer(observer);
         }
         let handle = builder
-            .open(|conn| {
-                conn.execute_batch(include_str!("../../migrations/001_initial.sql"))?;
-                Ok(())
-            })
+            .migrations(crate::migrations::all())
+            .open()
             .map_err(Self::coven_error)?;
         Ok(Self::from_handle(handle, clock))
     }

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod library_name;
 // measurements with plain arithmetic and needs no ebur128).
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 pub mod loudness;
+pub mod migrations;
 pub mod musicbrainz;
 pub mod network;
 pub mod playback;

--- a/bae-core/src/library/manager.rs
+++ b/bae-core/src/library/manager.rs
@@ -1127,10 +1127,8 @@ impl LibraryManager {
             .clock(clock.clone())
             .key_service(key_service.clone())
             .observer(observer.clone() as Arc<dyn coven::BlobTransitionObserver>)
-            .open(|conn| {
-                conn.execute_batch(include_str!("../../migrations/001_initial.sql"))?;
-                Ok(())
-            })
+            .migrations(crate::migrations::all())
+            .open()
             .map_err(|e| match e {
                 coven::CovenError::Database(error) => error,
                 other => coven::DbError(other.to_string()),

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -107,6 +107,7 @@ pub async fn restore_from_cloud(
         Some(encryption_key_hex),
         library_name,
         &crate::sync::synced_tables(),
+        &crate::migrations::all(),
         source,
         &keypair,
         &app_dir,
@@ -158,10 +159,12 @@ async fn restore_from_code_with_cancel(
         None
     };
     let synced_tables = crate::sync::synced_tables();
+    let migrations = crate::migrations::all();
 
     let restore = crate::sync::restore_from_code(
         code,
         &synced_tables,
+        &migrations,
         oauth_tokens,
         cloudkit_ops,
         &app_dir,
@@ -266,11 +269,13 @@ async fn join_from_code_with_cancel(
         None
     };
     let synced_tables = crate::sync::synced_tables();
+    let migrations = crate::migrations::all();
 
     let join = crate::sync::join_from_invite_code(
         code,
         &app_dir,
         &synced_tables,
+        &migrations,
         oauth_tokens,
         cloudkit_ops,
         std::sync::Arc::new(coven::SystemClock),

--- a/bae-core/src/migrations.rs
+++ b/bae-core/src/migrations.rs
@@ -1,0 +1,12 @@
+//! bae's synced-schema migration ladder, registered on the coven builder.
+//! coven runs each migration whose version exceeds the db's `PRAGMA user_version`
+//! at open; the applied version becomes the wire `schema_version`.
+
+/// The ordered migration ladder. Versions are 1-based and contiguous.
+pub fn all() -> Vec<coven::Migration> {
+    vec![coven::Migration::sql(
+        1,
+        "initial",
+        include_str!("../migrations/001_initial.sql"),
+    )]
+}

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -3932,7 +3932,13 @@ pub unsafe extern "C" fn bae_get_members(handle: *const BaeHandle) -> *mut c_cha
         .into_iter()
         .map(|member| FfiMember {
             pubkey: member.pubkey,
-            role: member.role.as_str().to_string(),
+            // Lowercase wire role this FFI promises its caller (see `FfiMember.role`).
+            role: match member.role {
+                bae_core::sync::sync_manager::MemberRole::Owner => "owner",
+                bae_core::sync::sync_manager::MemberRole::Member => "member",
+                bae_core::sync::sync_manager::MemberRole::Follower => "follower",
+            }
+            .to_string(),
             is_self: member.is_self,
             fingerprint: member.fingerprint,
             can_remove: member.can_remove,


### PR DESCRIPTION
bae had pinned coven at `ec4027e` — before coven's owner-only-snapshots, member-write-proxy removal, and the new schema-migration ladder. This bumps the pin to current coven `main` and adapts bae to all of it at once (the migration API can't be adopted without crossing those other changes).

coven's builder no longer takes a `migrate` closure; it takes an ordered `Vec<coven::Migration>` and runs each migration whose version exceeds the database's `PRAGMA user_version` at open. The applied version becomes the wire `schema_version`, so adding a migration is the only way to advance it. bae's existing schema becomes migration #1 (`bae-core/src/migrations.rs`), registered on the two builder sites (`LibraryManager::open` and `Database::open`) and threaded through the three bootstrap entry points the new `migrations` parameter touches (`restore_from_cloud`, `restore_from_code`, `join_from_invite_code`).

One call-site adaptation falls out of the proxy removal: it deleted `MemberRole::as_str`, so the Windows FFI now produces its lowercase wire role ("owner"/"member"/"follower") with a local match — that string is the FFI's own contract, not coven's.

## Test plan
- [x] `cargo build` (full workspace): bae-bridge and bae-windows-ffi both compile against the new coven (the prior `!Send` bootstrap-future break is fixed in coven).
- [x] `cargo test -p bae-core --features test-utils -- --test-threads=1`: 980 passed, identical to before — the schema runs identically, just registered as migration #1.
- [x] `cargo clippy -p bae-core -p bae-windows-ffi --all-targets` clean.