### PR TITLE
Link the bae-ffmpeg fork everywhere; drop vanilla and system FFmpeg

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,11 +2,17 @@
 rustc-wrapper = "sccache"
 
 [env]
-# macOS Homebrew paths for native dependencies (libdiscid, ffmpeg, etc.)
-# On Apple Silicon Macs, Homebrew installs to /opt/homebrew.
-# On Intel Macs, it installs to /usr/local.
-# force = false means these won't override if already set in the environment.
-PKG_CONFIG_PATH = { value = "/opt/homebrew/lib/pkgconfig:/usr/local/lib/pkgconfig", force = false }
+# FFmpeg comes exclusively from the bae-ffmpeg fork's prebuilt dist, never from a
+# system/Homebrew install -- local dev links the same artifacts CI and release
+# do. scripts/setup-ffmpeg.sh populates bae-ffmpeg/dist; it is required local
+# setup. Pointing pkg-config only there means ffmpeg-sys-next can't resolve a
+# Homebrew ffmpeg even if one is installed. relative=true resolves against the
+# repo root (the parent of this .cargo dir). force=false lets setup-ffmpeg.sh's
+# shell exports take over when present.
+PKG_CONFIG_PATH = { value = "bae-ffmpeg/dist/lib/pkgconfig", relative = true, force = false }
+# Homebrew provides genuinely-separate native deps (libdiscid), which discid-sys
+# finds via LIBRARY_PATH + clang include args (it does not use pkg-config). The
+# fork's ffmpeg lib/include dirs are layered on top of these by setup-ffmpeg.sh's
+# shell exports (fork-first); on Intel Macs Homebrew lives under /usr/local.
 LIBRARY_PATH = { value = "/opt/homebrew/lib:/usr/local/lib", force = false }
-# For bindgen/clang to find headers
 BINDGEN_EXTRA_CLANG_ARGS = { value = "-I/opt/homebrew/include -I/usr/local/include", force = false }

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -5,7 +5,7 @@ inputs:
   ffmpeg-version:
     description: 'bae-ffmpeg release tag'
     required: false
-    default: 'v8.0.1-bae8'
+    default: 'v8.1.2-bae2'
 
 runs:
   using: 'composite'

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -5,7 +5,7 @@ inputs:
   ffmpeg-version:
     description: 'bae-ffmpeg release tag'
     required: false
-    default: 'v8.0.1-bae8'
+    default: 'v8.1.2-bae2'
 
 runs:
   using: 'composite'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  FFMPEG_VERSION: v8.0.1-bae8
+  FFMPEG_VERSION: v8.1.2-bae2
 
 jobs:
   macos:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -175,7 +175,7 @@ jobs:
           PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
           PRODUCT_NAME="$PRODUCT_NAME" \
           DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
-          LIBRARY_SEARCH_PATHS="/opt/homebrew/lib /opt/bae-ffmpeg/lib ${FFMPEG_DIR}/lib" \
+          LIBRARY_SEARCH_PATHS="${FFMPEG_DIR}/lib /opt/bae-ffmpeg/lib /opt/homebrew/lib" \
           build
         echo "APP_PATH=build/Build/Products/Release/${PRODUCT_NAME}.app" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: windows-latest
     needs: calculate-version
     env:
