### PR TITLE
Drop the redundant current_track_info cache in PlaybackService

### DIFF
--- a/bae-core/src/playback/service/advance.rs
+++ b/bae-core/src/playback/service/advance.rs
@@ -127,7 +127,11 @@ impl PlaybackService {
             return Ok(None);
         }
 
-        let Some(current) = self.current_track_info.clone() else {
+        let Some(current) = self
+            .current_prepared
+            .as_ref()
+            .map(|prepared| prepared.track_info.clone())
+        else {
             error!("side-pause decision requested without current track metadata");
             return Err(());
         };
@@ -367,7 +371,6 @@ impl PlaybackService {
             }
         }
 
-        self.current_track_info = Some(next_prepared.track_info.clone());
         self.current_prepared = Some(next_prepared);
 
         // Advance the queue position to the now-playing track.
@@ -456,8 +459,6 @@ impl PlaybackService {
                 .await;
             return;
         }
-
-        self.current_track_info = Some(next_prepared.track_info.clone());
 
         // Recover the preloaded next source (staged in the gapless chain or held
         // for the rebuild path) BEFORE tearing down the current stream.

--- a/bae-core/src/playback/service/mod.rs
+++ b/bae-core/src/playback/service/mod.rs
@@ -646,8 +646,6 @@ pub struct PlaybackService {
     /// Mute state — core tracks this so UI doesn't need to.
     is_muted: bool,
     pre_mute_volume: f32,
-    /// Cached track info for the currently playing track.
-    current_track_info: Option<PlaybackTrackInfo>,
     /// The preview player — a self-contained second player for auditioning a
     /// local file. The service only coordinates pause/resume of the main player
     /// around it; the preview's own state lives entirely in `PreviewPlayer`.
@@ -1000,7 +998,6 @@ impl PlaybackService {
                     next_prepared: None,
                     next_track_stream: None,
                     next_decoder_handle: None,
-                    current_track_info: None,
                     preview,
                     main_was_playing_before_preview: false,
                     is_muted: false,

--- a/bae-core/src/playback/service/pipeline.rs
+++ b/bae-core/src/playback/service/pipeline.rs
@@ -53,7 +53,6 @@ impl PlaybackService {
         }
         self.abort_current_listeners();
         self.current_prepared = None;
-        self.current_track_info = None;
         self.current_decoder_handle = None;
     }
 
@@ -352,7 +351,6 @@ impl PlaybackService {
         };
         let sample_rate = prepared.sample_rate;
         let channels = prepared.channels;
-        self.current_track_info = Some(prepared.track_info.clone());
         let fmt = prepared.track_fmt(position_offset);
 
         // Store prepared track state so the shared tail reads this load's buffer

--- a/bae-core/src/playback/service/preview.rs
+++ b/bae-core/src/playback/service/preview.rs
@@ -13,7 +13,7 @@ impl PlaybackService {
             self.audio_output
                 .set_state(crate::playback::audio_output::AudioState::Paused);
 
-            if self.current_prepared.is_some() && self.current_track_info.is_some() {
+            if self.current_prepared.is_some() {
                 emit_progress(
                     &self.progress_tx,
                     PlaybackProgress::StateChanged {
@@ -33,7 +33,7 @@ impl PlaybackService {
         self.audio_output
             .set_state(crate::playback::audio_output::AudioState::Playing);
 
-        if self.current_prepared.is_some() && self.current_track_info.is_some() {
+        if self.current_prepared.is_some() {
             emit_progress(
                 &self.progress_tx,
                 PlaybackProgress::StateChanged {

--- a/bae-core/src/playback/service/state.rs
+++ b/bae-core/src/playback/service/state.rs
@@ -36,12 +36,11 @@ impl PlaybackService {
     /// prepared track. Position data is excluded — it flows through
     /// PositionUpdate/Seeked events.
     pub(super) fn current_state_fields(&self) -> (PlaybackTrackInfo, u64) {
-        let track_info = self
-            .current_track_info
-            .clone()
-            .expect("no current_track_info");
         let prepared = self.current_prepared.as_ref().expect("no current_prepared");
-        (track_info, pregap_adjusted_duration(prepared))
+        (
+            prepared.track_info.clone(),
+            pregap_adjusted_duration(prepared),
+        )
     }
 
     /// Build a Playing state from the current prepared track and track info.
@@ -302,7 +301,7 @@ impl PlaybackService {
         self.pending_side_pause = None;
         self.audio_output
             .set_state(crate::playback::audio_output::AudioState::Paused);
-        if self.current_prepared.is_some() && self.current_track_info.is_some() {
+        if self.current_prepared.is_some() {
             emit_progress(
                 &self.progress_tx,
                 PlaybackProgress::StateChanged {
@@ -326,7 +325,7 @@ impl PlaybackService {
 
         self.audio_output
             .set_state(crate::playback::audio_output::AudioState::Playing);
-        if self.current_prepared.is_some() && self.current_track_info.is_some() {
+        if self.current_prepared.is_some() {
             emit_progress(
                 &self.progress_tx,
                 PlaybackProgress::StateChanged {


### PR DESCRIPTION
Resolves #198. `PlaybackService.current_track_info` was a redundant cache of `current_prepared.track_info` — set/cleared in lockstep with `current_prepared` at every write site (pipeline + the two advance.rs boundary paths). The field and its writes are removed; readers source `track_info` from `current_prepared`, and the four `&& current_track_info.is_some()` guards collapse to `current_prepared.is_some()`. One access path to the state. (It also removes a brief window where the cache could be set while `current_prepared` still held the old track.)

## Test plan
- clippy clean; 989 tests unchanged.
