### PR TITLE
Extract WatchedFolderControl from ImportServiceHandle

### DIFF
--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -16,6 +16,9 @@ mod import;
 mod scan;
 mod search;
 mod watch;
+mod watched_folders;
+
+use watched_folders::WatchedFolderControl;
 
 #[cfg(test)]
 mod tests;
@@ -154,12 +157,12 @@ pub struct ImportServiceHandle {
     pub progress_handle: ImportProgressHandle,
     pub library_manager: LibraryManager,
     pub runtime_handle: tokio::runtime::Handle,
-    pub watcher_tx: mpsc::UnboundedSender<WatcherCommand>,
     /// Unified event channel — all import service events go here.
     pub event_tx: broadcast::Sender<ImportEvent>,
-    /// The persistent watched-folder list. Mutated by `add_watched_folder` /
-    /// `remove_watched_folder`, which persist it and broadcast the new list.
-    pub folder_registry: Arc<Mutex<ImportFolderRegistry>>,
+    /// The watched-folders / scan-driving surface: the watched-folder list, the
+    /// folder-watcher command channel, and the shared handles those methods
+    /// need. The public watched-folder methods delegate here.
+    watched_folders: WatchedFolderControl,
     cover_art_archive: CoverArtArchiveClient,
 }
 
@@ -212,14 +215,20 @@ impl ImportServiceHandle {
     ) -> Self {
         let progress_handle =
             ImportProgressHandle::new(event_tx.subscribe(), runtime_handle.clone());
+        let watched_folders = WatchedFolderControl::new(
+            folder_registry,
+            watcher_tx,
+            event_tx.clone(),
+            runtime_handle.clone(),
+            library_manager.library_dir().clone(),
+        );
         Self {
             requests_tx,
             progress_handle,
             library_manager,
             runtime_handle,
-            watcher_tx,
             event_tx,
-            folder_registry,
+            watched_folders,
             cover_art_archive,
         }
     }

