### PR TITLE
Stabilize signals dump output and align its log prefix

### DIFF
--- a/bae-core/src/signals/dump.rs
+++ b/bae-core/src/signals/dump.rs
@@ -8,7 +8,7 @@
 use super::pool::Pool;
 use super::SourcedValue;
 use crate::identify::candidate_text::{self, Source, SourcedLine};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use tracing::warn;
 
@@ -27,7 +27,7 @@ pub(super) fn dump_scan(
     now: chrono::DateTime<chrono::Utc>,
 ) -> std::io::Result<()> {
     let Some(home) = dirs::home_dir() else {
-        warn!("candidate_text: no home dir, skipping dump");
+        warn!("signals: no home dir, skipping dump");
         return Ok(());
     };
     let dir = home.join(".bae").join("candidate-text-scans");
@@ -115,11 +115,11 @@ fn build_dump_json(
         })
         .collect();
 
-    let mut sources_artwork: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    let mut sources_artwork: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
     let mut path_components: Vec<String> = Vec::new();
     let mut filenames: Vec<serde_json::Value> = Vec::new();
     let mut cue_fields: Vec<String> = Vec::new();
-    let mut text_files: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    let mut text_files: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
     for line in &pool.lines {
         match &line.source {
             Source::Artwork(p) => {


### PR DESCRIPTION
Resolves #192 and #193. `dump_scan`s no-home-dir warning now uses the `signals:` log prefix (was `candidate_text:`), matching the rest of the extraction service. And the dump JSON `artwork`/`text_files` sections switch from `HashMap` to `BTreeMap` so they serialize in stable key order — the dump is a regression corpus, so deterministic output matters for diffing. No test asserts on dump output; 989 tests unchanged.
