### PR TITLE
Unify db row mappers to fallible free functions

### DIFF
--- a/bae-core/src/db/client/album.rs
+++ b/bae-core/src/db/client/album.rs
@@ -141,7 +141,7 @@ impl Database {
 
         self.call(move |conn| {
             let mut stmt = conn.prepare(&query)?;
-            let rows = stmt.query_map([], |row| Ok(Self::row_to_album(row)))?;
+            let rows = stmt.query_map([], row_to_album)?;
             rows.collect::<coven::rusqlite::Result<Vec<_>>>()
                 .map_err(DbError::from)
         })
@@ -223,7 +223,7 @@ impl Database {
                     WHERE id = ?
                     "#,
                 params![album_id],
-                |row| Ok(Self::row_to_album(row)),
+                row_to_album,
             )
             .optional()
             .map_err(DbError::from)
@@ -246,7 +246,7 @@ impl Database {
                     WHERE id = ?
                     "#,
                 params![album_id],
-                |row| Ok(Self::row_to_album(row)),
+                row_to_album,
             )
             .map_err(DbError::from)
         })

--- a/bae-core/src/db/client/artist.rs
+++ b/bae-core/src/db/client/artist.rs
@@ -38,7 +38,7 @@ impl Database {
         value: String,
     ) -> Result<Option<DbArtist>, DbError> {
         self.call(move |conn| {
-            conn.query_row(sql, params![value], |row| Ok(Self::row_to_artist(row)))
+            conn.query_row(sql, params![value], row_to_artist)
                 .optional()
                 .map_err(DbError::from)
         })
@@ -141,9 +141,7 @@ impl Database {
                         ORDER BY sort_key
                         "#,
             )?;
-            let rows = stmt.query_map(params![album_id, album_id], |row| {
-                Ok(Self::row_to_artist(row))
-            })?;
+            let rows = stmt.query_map(params![album_id, album_id], row_to_artist)?;
             rows.collect::<coven::rusqlite::Result<Vec<_>>>()
                 .map_err(DbError::from)
         })
@@ -161,7 +159,7 @@ impl Database {
                         ORDER BY ta.position
                         "#,
             )?;
-            let rows = stmt.query_map(params![track_id], |row| Ok(Self::row_to_artist(row)))?;
+            let rows = stmt.query_map(params![track_id], row_to_artist)?;
             rows.collect::<coven::rusqlite::Result<Vec<_>>>()
                 .map_err(DbError::from)
         })