-      FFMPEG_VERSION: v8.0.1-bae8
+      FFMPEG_VERSION: v8.1.2-bae2
       BAE_ENVIRONMENT: production
       BAE_DATADOG_SITE: ${{ secrets.BAE_DATADOG_SITE }}
       BAE_DATADOG_CLIENT_TOKEN: ${{ secrets.BAE_DATADOG_CLIENT_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: windows-latest
     env:
-      FFMPEG_VERSION: v8.0.1-bae8
+      FFMPEG_VERSION: v8.1.2-bae2
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2064,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
+checksum = "f7c4bd5ab1ac61f29c634df1175d350ded29cf74c3c6d4f7030431a5ae3c7d5d"
 dependencies = [
  "bitflags 2.11.0",
  "ffmpeg-sys-next",
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "8.0.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
+checksum = "a314bc0e022a33a99567ed4bd2576bd58ffd8fcff7891c29194cfecc26a62547"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -3417,7 +3417,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3919,7 +3919,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4383,7 +4383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4441,7 +4441,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5051,7 +5051,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5883,7 +5883,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ brew install cmake pkg-config libdiscid
 git clone <repository-url>
 cd bae
 
-# Setup bae-ffmpeg (downloads prebuilt binaries)
+# Setup bae-ffmpeg (downloads the prebuilt fork binaries). bae links FFmpeg only
+# from here, never from a system/Homebrew install -- so local dev, CI, and
+# release all link the same artifacts. Required setup.
 ./scripts/setup-ffmpeg.sh
 
 # Add to your shell profile (~/.zshrc):
@@ -77,6 +79,7 @@ export FFMPEG_DIR="$PWD/bae-ffmpeg/dist"
 export PKG_CONFIG_PATH="$FFMPEG_DIR/lib/pkgconfig:$PKG_CONFIG_PATH"
 export LIBRARY_PATH="$FFMPEG_DIR/lib:$LIBRARY_PATH"
 export DYLD_LIBRARY_PATH="$FFMPEG_DIR/lib:$DYLD_LIBRARY_PATH"
+export BINDGEN_EXTRA_CLANG_ARGS="-I$FFMPEG_DIR/include ${BINDGEN_EXTRA_CLANG_ARGS:-}"
 
 ./scripts/install-hooks.sh
 

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -102,8 +102,8 @@ cpal = "0.15"
 # see scripts/build-ffmpeg-{android,ios}.sh and the FFMPEG_DIR/BINDGEN_EXTRA_CLANG_ARGS
 # exports in bae-bridge/build-{android,ios}.sh.
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", target_os = "android", target_os = "ios"))'.dependencies]
-ffmpeg-next = { version = "8.0", default-features = false, features = ["codec", "format", "software-resampling"] }
-ffmpeg-sys-next = { version = "8.0", default-features = false, features = ["avcodec", "avformat", "swresample"] }
+ffmpeg-next = { version = "8.1", default-features = false, features = ["codec", "format", "software-resampling"] }
+ffmpeg-sys-next = { version = "8.1", default-features = false, features = ["avcodec", "avformat", "swresample"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["test-util"] }

--- a/bae-macos/README.md
+++ b/bae-macos/README.md
@@ -7,7 +7,8 @@ Native macOS app for bae, built with SwiftUI.
 - macOS 14.0+
 - Xcode 26+
 - Rust toolchain with `aarch64-apple-darwin` target
-- FFmpeg (`brew install ffmpeg`)
+- FFmpeg from the bae-ffmpeg fork (`./scripts/setup-ffmpeg.sh` from the repo
+  root) -- bae links these prebuilt libs, not a system/Homebrew ffmpeg
 - xcodegen (`brew install xcodegen`)
 
 Install the Rust target if you haven't:

--- a/bae-macos/bae/project.yml
+++ b/bae-macos/bae/project.yml
@@ -113,9 +113,17 @@ targets:
         # by the generated Features.xcconfig (baeium), not here — a setting in this
         # block lands in the pbxproj and would override the xcconfig layer the
         # feature set drives.
+        # FFmpeg is linked from the bae-ffmpeg fork's prebuilt dist, never a
+        # system/Homebrew install. The fork dirs are listed first so their
+        # libav* dylibs win over any Homebrew ffmpeg that happens to be in
+        # /opt/homebrew/lib (kept only for libdiscid, -ldiscid below). The local
+        # path is scripts/setup-ffmpeg.sh's bae-ffmpeg/dist; /opt/bae-ffmpeg is
+        # where the setup-macos CI action unpacks the same release. Non-existent
+        # search paths are harmless to the linker.
         LIBRARY_SEARCH_PATHS:
+          - $(SRCROOT)/../../bae-ffmpeg/dist/lib
+          - /opt/bae-ffmpeg/lib
           - /opt/homebrew/lib
-          - /opt/homebrew/opt/ffmpeg/lib
         OTHER_LDFLAGS:
           - -lavcodec
           - -lavformat

--- a/bae-macos/scripts/bundle_dylibs.sh
+++ b/bae-macos/scripts/bundle_dylibs.sh
@@ -51,8 +51,10 @@ resolve_rpath() {
         fi
     fi
 
-    # Try common library locations (Homebrew and bae-ffmpeg)
-    for base in "/opt/homebrew/lib" "/usr/local/lib" "${FFMPEG_DIR:-}/lib" "/opt/bae-ffmpeg/lib"; do
+    # Try common library locations. The bae-ffmpeg fork dirs come first so the
+    # bundled libav* dylibs are the fork's, never a Homebrew ffmpeg (Homebrew is
+    # only here for genuinely-separate deps like libdiscid).
+    for base in "${FFMPEG_DIR:-}/lib" "/opt/bae-ffmpeg/lib" "/opt/homebrew/lib" "/usr/local/lib"; do
         local candidate="$base/$lib_name"
         if [[ -f "$candidate" ]]; then
             echo "$candidate"

--- a/scripts/build-ffmpeg-android.sh
+++ b/scripts/build-ffmpeg-android.sh
@@ -1,104 +1,39 @@
 #!/usr/bin/env bash
 #
-# Cross-compile FFmpeg for the Android NDK targets so bae-core can decode audio
-# in-process (the in-core decode half of the dual-mode player). ffmpeg-sys-next
-# links these via the FFMPEG_DIR discovery path; build-android.sh points it here.
+# Download prebuilt audio-only FFmpeg for the Android NDK targets from the
+# bae-ffmpeg fork's release. Every platform and build context (local dev, CI,
+# release) now links the SAME prebuilt fork artifacts at the same FFmpeg version
+# -- no system FFmpeg, and no per-machine cross-compile from vanilla source.
+# ffmpeg-sys-next links these via FFMPEG_DIR; bae-bridge/build-android.sh points
+# it at the per-arch dirs below.
 #
-# Output: third_party/ffmpeg-android/<arch>/{lib,include}, shared libs with
-# UNVERSIONED sonames (libavcodec.so, not libavcodec.so.61) so Android's
-# packager + dynamic loader find them. LGPL-clean: no --enable-gpl/version3/
-# nonfree, shared libs (replaceable). Only the decoders/demuxers audio_codec.rs
-# actually touches are enabled.
+# The fork builds SHARED libs with UNVERSIONED sonames (libavcodec.so, not
+# libavcodec.so.61) so Android's packager + dynamic loader find them;
+# bae-bridge/build-android.sh ships them as jniLibs sidecars next to
+# libbae_bridge.so. LGPL-clean: no gpl/version3/nonfree, shared (replaceable).
 #
-# Re-runnable. FFmpeg source is cloned once into third_party/ffmpeg-src.
+# Output: third_party/ffmpeg-android/<arch>/{lib,include} for aarch64, x86_64.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-NDK="${ANDROID_NDK_HOME:-$HOME/Library/Android/sdk/ndk/29.0.14206865}"
-# NDK prebuilt toolchains are named by host: darwin-x86_64 on macOS (incl Apple
-# Silicon via Rosetta), linux-x86_64 on the x86_64 Linux CI runner.
-case "$(uname -s)" in
-    Darwin) NDK_HOST_TAG="darwin-x86_64" ;;
-    Linux) NDK_HOST_TAG="linux-x86_64" ;;
-    *) echo "build-ffmpeg-android.sh: unsupported host OS $(uname -s)" >&2; exit 1 ;;
-esac
-TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/$NDK_HOST_TAG"
-API=26 # matches minSdk in bae-android/app/build.gradle.kts
-FF_TAG="n7.1" # matches ffmpeg-sys-next 8.x (FFmpeg 7.1)
-
-SRC="$REPO_ROOT/third_party/ffmpeg-src"
+VERSION="v8.1.2-bae2"
+BASE_URL="https://github.com/bae-fm/bae-ffmpeg/releases/download/$VERSION"
 OUT="$REPO_ROOT/third_party/ffmpeg-android"
 
-if [ ! -x "$TOOLCHAIN/bin/llvm-ar" ]; then
-  echo "FATAL: NDK toolchain not found at $TOOLCHAIN (set ANDROID_NDK_HOME)" >&2
-  exit 1
-fi
-
-# --- FFmpeg source ---
-if [ ! -d "$SRC/.git" ]; then
-  echo "=== cloning FFmpeg $FF_TAG ==="
-  git clone --depth 1 --branch "$FF_TAG" https://github.com/FFmpeg/FFmpeg.git "$SRC"
-fi
-
-# Audio components bae-core needs (audio_codec.rs): FLAC/MP3/APE/ALAC/AAC decode,
-# FLAC encode+mux (synthetic standalone-FLAC for CUE byte-range tracks),
-# swresample, custom AVIO (no protocols/network).
-DECODERS="flac,mp3,ape,alac,aac,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,pcm_u8,pcm_s16be,pcm_s24be,pcm_s32be"
-ENCODERS="flac"
-MUXERS="flac"
-DEMUXERS="flac,mp3,ape,mov,ipod,ogg,wav,aiff"
-PARSERS="flac,mpegaudio,aac"
-
-build_arch() {
-  local ARCH="$1" FFARCH="$2" TRIPLE="$3" EXTRA="$4"
-  local PREFIX="$OUT/$ARCH"
-  local BUILD="$SRC/build-$ARCH"
-  echo "=== configuring FFmpeg for $ARCH ($TRIPLE) ==="
-  rm -rf "$BUILD"; mkdir -p "$BUILD"
-  ( cd "$BUILD" && "$SRC/configure" \
-      --prefix="$PREFIX" \
-      --enable-cross-compile --target-os=android --arch="$FFARCH" \
-      --sysroot="$TOOLCHAIN/sysroot" \
-      --cc="$TOOLCHAIN/bin/${TRIPLE}${API}-clang" \
-      --cxx="$TOOLCHAIN/bin/${TRIPLE}${API}-clang++" \
-      --cross-prefix="$TOOLCHAIN/bin/llvm-" \
-      --nm="$TOOLCHAIN/bin/llvm-nm" --ar="$TOOLCHAIN/bin/llvm-ar" \
-      --ranlib="$TOOLCHAIN/bin/llvm-ranlib" --strip="$TOOLCHAIN/bin/llvm-strip" \
-      --enable-pic --enable-shared --disable-static \
-      --disable-programs --disable-doc \
-      --disable-avdevice --disable-avfilter --disable-postproc --disable-network \
-      --enable-swresample \
-      --disable-everything \
-      --enable-decoder="$DECODERS" \
-      --enable-encoder="$ENCODERS" \
-      --enable-muxer="$MUXERS" \
-      --enable-demuxer="$DEMUXERS" \
-      --enable-parser="$PARSERS" \
-      --extra-ldflags="-Wl,-z,max-page-size=16384" \
-      $EXTRA )
-  echo "=== building FFmpeg for $ARCH ==="
-  # Override the soname/install vars so output is libavcodec.so with SONAME
-  # libavcodec.so (no version suffix) — required for Android's loader.
-  make -C "$BUILD" -j"$(sysctl -n hw.ncpu)" \
-    SLIBNAME_WITH_VERSION='$(SLIBNAME)' \
-    SLIBNAME_WITH_MAJOR='$(SLIBNAME)' \
-    SLIB_INSTALL_NAME='$(SLIBNAME)' \
-    SLIB_INSTALL_LINKS=''
-  make -C "$BUILD" install \
-    SLIBNAME_WITH_VERSION='$(SLIBNAME)' \
-    SLIBNAME_WITH_MAJOR='$(SLIBNAME)' \
-    SLIB_INSTALL_NAME='$(SLIBNAME)' \
-    SLIB_INSTALL_LINKS=''
-  echo "=== $ARCH sonames ==="
-  for so in "$PREFIX"/lib/lib*.so; do
-    printf '  %s -> SONAME ' "$(basename "$so")"
-    "$TOOLCHAIN/bin/llvm-readelf" -d "$so" | grep SONAME || echo "(none)"
-  done
+download() {
+  local arch="$1"
+  local dest="$OUT/$arch"
+  echo "=== downloading ffmpeg-android-$arch ($VERSION) ==="
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  curl -fL "$BASE_URL/ffmpeg-android-$arch.tar.gz" | tar xz -C "$dest"
+  if [ ! -f "$dest/lib/libavcodec.so" ]; then
+    echo "FATAL: libavcodec.so missing in $dest after download" >&2
+    exit 1
+  fi
 }
 
-# arm64: real devices, clang/NEON (no external assembler).
-build_arch "aarch64" "aarch64" "aarch64-linux-android" ""
-# x86_64: emulator only — disable x86 asm so we don't need nasm on the host.
-build_arch "x86_64" "x86_64" "x86_64-linux-android" "--disable-x86asm"
+download aarch64
+download x86_64
 
 echo "=== DONE. FFmpeg installed under $OUT/{aarch64,x86_64} ==="

--- a/scripts/build-ffmpeg-ios.sh
+++ b/scripts/build-ffmpeg-ios.sh
@@ -1,79 +1,42 @@
 #!/usr/bin/env bash
 #
-# Cross-compile FFmpeg for the iOS targets so bae-core can decode audio in-core
-# on iOS (mirrors scripts/build-ffmpeg-android.sh). iOS forbids shipping custom
-# dynamic libs, so these are STATIC archives (.a) that link into libbae_bridge.a
-# inside the xcframework — there is no jniLibs sidecar like Android. ffmpeg-sys-next
-# links them via FFMPEG_DIR; bae-bridge/build-ios.sh points it here.
+# Download prebuilt audio-only FFmpeg for the iOS targets from the bae-ffmpeg
+# fork's release. Every platform and build context (local dev, CI, release) now
+# links the SAME prebuilt fork artifacts at the same FFmpeg version -- no system
+# FFmpeg, and no per-machine cross-compile from vanilla source. ffmpeg-sys-next
+# links these via FFMPEG_DIR; bae-bridge/build-ios.sh points it at the per-arch
+# dirs below.
 #
-# Output: third_party/ffmpeg-ios/<arch>/{lib,include}. Two arches, never lipo'd
-# together (device and simulator are distinct platforms in the xcframework):
-#   aarch64-apple-ios       (device,    iphoneos SDK)
-#   aarch64-apple-ios-sim   (simulator, iphonesimulator SDK)
+# iOS forbids shipping custom dynamic libs, so the fork builds STATIC archives
+# (.a) for iOS; bae-bridge/build-ios.sh merges them into libbae_bridge.a inside
+# the xcframework. Device and simulator are distinct platforms in the
+# xcframework and are never lipo'd together.
 #
-# Re-runnable. Reuses the FFmpeg source cloned by build-ffmpeg-android.sh.
+# Output: third_party/ffmpeg-ios/<arch>/{lib,include}
+#   aarch64-apple-ios       (device,    fork label ios-arm64)
+#   aarch64-apple-ios-sim   (simulator, fork label ios-sim-arm64)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IOS_MIN="16.0"
-FF_TAG="n7.1" # matches ffmpeg-sys-next 8.x (FFmpeg 7.1)
-
-SRC="$REPO_ROOT/third_party/ffmpeg-src"
+VERSION="v8.1.2-bae2"
+BASE_URL="https://github.com/bae-fm/bae-ffmpeg/releases/download/$VERSION"
 OUT="$REPO_ROOT/third_party/ffmpeg-ios"
 
-# --- FFmpeg source (shared with the Android build) ---
-if [ ! -d "$SRC/.git" ]; then
-  echo "=== cloning FFmpeg $FF_TAG ==="
-  git clone --depth 1 --branch "$FF_TAG" https://github.com/FFmpeg/FFmpeg.git "$SRC"
-fi
-
-# Same audio components as Android (audio_codec.rs is identical across platforms).
-DECODERS="flac,mp3,ape,alac,aac,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,pcm_u8,pcm_s16be,pcm_s24be,pcm_s32be"
-ENCODERS="flac"
-MUXERS="flac"
-DEMUXERS="flac,mp3,ape,mov,ipod,ogg,wav,aiff"
-PARSERS="flac,mpegaudio,aac"
-
-build_arch() {
-  local ARCH="$1" SDK="$2" MIN_FLAG="$3" TARGET_TRIPLE="$4"
-  local PREFIX="$OUT/$ARCH"
-  local BUILD="$SRC/build-$ARCH"
-  local SYSROOT; SYSROOT="$(xcrun --sdk "$SDK" --show-sdk-path)"
-  local CLANG; CLANG="$(xcrun --sdk "$SDK" -f clang)"
-  # `-target` marks simulator vs device for the integrated assembler/linker; the
-  # min-version flag pins the deployment floor.
-  local CFLAGS="-arch arm64 -isysroot $SYSROOT $MIN_FLAG"
-  [ -n "$TARGET_TRIPLE" ] && CFLAGS="$CFLAGS -target $TARGET_TRIPLE"
-
-  echo "=== configuring FFmpeg for $ARCH ($SDK) ==="
-  rm -rf "$BUILD"; mkdir -p "$BUILD"
-  ( cd "$BUILD" && "$SRC/configure" \
-      --prefix="$PREFIX" \
-      --enable-cross-compile --target-os=darwin --arch=arm64 \
-      --sysroot="$SYSROOT" \
-      --cc="$CLANG" \
-      --extra-cflags="$CFLAGS" \
-      --extra-ldflags="$CFLAGS" \
-      --enable-pic --enable-static --disable-shared \
-      --disable-programs --disable-doc \
-      --disable-avdevice --disable-avfilter --disable-postproc --disable-network \
-      --enable-swresample \
-      --disable-everything \
-      --enable-decoder="$DECODERS" \
-      --enable-encoder="$ENCODERS" \
-      --enable-muxer="$MUXERS" \
-      --enable-demuxer="$DEMUXERS" \
-      --enable-parser="$PARSERS" )
-  echo "=== building FFmpeg for $ARCH ==="
-  make -C "$BUILD" -j"$(sysctl -n hw.ncpu)"
-  make -C "$BUILD" install
-  echo "=== $ARCH static libs ==="
-  ls -la "$PREFIX"/lib/*.a
+# fork release tarball label -> bae per-target dir.
+download() {
+  local label="$1" dir="$2"
+  local dest="$OUT/$dir"
+  echo "=== downloading ffmpeg-$label ($VERSION) ==="
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  curl -fL "$BASE_URL/ffmpeg-$label.tar.gz" | tar xz -C "$dest"
+  if [ ! -f "$dest/lib/libavcodec.a" ]; then
+    echo "FATAL: libavcodec.a missing in $dest after download" >&2
+    exit 1
+  fi
 }
 
-# Device: arm64 iphoneos. Apple arm64 uses clang's integrated assembler (no nasm).
-build_arch "aarch64-apple-ios" "iphoneos" "-mios-version-min=$IOS_MIN" ""
-# Simulator: arm64 iphonesimulator — the -target triple is what distinguishes it.
-build_arch "aarch64-apple-ios-sim" "iphonesimulator" "-mios-simulator-version-min=$IOS_MIN" "arm64-apple-ios${IOS_MIN}-simulator"
+download ios-arm64     aarch64-apple-ios
+download ios-sim-arm64 aarch64-apple-ios-sim
 
 echo "=== DONE. FFmpeg installed under $OUT/{aarch64-apple-ios,aarch64-apple-ios-sim} ==="

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -32,13 +32,13 @@ fi
 # at ~/dev/agent-instructions/projects/bae.md.
 ln -sf "$HOME/dev/agent-instructions/projects/bae.md" CLAUDE.md
 
-# Share the machine's prebuilt cross-compiled FFmpeg from the main checkout. The
-# per-target static libs under third_party/ (ffmpeg-ios, ffmpeg-android, and the
-# ffmpeg-src tree they build from) are expensive to compile from source and don't
+# Share the machine's prebuilt FFmpeg from the main checkout. The per-target
+# libs under third_party/ (ffmpeg-ios, ffmpeg-android) are downloaded from the
+# bae-ffmpeg fork's release by scripts/build-ffmpeg-{ios,android}.sh and don't
 # come along when git creates a worktree (they're gitignored), so an iOS or
-# Android bridge build here would otherwise re-run the whole FFmpeg cross-compile.
-# Symlink the main checkout's directory so every worktree shares one build; the
-# whole path is gitignored, so the symlink stays out of `git status`.
+# Android bridge build here would otherwise re-download them. Symlink the main
+# checkout's directory so every worktree shares one copy; the whole path is
+# gitignored, so the symlink stays out of `git status`.
 main_checkout="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 if [ "$main_checkout" != "$worktree_root" ] \
     && [ -d "$main_checkout/third_party" ] && [ ! -e third_party ]; then

--- a/scripts/setup-ffmpeg.sh
+++ b/scripts/setup-ffmpeg.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 FFMPEG_DIR="$PROJECT_ROOT/bae-ffmpeg/dist"
-VERSION="v8.0.1-bae8"
+VERSION="v8.1.2-bae2"
 
 ARCH=$(uname -m)
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -41,10 +41,12 @@ fi
 echo ""
 echo "bae-ffmpeg installed to: $FFMPEG_DIR"
 echo ""
-echo "Add to your shell profile (.zshrc or .bashrc):"
+echo "This is required local setup: bae links FFmpeg exclusively from here, never"
+echo "from a system/Homebrew install. Add to your shell profile (.zshrc or .bashrc):"
 echo ""
 echo "  export FFMPEG_DIR=\"$FFMPEG_DIR\""
 echo "  export PKG_CONFIG_PATH=\"$FFMPEG_DIR/lib/pkgconfig:\$PKG_CONFIG_PATH\""
 echo "  export LIBRARY_PATH=\"$FFMPEG_DIR/lib:\$LIBRARY_PATH\""
 echo "  export DYLD_LIBRARY_PATH=\"$FFMPEG_DIR/lib:\$DYLD_LIBRARY_PATH\""
+echo "  export BINDGEN_EXTRA_CLANG_ARGS=\"-I$FFMPEG_DIR/include \${BINDGEN_EXTRA_CLANG_ARGS:-}\""
 echo ""


### PR DESCRIPTION
bae linked FFmpeg through two unrelated supply chains. The desktop platforms (macOS, Linux, Windows) downloaded the bae-ffmpeg fork's prebuilt audio-only libraries, but iOS and Android cross-compiled vanilla FFmpeg 7.1 from a `git clone` into `third_party/ffmpeg-src` — a whole major version behind the desktop's 8.0, and not the fork at all. On top of that, local macOS dev linked Homebrew's ffmpeg 7.1 (a silent dev/release version mismatch), and the macOS app bundled Homebrew's ffmpeg dylibs through a `/opt/homebrew/opt/ffmpeg/lib` search path.

This collapses all of that onto one source. Every platform and every build context — local dev, CI, release — now links the same prebuilt fork artifacts at the same FFmpeg version. The iOS and Android scripts download the fork's mobile artifacts instead of cloning vanilla FFmpeg, and the vanilla clone and its references are gone. For local dev, pkg-config points only at the fork's `bae-ffmpeg/dist`, so a system or Homebrew ffmpeg cannot be resolved even if one is installed; Homebrew remains only for genuinely-separate native deps (libdiscid, which discid-sys finds via `LIBRARY_PATH` and clang include args, not pkg-config). The macOS app's library search paths and the dylib bundler now prefer the fork dist and never a Homebrew ffmpeg. `scripts/setup-ffmpeg.sh` is the required local setup that fills `bae-ffmpeg/dist`.

The Rust bindings move from `ffmpeg-sys-next`/`ffmpeg-next` 8.0 to 8.1 — the newest released bindings, which bind the FFmpeg 8.1 series — matching the fork's move to FFmpeg 8.1.2.

## Depends on (blocked)
This references the bae-ffmpeg release tag `v8.1.2-bae1`, which **does not exist yet**. It is blocked on:
1. bae-fm/bae-ffmpeg#2 merging, and
2. a human cutting the `v8.1.2-bae1` tag on bae-ffmpeg (the release CI then publishes the macOS/Linux/Windows/iOS/Android assets this PR fetches).

Until that tag exists, the mobile download scripts and the CI version pins resolve nothing.

## Verified locally
- `cargo build -p bae-core` against ffmpeg-sys-next 8.1.0 + the fork's FFmpeg 8.1.2 (built locally from the companion PR's `build-macos.sh`), relying only on the new `.cargo/config.toml` + a populated `bae-ffmpeg/dist`.
- Full macOS pre-commit suite: bae-bridge clippy, the macOS bridge build, and the macOS app `xcodebuild` linking ffmpeg from the fork dist via the new `LIBRARY_SEARCH_PATHS`.

## NOT verified locally (rides on CI / the tag)
- The mobile download scripts actually fetching assets — the `v8.1.2-bae1` tag and its iOS/Android artifacts don't exist yet.
- iOS and Android cross-compiled bridge builds against the downloaded artifacts (cross-compiles run only in CI).
- The Windows and Linux CI link paths against the new tag.
- The macOS/Windows release packaging workflows end to end.

## Test plan
- [ ] Merge bae-ffmpeg#2 and cut `v8.1.2-bae1`.
- [ ] CI green here across macOS, Linux, Windows, iOS, Android.
- [ ] Confirm a shipped macOS app bundles the fork's ffmpeg dylibs (`otool -L` shows no `/opt/homebrew` ffmpeg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)