--- a/bae-core/src/import/handle/scan.rs
+++ b/bae-core/src/import/handle/scan.rs
@@ -6,43 +6,12 @@ impl ImportServiceHandle {
     /// A no-op request (already in the requested state) persists nothing and
     /// emits no event.
     pub fn set_candidate_skipped(&self, path: String, skipped: bool) -> Result<(), String> {
-        let library_dir = self.library_manager.library_dir();
-        let mut registry = self.folder_registry.lock().unwrap();
-        let changed = registry.set_skipped(library_dir, path.clone(), skipped)?;
-        drop(registry);
-        if changed {
-            send_event(
-                &self.event_tx,
-                ImportEvent::Scan(ScanEvent::CandidateSkipChanged {
-                    candidate_key: path,
-                    skipped,
-                }),
-            );
-        }
-        Ok(())
+        self.watched_folders.set_candidate_skipped(path, skipped)
     }
 
     /// Subscribe to scan events, filtered from the unified event channel.
     /// Returns an mpsc receiver that yields only ScanEvent variants.
     pub fn subscribe_folder_scan_events(&self) -> mpsc::UnboundedReceiver<ScanEvent> {
-        let mut rx = self.event_tx.subscribe();
-        let (tx, out_rx) = mpsc::unbounded_channel();
-        self.runtime_handle.spawn(async move {
-            loop {
-                match rx.recv().await {
-                    Ok(ImportEvent::Scan(event)) => {
-                        if tx.send(event).is_err() {
-                            break;
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!("Scan event subscriber lagged by {n} events");
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                }
-            }
-        });
-        out_rx
+        self.watched_folders.subscribe_folder_scan_events()
     }
 }

--- a/bae-core/src/import/handle/watch.rs
+++ b/bae-core/src/import/handle/watch.rs
@@ -5,28 +5,14 @@ impl ImportServiceHandle {
     /// view appears to render the group headers, sidestepping the broadcast
     /// race (the list is durable; events only fire on later changes).
     pub fn watched_folders(&self) -> Vec<WatchedFolder> {
-        self.folder_registry.lock().unwrap().watched_folders()
+        self.watched_folders.watched_folders()
     }
 
     /// Add a folder to watch for imports: persist it, broadcast the new list,
     /// and start watching + scanning it so its releases appear as candidates and
     /// later on-disk changes propagate. A folder already watched is left as-is.
     pub fn add_watched_folder(&self, path: String) -> Result<(), String> {
-        let library_dir = self.library_manager.library_dir();
-        let mut registry = self.folder_registry.lock().unwrap();
-        let added = registry.add(library_dir, path.clone())?;
-        let folders = registry.watched_folders();
-        drop(registry);
-        if !added {
-            return Ok(());
-        }
-        send_event(
-            &self.event_tx,
-            ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
-        );
-        self.watcher_tx
-            .send(WatcherCommand::Watch(std::path::PathBuf::from(path)))
-            .map_err(|_| "Failed to start watching folder".to_string())
+        self.watched_folders.add_watched_folder(path)
     }
 
     /// Stop watching `path`: persist the removal, broadcast the new list, and
@@ -34,33 +20,13 @@ impl ImportServiceHandle {
     /// candidates by reconciling against the list, so no per-candidate removal
     /// events are needed here.
     pub fn remove_watched_folder(&self, path: String) -> Result<(), String> {
-        let library_dir = self.library_manager.library_dir();
-        let mut registry = self.folder_registry.lock().unwrap();
-        let removed = registry.remove(library_dir, &path)?;
-        let folders = registry.watched_folders();
-        drop(registry);
-        if removed {
-            send_event(
-                &self.event_tx,
-                ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
-            );
-            self.watcher_tx
-                .send(WatcherCommand::Unwatch(std::path::PathBuf::from(path)))
-                .map_err(|_| "Failed to stop watching folder".to_string())?;
-        }
-        Ok(())
+        self.watched_folders.remove_watched_folder(path)
     }
 
     /// Start watching + scanning every watched folder, emitting one
     /// `FolderCandidate` per release found and `CandidateRemoved` for any that
     /// have since vanished. The UI calls this when the import view appears.
     pub fn scan_watched_folders(&self) -> Result<(), String> {
-        let folders = self.folder_registry.lock().unwrap().watched_folders();
-        for folder in folders {
-            self.watcher_tx
-                .send(WatcherCommand::Watch(std::path::PathBuf::from(folder.path)))
-                .map_err(|_| "Failed to start watching folder".to_string())?;
-        }
-        Ok(())
+        self.watched_folders.scan_watched_folders()
     }
 }

--- a/bae-core/src/import/handle/watched_folders.rs
+++ b/bae-core/src/import/handle/watched_folders.rs
@@ -1,0 +1,127 @@
+use super::*;
+use coven::LibraryDir;
+
+/// The watched-folders / scan-driving identity split out of
+/// `ImportServiceHandle`: the persistent watched-folder list, the folder-watcher
+/// command channel, and the shared handles the scan-driving methods need, held
+/// as clones (the broadcast sender, the runtime handle, and the library dir).
+/// It never points back at `ImportServiceHandle`.
+#[derive(Clone)]
+pub(crate) struct WatchedFolderControl {
+    /// The persistent watched-folder list. Mutated by `add_watched_folder` /
+    /// `remove_watched_folder`, which persist it and broadcast the new list.
+    folder_registry: Arc<Mutex<ImportFolderRegistry>>,
+    watcher_tx: mpsc::UnboundedSender<WatcherCommand>,
+    event_tx: broadcast::Sender<ImportEvent>,
+    runtime_handle: tokio::runtime::Handle,
+    /// The library's on-disk directory, where the registry persists its
+    /// `import_folders.yaml` sibling file.
+    library_dir: LibraryDir,
+}
+
+impl WatchedFolderControl {
+    pub(crate) fn new(
+        folder_registry: Arc<Mutex<ImportFolderRegistry>>,
+        watcher_tx: mpsc::UnboundedSender<WatcherCommand>,
+        event_tx: broadcast::Sender<ImportEvent>,
+        runtime_handle: tokio::runtime::Handle,
+        library_dir: LibraryDir,
+    ) -> Self {
+        Self {
+            folder_registry,
+            watcher_tx,
+            event_tx,
+            runtime_handle,
+            library_dir,
+        }
+    }
+
+    pub(crate) fn watched_folders(&self) -> Vec<WatchedFolder> {
+        self.folder_registry.lock().unwrap().watched_folders()
+    }
+
+    pub(crate) fn add_watched_folder(&self, path: String) -> Result<(), String> {
+        let library_dir = &self.library_dir;
+        let mut registry = self.folder_registry.lock().unwrap();
+        let added = registry.add(library_dir, path.clone())?;
+        let folders = registry.watched_folders();
+        drop(registry);
+        if !added {
+            return Ok(());
+        }
+        send_event(
+            &self.event_tx,
+            ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
+        );
+        self.watcher_tx
+            .send(WatcherCommand::Watch(std::path::PathBuf::from(path)))
+            .map_err(|_| "Failed to start watching folder".to_string())
+    }
+
+    pub(crate) fn remove_watched_folder(&self, path: String) -> Result<(), String> {
+        let library_dir = &self.library_dir;
+        let mut registry = self.folder_registry.lock().unwrap();
+        let removed = registry.remove(library_dir, &path)?;
+        let folders = registry.watched_folders();
+        drop(registry);
+        if removed {
+            send_event(
+                &self.event_tx,
+                ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
+            );
+            self.watcher_tx
+                .send(WatcherCommand::Unwatch(std::path::PathBuf::from(path)))
+                .map_err(|_| "Failed to stop watching folder".to_string())?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn scan_watched_folders(&self) -> Result<(), String> {
+        let folders = self.folder_registry.lock().unwrap().watched_folders();
+        for folder in folders {
+            self.watcher_tx
+                .send(WatcherCommand::Watch(std::path::PathBuf::from(folder.path)))
+                .map_err(|_| "Failed to start watching folder".to_string())?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_candidate_skipped(&self, path: String, skipped: bool) -> Result<(), String> {
+        let library_dir = &self.library_dir;
+        let mut registry = self.folder_registry.lock().unwrap();
+        let changed = registry.set_skipped(library_dir, path.clone(), skipped)?;
+        drop(registry);
+        if changed {
+            send_event(
+                &self.event_tx,
+                ImportEvent::Scan(ScanEvent::CandidateSkipChanged {
+                    candidate_key: path,
+                    skipped,
+                }),
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn subscribe_folder_scan_events(&self) -> mpsc::UnboundedReceiver<ScanEvent> {
+        let mut rx = self.event_tx.subscribe();
+        let (tx, out_rx) = mpsc::unbounded_channel();
+        self.runtime_handle.spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(ImportEvent::Scan(event)) => {
+                        if tx.send(event).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!("Scan event subscriber lagged by {n} events");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        out_rx
+    }
+}


### PR DESCRIPTION
`ImportServiceHandle` carried the watched-folders responsibility — the registry
of watched roots, the watcher command channel, and the scan-driving methods —
bundled with its search/import/token surface. This extracts that identity into a
`WatchedFolderControl` (`import/handle/watched_folders.rs`), in the same shape as
the merged `SyncController`: it owns `folder_registry` and `watcher_tx` and holds
clones of the shared `event_tx`/`runtime_handle` plus the narrow `LibraryDir` the
registry's save path needs — never a pointer back to the handle.

`ImportServiceHandle` keeps one `watched_folders` field and delegates
`watched_folders` / `add_watched_folder` / `remove_watched_folder` /
`scan_watched_folders` / `set_candidate_skipped` / `subscribe_folder_scan_events`
with their exact signatures, so bae-bridge and tests are untouched. The only edit
to the moved bodies was `self.library_manager.library_dir()` → `&self.library_dir`.

## Test plan
- `cargo clippy -p bae-core --all-targets` clean; `cargo fmt` clean.
- `cargo test -p bae-core --features test-utils -- --test-threads=1`: 980 passed, identical before and after.
