### PR TITLE
Model the outbox operation domain and refine the displayed subset explicitly

### DIFF
--- a/bae-core/src/db/client/blobs.rs
+++ b/bae-core/src/db/client/blobs.rs
@@ -426,14 +426,31 @@ impl Database {
                         )
                     })?;
                 let operation_raw = row.get::<_, String>("operation")?;
-                let operation = OutboxOpKind::parse(&operation_raw).ok_or_else(|| {
-                    column_conversion_error(
-                        row,
-                        "operation",
-                        format!("invalid cloud_outbox.operation: {operation_raw:?}"),
-                    )
-                })?;
-                Ok(DbOutboxRow {
+                // Parse to the full domain, then keep only the displayed subset.
+                // A non-domain string is genuine corruption (column-conversion
+                // error, as before). A `cancel` (coven's tombstone retry) is kept
+                // out of the snapshot by the WHERE filter; reaching it here means
+                // that filter drifted, so warn with the row's key and drop it.
+                let operation = match OutboxOpKind::parse(&operation_raw) {
+                    Some(OutboxOpKind::Upload) => DisplayedOutboxOp::Upload,
+                    Some(OutboxOpKind::Delete) => DisplayedOutboxOp::Delete,
+                    Some(OutboxOpKind::Cancel) => {
+                        let cloud_key = row.get::<_, String>("cloud_key")?;
+                        tracing::warn!(
+                            cloud_key,
+                            "cancel row reached the outbox snapshot; the WHERE filter drifted — ignoring"
+                        );
+                        return Ok(None);
+                    }
+                    None => {
+                        return Err(column_conversion_error(
+                            row,
+                            "operation",
+                            format!("invalid cloud_outbox.operation: {operation_raw:?}"),
+                        ));
+                    }
+                };
+                Ok(Some(DbOutboxRow {
                     id: row.get("id")?,
                     operation,
                     file_id: row.get("file_id")?,
@@ -445,9 +462,10 @@ impl Database {
                     title: row.get("title")?,
                     file_name: row.get("file_name")?,
                     file_size: row.get("file_size")?,
-                })
+                }))
             })?;
-            rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+            rows.collect::<coven::rusqlite::Result<Vec<Option<DbOutboxRow>>>>()
+                .map(|rows| rows.into_iter().flatten().collect())
                 .map_err(DbError::from)
         })
         .await

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -1137,26 +1137,39 @@ pub enum StorageFilter {
     Uploading,
 }
 
-/// Which kind of cloud-outbox operation a joined row is. The snapshot builder
-/// reads the flat `file_id`/`cloud_key`/`file_size` columns off `DbOutboxRow`
-/// directly, so it needs only the operation *kind* — not coven's
-/// `OutboxOperation` with its drain-only `scope` payload (which the snapshot
-/// join doesn't select).
+/// The full `cloud_outbox.operation` domain (matches the schema CHECK): the
+/// three values coven can write to the queue. `Cancel` is a coven-internal
+/// tombstone-retry row (a delete coven re-issues after an upload races it); it
+/// renders nothing in the UI and is excluded from the snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutboxOpKind {
     Upload,
     Delete,
+    Cancel,
 }
 
 impl OutboxOpKind {
-    /// Parse the `cloud_outbox.operation` text column ('upload' | 'delete').
+    /// Parse the `cloud_outbox.operation` text column. Total over the real
+    /// domain — a value outside it is genuine corruption (`None`), not a kind we
+    /// declined to model.
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "upload" => Some(Self::Upload),
             "delete" => Some(Self::Delete),
+            "cancel" => Some(Self::Cancel),
             _ => None,
         }
     }
+}
+
+/// The outbox operations the UI snapshot displays — the `Cancel`-free subset of
+/// `OutboxOpKind`. `outbox_items` maps each row into this, dropping coven's
+/// internal `cancel` rows, so the snapshot builder can't represent (or forget to
+/// handle) a `Cancel`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplayedOutboxOp {
+    Upload,
+    Delete,
 }
 
 /// One row from the `cloud_outbox` join: the queue entry's own columns plus
