### PR TITLE
Remove spawn_on_runtime; rely on coven's big-stack S3 runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -154,7 +154,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=01ed7c7518ca26bf13d3f64de470c3607da9e3ed#01ed7c7518ca26bf13d3f64de470c3607da9e3ed"
+source = "git+https://github.com/bae-fm/coven?rev=d5b9a5b#d5b9a5b81ec11f996e1e835233961025186aa901"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2010,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3919,7 +3919,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4383,7 +4383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4441,7 +4441,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4899,7 +4899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5051,7 +5051,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5883,7 +5883,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -154,7 +154,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=d5b9a5b#d5b9a5b81ec11f996e1e835233961025186aa901"
+source = "git+https://github.com/bae-fm/coven?rev=f3ad68d#f3ad68d2d83fb8bfc443d969fe11859caee31c40"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2010,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3919,7 +3919,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4383,7 +4383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4441,7 +4441,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4899,7 +4899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5051,7 +5051,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5883,7 +5883,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "d5b9a5b" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "f3ad68d" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "01ed7c7518ca26bf13d3f64de470c3607da9e3ed" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "d5b9a5b" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1,4 +1,3 @@
-use std::future::Future;
 #[cfg(feature = "desktop")]
 use std::ops::Deref;
 
@@ -57,45 +56,6 @@ impl Deref for AppHandle {
     }
 }
 
