### PR TITLE
Remove dead mobile import start and banned serde(default)

### DIFF
--- a/bae-core/src/import/folder_registry.rs
+++ b/bae-core/src/import/folder_registry.rs
@@ -49,10 +49,7 @@ pub struct ImportFolderRegistry {
     folders: Vec<String>,
     /// Candidate folder paths the user manually marked as skipped. A skipped
     /// candidate still scans but renders under the import view's "Skipped" tab
-    /// instead of "New". `#[serde(default)]` so an `import_folders.yaml` that
-    /// omits this field (only `folders`) still loads as an empty skip set
-    /// instead of failing to deserialize.
-    #[serde(default)]
+    /// instead of "New".
     skipped: Vec<String>,
 }
 
@@ -300,12 +297,11 @@ mod tests {
     }
 
     #[test]
-    fn loads_file_omitting_skipped_field() {
-        // An `import_folders.yaml` that omits the `skipped` field (only
-        // `folders`) must still load, defaulting to an empty skip set.
+    fn loads_file_with_both_fields() {
+        // An `import_folders.yaml` carrying both fields loads as written.
         let (_tmp, library_dir) = temp_library_dir();
         let path = ImportFolderRegistry::file_path(&library_dir);
-        std::fs::write(&path, "folders:\n  - /a\n").unwrap();
+        std::fs::write(&path, "folders:\n  - /a\nskipped:\n  - /a/Album\n").unwrap();
 
         let registry = ImportFolderRegistry::load(&library_dir);
         assert_eq!(
@@ -315,6 +311,7 @@ mod tests {
                 name: "a".to_string(),
             }]
         );
+        assert!(registry.is_skipped("/a/Album"));
         assert!(!registry.is_skipped("/a"));
     }
 }

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -76,31 +76,10 @@ fn storage_mode_label(mode: &StorageMode) -> &'static str {
 /// Send an import event on the broadcast bus, logging on send failure.
 use crate::import::handle::send_event;
 
-#[cfg_attr(any(target_os = "ios", target_os = "android"), allow(dead_code))]
 pub struct ImportService {
     commands_rx: mpsc::UnboundedReceiver<ImportCommand>,
     event_tx: broadcast::Sender<crate::import::handle::ImportEvent>,
     library_manager: LibraryManager,
-}
-
-#[cfg(any(target_os = "ios", target_os = "android"))]
-impl ImportService {
-    pub fn start(
-        _runtime_handle: tokio::runtime::Handle,
-        library_manager: LibraryManager,
-    ) -> ImportServiceHandle {
-        let (commands_tx, _commands_rx) = mpsc::unbounded_channel();
-        let (scan_tx, _scan_rx) = mpsc::unbounded_channel();
-        let (event_tx, _) = broadcast::channel(1024);
-
-        ImportServiceHandle::new(
-            commands_tx,
-            library_manager,
-            _runtime_handle,
-            scan_tx,
-            event_tx,
-        )
-    }
 }
 
 /// The watched roots that contain at least one of the `changed` paths, in


### PR DESCRIPTION
Resolves #189 and #191. Removes the dead `#[cfg(any(ios,android))] ImportService::start` (it compiled on no target — the module is desktop-only — and called `new` with the wrong arg count) and the banned conditional `#[allow(dead_code)]` on the struct; and removes the greenfield-banned `#[serde(default)]` on `ImportFolderRegistry.skipped` (one test fixture updated to write the field rather than rely on the default).

## Test plan
- clippy clean (no dead-code warning after removing the allow); folder_registry tests pass; 985 total, unchanged.
