### PR TITLE
Extract DiscogsCredentials from LibraryManager

### DIFF
--- a/bae-core/src/library/discogs_credentials.rs
+++ b/bae-core/src/library/discogs_credentials.rs
@@ -1,0 +1,139 @@
+//! The Discogs-credentials responsibility extracted from [`LibraryManager`]: the
+//! stored API key (keyring-backed) and its validation state (config-backed),
+//! plus the client built from them.
+//!
+//! `LibraryManager` holds one `DiscogsCredentials` and delegates its public
+//! Discogs API to it. The type never references the manager back; it touches
+//! only the config handle (validation state) and the key service (the key
+//! itself).
+
+use std::sync::Arc;
+
+use crate::config::ConfigHandle;
+use crate::keys::{BaeKeyServiceExt, KeyService};
+
+/// Owns the Discogs API key and its validation state. Holds clones of the two
+/// handles those touch — the config handle (stored-key hint + validation) and
+/// the key service (the keyring-backed key). Cloned alongside the manager; both
+/// fields are themselves clone-shared handles.
+#[derive(Clone)]
+pub(crate) struct DiscogsCredentials {
+    config_handle: Arc<ConfigHandle>,
+    key_service: KeyService,
+}
+
+impl DiscogsCredentials {
+    pub(crate) fn new(config_handle: Arc<ConfigHandle>, key_service: KeyService) -> Self {
+        Self {
+            config_handle,
+            key_service,
+        }
+    }
+
+    pub(crate) fn has_discogs_token(&self) -> bool {
+        self.config_handle.has_discogs_key()
+    }
+
+    pub(crate) fn get_discogs_token(&self) -> Result<Option<String>, String> {
+        self.key_service
+            .get_discogs_key()
+            .map_err(|e| e.to_string())
+    }
+
+    pub(crate) fn save_discogs_key(&self, token: &str) -> Result<(), String> {
+        self.key_service
+            .set_discogs_key(token)
+            .map_err(|e| e.to_string())
+    }
+
+    pub(crate) fn delete_discogs_key(&self) -> Result<(), String> {
+        self.key_service
+            .delete_discogs_key()
+            .map_err(|e| e.to_string())
+    }
+
+    /// Record a stored key with its validation state — the single write for the
+    /// save path. `Some(validation)` is both the stored-key hint and the state,
+    /// so one `update` keeps them consistent and fires one watch-channel
+    /// notification.
+    pub(crate) fn set_discogs_key_stored(
+        &self,
+        validation: crate::config::DiscogsValidation,
+    ) -> Result<(), crate::config::ConfigError> {
+        self.config_handle.update(|c| c.discogs = Some(validation))
+    }
+
+    /// Clear the stored-key state — no key, so no validation.
+    pub(crate) fn clear_discogs_key_stored(&self) -> Result<(), crate::config::ConfigError> {
+        self.config_handle.update(|c| c.discogs = None)
+    }
+
+    /// Update the stored key's validation state. No-op when no key is stored —
+    /// validation describes a key that exists.
+    pub(crate) fn set_discogs_validation(
+        &self,
+        validation: crate::config::DiscogsValidation,
+    ) -> Result<(), crate::config::ConfigError> {
+        self.config_handle.update(|c| {
+            if c.discogs.is_some() {
+                c.discogs = Some(validation);
+            }
+        })
+    }
+
+    pub(crate) fn discogs_validation(&self) -> Option<crate::config::DiscogsValidation> {
+        self.config_handle.config().discogs
+    }
+
+    /// An observer that folds a Discogs call's outcome into the stored key's
+    /// validation, so every call site updates the stored validation state
+    /// without recording the outcome itself. A 401 marks it `Rejected`; a
+    /// success while it was `Unvalidated` confirms it `Valid`; any other outcome
+    /// (network, rate-limit, success while already settled, or no key stored)
+    /// leaves it untouched. Injected into the client by [`Self::discogs_client`].
+    pub(crate) fn discogs_validation_observer(
+        &self,
+    ) -> crate::discogs::client::DiscogsValidationObserver {
+        use crate::config::DiscogsValidation;
+        use crate::discogs::client::DiscogsKeySignal;
+        let config_handle = self.config_handle.clone();
+        std::sync::Arc::new(move |signal| {
+            let Some(current) = config_handle.config().discogs else {
+                // The key was removed while a Discogs call was in flight: the
+                // client outlives the config entry it was built from. Nothing to
+                // fold the outcome into.
+                tracing::debug!("discogs validation signal ignored: no key stored");
+                return;
+            };
+            let next = match signal {
+                DiscogsKeySignal::Rejected => DiscogsValidation::Rejected,
+                DiscogsKeySignal::Accepted if current == DiscogsValidation::Unvalidated => {
+                    DiscogsValidation::Valid
+                }
+                _ => return,
+            };
+            if current == next {
+                return;
+            }
+            if let Err(e) = config_handle.update(|c| c.discogs = Some(next)) {
+                tracing::warn!("failed to persist discogs validation {next:?}: {e}");
+            }
+        })
+    }
+
+    /// A client for the stored key, unless that key is `Rejected`. A `Valid` or
+    /// `Unvalidated` key is served (the latter used optimistically); a
+    /// `Rejected` key is withheld so search call sites skip Discogs entirely.
+    /// The client reports each call's outcome back into the validation state.
+    pub(crate) fn discogs_client(&self) -> Result<Option<crate::discogs::DiscogsClient>, String> {
+        if self.discogs_validation() == Some(crate::config::DiscogsValidation::Rejected) {
+            return Ok(None);
+        }
+        let observer = self.discogs_validation_observer();
+        Ok(self
+            .key_service
+            .get_discogs_key()
+            .map_err(|e| e.to_string())?
+            .map(|key| crate::discogs::DiscogsClient::with_observer(key, observer)))
+    }
+}

