### PR TITLE
Fix stale identify doc references

### DIFF
--- a/bae-core/src/identify/state.rs
+++ b/bae-core/src/identify/state.rs
@@ -339,8 +339,8 @@ impl IdentifyState {
                     context,
                 }
             }
-            // Settled states re-combine immediately; `Idle`/`Error` (no
-            // context) are unreachable here behind `has_context` but stay total.
+            // Settled states re-combine immediately; `Idle` (no context) is
+            // unreachable here behind `has_context` but stays total.
             other => match other.context_cloned() {
                 Some(mut context) => {
                     context.toggle(signal);
@@ -354,7 +354,7 @@ impl IdentifyState {
     /// Project the current state into the flat list of toolbar badges the UI
     /// renders: the disc-ID badge, the barcode badge, then one badge per
     /// catalog candidate. Each carries its value, origin, live state, and
-    /// whether the user has excluded it. `Idle` and `Error` have no toolbar.
+    /// whether the user has excluded it. `Idle` has no toolbar.
     pub fn toolbar(&self) -> Vec<ToolbarSignal> {
         let Some(context) = self.context_cloned() else {
             return Vec::new();

--- a/bae-core/src/identify/toolbar.rs
+++ b/bae-core/src/identify/toolbar.rs
@@ -2,11 +2,12 @@
 //! renders directly. Each identifying signal — the disc ID, the barcode, and
 //! every catalog candidate — becomes one [`ToolbarSignal`] carrying its value,
 //! where it came from, its lookup state, and whether the user has excluded it
-//! from triangulation. The UI iterates and renders; all of the per-signal
-//! state derivation lives here.
+//! from triangulation. The UI iterates and renders.
 //!
-//! Built by [`crate::identify::IdentifyState::toolbar`] and broadcast alongside
-//! each identify-state transition.
+//! This module defines the badge types. The per-signal state derivation that
+//! produces them from `IdentifyState` lives in [`super::state`], built by
+//! [`crate::identify::IdentifyState::toolbar`] and broadcast alongside each
+//! identify-state transition.
 
 use crate::signals::{LookupFailure, SignalOrigin};
 


### PR DESCRIPTION
Two stale doc references in `identify/`:

`toolbar.rs`'s module doc claimed the per-signal toolbar projection lived there,
but it lives in `state.rs`. Relocating it would mean widening the
reducer-private `IdentifyState::context_cloned` to `pub(super)` purely to enable
the move — the projection reads the reducer's carried context, so it belongs
with the reducer. The doc now points at `super::state` instead.

`state.rs` also named a phantom `Error` state in two comments (the `toolbar`
method doc and the `with_toggled` comment). `IdentifyState` has no `Error`
variant; only `Idle` lacks a context, and thus a toolbar. Corrected both.

Doc/comment-only; no code change.

## Test plan
- `cargo clippy -p bae-core --all-targets` clean; `cargo test -p bae-core --features test-utils -- --test-threads=1`: 980 passed, unchanged.
