### PR TITLE
Read connection and encryption state from coven instead of mirroring it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=6d450fffd8bdad9dbd60e15743acfa47e376d3a3#6d450fffd8bdad9dbd60e15743acfa47e376d3a3"
+source = "git+https://github.com/bae-fm/coven?rev=61d0d1071389cff8a275f36cb6223eec9e2b441c#61d0d1071389cff8a275f36cb6223eec9e2b441c"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "6d450fffd8bdad9dbd60e15743acfa47e376d3a3" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "61d0d1071389cff8a275f36cb6223eec9e2b441c" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -635,8 +635,6 @@ impl LibraryManager {
         let outbox_in_flight = Arc::new(Mutex::new(HashMap::new()));
         let upload_throughput = Arc::new(crate::library::UploadThroughput::new());
         let sync_paused = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let sync_connected = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let encryption_service = Arc::new(RwLock::new(None));
 
         let observer = Arc::new(crate::sync::upload_observer::ReleaseUploadObserver::new(
             outbox_in_flight.clone(),
@@ -668,11 +666,9 @@ impl LibraryManager {
             key_service.clone(),
             event_tx.clone(),
             database.clone(),
-            encryption_service,
             outbox_in_flight,
             upload_throughput,
             sync_paused,
-            sync_connected,
         );
 
         let discogs = DiscogsCredentials::new(config_handle.clone(), key_service.clone());
@@ -719,10 +715,8 @@ impl LibraryManager {
             key_service.clone(),
             event_tx.clone(),
             database.clone(),
-            Arc::new(RwLock::new(None)),
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(crate::library::UploadThroughput::new()),
-            Arc::new(std::sync::atomic::AtomicBool::new(false)),
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
         );
 

--- a/bae-core/src/library/sync_controller.rs
+++ b/bae-core/src/library/sync_controller.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
@@ -40,9 +40,6 @@ pub(crate) struct SyncController {
     key_service: KeyService,
     event_tx: broadcast::Sender<LibraryEvent>,
     database: Database,
-    /// The active encryption service for opaque homes, kept for UI state and
-    /// tests that seed encrypted fixtures. Browsable homes leave this empty.
-    encryption_service: Arc<RwLock<Option<EncryptionService>>>,
     /// `file_id`s whose upload is in flight right now, mapped to the live count
     /// of encrypted bytes that have reached the cloud for that file. Shared with
     /// the sync loop's `ReleaseUploadObserver`. Read by `outbox_snapshot`.
@@ -52,8 +49,6 @@ pub(crate) struct SyncController {
     upload_throughput: Arc<UploadThroughput>,
     /// User-driven pause flag for the cloud-upload pipeline.
     sync_paused: Arc<AtomicBool>,
-    /// Whether a sync manager is installed in the coven handle.
-    sync_connected: Arc<AtomicBool>,
 }
 
 impl SyncController {
@@ -64,11 +59,9 @@ impl SyncController {
         key_service: KeyService,
         event_tx: broadcast::Sender<LibraryEvent>,
         database: Database,
-        encryption_service: Arc<RwLock<Option<EncryptionService>>>,
         outbox_in_flight: Arc<Mutex<HashMap<String, u64>>>,
         upload_throughput: Arc<UploadThroughput>,
         sync_paused: Arc<AtomicBool>,
-        sync_connected: Arc<AtomicBool>,
     ) -> Self {
         Self {
             handle,
@@ -76,11 +69,9 @@ impl SyncController {
             key_service,
             event_tx,
             database,
-            encryption_service,
             outbox_in_flight,
             upload_throughput,
             sync_paused,
-            sync_connected,
         }
     }
 
@@ -92,21 +83,12 @@ impl SyncController {
         }
     }
 
-    fn sync_connected(&self) -> bool {
-        self.sync_connected
-            .load(std::sync::atomic::Ordering::SeqCst)
-    }
-
-    fn encryption_service_inner(&self) -> Option<EncryptionService> {
-        self.encryption_service.read().unwrap().clone()
-    }
-
     pub(crate) fn has_encryption(&self) -> bool {
-        self.encryption_service_inner().is_some()
+        self.handle.encryption_service().is_some()
     }
 
     pub(crate) fn get_encryption_service(&self) -> Option<EncryptionService> {
-        self.encryption_service_inner()
+        self.handle.encryption_service()
     }
 
     /// The shared upload-in-flight map, for tests that drive the outbox snapshot
@@ -143,7 +125,7 @@ impl SyncController {
     }
 
     pub(crate) fn has_cloud_home(&self) -> bool {
-        self.sync_connected()
+        self.handle.is_connected()
     }
 
     /// Whether the background sync loop is running and draining uploads. The
@@ -151,7 +133,7 @@ impl SyncController {
     /// release only becomes remote once the upload observer (which fires from
     /// inside the running loop) confirms the last upload landed.
     pub(crate) fn is_sync_ready(&self) -> bool {
-        self.sync_connected() && self.handle.is_syncing()
+        self.handle.is_syncing()
     }
 
     pub(crate) fn trigger_sync(&self) {
@@ -525,9 +507,6 @@ impl SyncController {
         // Stop the sync loop and drop the installed manager; the library becomes
         // home-less until the next connect.
         self.handle.disconnect_sync();
-        self.sync_connected
-            .store(false, std::sync::atomic::Ordering::SeqCst);
-        *self.encryption_service.write().unwrap() = None;
 
         // Connecting fills the whole cloud home; disconnecting clears it as a unit.
         self.config_handle
@@ -550,10 +529,7 @@ impl SyncController {
         &self,
         encryption_service: Option<EncryptionService>,
     ) -> Result<(), String> {
-        self.handle.connect_sync(encryption_service.clone()).await?;
-        *self.encryption_service.write().unwrap() = encryption_service;
-        self.sync_connected
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.handle.connect_sync(encryption_service).await?;
         Ok(())
     }
 
@@ -570,23 +546,16 @@ impl SyncController {
         cloud_home: Arc<dyn CloudHome>,
         cipher: crate::sync::CloudCipher,
     ) -> Result<(), String> {
-        let active_encryption = match &cipher {
-            crate::sync::CloudCipher::Encrypted(service) => Some(service.clone()),
-            crate::sync::CloudCipher::Plaintext => None,
-        };
         self.handle
             .connect_sync_with_test_home(cloud_home, cipher)
             .await?;
-        *self.encryption_service.write().unwrap() = active_encryption;
-        self.sync_connected
-            .store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 
     /// Ensure a SyncManager exists (creating encryption key if needed) and start sync.
     async fn ensure_sync_manager_and_start(&self) -> Result<(), String> {
         // If we already have a sync manager, just (re)start its loop.
-        if self.sync_connected() {
+        if self.handle.is_connected() {
             self.handle.start_sync().await?;
             return Ok(());
         }
@@ -616,10 +585,7 @@ impl SyncController {
         // — and the encryption-key fingerprint below is reached only on success, so
         // a failed setup stays a clean retry (no fingerprint telling the next
         // launch's unlock flow "encryption is set up" while sync is still broken).
-        self.handle.connect_sync(enc_service.clone()).await?;
-        *self.encryption_service.write().unwrap() = enc_service;
-        self.sync_connected
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.handle.connect_sync(enc_service).await?;
 
         // Sync started. For an opaque home, persist the encryption-key hint flag so
         // the next launch's unlock flow knows this library has encryption set up. A
@@ -631,9 +597,6 @@ impl SyncController {
                 .record_encryption_key_fingerprint(fingerprint)
             {
                 self.handle.disconnect_sync();
-                *self.encryption_service.write().unwrap() = None;
-                self.sync_connected
-                    .store(false, std::sync::atomic::Ordering::SeqCst);
                 return Err(format!("Failed to save config: {e}"));
             }
         }


### PR DESCRIPTION
Resolves #182. `SyncController` hand-maintained a `sync_connected: AtomicBool`
and a cached `encryption_service` that shadowed state coven's `CovenHandle`
already owns — kept in step only by convention, so any change to coven's manager
lifecycle could silently desync them.

coven now exposes the accessors (rev bumped `6d450ff` → `61d0d10`), so the two
fields, their constructor params, and every store/clear site are deleted and the
readers go to coven: `has_cloud_home` → `handle.is_connected()`,
`has_encryption`/`get_encryption_service` → `handle.encryption_service()`,
`is_sync_ready` → `handle.is_syncing()` (the old `sync_connected &&` conjunct was
redundant). `is_sync_configured` stays config-based by design. One source of
truth.

## Test plan
- bae-core and bae-bridge both build against the new coven (the `MemberInfo`
  re-export held; no caller edits needed).
- `cargo clippy -p bae-core --all-targets` clean; `cargo fmt` no-op.
- `cargo test -p bae-core --features test-utils -- --test-threads=1`: 980 passed, identical before/after (sync connect/disconnect/encryption suites green).