--- a/bae-core/src/library/manager/config.rs
+++ b/bae-core/src/library/manager/config.rs
@@ -88,25 +88,19 @@ impl LibraryManager {
     // =========================================================================
 
     pub fn has_discogs_token(&self) -> bool {
-        self.config_handle.has_discogs_key()
+        self.discogs.has_discogs_token()
     }
 
     pub fn get_discogs_token(&self) -> Result<Option<String>, String> {
-        self.key_service
-            .get_discogs_key()
-            .map_err(|e| e.to_string())
+        self.discogs.get_discogs_token()
     }
 
     pub fn save_discogs_key(&self, token: &str) -> Result<(), String> {
-        self.key_service
-            .set_discogs_key(token)
-            .map_err(|e| e.to_string())
+        self.discogs.save_discogs_key(token)
     }
 
     pub fn delete_discogs_key(&self) -> Result<(), String> {
-        self.key_service
-            .delete_discogs_key()
-            .map_err(|e| e.to_string())
+        self.discogs.delete_discogs_key()
     }
 
     /// Record a stored key with its validation state — the single write for the
@@ -117,12 +111,12 @@ impl LibraryManager {
         &self,
         validation: crate::config::DiscogsValidation,
     ) -> Result<(), crate::config::ConfigError> {
-        self.config_handle.update(|c| c.discogs = Some(validation))
+        self.discogs.set_discogs_key_stored(validation)
     }
 
     /// Clear the stored-key state — no key, so no validation.
     pub fn clear_discogs_key_stored(&self) -> Result<(), crate::config::ConfigError> {
-        self.config_handle.update(|c| c.discogs = None)
+        self.discogs.clear_discogs_key_stored()
     }
 
     /// Update the stored key's validation state. No-op when no key is stored —
@@ -131,51 +125,11 @@ impl LibraryManager {
         &self,
         validation: crate::config::DiscogsValidation,
     ) -> Result<(), crate::config::ConfigError> {
-        self.config_handle.update(|c| {
-            if c.discogs.is_some() {
-                c.discogs = Some(validation);
-            }
-        })
+        self.discogs.set_discogs_validation(validation)
     }
 
     pub fn discogs_validation(&self) -> Option<crate::config::DiscogsValidation> {
-        self.config_handle.config().discogs
-    }
-
-    /// An observer that folds a Discogs call's outcome into the stored key's
-    /// validation, so every call site updates the stored validation state
-    /// without recording the outcome itself. A 401 marks it `Rejected`; a
-    /// success while it was `Unvalidated` confirms it `Valid`; any other outcome
-    /// (network, rate-limit, success while already settled, or no key stored)
-    /// leaves it untouched. Injected into the client by [`Self::discogs_client`].
-    pub(crate) fn discogs_validation_observer(
-        &self,
-    ) -> crate::discogs::client::DiscogsValidationObserver {
-        use crate::config::DiscogsValidation;
-        use crate::discogs::client::DiscogsKeySignal;
-        let config_handle = self.config_handle.clone();
-        std::sync::Arc::new(move |signal| {
-            let Some(current) = config_handle.config().discogs else {
-                // The key was removed while a Discogs call was in flight: the
-                // client outlives the config entry it was built from. Nothing to
-                // fold the outcome into.
-                tracing::debug!("discogs validation signal ignored: no key stored");
-                return;
-            };
-            let next = match signal {
-                DiscogsKeySignal::Rejected => DiscogsValidation::Rejected,
-                DiscogsKeySignal::Accepted if current == DiscogsValidation::Unvalidated => {
-                    DiscogsValidation::Valid
-                }
-                _ => return,
-            };
-            if current == next {
-                return;
-            }
-            if let Err(e) = config_handle.update(|c| c.discogs = Some(next)) {
-                tracing::warn!("failed to persist discogs validation {next:?}: {e}");
-            }
-        })
+        self.discogs.discogs_validation()
     }
 
     /// A client for the stored key, unless that key is `Rejected`. A `Valid` or
@@ -183,14 +137,6 @@ impl LibraryManager {
     /// `Rejected` key is withheld so search call sites skip Discogs entirely.
     /// The client reports each call's outcome back into the validation state.
     pub fn discogs_client(&self) -> Result<Option<crate::discogs::DiscogsClient>, String> {
-        if self.discogs_validation() == Some(crate::config::DiscogsValidation::Rejected) {
-            return Ok(None);
-        }
-        let observer = self.discogs_validation_observer();
-        Ok(self
-            .key_service
-            .get_discogs_key()
-            .map_err(|e| e.to_string())?
-            .map(|key| crate::discogs::DiscogsClient::with_observer(key, observer)))
+        self.discogs.discogs_client()
     }
 }

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -42,6 +42,7 @@ use crate::db::{
 };
 use crate::keys::BaeKeyServiceExt;
 use crate::keys::KeyService;
+use crate::library::discogs_credentials::DiscogsCredentials;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 use crate::library::export::ExportService;
 use crate::library::sync_controller::SyncController;
@@ -568,6 +569,10 @@ pub struct LibraryManager {
     /// encryption-service cell, membership, and the coven make-Remote/make-Local
     /// primitives. The manager delegates its public sync API here.
     sync: SyncController,
+    /// The Discogs-credentials responsibility: the stored API key (keyring) and
+    /// its validation state (config), plus the client built from them. The
+    /// manager delegates its public Discogs API here.
+    discogs: DiscogsCredentials,
     /// Cancellation tokens for in-progress foreground transfers (unmanage),
     /// keyed by release id. `cancel_release_transition` fires the token; the
     /// transfer observes it between files, deletes the partial copies it wrote,
@@ -619,6 +624,7 @@ impl Clone for LibraryManager {
             handle: self.handle.clone(),
             event_tx: self.event_tx.clone(),
             sync: self.sync.clone(),
+            discogs: self.discogs.clone(),
             transfer_cancels: self.transfer_cancels.clone(),
             download_queue: self.download_queue.clone(),
             #[cfg(any(test, feature = "test-utils"))]
@@ -681,6 +687,8 @@ impl LibraryManager {
             sync_connected,
         );
 
+        let discogs = DiscogsCredentials::new(config_handle.clone(), key_service.clone());
+
         Ok(LibraryManager {
             database,
             library_dir,
@@ -692,6 +700,7 @@ impl LibraryManager {
             handle,
             event_tx,
             sync,
+            discogs,
             transfer_cancels: Arc::new(Mutex::new(HashMap::new())),
             download_queue: Arc::new(crate::library::DownloadQueue::new()),
             #[cfg(any(test, feature = "test-utils"))]
@@ -729,6 +738,8 @@ impl LibraryManager {
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
         );
 
+        let discogs = DiscogsCredentials::new(config_handle.clone(), key_service.clone());
+
         LibraryManager {
             database,
             library_dir,
@@ -740,6 +751,7 @@ impl LibraryManager {
             handle,
             event_tx,
             sync,
+            discogs,
             transfer_cancels: Arc::new(Mutex::new(HashMap::new())),
             download_queue: Arc::new(crate::library::DownloadQueue::new()),
             #[cfg(any(test, feature = "test-utils"))]

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -3382,7 +3382,7 @@ async fn discogs_validation_observer_confirms_and_rejects() {
     use crate::config::DiscogsValidation;
     use crate::discogs::client::DiscogsKeySignal;
     let (manager, _temp_dir) = setup_test_manager().await;
-    let observe = manager.discogs_validation_observer();
+    let observe = manager.discogs.discogs_validation_observer();
 
     // A success confirms a stored Unvalidated key.
     manager

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_services;
+mod discogs_credentials;
 pub mod download_queue;
 pub mod download_snapshot;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]


### PR DESCRIPTION
`LibraryManager` carried a Discogs-credentials concern — the API token and its
validation state machine — inside its config surface. This extracts it into a
`DiscogsCredentials` (`library/discogs_credentials.rs`), in the same shape as
`SyncController`: it holds clones of `config_handle` and `key_service` (the only
things these methods touch — no database, coven handle, or event bus, and no
back-pointer). `LibraryManager` keeps one `discogs` field and delegates the ten
public methods with identical signatures and visibility, so bae-bridge and the
import callers are untouched.

`discogs_validation_observer` is consumed in production by `discogs_client` and
otherwise only by one test; rather than introduce a manager-level delegator that
would be dead outside tests, the test reaches `manager.discogs` directly — the
same precedent SyncController set for its test-only accessors.

## Test plan
- `cargo clippy -p bae-core --all-targets` clean; `cargo fmt` no-op.
- `cargo test -p bae-core --features test-utils -- --test-threads=1`: pass count identical before and after (no test functions added/removed).