-impl AppHandle {
-    /// Run `fut` on a worker thread of the bridge runtime and resolve to its
-    /// output, aborting the work if this call is cancelled.
-    ///
-    /// Why this exists — the stack: uniffi exports an `async fn` by polling its
-    /// future *inline on whatever foreign thread drives it*. Swift runs a
-    /// `nonisolated async` call on its cooperative pool, whose threads have
-    /// ~0.5 MB stacks. The AWS-SDK S3 future chain these cloud/membership ops
-    /// reach descends far deeper than that *synchronously* in one poll — endpoint
-    /// and auth-scheme resolution, uncollapsed in debug builds — so polling it on
-    /// the foreign thread overflows — the "Thread stack size exceeded" SIGBUS we
-    /// hit at startup once sync was configured. `Runtime::block_on` has the same
-    /// flaw: it drives the root future on the *caller*, not a worker. `spawn`
-    /// moves the future onto a runtime worker instead — those have 16 MB stacks
-    /// (sized in `init` for exactly these deep futures) — and the foreign thread
-    /// only polls the shallow `JoinHandle`. The deep descent never touches the
-    /// Swift stack.
-    ///
-    /// Why this exists — cancellation: our uniffi fork drops the inflight Rust
-    /// future when the Swift `Task` is cancelled. A dropped `JoinHandle` merely
-    /// *detaches* its task (tokio runs it to completion), which would leak the
-    /// work and skip its teardown, so the guard aborts the task on drop. `coven`'s
-    /// own drop guards (AbortOnDrop, connection release) then fire on the worker.
-    async fn spawn_on_runtime<T: Send + 'static>(
-        &self,
-        fut: impl Future<Output = T> + Send + 'static,
-    ) -> T {
-        let handle = self.runtime.spawn(fut);
-        struct AbortOnDrop(tokio::task::AbortHandle);
-        impl Drop for AbortOnDrop {
-            fn drop(&mut self) {
-                self.0.abort();
-            }
-        }
-        let _abort_on_drop = AbortOnDrop(handle.abort_handle());
-        handle.await.expect("bridge runtime task panicked")
-    }
-}
-
 #[uniffi::export(async_runtime = "tokio")]
 impl AppHandle {
     // =========================================================================
@@ -109,11 +69,9 @@ impl AppHandle {
         limit: u64,
     ) -> Result<Vec<BridgeAlbum>, BridgeError> {
         // Local SQLite read — shallow and instant, so it polls inline on the
-        // caller via block_on. Only the deep, network-bound cloud/membership
-        // calls need spawn_on_runtime; these reads can't descend deep enough to
-        // overflow the caller stack. Staying synchronous also keeps them usable
-        // from the synchronous SwiftUI render path (e.g. image/file-path lookups
-        // feeding `NSImage(contentsOfFile:)`), which has no `await` point.
+        // caller via block_on. Staying synchronous keeps it usable from the
+        // synchronous SwiftUI render path (e.g. image/file-path lookups feeding
+        // `NSImage(contentsOfFile:)`), which has no `await` point.
         self.runtime.block_on(async {
             let sort: Vec<bae_core::db::AlbumSortCriterion> =
                 sort_criteria.iter().map(bridge_sort_to_core).collect();
@@ -525,19 +483,12 @@ impl AppHandle {
     // Storage
     // =========================================================================
 
-    // These descend into the AWS S3 future chain (cloud reads/writes), so they
-    // run on a runtime worker via `spawn_on_runtime` rather than `block_on`
-    // (which would drive the deep future on the shallow Swift stack — see
-    // `spawn_on_runtime`'s doc). Pinning is the exception: it routes through the
-    // in-memory download queue (`queue_pin_releases`), which enqueues quickly
-    // and downloads on the queue worker.
     pub async fn unpin_release(&self, release_id: String) -> Result<(), BridgeError> {
-        let services = self.services.clone();
-        self.spawn_on_runtime(
-            async move { services.library_manager().unpin_release(&release_id).await },
-        )
-        .await
-        .map_err(BridgeError::internal)
+        self.services
+            .library_manager()
+            .unpin_release(&release_id)
+            .await
+            .map_err(BridgeError::internal)
     }
 
     pub async fn make_release_remote(
@@ -545,15 +496,11 @@ impl AppHandle {
         release_id: String,
         pin: bool,
     ) -> Result<(), BridgeError> {
-        let services = self.services.clone();
-        self.spawn_on_runtime(async move {
-            services
-                .library_manager()
-                .make_release_remote(&release_id, pin)
-                .await
-        })
-        .await
-        .map_err(BridgeError::internal)
+        self.services
+            .library_manager()
+            .make_release_remote(&release_id, pin)
+            .await
+            .map_err(BridgeError::internal)
     }
 
     pub async fn make_release_local(
@@ -561,15 +508,11 @@ impl AppHandle {
         release_id: String,
         new_path: String,
     ) -> Result<(), BridgeError> {
-        let services = self.services.clone();
-        self.spawn_on_runtime(async move {
-            services
-                .library_manager()
-                .make_release_local(&release_id, &new_path)
-                .await
-        })
-        .await
-        .map_err(BridgeError::internal)
+        self.services
+            .library_manager()
+            .make_release_local(&release_id, &new_path)
+            .await
+            .map_err(BridgeError::internal)
     }
 
     pub fn delete_release(&self, release_id: String) {
@@ -598,24 +541,19 @@ impl AppHandle {
         config_data: BridgeSaveSyncConfig,
     ) -> Result<(), BridgeError> {
         use bae_core::sync::sync_manager::S3ConfigData;
-        // Probes the bucket (HeadBucket) then starts sync — deep; on a worker.
-        let services = self.services.clone();
-        self.spawn_on_runtime(async move {
-            services
-                .library_manager()
-                .save_s3_config(S3ConfigData {
-                    bucket: config_data.bucket,
-                    region: config_data.region,
-                    endpoint: config_data.endpoint,
-                    key_prefix: config_data.key_prefix,
-                    access_key: config_data.access_key,
-                    secret_key: config_data.secret_key,
-                    storage: bridge_home_storage_to_core(config_data.storage),
-                })
-                .await
-        })
-        .await
-        .map_err(BridgeError::config)
+        self.services
+            .library_manager()
+            .save_s3_config(S3ConfigData {
+                bucket: config_data.bucket,
+                region: config_data.region,
+                endpoint: config_data.endpoint,
+                key_prefix: config_data.key_prefix,
+                access_key: config_data.access_key,
+                secret_key: config_data.secret_key,
+                storage: bridge_home_storage_to_core(config_data.storage),
+            })
+            .await
+            .map_err(BridgeError::config)
     }
 
     pub fn disconnect_cloud_provider(&self) -> Result<(), BridgeError> {
@@ -644,11 +582,12 @@ impl AppHandle {
 
     /// The library's membership (devices, with this device flagged, and whether
     /// the running device is an owner). Reads the membership chain from cloud
-    /// storage, so it runs on a runtime worker.
+    /// storage.
     pub async fn get_members(&self) -> Result<crate::types::BridgeMembership, BridgeError> {
-        let services = self.services.clone();
         let membership = self
-            .spawn_on_runtime(async move { services.library_manager().get_members().await })
+            .services
+            .library_manager()
+            .get_members()
             .await
             .map_err(BridgeError::internal)?;
         Ok(crate::types::bridge_membership(membership))
@@ -657,28 +596,20 @@ impl AppHandle {
     /// Approve a joining device by its public key (from its join-request code),
     /// returning the invite code to hand back to that device.
     pub async fn invite_member(&self, public_key_hex: String) -> Result<String, BridgeError> {
-        let services = self.services.clone();
-        self.spawn_on_runtime(async move {
-            services
-                .library_manager()
-                .invite_member(&public_key_hex)
-                .await
-        })
-        .await
-        .map_err(BridgeError::internal)
+        self.services
+            .library_manager()
+            .invite_member(&public_key_hex)
+            .await
+            .map_err(BridgeError::internal)
     }
 
     /// Remove a device from the library and rotate the library key.
     pub async fn remove_member(&self, public_key_hex: String) -> Result<(), BridgeError> {
-        let services = self.services.clone();
-        self.spawn_on_runtime(async move {
-            services
-                .library_manager()
-                .remove_member(&public_key_hex)
-                .await
-        })
-        .await
-        .map_err(BridgeError::internal)
+        self.services
+            .library_manager()
+            .remove_member(&public_key_hex)
+            .await
+            .map_err(BridgeError::internal)
     }
 
     /// Forget the active local library on this device: delete its key, clear the
@@ -863,10 +794,10 @@ impl AppHandle {
 #[uniffi::export(async_runtime = "tokio")]
 impl AppHandle {
     pub async fn use_cloudkit(&self, storage: BridgeHomeStorage) -> Result<(), BridgeError> {
-        // Starts sync against CloudKit — deep; on a worker.
-        let services = self.services.clone();
         let storage = bridge_home_storage_to_core(storage);
-        self.spawn_on_runtime(async move { services.library_manager().use_cloudkit(storage).await })
+        self.services
+            .library_manager()
+            .use_cloudkit(storage)
             .await
             .map_err(BridgeError::config)
     }
@@ -884,19 +815,16 @@ impl AppHandle {
         provider: BridgeCloudProvider,
         storage: BridgeHomeStorage,
     ) -> Result<(), BridgeError> {
-        // OAuth + cloud-folder setup then starts sync — network; on a worker.
-        // Cancellation tears down the OAuth listener via coven's own drop guard.
-        let services = self.services.clone();
+        // OAuth + cloud-folder setup then starts sync. Cancellation (the Swift
+        // Task dropping this future) tears down the OAuth listener via coven's
+        // own drop guard.
         let core_provider = bridge_cloud_provider_to_core(provider);
         let storage = bridge_home_storage_to_core(storage);
-        self.spawn_on_runtime(async move {
-            services
-                .library_manager()
-                .sign_in_cloud_provider(core_provider, storage)
-                .await
-        })
-        .await
-        .map_err(BridgeError::config)
+        self.services
+            .library_manager()
+            .sign_in_cloud_provider(core_provider, storage)
+            .await
+            .map_err(BridgeError::config)
     }
 }
 

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -211,12 +211,13 @@ pub fn create_library(name: Option<String>) -> Result<BridgeLibrary, BridgeError
 /// Run the future built by `make_fut` on a worker of a shared onboarding
 /// runtime, blocking the calling thread until it completes.
 ///
-/// The onboarding exports (restore, OAuth) run before any `AppHandle`, so
-/// they can't borrow `AppHandle::spawn_on_runtime` (see `handle`); they share
-/// this process-wide runtime instead. Its workers have 16 MB stacks (like
-/// `init`'s) — deep enough for the AWS-SDK S3 / coven pull descents. `spawn`
-/// moves that deep work onto a worker; the foreign caller only `block_on`s the
-/// shallow `JoinHandle`, so nothing deep is ever polled on its ~0.5 MB stack.
+/// The onboarding exports (restore, OAuth) run before any `AppHandle` (and its
+/// tokio runtime) exists, so they share this process-wide runtime instead. Its
+/// workers have 16 MB stacks (like `init`'s) — deep enough for coven's pull
+/// descents. `spawn` moves that work onto a worker; the foreign caller only
+/// `block_on`s the shallow `JoinHandle`, so nothing deep is ever polled on its
+/// ~0.5 MB stack. (The AWS-SDK S3 endpoint descent runs on coven's own
+/// big-stack S3 runtime regardless of who awaits it.)
 ///
 /// This requires the futures to be `Send` + `'static`. They are: coven's pull
 /// path carries the database handle as a `Send`-able `SendDbPtr`, so no


### PR DESCRIPTION
Pairs with coven #179. Coven now runs every S3 call on its own 16 MiB-stack runtime, so the aws-sdk endpoint resolver can no longer overflow the foreign UI thread that polls a CloudHome read. That makes bae's `spawn_on_runtime` workaround unnecessary: it hand-wrapped 9 bridge methods to dodge the same crash, but only the ones someone remembered to classify as "deep" — and a remote-cover read was never on the list, which is why the crash came back.

With the protection now living where the deep AWS code lives, `spawn_on_runtime` and its abort guard are deleted and all 9 methods go back to inline `.await`. Verified (in coven) that the only path reaching the giant aws resolver is `S3CloudHome` — OAuth (reqwest) and CloudKit (a Swift callback) don't touch it — so the unwrapped methods lose no real stack protection.

Re-pins coven to the paired fix. Merge coven #179 first, then this re-pins to coven main's merge commit.

## Test plan
- [x] cargo build -p bae-core -p bae-bridge clean; pre-commit hook (bae-bridge clippy -D warnings, loc-gen, swift-format, macOS xcodebuild, periphery dead-code) passed
- [ ] On-device: rebuild bae-macos, load the remote album cover that crashed → no SIGBUS

🤖 Generated with [Claude Code](https://claude.com/claude-code)