### PR TITLE
Split library-lifecycle ops out of manager config.rs

### DIFF
--- a/bae-core/src/library/manager/config.rs
+++ b/bae-core/src/library/manager/config.rs
@@ -1,4 +1,8 @@
 //! Config access and Discogs token management for [`LibraryManager`].
+//!
+//! Reads and writes config fields only. Library-lifecycle operations that
+//! mutate the on-disk library presence (rename, lock, forget) live in
+//! `lifecycle.rs`.
 
 use super::*;
 
@@ -6,36 +10,6 @@ impl LibraryManager {
     /// Get a snapshot of the current config.
     pub fn get_config(&self) -> crate::config::Config {
         self.config_handle.config().clone()
-    }
-
-    /// Rename a library by id. If the id matches the active library, the
-    /// rename goes through the reactive `ConfigState` so all current
-    /// subscribers see it. Otherwise the library's `config.yaml` on disk
-    /// is edited in place — the inactive library isn't loaded into
-    /// memory.
-    pub fn rename_library(&self, library_id: &str, name: &str) -> Result<(), String> {
-        if name.trim().is_empty() {
-            return Err("Library name cannot be empty".to_string());
-        }
-        if library_id == self.config_handle.config().library_id {
-            return self
-                .config_handle
-                .rename_library(name)
-                .map_err(|e| format!("{e}"));
-        }
-        let bae_dir = crate::config::bae_dir().map_err(|e| format!("{e}"))?;
-        crate::config::rename_inactive_library(&bae_dir, library_id, name)
-            .map_err(|e| format!("{e}"))
-    }
-
-    /// Forget the active library's encryption key. The running
-    /// `sync_manager` still holds the key in memory so this session
-    /// keeps working; the next launch lands on `UnlockView` because
-    /// the keyring is empty. Used by the sidebar's "Lock Library" action.
-    pub fn forget_encryption_key(&self) -> Result<(), String> {
-        self.key_service
-            .forget_encryption_key()
-            .map_err(|e| format!("{e}"))
     }
 
     /// Subscribe to the config-state stream; each change yields the whole latest
@@ -48,39 +22,6 @@ impl LibraryManager {
     pub fn set_pause_between_sides(&self, enabled: bool) -> Result<(), crate::config::ConfigError> {
         self.config_handle
             .update(|c| c.pause_between_sides = enabled)
-    }
-
-    /// Forget this (local) library on this device: delete its master encryption
-    /// key, clear the active-library pointer, and remove its data directory. The
-    /// owner's cloud copy (if any) is untouched — this only drops the device's
-    /// local presence.
-    ///
-    /// The caller must drop this handle immediately afterward: the database
-    /// lives in the directory being removed, so this must be the handle's last
-    /// operation. The next launch re-discovers and opens another library (or
-    /// onboards) since the active pointer is gone.
-    pub fn forget_library(&self) -> Result<(), String> {
-        if let Err(e) = self.key_service.delete_encryption_key() {
-            warn!("Failed to delete encryption key while forgetting library: {e}");
-        }
-
-        let library_id = self.config_handle.config().library_id.clone();
-        let bae_dir = crate::config::bae_dir().map_err(|e| e.to_string())?;
-
-        let active_pointer = bae_dir.join("active-library");
-        if active_pointer.exists() {
-            if let Err(e) = std::fs::remove_file(&active_pointer) {
-                warn!("Failed to clear active-library pointer: {e}");
-            }
-        }
-
-        if let Some(dir) = crate::config::library_data_dir(&bae_dir, &library_id) {
-            if let Err(e) = std::fs::remove_dir_all(&dir) {
-                warn!("Failed to remove library data at {}: {e}", dir.display());
-            }
-        }
-
-        Ok(())
     }
 
     // =========================================================================

--- a/bae-core/src/library/manager/lifecycle.rs
+++ b/bae-core/src/library/manager/lifecycle.rs
@@ -1,0 +1,73 @@
+//! Library-lifecycle operations for [`LibraryManager`]: rename a library,
+//! lock it (forget the active encryption key), and forget a local library
+//! (drop the master key, clear the active-library pointer, and remove its
+//! data directory). These mutate the library's on-disk presence and the
+//! active-library pointer — distinct from the config-access surface in
+//! `config.rs`, which only reads and writes config fields.
+
+use super::*;
+
+impl LibraryManager {
+    /// Rename a library by id. If the id matches the active library, the
+    /// rename goes through the reactive `ConfigState` so all current
+    /// subscribers see it. Otherwise the library's `config.yaml` on disk
+    /// is edited in place — the inactive library isn't loaded into
+    /// memory.
+    pub fn rename_library(&self, library_id: &str, name: &str) -> Result<(), String> {
+        if name.trim().is_empty() {
+            return Err("Library name cannot be empty".to_string());
+        }
+        if library_id == self.config_handle.config().library_id {
+            return self
+                .config_handle
+                .rename_library(name)
+                .map_err(|e| format!("{e}"));
+        }
+        let bae_dir = crate::config::bae_dir().map_err(|e| format!("{e}"))?;
+        crate::config::rename_inactive_library(&bae_dir, library_id, name)
+            .map_err(|e| format!("{e}"))
+    }
+
+    /// Forget the active library's encryption key. The running
+    /// `sync_manager` still holds the key in memory so this session
+    /// keeps working; the next launch lands on `UnlockView` because
+    /// the keyring is empty. Used by the sidebar's "Lock Library" action.
+    pub fn forget_encryption_key(&self) -> Result<(), String> {
+        self.key_service
+            .forget_encryption_key()
+            .map_err(|e| format!("{e}"))
+    }
+
+    /// Forget this (local) library on this device: delete its master encryption
+    /// key, clear the active-library pointer, and remove its data directory. The
+    /// owner's cloud copy (if any) is untouched — this only drops the device's
+    /// local presence.
+    ///
+    /// The caller must drop this handle immediately afterward: the database
+    /// lives in the directory being removed, so this must be the handle's last
+    /// operation. The next launch re-discovers and opens another library (or
+    /// onboards) since the active pointer is gone.
+    pub fn forget_library(&self) -> Result<(), String> {
+        if let Err(e) = self.key_service.delete_encryption_key() {
+            warn!("Failed to delete encryption key while forgetting library: {e}");
+        }
+
+        let library_id = self.config_handle.config().library_id.clone();
+        let bae_dir = crate::config::bae_dir().map_err(|e| e.to_string())?;
+
+        let active_pointer = bae_dir.join("active-library");
+        if active_pointer.exists() {
+            if let Err(e) = std::fs::remove_file(&active_pointer) {
+                warn!("Failed to clear active-library pointer: {e}");
+            }
+        }
+
+        if let Some(dir) = crate::config::library_data_dir(&bae_dir, &library_id) {
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                warn!("Failed to remove library data at {}: {e}", dir.display());
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -69,6 +69,7 @@ mod export;
 mod identity;
 mod image;
 mod import;
+mod lifecycle;
 mod locality;
 mod playback_state;
 mod release;


### PR DESCRIPTION
Closes #197. Splits the library-lifecycle operations out of the "config access" module: `rename_library`, `forget_encryption_key`, and `forget_library` (filesystem/active-pointer/keyring side effects — not config reads) move to a new `manager/lifecycle.rs`; module docs updated on both. The lone-setter point is low-value (only `set_pause_between_sides` exists; no action). The error-type inconsistency is real but needs a unified lifecycle error type + bridge changes — filed as a focused follow-up. Verbatim moves; bae-core + bae-bridge build; 988 tests unchanged.