--- a/bae-core/src/db/client/blobs.rs
+++ b/bae-core/src/db/client/blobs.rs
@@ -49,7 +49,7 @@ impl Database {
         let sql = format!("SELECT * FROM {table} WHERE id = ?");
         self.call(move |conn| {
             conn.query_row(&sql, params![id], |row| {
-                Ok(row_to_library_image(row, image_type.clone()))
+                row_to_library_image(row, image_type.clone())
             })
             .optional()
             .map_err(DbError::from)

--- a/bae-core/src/db/client/identity.rs
+++ b/bae-core/src/db/client/identity.rs
@@ -119,7 +119,7 @@ impl Database {
             conn.query_row(
                 &sql,
                 coven::rusqlite::params_from_iter(binds.iter()),
-                |row| Ok(Self::row_to_album(row)),
+                row_to_album,
             )
             .optional()
             .map_err(DbError::from)
@@ -512,7 +512,7 @@ impl Database {
                             LIMIT 1
                             "#,
                         params![source, release_id],
-                        |row| Ok(Self::row_to_album(row)),
+                        row_to_album,
                     )
                     .optional()?;
 
@@ -537,7 +537,7 @@ impl Database {
                                 LIMIT 1
                                 "#,
                             params![source, group_id],
-                            |row| Ok(Self::row_to_album(row)),
+                            row_to_album,
                         )
                         .optional()?;
 

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -100,21 +100,24 @@ fn row_to_outbox_entry(row: &Row<'_>) -> coven::rusqlite::Result<coven::OutboxEn
 
 /// Build a `DbLibraryImage` from a `covers`/`artist_images` row. The table is the
 /// type, so `image_type` is supplied by the caller rather than read from a column.
-fn row_to_library_image(row: &Row, image_type: LibraryImageType) -> DbLibraryImage {
-    DbLibraryImage {
-        id: row.get("id").unwrap(),
+fn row_to_library_image(
+    row: &Row,
+    image_type: LibraryImageType,
+) -> coven::rusqlite::Result<DbLibraryImage> {
+    Ok(DbLibraryImage {
+        id: row.get("id")?,
         image_type,
-        content_type: ContentType::from_mime(&row.get::<_, String>("content_type").unwrap()),
-        file_size: row.get("file_size").unwrap(),
-        width: row.get("width").unwrap(),
-        height: row.get("height").unwrap(),
-        source: row.get("source").unwrap(),
-        source_url: row.get("source_url").unwrap(),
-        cloud_path: row.get("cloud_path").unwrap(),
-        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
+        content_type: ContentType::from_mime(&row.get::<_, String>("content_type")?),
+        file_size: row.get("file_size")?,
+        width: row.get("width")?,
+        height: row.get("height")?,
+        source: row.get("source")?,
+        source_url: row.get("source_url")?,
+        cloud_path: row.get("cloud_path")?,
+        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
             .unwrap()
             .with_timezone(&Utc),
-    }
+    })
 }
 
 /// Build an ORDER BY clause from sort criteria.
@@ -435,79 +438,6 @@ impl Database {
         .await
     }
 
-    fn row_to_release(row: &Row) -> DbRelease {
-        let metadata_source: String = row.get("metadata_source").unwrap();
-        let metadata_source = metadata_source.parse::<ReleaseMetadataSource>().expect(
-            "releases.metadata_source must be one of 'musicbrainz' | 'discogs' | 'file_tags'",
-        );
-        DbRelease {
-            id: row.get("id").unwrap(),
-            album_id: row.get("album_id").unwrap(),
-            release_name: row.get("release_name").unwrap(),
-            pressing: Pressing {
-                year: row.get("year").unwrap(),
-                format: row.get("format").unwrap(),
-                label: row.get("label").unwrap(),
-                catalog_number: row.get("catalog_number").unwrap(),
-                country: row.get("country").unwrap(),
-                barcode: row.get("barcode").unwrap(),
-            },
-            disc_id: row.get("disc_id").unwrap(),
-            metadata_source,
-            metadata_source_release_id: row.get("metadata_source_release_id").unwrap(),
-            remote: row.get("remote").unwrap(),
-            source_folder_name: row.get("source_folder_name").unwrap(),
-            content_hash: row.get("content_hash").unwrap(),
-            album_loudness_lufs: row.get("album_loudness_lufs").unwrap(),
-            album_peak_linear: row.get("album_peak_linear").unwrap(),
-            created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
-                .unwrap()
-                .with_timezone(&Utc),
-        }
-    }
-
-    fn row_to_file(row: &Row) -> DbFile {
-        DbFile {
-            id: row.get("id").unwrap(),
-            release_id: row.get("release_id").unwrap(),
-            original_filename: row.get("original_filename").unwrap(),
-            file_size: row.get("file_size").unwrap(),
-            content_type: ContentType::from_mime(&row.get::<_, String>("content_type").unwrap()),
-            cloud_path: row.get("cloud_path").unwrap(),
-            created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
-                .unwrap()
-                .with_timezone(&Utc),
-        }
-    }
-
-    fn row_to_artist(row: &Row) -> DbArtist {
-        DbArtist {
-            id: row.get("id").unwrap(),
-            name: row.get("name").unwrap(),
-            sort_name: row.get("sort_name").unwrap(),
-            discogs_artist_id: row.get("discogs_artist_id").unwrap(),
-            musicbrainz_artist_id: row.get("musicbrainz_artist_id").unwrap(),
-            created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
-                .unwrap()
-                .with_timezone(&Utc),
-        }
-    }
-
-    /// Parse a DbAlbum from a SQL row.
-    fn row_to_album(row: &Row) -> DbAlbum {
-        DbAlbum {
-            id: row.get("id").unwrap(),
-            title: row.get("title").unwrap(),
-            artist_id: row.get("artist_id").unwrap(),
-            year: row.get("year").unwrap(),
-            primary_release_id: row.get("primary_release_id").unwrap(),
-            is_compilation: row.get("is_compilation").unwrap(),
-            created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at").unwrap())
-                .unwrap()
-                .with_timezone(&Utc),
-        }
-    }
-
     /// Shared SQL assembly for `find_album_detail` / `find_release_detail`.
     /// Returns the raw per-release aggregate.
     async fn build_release_detail(&self, release: DbRelease) -> Result<DbReleaseDetail, DbError> {
@@ -533,6 +463,79 @@ impl Database {
 }
 
 // ─── Row-map helpers (free functions; take `&Row`) ──────────────────────────
+
+fn row_to_release(row: &Row) -> coven::rusqlite::Result<DbRelease> {
+    let metadata_source: String = row.get("metadata_source")?;
+    let metadata_source = metadata_source
+        .parse::<ReleaseMetadataSource>()
+        .expect("releases.metadata_source must be one of 'musicbrainz' | 'discogs' | 'file_tags'");
+    Ok(DbRelease {
+        id: row.get("id")?,
+        album_id: row.get("album_id")?,
+        release_name: row.get("release_name")?,
+        pressing: Pressing {
+            year: row.get("year")?,
+            format: row.get("format")?,
+            label: row.get("label")?,
+            catalog_number: row.get("catalog_number")?,
+            country: row.get("country")?,
+            barcode: row.get("barcode")?,
+        },
+        disc_id: row.get("disc_id")?,
+        metadata_source,
+        metadata_source_release_id: row.get("metadata_source_release_id")?,
+        remote: row.get("remote")?,
+        source_folder_name: row.get("source_folder_name")?,
+        content_hash: row.get("content_hash")?,
+        album_loudness_lufs: row.get("album_loudness_lufs")?,
+        album_peak_linear: row.get("album_peak_linear")?,
+        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
+            .unwrap()
+            .with_timezone(&Utc),
+    })
+}
+
+fn row_to_file(row: &Row) -> coven::rusqlite::Result<DbFile> {
+    Ok(DbFile {
+        id: row.get("id")?,
+        release_id: row.get("release_id")?,
+        original_filename: row.get("original_filename")?,
+        file_size: row.get("file_size")?,
+        content_type: ContentType::from_mime(&row.get::<_, String>("content_type")?),
+        cloud_path: row.get("cloud_path")?,
+        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
+            .unwrap()
+            .with_timezone(&Utc),
+    })
+}
+
+fn row_to_artist(row: &Row) -> coven::rusqlite::Result<DbArtist> {
+    Ok(DbArtist {
+        id: row.get("id")?,
+        name: row.get("name")?,
+        sort_name: row.get("sort_name")?,
+        discogs_artist_id: row.get("discogs_artist_id")?,
+        musicbrainz_artist_id: row.get("musicbrainz_artist_id")?,
+        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
+            .unwrap()
+            .with_timezone(&Utc),
+    })
+}
+
+/// Parse a DbAlbum from a SQL row.
+fn row_to_album(row: &Row) -> coven::rusqlite::Result<DbAlbum> {
+    Ok(DbAlbum {
+        id: row.get("id")?,
+        title: row.get("title")?,
+        artist_id: row.get("artist_id")?,
+        year: row.get("year")?,
+        primary_release_id: row.get("primary_release_id")?,
+        is_compilation: row.get("is_compilation")?,
+        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>("created_at")?)
+            .unwrap()
+            .with_timezone(&Utc),
+    })
+}
 
 fn row_to_track(row: &Row) -> coven::rusqlite::Result<DbTrack> {
     Ok(DbTrack {
@@ -588,6 +591,22 @@ fn row_to_import(row: &Row) -> coven::rusqlite::Result<DbImport> {
         created_at: row.get("created_at")?,
         updated_at: row.get("updated_at")?,
         error_message: row.get("error_message")?,
+    })
+}
+
+/// Map one row of the release-storage-summary query to a `DbReleaseStorageSummary`.
+fn row_to_release_storage_summary(row: &Row) -> coven::rusqlite::Result<DbReleaseStorageSummary> {
+    Ok(DbReleaseStorageSummary {
+        release_id: row.get("release_id")?,
+        album_id: row.get("album_id")?,
+        album_title: row.get("album_title")?,
+        artist_names: row.get("artist_names")?,
+        format: row.get("format")?,
+        primary_release_id: row.get("primary_release_id")?,
+        remote: row.get("remote")?,
+        any_file_id: row.get("any_file_id")?,
+        file_count: row.get("file_count")?,
+        total_size: row.get("total_size")?,
     })
 }
 

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -211,32 +211,13 @@ impl Database {
         )
     }
 
-    /// Map one row of [`release_storage_summary_query`] to a
-    /// `DbReleaseStorageSummary`.
-    fn row_to_release_storage_summary(
-        row: &Row,
-    ) -> coven::rusqlite::Result<DbReleaseStorageSummary> {
-        Ok(DbReleaseStorageSummary {
-            release_id: row.get("release_id")?,
-            album_id: row.get("album_id")?,
-            album_title: row.get("album_title")?,
-            artist_names: row.get("artist_names")?,
-            format: row.get("format")?,
-            primary_release_id: row.get("primary_release_id")?,
-            remote: row.get("remote")?,
-            any_file_id: row.get("any_file_id")?,
-            file_count: row.get("file_count")?,
-            total_size: row.get("total_size")?,
-        })
-    }
-
     pub async fn get_release_storage_summaries(
         &self,
     ) -> Result<Vec<DbReleaseStorageSummary>, DbError> {
         let query = Self::release_storage_summary_query("ORDER BY a.title, r.created_at");
         self.call(move |conn| {
             let mut stmt = conn.prepare(&query)?;
-            let rows = stmt.query_map([], Self::row_to_release_storage_summary)?;
+            let rows = stmt.query_map([], row_to_release_storage_summary)?;
             rows.collect::<coven::rusqlite::Result<Vec<_>>>()
                 .map_err(DbError::from)
         })
@@ -254,7 +235,7 @@ impl Database {
         let release_id = release_id.to_string();
         let query = Self::release_storage_summary_query("WHERE r.id = ?1");
         self.call(move |conn| {
-            conn.query_row(&query, [release_id], Self::row_to_release_storage_summary)
+            conn.query_row(&query, [release_id], row_to_release_storage_summary)
                 .optional()
                 .map_err(DbError::from)
         })
@@ -394,7 +375,7 @@ impl Database {
             conn.query_row(
                 "SELECT * FROM releases WHERE id = ?",
                 params![release_id],
-                |row| Ok(Self::row_to_release(row)),
+                row_to_release,
             )
             .map_err(DbError::from)
         })
@@ -419,7 +400,7 @@ impl Database {
         self.call(move |conn| {
             let mut stmt =
                 conn.prepare("SELECT * FROM releases WHERE album_id = ? ORDER BY created_at")?;
-            let rows = stmt.query_map(params![album_id], |row| Ok(Self::row_to_release(row)))?;
+            let rows = stmt.query_map(params![album_id], row_to_release)?;
             rows.collect::<coven::rusqlite::Result<Vec<_>>>()
                 .map_err(DbError::from)
         })
@@ -438,7 +419,7 @@ impl Database {
         let release_id = release_id.to_string();
         self.call(move |conn| {
             let mut stmt = conn.prepare("SELECT * FROM release_files WHERE release_id = ?")?;
-            let rows = stmt.query_map(params![release_id], |row| Ok(Self::row_to_file(row)))?;
+            let rows = stmt.query_map(params![release_id], row_to_file)?;
             rows.collect::<coven::rusqlite::Result<Vec<_>>>()
                 .map_err(DbError::from)
         })
@@ -451,7 +432,7 @@ impl Database {
             conn.query_row(
                 "SELECT * FROM release_files WHERE id = ?",
                 params![file_id],
-                |row| Ok(Self::row_to_file(row)),
+                row_to_file,
             )
             .optional()
             .map_err(DbError::from)
@@ -715,7 +696,7 @@ impl Database {
             conn.query_row(
                 "SELECT * FROM releases WHERE id = ?",
                 params![release_id],
-                |row| Ok(Self::row_to_release(row)),
+                row_to_release,
             )
             .optional()
             .map_err(DbError::from)
@@ -774,7 +755,7 @@ impl Database {
                      JOIN release_files rf ON rf.release_id = r.id \
                      WHERE rf.id = ?",
                 params![file_id],
-                |row| Ok(Self::row_to_release(row)),
+                row_to_release,
             )
             .optional()
             .map_err(DbError::from)


### PR DESCRIPTION
The `db/client` SQL row mappers were split two inconsistent ways: half
(`row_to_release/file/artist/album`, plus `row_to_library_image`) were
`.unwrap()`-on-every-column helpers that PANIC the process when a column is
NULL, the wrong type, or corrupt; the other half already returned
`rusqlite::Result` and propagated. A row-mapping column error should surface, not
crash.

This unifies all of them to the `Result`-returning free-function form: each
column read becomes `?`, and the four panicking `impl Database` associated fns
plus `row_to_library_image` move out to free functions next to the others in
`mod.rs`. `row_to_release_storage_summary` already returned `Result` but was
still an associated fn — it moves to a free function too, so the whole mapper
surface is one consistent shape. Call sites pass the function directly (dropping
redundant `|row| Ok(Self::row_to_x(row))` closures).

Behavior change, intentional: panic-on-bad-column becomes a propagated
`DbError`. Several mappers still panic on malformed *parsed* columns (chrono
timestamps, enum strings) and on unknown enum values — those are a separate class
tracked as follow-up issues, out of scope here.

## Test plan
- `cargo clippy -p bae-core --all-targets` clean.
- `cargo test -p bae-core --features test-utils -- --test-threads=1`: 980 passed, 0 failed. Diff touches no test code.