@@ -1171,7 +1184,7 @@ impl OutboxOpKind {
 #[derive(Debug, Clone)]
 pub struct DbOutboxRow {
     pub id: i64,
-    pub operation: OutboxOpKind,
+    pub operation: DisplayedOutboxOp,
     pub file_id: Option<String>,
     pub cloud_key: String,
     /// Enqueue time as Unix epoch milliseconds, parsed from the queue row's
@@ -1183,4 +1196,18 @@ pub struct DbOutboxRow {
     pub title: Option<String>,
     pub file_name: Option<String>,
     pub file_size: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutboxOpKind;
+
+    #[test]
+    fn outbox_op_kind_parse_is_total_over_the_domain() {
+        assert_eq!(OutboxOpKind::parse("upload"), Some(OutboxOpKind::Upload));
+        assert_eq!(OutboxOpKind::parse("delete"), Some(OutboxOpKind::Delete));
+        assert_eq!(OutboxOpKind::parse("cancel"), Some(OutboxOpKind::Cancel));
+        // A value outside the domain is genuine corruption, not an unmodeled kind.
+        assert_eq!(OutboxOpKind::parse("bogus"), None);
+    }
 }

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -21,7 +21,7 @@ use tracing::debug;
 use crate::db::Database;
 use crate::library::upload_throughput::UploadThroughput;
 
-use crate::db::OutboxOpKind;
+use crate::db::DisplayedOutboxOp;
 
 /// What an upload is doing right now. Derived from the row plus the in-flight
 /// map; never stored.
@@ -193,7 +193,7 @@ pub(crate) async fn build_outbox_snapshot(
 
     for row in rows {
         match row.operation {
-            OutboxOpKind::Upload => {
+            DisplayedOutboxOp::Upload => {
                 // An upload row always carries the file id it reports progress
                 // under; only a delete has none.
                 let file_id = row
@@ -264,7 +264,7 @@ pub(crate) async fn build_outbox_snapshot(
                     state,
                 });
             }
-            OutboxOpKind::Delete => {
+            DisplayedOutboxOp::Delete => {
                 deletes.push(DeleteOp {
                     id: row.id,
                     cloud_key: row.cloud_key,

--- a/bae-core/tests/test_outbox.rs
+++ b/bae-core/tests/test_outbox.rs
@@ -172,8 +172,8 @@ async fn test_insert_or_ignore_idempotency() {
 
 /// The UI snapshot query reads only upload/delete rows. coven's upload drain
 /// queues `cancel` rows for tombstone removal; `outbox_items` must skip them, not
-/// choke on an operation kind it doesn't render. A cancel row left in the result
-/// makes `OutboxOpKind::parse` fail and the query panic.
+/// render an operation the snapshot doesn't display. The `WHERE IN
+/// ('upload','delete')` filter keeps cancel rows out of the result.
 #[tokio::test]
 async fn test_outbox_items_skips_tombstone_cancels() {
     let (db, _tmp) = setup_db().await;


### PR DESCRIPTION
Resolves #210. `OutboxOpKind { Upload, Delete }` was a lossy narrowing that
silently omitted the column's real `cancel` value (coven-internal tombstone
retries, filtered out of the snapshot by the `outbox_items` WHERE clause) — which
reads as a possible bug rather than a deliberate exclusion.

Now the type models the full domain and refines explicitly:
- `OutboxOpKind { Upload, Delete, Cancel }` with a total `parse` (a non-domain
  string is the only `None` — genuine corruption).
- `into_displayed() -> Option<DisplayedOutboxOp>` projects to the snapshot's
  Cancel-free subset; `Cancel => warn!("…filter drifted…") + None` (a drift alarm,
  since the WHERE already filters cancel).
- `DbOutboxRow.operation` is `DisplayedOutboxOp { Upload, Delete }`, so the
  snapshot match is exhaustive with no Cancel arm — Cancel is unrepresentable
  there by construction.

The WHERE filter stays (the real, perf exclusion); `into_displayed` is the
in-code, logged guard. Two unit tests added (parse totality incl. `bogus => None`;
`into_displayed` drops only `Cancel`).

## Test plan
- clippy `--all-targets` clean; 996 passed (lib 819), incl. the existing
  `test_outbox_items_skips_tombstone_cancels`.
