### PR TITLE
Add composer library mode

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/data/Library.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/Library.kt
@@ -8,7 +8,7 @@ import uniffi.bae_bridge.BridgeSortCriterion
 
 /**
  * Narrow projection of [AppHandle] for library browse and detail reads — DB
- * queries and library-image reads. The page/detail calls touch the database and
+ * queries and cover-image reads. The page/detail calls touch the database and
  * must run off the main thread; the suspend calls cross the bridge themselves.
  * Mirrors the macOS `Library` / `MediaPaths` domain services.
  */
@@ -25,9 +25,9 @@ class Library(
 
     fun albumDetail(albumId: String): BridgeAlbumDetail = handle.getAlbumDetail(albumId)
 
-    /** Bytes of a library image (a cover or artist image) by id, read through
-     *  coven's locality-aware store, or null when no such image exists. */
-    suspend fun imageBytes(imageId: String): ByteArray? = handle.fetchImageBytes(imageId)
+    /** Bytes of a release cover by release id, read through coven's
+     *  locality-aware store, or null when no such cover exists. */
+    suspend fun imageBytes(imageId: String): ByteArray? = handle.fetchCoverImageBytes(imageId)
 
     /**
      * Search albums and tracks by free-text query. Suspends: the bridge call is

--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -670,7 +670,7 @@ class BaeCorePlayer(
         scope.launch {
             val bytes =
                 try {
-                    appHandle.fetchImageBytes(coverImageId)
+                    appHandle.fetchCoverImageBytes(coverImageId)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/CoverImage.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/CoverImage.kt
@@ -155,8 +155,7 @@ private fun rememberCoverState(
  * `(id, version)`) clipped to a rounded square, or a MusicNote placeholder when
  * there is no cover. The caller's [modifier] carries the sizing —
  * `Modifier.size(48.dp)` for list rows, `Modifier.fillMaxWidth().aspectRatio(1f)`
- * for full-width art. [loadImage] reads the bytes off the bridge (covers/artist
- * images by id).
+ * for full-width art. [loadImage] reads cover bytes off the bridge by release id.
  */
 @Composable
 fun CoverImage(

--- a/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackServiceTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackServiceTest.kt
@@ -140,5 +140,5 @@ internal class FakeAppHandle(
 
     override fun triggerSync() {}
 
-    override suspend fun fetchImageBytes(imageId: String): ByteArray? = imageBytes[imageId]
+    override suspend fun fetchCoverImageBytes(releaseId: String): ByteArray? = imageBytes[releaseId]
 }

--- a/bae-automation/src/lib.rs
+++ b/bae-automation/src/lib.rs
@@ -360,6 +360,11 @@ pub enum AutomationImportProgress {
         import_id: String,
         album_id: String,
     },
+    RemoteUploadQueued {
+        id: String,
+        import_id: String,
+        album_id: String,
+    },
     Failed {
         id: String,
         error: String,
@@ -1787,6 +1792,15 @@ fn automation_import_progress(progress: ImportProgress) -> AutomationImportProgr
             import_id,
             album_id,
         } => AutomationImportProgress::Complete {
+            id,
+            import_id,
+            album_id,
+        },
+        ImportProgress::RemoteUploadQueued {
+            id,
+            import_id,
+            album_id,
+        } => AutomationImportProgress::RemoteUploadQueued {
             id,
             import_id,
             album_id,

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -12,8 +12,6 @@ use crate::bridge_utils::build_bridge_config;
 #[cfg(feature = "desktop")]
 use crate::types::BridgeDiscogsSaveOutcome;
 #[cfg(feature = "desktop")]
-use crate::types::BridgeMetadataSource;
-#[cfg(feature = "desktop")]
 use crate::types::BridgeRemoteCover;
 #[cfg(feature = "oauth-providers")]
 use crate::types::{bridge_cloud_provider_to_core, BridgeCloudProvider};
@@ -23,12 +21,15 @@ use crate::types::{bridge_cloud_provider_to_core, BridgeCloudProvider};
 #[cfg(any(feature = "oauth-providers", feature = "cloudkit"))]
 use crate::types::BridgeHomeStorage;
 use crate::types::{
-    bridge_home_storage_to_core, bridge_sort_to_core, BridgeAlbum, BridgeAlbumDetail,
-    BridgeAlbumSearchResult, BridgeConfig, BridgeCoverSelection, BridgeError, BridgeFile,
-    BridgeGalleryItem, BridgeGallerySource, BridgeRelease, BridgeReleaseSummary, BridgeRepeatMode,
+    bridge_composer_sort_to_core, bridge_home_storage_to_core, bridge_sort_to_core, BridgeAlbum,
+    BridgeAlbumDetail, BridgeAlbumSearchResult, BridgeComposerDetail, BridgeComposerSortCriterion,
+    BridgeComposerSummary, BridgeComposerWorkGroup, BridgeConfig, BridgeCoverSelection,
+    BridgeError, BridgeFile, BridgeGalleryItem, BridgeGallerySource, BridgeMetadataSource,
+    BridgeRelease, BridgeReleaseRoleSummary, BridgeReleaseSummary, BridgeRepeatMode,
     BridgeSaveSyncConfig, BridgeSearchResults, BridgeSortCriterion, BridgeStorageFilter,
     BridgeStoragePage, BridgeStorageRow, BridgeStorageSort, BridgeTrack, BridgeTrackGroup,
-    BridgeTrackSearchResult,
+    BridgeTrackRoleSummary, BridgeTrackSearchResult, BridgeWorkDetail, BridgeWorkSummary,
+    BridgeWorkTrackSummary,
 };
 #[cfg(feature = "desktop")]
 use crate::types::{bridge_storage_mode_to_core, BridgeMcpServerStatus, BridgeStorageMode};
@@ -96,12 +97,72 @@ impl AppHandle {
         })
     }
 
+    pub fn get_composer_count(&self) -> Result<u64, BridgeError> {
+        self.runtime.block_on(async {
+            self.services
+                .library_manager()
+                .get_composer_count()
+                .await
+                .map_err(|e| BridgeError::database(format!("{e}")))
+        })
+    }
+
+    pub fn get_composer_page(
+        &self,
+        sort_criterion: BridgeComposerSortCriterion,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<BridgeComposerSummary>, BridgeError> {
+        self.runtime.block_on(async {
+            let sort = bridge_composer_sort_to_core(&sort_criterion);
+            let composers = self
+                .services
+                .library_manager()
+                .get_composer_page(sort, offset, limit)
+                .await
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
+            Ok(composers
+                .into_iter()
+                .map(convert_composer_summary)
+                .collect())
+        })
+    }
+
+    pub fn get_composer_detail(
+        &self,
+        artist_id: String,
+    ) -> Result<Option<BridgeComposerDetail>, BridgeError> {
+        self.runtime.block_on(async {
+            let detail = self
+                .services
+                .library_manager()
+                .get_composer_detail(&artist_id)
+                .await
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
+            Ok(detail.map(convert_composer_detail))
+        })
+    }
+
+    pub fn get_work_detail(
+        &self,
+        work_id: String,
+    ) -> Result<Option<BridgeWorkDetail>, BridgeError> {
+        self.runtime.block_on(async {
+            let detail = self
+                .services
+                .library_manager()
+                .get_work_detail(&work_id)
+                .await
+                .map_err(|e| BridgeError::database(format!("{e}")))?;
+            Ok(detail.map(convert_work_detail))
+        })
+    }
+
     /// Filesystem path for the user's own external file behind a library file
     /// (the DiscID re-read of a rip's LOG/CUE/audio). Returns `Ok(None)` if the
     /// file has no readable local location (e.g. cloud-only and not cached).
     /// Returns `Err` on DB failures so callers can distinguish a missing file
-    /// from a broken library state. NOT a substitute for a coven byte read —
-    /// library images are read by id via `fetch_image_bytes`.
+    /// from a broken library state. NOT a substitute for a coven byte read.
     pub fn file_path(&self, file_id: String) -> Result<Option<String>, BridgeError> {
         self.runtime.block_on(async {
             let path = self
@@ -218,6 +279,16 @@ impl AppHandle {
                     album_title: t.album_title,
                     artist_name: t.artist_name,
                 })
+                .collect(),
+            composers: results
+                .composers
+                .into_iter()
+                .map(convert_composer_summary)
+                .collect(),
+            works: results
+                .works
+                .into_iter()
+                .map(convert_work_summary)
                 .collect(),
         })
     }
@@ -753,18 +824,32 @@ fn bridge_mcp_error(error: bae_desktop::McpServerError) -> crate::types::BridgeM
 
 #[uniffi::export(async_runtime = "tokio")]
 impl AppHandle {
-    /// Bytes of a host-provided library image (a cover or an artist image) for
-    /// `image_id`, read through coven's locality-aware read (local store while
-    /// Local, cache/cloud while Remote). `None` when no such image exists. The UI
-    /// decodes the bytes and caches them under `(id, version)` — the version it
-    /// already holds on the `BridgeImageRef`. A read error surfaces, not masked.
+    /// Bytes of a host-provided library image (a cover or an artist image), read
+    /// through coven's locality-aware read (local store while Local, cache/cloud
+    /// while Remote). `None` when no such image exists. The `BridgeImageRef`
+    /// carries the image kind, so core reads the known image namespace directly.
+    /// A read error surfaces, not masked.
     pub async fn fetch_image_bytes(
         &self,
-        image_id: String,
+        image: crate::types::BridgeImageRef,
     ) -> Result<Option<Vec<u8>>, BridgeError> {
         self.services
             .library_manager()
-            .read_image_blob(&image_id)
+            .read_image_blob(&image.into_core())
+            .await
+            .map_err(|e| BridgeError::database(format!("{e}")))
+    }
+
+    /// Bytes of a release cover image, read through coven's locality-aware
+    /// store. Use this for cover-only UI payloads that carry a release id rather
+    /// than a full `BridgeImageRef`.
+    pub async fn fetch_cover_image_bytes(
+        &self,
+        release_id: String,
+    ) -> Result<Option<Vec<u8>>, BridgeError> {
+        self.services
+            .library_manager()
+            .read_cover_image_blob(&release_id)
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))
     }
@@ -1882,6 +1967,121 @@ fn convert_album_summary(a: bae_core::album_detail::AlbumSummary) -> BridgeAlbum
     }
 }
 
+fn convert_composer_summary(s: bae_core::album_detail::ComposerSummary) -> BridgeComposerSummary {
+    BridgeComposerSummary {
+        artist_id: s.raw.artist.id,
+        name: s.raw.artist.name,
+        sort_name: s.raw.artist.sort_name,
+        work_count: s.raw.work_count,
+        linked_release_count: s.raw.linked_release_count,
+        unlinked_credit_count: s.raw.unlinked_credit_count,
+        image: s.image.map(crate::types::BridgeImageRef::from_core),
+    }
+}
+
+fn convert_work_summary(s: bae_core::album_detail::WorkSummary) -> BridgeWorkSummary {
+    BridgeWorkSummary {
+        work_id: s.raw.work.id,
+        title: s.raw.work.title,
+        disambiguation: s.raw.work.disambiguation,
+        work_type: s.raw.work.work_type,
+        parent_work_id: s.raw.parent_work_id,
+        composer_names: s.raw.composer_names,
+        linked_release_count: s.raw.linked_release_count,
+        representative_release_id: s.raw.representative_release_id,
+        representative_cover: s
+            .representative_cover
+            .map(crate::types::BridgeImageRef::from_core),
+    }
+}
+
+fn convert_release_role_summary(
+    s: bae_core::album_detail::ReleaseRoleSummary,
+) -> BridgeReleaseRoleSummary {
+    BridgeReleaseRoleSummary {
+        release_id: s.role.release_id,
+        album_id: s.album.id,
+        album_title: s.album.title,
+        source: BridgeMetadataSource::from_core(s.role.source),
+        source_credit: s.role.source_credit,
+    }
+}
+
+fn convert_track_role_summary(
+    s: bae_core::album_detail::TrackRoleSummary,
+) -> BridgeTrackRoleSummary {
+    BridgeTrackRoleSummary {
+        track_id: s.role.track_id,
+        track_title: s.track.title,
+        release_id: s.track.release_id,
+        album_id: s.album.id,
+        album_title: s.album.title,
+        artist_id: s.role.artist_id,
+        artist_name: s.artist.name,
+        source: BridgeMetadataSource::from_core(s.role.source),
+        source_credit: s.role.source_credit,
+    }
+}
+
+fn convert_work_track_summary(
+    s: bae_core::album_detail::WorkTrackSummary,
+) -> BridgeWorkTrackSummary {
+    BridgeWorkTrackSummary {
+        track_id: s.link.track_id,
+        track_title: s.track.title,
+        release_id: s.track.release_id,
+        album_id: s.album.id,
+        album_title: s.album.title,
+    }
+}
+
+fn convert_composer_detail(d: bae_core::album_detail::ComposerDetail) -> BridgeComposerDetail {
+    BridgeComposerDetail {
+        composer: convert_composer_summary(d.composer),
+        work_groups: d
+            .work_groups
+            .into_iter()
+            .map(|group| BridgeComposerWorkGroup {
+                id: group.id,
+                parent: group.parent.map(convert_work_summary),
+                works: group.works.into_iter().map(convert_work_summary).collect(),
+            })
+            .collect(),
+        unlinked_release_roles: d
+            .unlinked_release_roles
+            .into_iter()
+            .map(convert_release_role_summary)
+            .collect(),
+        unlinked_track_roles: d
+            .unlinked_track_roles
+            .into_iter()
+            .map(convert_track_role_summary)
+            .collect(),
+        default_work_id: d.default_work_id,
+    }
+}
+
+fn convert_work_detail(d: bae_core::album_detail::WorkDetail) -> BridgeWorkDetail {
+    BridgeWorkDetail {
+        work: convert_work_summary(d.work),
+        child_works: d
+            .child_works
+            .into_iter()
+            .map(convert_work_summary)
+            .collect(),
+        releases: d
+            .releases
+            .into_iter()
+            .map(convert_release_summary)
+            .collect(),
+        tracks: d
+            .tracks
+            .into_iter()
+            .map(convert_work_track_summary)
+            .collect(),
+    }
+}
+
 fn bridge_album_to_summary(a: BridgeAlbum) -> bae_core::album_detail::AlbumSummary {
     bae_core::album_detail::AlbumSummary {
         id: a.id,
@@ -1995,6 +2195,8 @@ pub fn raw_release_edit_from_user_edit(
 
 #[cfg(test)]
 mod tests {
+    use bae_core::album_detail::{ComposerDetail, ComposerSummary, ComposerWorkGroup, WorkSummary};
+    use bae_core::db::{DbArtist, DbComposerSummary, DbWork, DbWorkSummary};
     use std::sync::{Arc, Mutex};
 
     /// Records every delivered event so tests can assert on the stream.
@@ -2040,6 +2242,88 @@ mod tests {
                 [crate::types::BridgeUiEvent::MuteChanged { is_muted: true }]
             ),
             "expected the event behind the lag to still be delivered, got: {events:?}",
+        );
+    }
+
+    #[test]
+    fn composer_detail_conversion_preserves_work_groups() {
+        let created_at = "2026-01-01T00:00:00Z".parse().unwrap();
+        let detail = ComposerDetail {
+            composer: ComposerSummary {
+                raw: DbComposerSummary {
+                    artist: DbArtist {
+                        id: "artist-composer-a".to_string(),
+                        name: "Composer Name A".to_string(),
+                        sort_name: Some("Composer Name Sort A".to_string()),
+                        discogs_artist_id: None,
+                        musicbrainz_artist_id: None,
+                        created_at,
+                    },
+                    work_count: 2,
+                    linked_release_count: 1,
+                    unlinked_credit_count: 0,
+                },
+                image: None,
+            },
+            work_groups: vec![ComposerWorkGroup {
+                id: "work-parent-a".to_string(),
+                parent: Some(WorkSummary {
+                    raw: DbWorkSummary {
+                        work: DbWork {
+                            id: "work-parent-a".to_string(),
+                            title: "Parent Work A".to_string(),
+                            disambiguation: None,
+                            work_type: Some("work".to_string()),
+                            created_at,
+                        },
+                        parent_work_id: None,
+                        composer_names: Some("Composer Name A".to_string()),
+                        linked_release_count: 1,
+                        representative_release_id: Some("release-a".to_string()),
+                    },
+                    representative_cover: None,
+                }),
+                works: vec![WorkSummary {
+                    raw: DbWorkSummary {
+                        work: DbWork {
+                            id: "work-child-a".to_string(),
+                            title: "Child Work A".to_string(),
+                            disambiguation: None,
+                            work_type: Some("part".to_string()),
+                            created_at,
+                        },
+                        parent_work_id: Some("work-parent-a".to_string()),
+                        composer_names: Some("Composer Name A".to_string()),
+                        linked_release_count: 1,
+                        representative_release_id: Some("release-a".to_string()),
+                    },
+                    representative_cover: None,
+                }],
+            }],
+            unlinked_release_roles: Vec::new(),
+            unlinked_track_roles: Vec::new(),
+            default_work_id: Some("work-parent-a".to_string()),
+        };
+
+        let bridge = super::convert_composer_detail(detail);
+
+        assert_eq!(bridge.work_groups.len(), 1);
+        assert_eq!(bridge.default_work_id.as_deref(), Some("work-parent-a"));
+        let group = &bridge.work_groups[0];
+        assert_eq!(group.id, "work-parent-a");
+        assert_eq!(
+            group.parent.as_ref().map(|work| work.work_id.as_str()),
+            Some("work-parent-a")
+        );
+        assert_eq!(group.works.len(), 1);
+        assert_eq!(group.works[0].work_id, "work-child-a");
+        assert_eq!(
+            group.works[0].parent_work_id.as_deref(),
+            Some("work-parent-a")
+        );
+        assert_eq!(
+            group.works[0].representative_release_id.as_deref(),
+            Some("release-a")
         );
     }
 }

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -89,16 +89,40 @@ pub struct BridgeLibrary {
     pub is_active: bool,
 }
 
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum BridgeLibraryImageType {
+    Cover,
+    Artist,
+}
+
+impl From<bae_core::db::LibraryImageType> for BridgeLibraryImageType {
+    fn from(value: bae_core::db::LibraryImageType) -> Self {
+        match value {
+            bae_core::db::LibraryImageType::Cover => Self::Cover,
+            bae_core::db::LibraryImageType::Artist => Self::Artist,
+        }
+    }
+}
+
+impl From<BridgeLibraryImageType> for bae_core::db::LibraryImageType {
+    fn from(value: BridgeLibraryImageType) -> Self {
+        match value {
+            BridgeLibraryImageType::Cover => Self::Cover,
+            BridgeLibraryImageType::Artist => Self::Artist,
+        }
+    }
+}
+
 /// A reference to a host-provided library image (a cover or an artist image):
-/// the image id plus a content version. The UI fetches the bytes by id
-/// (`fetch_image_bytes`) and caches them under `(id, version)`, so a grid of
-/// covers renders without re-crossing the bridge on scroll yet reloads when a
-/// cover is replaced. `version` is the image row's `_updated_at`, which moves
-/// when the bytes change. Mirrors `bae_core::album_detail::ImageRef`.
+/// the image kind, subject id, and content version. The UI passes the whole ref
+/// to `fetch_image_bytes`, so core dispatches to the known image namespace.
+/// `version` is the image row's `_updated_at`, which moves when the bytes
+/// change. Mirrors `bae_core::album_detail::ImageRef`.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeImageRef {
     pub id: String,
     pub version: String,
+    pub image_type: BridgeLibraryImageType,
 }
 
 impl BridgeImageRef {
@@ -106,6 +130,7 @@ impl BridgeImageRef {
         Self {
             id: r.id,
             version: r.version,
+            image_type: r.image_type.into(),
         }
     }
 
@@ -113,6 +138,7 @@ impl BridgeImageRef {
         bae_core::album_detail::ImageRef {
             id: self.id,
             version: self.version,
+            image_type: self.image_type.into(),
         }
     }
 }
@@ -1968,6 +1994,8 @@ pub struct BridgeSaveSyncConfig {
 pub struct BridgeSearchResults {
     pub albums: Vec<BridgeAlbumSearchResult>,
     pub tracks: Vec<BridgeTrackSearchResult>,
+    pub composers: Vec<BridgeComposerSummary>,
+    pub works: Vec<BridgeWorkSummary>,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -1989,6 +2017,98 @@ pub struct BridgeTrackSearchResult {
     pub album_id: String,
     pub album_title: String,
     pub artist_name: String,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeComposerSummary {
+    pub artist_id: String,
+    pub name: String,
+    pub sort_name: Option<String>,
+    pub work_count: i64,
+    pub linked_release_count: i64,
+    pub unlinked_credit_count: i64,
+    pub image: Option<BridgeImageRef>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeWorkSummary {
+    pub work_id: String,
+    pub title: String,
+    pub disambiguation: Option<String>,
+    pub work_type: Option<String>,
+    pub parent_work_id: Option<String>,
+    pub composer_names: Option<String>,
+    pub linked_release_count: i64,
+    pub representative_release_id: Option<String>,
+    pub representative_cover: Option<BridgeImageRef>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeReleaseRoleSummary {
+    pub release_id: String,
+    pub album_id: String,
+    pub album_title: String,
+    pub source: BridgeMetadataSource,
+    pub source_credit: Option<String>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeTrackRoleSummary {
+    pub track_id: String,
+    pub track_title: String,
+    pub release_id: String,
+    pub album_id: String,
+    pub album_title: String,
+    pub artist_id: String,
+    pub artist_name: String,
+    pub source: BridgeMetadataSource,
+    pub source_credit: Option<String>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeWorkTrackSummary {
+    pub track_id: String,
+    pub track_title: String,
+    pub release_id: String,
+    pub album_id: String,
+    pub album_title: String,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeComposerDetail {
+    pub composer: BridgeComposerSummary,
+    pub work_groups: Vec<BridgeComposerWorkGroup>,
+    pub unlinked_release_roles: Vec<BridgeReleaseRoleSummary>,
+    pub unlinked_track_roles: Vec<BridgeTrackRoleSummary>,
+    pub default_work_id: Option<String>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeComposerWorkGroup {
+    pub id: String,
+    pub parent: Option<BridgeWorkSummary>,
+    pub works: Vec<BridgeWorkSummary>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeWorkDetail {
+    pub work: BridgeWorkSummary,
+    pub child_works: Vec<BridgeWorkSummary>,
+    pub releases: Vec<BridgeReleaseSummary>,
+    pub tracks: Vec<BridgeWorkTrackSummary>,
+}
+
+#[derive(Debug, Clone, Copy, uniffi::Enum)]
+pub enum BridgeComposerSortField {
+    Name,
+    WorkCount,
+    LinkedReleaseCount,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeComposerSortCriterion {
+    pub field: BridgeComposerSortField,
+    pub direction: BridgeSortDirection,
 }
 
 /// One row on the Storage Manager: a release paired with its parent
@@ -2649,6 +2769,28 @@ pub(crate) fn bridge_storage_filter_to_core(
     }
 }
 
+pub(crate) fn bridge_composer_sort_to_core(
+    c: &BridgeComposerSortCriterion,
+) -> bae_core::db::ComposerSortCriterion {
+    bae_core::db::ComposerSortCriterion {
+        field: match c.field {
+            BridgeComposerSortField::Name => bae_core::db::ComposerSortField::Name,
+            BridgeComposerSortField::WorkCount => bae_core::db::ComposerSortField::WorkCount,
+            BridgeComposerSortField::LinkedReleaseCount => {
+                bae_core::db::ComposerSortField::LinkedReleaseCount
+            }
+        },
+        direction: bridge_sort_direction_to_core(&c.direction),
+    }
+}
+
+fn bridge_sort_direction_to_core(direction: &BridgeSortDirection) -> bae_core::db::SortDirection {
+    match direction {
+        BridgeSortDirection::Ascending => bae_core::db::SortDirection::Ascending,
+        BridgeSortDirection::Descending => bae_core::db::SortDirection::Descending,
+    }
+}
+
 pub(crate) fn bridge_sort_to_core(c: &BridgeSortCriterion) -> bae_core::db::AlbumSortCriterion {
     bae_core::db::AlbumSortCriterion {
         field: match c.field {
@@ -2657,10 +2799,7 @@ pub(crate) fn bridge_sort_to_core(c: &BridgeSortCriterion) -> bae_core::db::Albu
             BridgeSortField::Year => bae_core::db::AlbumSortField::Year,
             BridgeSortField::DateAdded => bae_core::db::AlbumSortField::DateAdded,
         },
-        direction: match c.direction {
-            BridgeSortDirection::Ascending => bae_core::db::SortDirection::Ascending,
-            BridgeSortDirection::Descending => bae_core::db::SortDirection::Descending,
-        },
+        direction: bridge_sort_direction_to_core(&c.direction),
     }
 }
 

--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -135,6 +135,82 @@ CREATE TABLE IF NOT EXISTS track_artists (
     FOREIGN KEY (artist_id) REFERENCES artists (id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS works (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    disambiguation TEXT,
+    work_type TEXT,
+    _updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS work_artists (
+    id TEXT PRIMARY KEY,
+    work_id TEXT NOT NULL,
+    artist_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    _updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (work_id) REFERENCES works (id) ON DELETE CASCADE,
+    FOREIGN KEY (artist_id) REFERENCES artists (id) ON DELETE CASCADE,
+    UNIQUE(work_id, artist_id, position)
+);
+
+CREATE TABLE IF NOT EXISTS work_parts (
+    id TEXT PRIMARY KEY,
+    parent_work_id TEXT NOT NULL,
+    child_work_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    _updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (parent_work_id) REFERENCES works (id) ON DELETE CASCADE,
+    FOREIGN KEY (child_work_id) REFERENCES works (id) ON DELETE CASCADE,
+    UNIQUE(parent_work_id, child_work_id)
+);
+
+CREATE TABLE IF NOT EXISTS track_works (
+    id TEXT PRIMARY KEY,
+    track_id TEXT NOT NULL,
+    work_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    _updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (track_id) REFERENCES tracks (id) ON DELETE CASCADE,
+    FOREIGN KEY (work_id) REFERENCES works (id) ON DELETE CASCADE,
+    UNIQUE(track_id, work_id)
+);
+
+CREATE TABLE IF NOT EXISTS release_artist_roles (
+    id TEXT PRIMARY KEY,
+    release_id TEXT NOT NULL,
+    artist_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    source_credit TEXT,
+    _updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (release_id) REFERENCES releases (id) ON DELETE CASCADE,
+    FOREIGN KEY (artist_id) REFERENCES artists (id) ON DELETE CASCADE,
+    UNIQUE(release_id, artist_id, position, source)
+);
+
+CREATE TABLE IF NOT EXISTS track_artist_roles (
+    id TEXT PRIMARY KEY,
+    track_id TEXT NOT NULL,
+    artist_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    source_credit TEXT,
+    _updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (track_id) REFERENCES tracks (id) ON DELETE CASCADE,
+    FOREIGN KEY (artist_id) REFERENCES artists (id) ON DELETE CASCADE,
+    UNIQUE(track_id, artist_id, position, source)
+);
+
 CREATE TABLE IF NOT EXISTS release_files (
     id TEXT PRIMARY KEY,
     release_id TEXT NOT NULL,
@@ -284,6 +360,18 @@ CREATE TABLE IF NOT EXISTS attribution_names (
 -- device-local convention as coven's own bookkeeping tables. A single row
 -- (id = 'current'). `source` is the context's release id (NULL for a single
 -- track); `shuffle_seed` NULL means sequential, else shuffled with that seed.
+
+CREATE INDEX IF NOT EXISTS idx_work_artists_artist ON work_artists(artist_id);
+CREATE INDEX IF NOT EXISTS idx_work_artists_work ON work_artists(work_id);
+CREATE INDEX IF NOT EXISTS idx_work_parts_parent ON work_parts(parent_work_id);
+CREATE INDEX IF NOT EXISTS idx_work_parts_child ON work_parts(child_work_id);
+CREATE INDEX IF NOT EXISTS idx_track_works_track ON track_works(track_id);
+CREATE INDEX IF NOT EXISTS idx_track_works_work ON track_works(work_id);
+CREATE INDEX IF NOT EXISTS idx_release_artist_roles_artist ON release_artist_roles(artist_id);
+CREATE INDEX IF NOT EXISTS idx_release_artist_roles_release ON release_artist_roles(release_id);
+CREATE INDEX IF NOT EXISTS idx_track_artist_roles_artist ON track_artist_roles(artist_id);
+CREATE INDEX IF NOT EXISTS idx_track_artist_roles_track ON track_artist_roles(track_id);
+
 CREATE TABLE IF NOT EXISTS playback_state (
     id               TEXT PRIMARY KEY,
     source           TEXT,

--- a/bae-core/src/album_detail/composer.rs
+++ b/bae-core/src/album_detail/composer.rs
@@ -1,0 +1,61 @@
+//! Resolved composer/work types and their pure projections from DB aggregates.
+
+use super::*;
+use crate::db::{
+    DbComposerSummary, DbReleaseRoleSummary, DbTrackRoleSummary, DbWorkSummary, DbWorkTrackSummary,
+};
+
+#[derive(Debug, Clone)]
+pub struct ComposerSummary {
+    pub raw: DbComposerSummary,
+    pub image: Option<ImageRef>,
+}
+
+impl ComposerSummary {
+    pub(crate) fn from_raw(raw: DbComposerSummary, image: Option<ImageRef>) -> Self {
+        Self { raw, image }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkSummary {
+    pub raw: DbWorkSummary,
+    pub representative_cover: Option<ImageRef>,
+}
+
+impl WorkSummary {
+    pub(crate) fn from_raw(raw: DbWorkSummary, representative_cover: Option<ImageRef>) -> Self {
+        Self {
+            raw,
+            representative_cover,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComposerDetail {
+    pub composer: ComposerSummary,
+    pub work_groups: Vec<ComposerWorkGroup>,
+    pub unlinked_release_roles: Vec<ReleaseRoleSummary>,
+    pub unlinked_track_roles: Vec<TrackRoleSummary>,
+    pub default_work_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComposerWorkGroup {
+    pub id: String,
+    pub parent: Option<WorkSummary>,
+    pub works: Vec<WorkSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkDetail {
+    pub work: WorkSummary,
+    pub child_works: Vec<WorkSummary>,
+    pub releases: Vec<ReleaseSummary>,
+    pub tracks: Vec<WorkTrackSummary>,
+}
+
+pub type ReleaseRoleSummary = DbReleaseRoleSummary;
+pub type TrackRoleSummary = DbTrackRoleSummary;
+pub type WorkTrackSummary = DbWorkTrackSummary;

--- a/bae-core/src/album_detail/mod.rs
+++ b/bae-core/src/album_detail/mod.rs
@@ -10,7 +10,7 @@
 //! in `bae-bridge` is then a pure field-by-field copy to UniFFI types.
 //!
 //! The type split enforces the invariant: once a caller holds a resolved
-//! type, derivation has already happened — no consumer downstream (bridge,
+//! type, derivation has already happened -- no consumer downstream (bridge,
 //! events, UI) has to re-compute.
 //!
 //! ## Summary / detail composition
@@ -20,11 +20,11 @@
 //! render a row and that's it. Detail views are "fat": tracks, files,
 //! galleries, etc. We split each entity into two resolved types:
 //!
-//! - `AlbumSummary` / `ReleaseSummary` — slim. What a list row renders.
-//! - `AlbumDetail`  / `ReleaseDetail`  — fat. Composes the summary with
+//! - `AlbumSummary` / `ReleaseSummary` -- slim. What a list row renders.
+//! - `AlbumDetail`  / `ReleaseDetail`  -- fat. Composes the summary with
 //!   the heavy per-entity data loaded on demand.
 //!
-//! The `Detail` embeds the `Summary` rather than duplicating its fields —
+//! The `Detail` embeds the `Summary` rather than duplicating its fields --
 //! consumers that hold a detail can treat it as a superset. Reducers on the
 //! UI side can intern the summary portion into the "summaries" slice and the
 //! detail portion into the "details" slice from a single event payload.
@@ -32,7 +32,7 @@
 //! Tracks carry a structured [`TrackPosition`] instead of pre-formatted prose.
 //! A *side* is a contiguous playback unit (one CD disc, one vinyl face, one
 //! cassette face); which case applies depends on the release's physical format.
-//! The side letter (A/B/C…) and the disc-vs-side decision are domain logic and
+//! The side letter (A/B/C...) and the disc-vs-side decision are domain logic and
 //! stay here; only the words "Side"/"Disc" are the UI's, resolved from catalog
 //! keys.
 //!
@@ -44,14 +44,16 @@
 //! state, cloud-home presence) and hands them to these constructors; the
 //! derivation logic lives with the type it produces.
 
-use crate::db::DbArtist;
+use crate::db::{DbArtist, LibraryImageType};
 
 mod album;
+mod composer;
 mod release;
 mod search;
 mod storage;
 
 pub use album::*;
+pub use composer::*;
 pub use release::*;
 pub use search::*;
 pub use storage::*;
@@ -66,7 +68,7 @@ pub(crate) fn join_artist_names(artists: &[DbArtist]) -> String {
         .join(", ")
 }
 
-/// The TWO storage states a release's audio can be in — the shared
+/// The TWO storage states a release's audio can be in -- the shared
 /// `releases.remote` fact. This is ORTHOGONAL to pinned-ness: whether coven keeps
 /// a remote release's blobs local (`storage/pinned/`) vs evictable
 /// (`storage/cache/`) is a separate per-device coven-cache property, carried
@@ -75,7 +77,7 @@ pub(crate) fn join_artist_names(artists: &[DbArtist]) -> String {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReleaseStorageState {
     /// A local file the user owns, played in place; not in the cloud. Stays
-    /// Local while uploading (the upload is a sub-state of local —
+    /// Local while uploading (the upload is a sub-state of local --
     /// `remote` only flips once every blob is in the cloud).
     Local,
     /// A cloud blob; coven's cache sits transparently in front of it. Whether a
@@ -84,7 +86,7 @@ pub enum ReleaseStorageState {
 }
 
 /// The storage state for the shared `remote` fact. Pinned-ness is NOT part of
-/// this — it is a separate coven-cache property the caller carries as a `pinned`
+/// this -- it is a separate coven-cache property the caller carries as a `pinned`
 /// bool. Pure: the no-cloud-home overlay belongs to [`available_storage_actions`].
 pub fn storage_state(remote: bool) -> ReleaseStorageState {
     if remote {
@@ -94,21 +96,21 @@ pub fn storage_state(remote: bool) -> ReleaseStorageState {
     }
 }
 
-/// A storage transition the user can trigger from the release "Storage…"
+/// A storage transition the user can trigger from the release "Storage..."
 /// sheet. The core computes which are available; the UI renders them and
 /// never re-derives availability. `MakeRemote`/`MakeLocal` move between the two storage
 /// states; `Pin`/`Unpin` toggle the orthogonal coven-cache pin on a remote
 /// release.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReleaseStorageAction {
-    /// Local → Remote (upload to the cloud home).
+    /// Local -> Remote (upload to the cloud home).
     MakeRemote,
     /// Keep a remote release offline: fetch its blobs into coven's pinned cache.
     Pin,
     /// Stop keeping a remote release offline: drop its blobs from the pinned
     /// cache (still in the cloud).
     Unpin,
-    /// Remote → Local (move the files back out to a user folder).
+    /// Remote -> Local (move the files back out to a user folder).
     MakeLocal,
 }
 
@@ -147,7 +149,7 @@ pub fn available_storage_actions(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrackPosition {
     /// Vinyl/cassette: header "Side A", position "A1". `side_letter` is the
-    /// letter for the face (A/B/C…); `number` is the within-side track number.
+    /// letter for the face (A/B/C...); `number` is the within-side track number.
     Sided {
         side_letter: String,
         number: Option<i32>,
@@ -158,7 +160,7 @@ pub enum TrackPosition {
     Flat { number: Option<i32> },
 }
 
-/// A track group's side discriminant — what the UI renders as the "Side A" /
+/// A track group's side discriminant -- what the UI renders as the "Side A" /
 /// "Disc 2" header. `Flat` is single-disc digital: one group, no header.
 /// Separate from [`TrackPosition`] because a header carries no per-track number
 /// (every track on a side shares one `TrackSide`).
@@ -177,7 +179,7 @@ pub struct TrackDetail {
     pub side: i32,
     pub track_number: Option<i32>,
     pub duration_ms: Option<i64>,
-    /// Effective artist names for display — the track's own artists when it
+    /// Effective artist names for display -- the track's own artists when it
     /// has per-track artist rows, otherwise the album artists. Always
     /// populated so UI consumers can render a row label without joining
     /// artist data themselves.
@@ -209,7 +211,7 @@ pub struct FileDetail {
 }
 
 /// Structured audio-format descriptor. The UI composes the one-line label
-/// ("FLAC · 44.1 kHz · 16-bit · stereo") from these parts: the codec is a
+/// ("FLAC - 44.1 kHz - 16-bit - stereo") from these parts: the codec is a
 /// proper noun, the channel count maps to a localized word, and the numbers
 /// format per locale. `bits_per_sample` present means lossless (show the bit
 /// depth); absent means lossy (show `bitrate_kbps` instead).
@@ -222,32 +224,31 @@ pub struct AudioFormat {
     pub channels: i64,
 }
 
-/// A host-provided library image's reference: the image id plus a content
-/// version. The id is the subject id (a release id for a cover, an artist id for
-/// an artist image); the version is the image row's `_updated_at`, which moves
-/// when the bytes change (the upsert bumps it). The UI fetches the bytes by id
-/// (`read_image_blob`) and caches them under `(id, version)`, so a grid of covers
-/// renders without re-crossing the boundary on scroll yet still reloads when a
-/// cover is replaced.
+/// A host-provided library image's reference: the image kind, subject id, and
+/// content version. The id is a release id for a cover and an artist id for an
+/// artist image; the version is the image row's `_updated_at`, which moves when
+/// the bytes change. The UI passes the whole reference back when reading bytes,
+/// so core dispatches to the known table instead of probing image namespaces.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageRef {
     pub id: String,
     pub version: String,
+    pub image_type: LibraryImageType,
 }
 
 /// Which byte source a gallery slot is read from. Each variant is
 /// self-contained: the release's own cover composes the [`ImageRef`] (id +
 /// version) and is read by image id, a release-file image carries its own file
-/// id and is read by it. Core dispatches the byte read on this (`read_gallery_bytes`)
-/// so the UI never picks the source itself.
+/// id and is read by it. Core dispatches the byte read on this
+/// (`read_gallery_bytes`) so the UI never picks the source itself.
 #[derive(Debug, Clone)]
 pub enum GallerySource {
     Cover(ImageRef),
     ReleaseFile { file_id: String },
 }
 
-/// One slot in a release's lightbox gallery. Every slot is read by id — there is
-/// no filesystem path — and `source` names which byte source core reads from.
+/// One slot in a release's lightbox gallery. Every slot is read by id -- there is
+/// no filesystem path -- and `source` names which byte source core reads from.
 #[derive(Debug, Clone)]
 pub struct GalleryItem {
     /// Stable list/ForEach identity only: `"cover"` for the cover slot, otherwise

--- a/bae-core/src/album_detail/search.rs
+++ b/bae-core/src/album_detail/search.rs
@@ -1,5 +1,6 @@
 //! Resolved search-result types (`SearchResults`, `AlbumSearchResult`,
-//! `TrackSearchResult`) and the pure projections that produce them.
+//! `TrackSearchResult`, composer hits, and work hits) and the pure projections
+//! that produce them.
 
 use std::collections::HashMap;
 
@@ -12,14 +13,20 @@ use crate::db::{DbLibrarySearchResults, DbTrackSearchResult};
 pub struct SearchResults {
     pub albums: Vec<AlbumSearchResult>,
     pub tracks: Vec<TrackSearchResult>,
+    pub composers: Vec<ComposerSummary>,
+    pub works: Vec<WorkSummary>,
 }
 
 impl SearchResults {
     /// Resolve the raw search-result container by mapping each inner list.
-    /// `covers` maps an album's primary release id to its cover reference.
+    /// Cover/image maps are keyed by the ids carried by the raw search rows:
+    /// album primary release ids, composer artist ids, and work representative
+    /// release ids.
     pub(crate) fn from_raw(
         raw: DbLibrarySearchResults,
-        covers: &HashMap<String, ImageRef>,
+        album_covers: &HashMap<String, ImageRef>,
+        composer_images: &HashMap<String, ImageRef>,
+        work_covers: &HashMap<String, ImageRef>,
     ) -> SearchResults {
         SearchResults {
             albums: raw
@@ -34,7 +41,7 @@ impl SearchResults {
                     let primary_release_id = raw
                         .primary_release_id
                         .expect("album has at least one release");
-                    let cover = covers.get(&primary_release_id).cloned();
+                    let cover = album_covers.get(&primary_release_id).cloned();
                     AlbumSearchResult {
                         id: raw.id,
                         title: raw.title,
@@ -48,6 +55,25 @@ impl SearchResults {
                 .tracks
                 .into_iter()
                 .map(TrackSearchResult::from)
+                .collect(),
+            composers: raw
+                .composers
+                .into_iter()
+                .map(|composer| {
+                    let image = composer_images.get(&composer.artist.id).cloned();
+                    ComposerSummary::from_raw(composer, image)
+                })
+                .collect(),
+            works: raw
+                .works
+                .into_iter()
+                .map(|work| {
+                    let cover = work
+                        .representative_release_id
+                        .as_ref()
+                        .and_then(|id| work_covers.get(id).cloned());
+                    WorkSummary::from_raw(work, cover)
+                })
                 .collect(),
         }
     }

--- a/bae-core/src/db/client/album.rs
+++ b/bae-core/src/db/client/album.rs
@@ -104,7 +104,28 @@ impl Database {
                     })?
                     .collect::<coven::rusqlite::Result<Vec<_>>>()?;
 
-                Ok(DbLibrarySearchResults { albums, tracks })
+                let mut composer_stmt = conn.prepare(&composer_summary_query(
+                    Some("WHERE composer.name LIKE ? OR composer.sort_name LIKE ?"),
+                    Some("ORDER BY composer.name LIMIT ?"),
+                ))?;
+                let composers = composer_stmt
+                    .query_map(params![pattern, pattern, limit_i64], row_to_composer_summary)?
+                    .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+
+                let mut work_stmt = conn.prepare(&work_summary_query(
+                    Some("WHERE w.title LIKE ?"),
+                    Some("ORDER BY w.title LIMIT ?"),
+                ))?;
+                let works = work_stmt
+                    .query_map(params![pattern, limit_i64], row_to_work_summary)?
+                    .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+
+                Ok(DbLibrarySearchResults {
+                    albums,
+                    tracks,
+                    composers,
+                    works,
+                })
             })
             .await
     }

--- a/bae-core/src/db/client/artist.rs
+++ b/bae-core/src/db/client/artist.rs
@@ -170,4 +170,278 @@ impl Database {
         self.get_artist_by_sql("SELECT * FROM artists WHERE id = ?", artist_id.to_string())
             .await
     }
+
+    pub async fn get_composer_count(&self) -> Result<u64, DbError> {
+        self.call(move |conn| {
+            let query = format!(
+                "SELECT COUNT(*) FROM ({})",
+                composer_summary_query(None, None)
+            );
+            conn.query_row(&query, [], |row| row.get::<_, i64>(0))
+                .map(|count| count as u64)
+                .map_err(DbError::from)
+        })
+        .await
+    }
+
+    pub async fn get_composer_page(
+        &self,
+        sort: ComposerSortCriterion,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<DbComposerSummary>, DbError> {
+        let order_by = composer_order_by(sort);
+        let tail = format!("ORDER BY {order_by} LIMIT ? OFFSET ?");
+        let query = composer_summary_query(None, Some(&tail));
+        self.call(move |conn| {
+            let mut stmt = conn.prepare(&query)?;
+            let rows = stmt.query_map(
+                params![limit as i64, offset as i64],
+                row_to_composer_summary,
+            )?;
+            rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+                .map_err(DbError::from)
+        })
+        .await
+    }
+
+    pub async fn find_composer_detail(
+        &self,
+        artist_id: &str,
+    ) -> Result<Option<DbComposerDetail>, DbError> {
+        let artist_id = artist_id.to_string();
+        self.call(move |conn| {
+            let composer = conn
+                .query_row(
+                    &composer_summary_query(Some("WHERE composer.id = ?"), None),
+                    params![artist_id],
+                    row_to_composer_summary,
+                )
+                .optional()?;
+            let Some(composer) = composer else {
+                return Ok(None);
+            };
+
+            let mut works_stmt = conn.prepare(&work_summary_query(
+                Some("JOIN work_artists wa_filter ON wa_filter.work_id = w.id AND wa_filter.artist_id = ?"),
+                Some("ORDER BY w.title"),
+            ))?;
+            let works = works_stmt
+                .query_map(params![composer.artist.id], row_to_work_summary)?
+                .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+            let parent_ids: Vec<String> = works
+                .iter()
+                .filter_map(|work| work.parent_work_id.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            let parent_summaries = if parent_ids.is_empty() {
+                HashMap::new()
+            } else {
+                let placeholders = (0..parent_ids.len())
+                    .map(|_| "?")
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let filter = format!("WHERE w.id IN ({placeholders})");
+                let query = work_summary_query(Some(&filter), None);
+                let mut parent_stmt = conn.prepare(&query)?;
+                let rows = parent_stmt
+                    .query_map(
+                        coven::rusqlite::params_from_iter(parent_ids.iter()),
+                        row_to_work_summary,
+                    )?
+                    .map(|row| row.map(|summary| (summary.work.id.clone(), summary)))
+                    .collect::<coven::rusqlite::Result<HashMap<_, _>>>()?;
+                rows
+            };
+            let mut grouped: HashMap<String, Vec<DbWorkSummary>> = HashMap::new();
+            let mut ungrouped = Vec::new();
+            for work in works {
+                if let Some(parent_id) = work.parent_work_id.clone() {
+                    grouped.entry(parent_id).or_default().push(work);
+                } else {
+                    let id = work.work.id.clone();
+                    ungrouped.push(DbComposerWorkGroup {
+                        id,
+                        parent: None,
+                        works: vec![work],
+                    });
+                }
+            }
+            let mut work_groups: Vec<DbComposerWorkGroup> = grouped
+                .into_iter()
+                .map(|(parent_id, mut works)| {
+                    works.sort_by_key(work_summary_sort_key);
+                    DbComposerWorkGroup {
+                        id: parent_id.clone(),
+                        parent: parent_summaries.get(&parent_id).cloned(),
+                        works,
+                    }
+                })
+                .collect();
+            work_groups.extend(ungrouped);
+            work_groups.sort_by_key(composer_work_group_sort_key);
+
+            let release_roles_query = format!(
+                "SELECT rar.id AS release_artist_role_id, rar.release_id,
+                        rar.artist_id, rar.position,
+                        rar.source AS role_source, rar.source_credit, rar.created_at,
+                        a.id AS album_id, a.title AS album_title,
+                        a.artist_id AS album_artist_id, a.year AS album_year,
+                        a.primary_release_id AS album_primary_release_id,
+                        a.is_compilation AS album_is_compilation,
+                        a.created_at AS album_created_at
+                 FROM release_artist_roles rar
+                 JOIN releases r ON r.id = rar.release_id
+                 JOIN albums a ON a.id = r.album_id
+                 WHERE rar.artist_id = ?
+                   AND {}
+                 ORDER BY a.title, r.created_at, rar.position",
+                unlinked_release_composer_role_predicate("rar")
+            );
+            let mut release_roles_stmt = conn.prepare(&release_roles_query)?;
+            let unlinked_release_roles = release_roles_stmt
+                .query_map(params![composer.artist.id], |row| {
+                    Ok(DbReleaseRoleSummary {
+                        role: DbReleaseArtistRole {
+                            id: row.get("release_artist_role_id")?,
+                            release_id: row.get("release_id")?,
+                            artist_id: row.get("artist_id")?,
+                            position: row.get("position")?,
+                            source: metadata_source_column(row, "role_source")?,
+                            source_credit: row.get("source_credit")?,
+                            created_at: rfc3339_column(row, "created_at")?,
+                        },
+                        album: row_to_aliased_album(row, "album")?,
+                    })
+                })?
+                .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+
+            let track_roles_query = format!(
+                "SELECT tar.id AS track_artist_role_id, tar.track_id, tar.artist_id,
+                        tar.position, tar.source AS role_source,
+                        tar.source_credit, tar.created_at,
+                        t.id AS track_id, t.release_id AS track_release_id,
+                        t.title AS track_title, t.side AS track_side,
+                        t.track_number AS track_track_number,
+                        t.duration_ms AS track_duration_ms,
+                        t.discogs_position AS track_discogs_position,
+                        t.created_at AS track_created_at,
+                        a.id AS album_id, a.title AS album_title,
+                        a.artist_id AS album_artist_id, a.year AS album_year,
+                        a.primary_release_id AS album_primary_release_id,
+                        a.is_compilation AS album_is_compilation,
+                        a.created_at AS album_created_at,
+                        art.id AS artist_id, art.name AS artist_name,
+                        art.sort_name AS artist_sort_name,
+                        art.discogs_artist_id AS artist_discogs_artist_id,
+                        art.musicbrainz_artist_id AS artist_musicbrainz_artist_id,
+                        art.created_at AS artist_created_at
+                 FROM track_artist_roles tar
+                 JOIN tracks t ON t.id = tar.track_id
+                 JOIN releases r ON r.id = t.release_id
+                 JOIN albums a ON a.id = r.album_id
+                 JOIN artists art ON art.id = tar.artist_id
+                 WHERE tar.artist_id = ?
+                   AND {}
+                 ORDER BY a.title, r.created_at, t.side, t.track_number, tar.position",
+                unlinked_track_composer_role_predicate("tar")
+            );
+            let mut track_roles_stmt = conn.prepare(&track_roles_query)?;
+            let unlinked_track_roles = track_roles_stmt
+                .query_map(params![composer.artist.id], row_to_track_role_summary)?
+                .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+
+            Ok(Some(DbComposerDetail {
+                composer,
+                work_groups,
+                unlinked_release_roles,
+                unlinked_track_roles,
+            }))
+        })
+        .await
+    }
+
+    pub async fn find_work_detail(&self, work_id: &str) -> Result<Option<DbWorkDetail>, DbError> {
+        let work_id = work_id.to_string();
+        self.call(move |conn| {
+            let work = conn
+                .query_row(
+                    &work_summary_query(Some("WHERE w.id = ?"), None),
+                    params![work_id],
+                    row_to_work_summary,
+                )
+                .optional()?;
+            let Some(work) = work else {
+                return Ok(None);
+            };
+
+            let mut child_stmt = conn.prepare(&work_summary_query(
+                Some("JOIN work_parts wp ON wp.child_work_id = w.id AND wp.parent_work_id = ?"),
+                Some("ORDER BY wp.position, w.title"),
+            ))?;
+            let child_works = child_stmt
+                .query_map(params![work.work.id], row_to_work_summary)?
+                .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+
+            let releases = work_release_rows(conn, &work.work.id)?;
+
+            let mut tracks_stmt = conn.prepare(
+                "SELECT tw.id AS track_work_id, tw.work_id,
+                        tw.position, tw.source AS link_source, tw.created_at,
+                        t.id AS track_id, t.release_id AS track_release_id,
+                        t.title AS track_title, t.side AS track_side,
+                        t.track_number AS track_track_number,
+                        t.duration_ms AS track_duration_ms,
+                        t.discogs_position AS track_discogs_position,
+                        t.created_at AS track_created_at,
+                        a.id AS album_id, a.title AS album_title,
+                        a.artist_id AS album_artist_id, a.year AS album_year,
+                        a.primary_release_id AS album_primary_release_id,
+                        a.is_compilation AS album_is_compilation,
+                        a.created_at AS album_created_at
+                 FROM track_works tw
+                 JOIN tracks t ON t.id = tw.track_id
+                 JOIN releases r ON r.id = t.release_id
+                 JOIN albums a ON a.id = r.album_id
+                 WHERE tw.work_id = ?
+                 ORDER BY a.title, r.created_at, t.side, t.track_number, tw.position",
+            )?;
+            let tracks = tracks_stmt
+                .query_map(params![work.work.id], |row| {
+                    Ok(DbWorkTrackSummary {
+                        link: DbTrackWork {
+                            id: row.get("track_work_id")?,
+                            track_id: row.get("track_id")?,
+                            work_id: row.get("work_id")?,
+                            position: row.get("position")?,
+                            source: metadata_source_column(row, "link_source")?,
+                            created_at: rfc3339_column(row, "created_at")?,
+                        },
+                        track: row_to_aliased_track(row, "track")?,
+                        album: row_to_aliased_album(row, "album")?,
+                    })
+                })?
+                .collect::<coven::rusqlite::Result<Vec<_>>>()?;
+
+            Ok(Some(DbWorkDetail {
+                work,
+                child_works,
+                releases,
+                tracks,
+            }))
+        })
+        .await
+    }
+}
+
+fn composer_work_group_sort_key(group: &DbComposerWorkGroup) -> String {
+    if let Some(parent) = group.parent.as_ref() {
+        return work_summary_sort_key(parent);
+    }
+    let work = group
+        .works
+        .first()
+        .expect("composer work group without parent must contain a work");
+    work_summary_sort_key(work)
 }

--- a/bae-core/src/db/client/blobs.rs
+++ b/bae-core/src/db/client/blobs.rs
@@ -17,7 +17,7 @@ impl Database {
         bytes: &[u8],
     ) -> Result<(), DbError> {
         let image = image.clone();
-        let namespace = image_namespace(&image.image_type).to_string();
+        let namespace = image.image_type.namespace().to_string();
         let id = image.id.clone();
         let bytes = bytes.to_vec();
         self.inner
@@ -66,25 +66,32 @@ impl Database {
         &self,
         release_ids: &[String],
     ) -> Result<HashMap<String, String>, DbError> {
-        if release_ids.is_empty() {
+        self.image_versions(LibraryImageType::Cover, release_ids)
+            .await
+    }
+
+    /// The `_updated_at` version of each given artist's `artist_images` row, for
+    /// the ids that have one. Ids with no artist image row are absent from the
+    /// map.
+    pub async fn artist_image_versions(
+        &self,
+        artist_ids: &[String],
+    ) -> Result<HashMap<String, String>, DbError> {
+        self.image_versions(LibraryImageType::Artist, artist_ids)
+            .await
+    }
+
+    async fn image_versions(
+        &self,
+        image_type: LibraryImageType,
+        ids: &[String],
+    ) -> Result<HashMap<String, String>, DbError> {
+        if ids.is_empty() {
             return Ok(HashMap::new());
         }
-        let ids = release_ids.to_vec();
-        self.call(move |conn| {
-            let placeholders = (0..ids.len()).map(|_| "?").collect::<Vec<_>>().join(",");
-            let sql = format!("SELECT id, _updated_at FROM covers WHERE id IN ({placeholders})");
-            let mut stmt = conn.prepare(&sql)?;
-            let rows = stmt.query_map(coven::rusqlite::params_from_iter(ids.iter()), |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })?;
-            let mut map = HashMap::new();
-            for row in rows {
-                let (id, version) = row?;
-                map.insert(id, version);
-            }
-            Ok(map)
-        })
-        .await
+        let ids = ids.to_vec();
+        self.call(move |conn| image_versions(conn, image_type, &ids))
+            .await
     }
 
     /// The `_updated_at` version of one release's `covers` row, or `None` when it
@@ -401,7 +408,6 @@ impl Database {
                          LEFT JOIN release_files rf ON rf.id = co.file_id \
                          LEFT JOIN releases r ON r.id = rf.release_id \
                          LEFT JOIN albums a ON a.id = r.album_id \
-                         WHERE co.operation IN ('upload', 'delete') \
                          ORDER BY co.id",
             )?;
             let rows = stmt.query_map([], |row| {
@@ -470,4 +476,24 @@ impl Database {
         })
         .await
     }
+}
+
+fn image_versions(
+    conn: &Connection,
+    image_type: LibraryImageType,
+    ids: &[String],
+) -> Result<HashMap<String, String>, DbError> {
+    let table = image_table(&image_type);
+    let placeholders = (0..ids.len()).map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!("SELECT id, _updated_at FROM {table} WHERE id IN ({placeholders})");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(coven::rusqlite::params_from_iter(ids.iter()), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut map = HashMap::new();
+    for row in rows {
+        let (id, version) = row?;
+        map.insert(id, version);
+    }
+    Ok(map)
 }

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -1,11 +1,12 @@
 use crate::db::models::*;
+use crate::import::MetadataSource;
 use crate::playback::QueueEntry;
 use crate::queue::QueueItem;
 use crate::util::content_type::ContentType;
 use chrono::{DateTime, Utc};
 use coven::rusqlite::{params, Connection, OptionalExtension, Row};
 use coven::{ClockRef, Coven, CovenError, CovenHandle, DbError};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -29,13 +30,6 @@ fn image_table(image_type: &LibraryImageType) -> &'static str {
     match image_type {
         LibraryImageType::Cover => "covers",
         LibraryImageType::Artist => "artist_images",
-    }
-}
-
-fn image_namespace(image_type: &LibraryImageType) -> &'static str {
-    match image_type {
-        LibraryImageType::Cover => crate::sync::COVERS_NAMESPACE,
-        LibraryImageType::Artist => crate::sync::ARTIST_IMAGES_NAMESPACE,
     }
 }
 
@@ -68,6 +62,228 @@ fn clear_external_blob_on(conn: &Connection, blob_id: &str) -> Result<(), DbErro
     conn.execute("DELETE FROM local_blob_refs WHERE blob_id = ?1", [blob_id])
         .map(|_| ())
         .map_err(DbError::from)
+}
+
+fn composer_summary_query(filter: Option<&str>, tail: Option<&str>) -> String {
+    let release_unlinked = unlinked_release_composer_role_predicate("rar");
+    let track_unlinked = unlinked_track_composer_role_predicate("tar");
+    let mut query = format!(
+        "SELECT composer.id AS artist_id,
+                composer.name AS artist_name,
+                composer.sort_name AS artist_sort_name,
+                composer.discogs_artist_id AS artist_discogs_artist_id,
+                composer.musicbrainz_artist_id AS artist_musicbrainz_artist_id,
+                composer.created_at AS artist_created_at,
+                COUNT(DISTINCT wa.work_id) AS work_count,
+                COUNT(DISTINCT linked.id) AS linked_release_count,
+                (
+                    SELECT COUNT(*) FROM release_artist_roles rar
+                    WHERE rar.artist_id = composer.id
+                      AND {release_unlinked}
+                ) + (
+                    SELECT COUNT(*) FROM track_artist_roles tar
+                    WHERE tar.artist_id = composer.id
+                      AND {track_unlinked}
+                ) AS unlinked_credit_count
+         FROM artists composer
+         LEFT JOIN work_artists wa ON wa.artist_id = composer.id
+         LEFT JOIN track_works tw ON tw.work_id = wa.work_id
+         LEFT JOIN tracks linked_track ON linked_track.id = tw.track_id
+         LEFT JOIN releases linked ON linked.id = linked_track.release_id
+         ",
+    );
+    if let Some(filter) = filter {
+        query.push_str(filter);
+    }
+    query.push_str(
+        "
+         GROUP BY composer.id, composer.name, composer.sort_name, composer.discogs_artist_id, composer.musicbrainz_artist_id, composer.created_at
+         HAVING work_count > 0 OR unlinked_credit_count > 0",
+    );
+    if let Some(tail) = tail {
+        query.push('\n');
+        query.push_str(tail);
+    }
+    query
+}
+
+fn unlinked_release_composer_role_predicate(role_alias: &str) -> String {
+    unlinked_composer_role_predicate(
+        role_alias,
+        "release",
+        "JOIN tracks t_unlinked_release ON t_unlinked_release.id = tw_unlinked_release.track_id",
+        "t_unlinked_release.release_id",
+        "release_id",
+    )
+}
+
+fn unlinked_track_composer_role_predicate(role_alias: &str) -> String {
+    unlinked_composer_role_predicate(
+        role_alias,
+        "track",
+        "",
+        "tw_unlinked_track.track_id",
+        "track_id",
+    )
+}
+
+fn unlinked_composer_role_predicate(
+    role_alias: &str,
+    scope: &str,
+    track_join: &str,
+    linked_target_column: &str,
+    role_target_column: &str,
+) -> String {
+    format!(
+        "NOT EXISTS (
+            SELECT 1 FROM work_artists wa_unlinked_{scope}
+            JOIN track_works tw_unlinked_{scope} ON tw_unlinked_{scope}.work_id = wa_unlinked_{scope}.work_id
+            {track_join}
+            WHERE wa_unlinked_{scope}.artist_id = {role_alias}.artist_id
+              AND {linked_target_column} = {role_alias}.{role_target_column}
+        )"
+    )
+}
+
+fn work_summary_query(filter: Option<&str>, tail: Option<&str>) -> String {
+    let mut query = String::from(
+        "SELECT w.id AS work_id,
+                w.title AS work_title,
+                w.disambiguation AS work_disambiguation,
+                w.work_type AS work_type,
+                w.created_at AS work_created_at,
+                (
+                    SELECT wp.parent_work_id
+                    FROM work_parts wp
+                    WHERE wp.child_work_id = w.id
+                    ORDER BY wp.position, wp.parent_work_id
+                    LIMIT 1
+                ) AS parent_work_id,
+                (
+                    SELECT tr.release_id
+                    FROM track_works tw_cover
+                    JOIN tracks tr ON tr.id = tw_cover.track_id
+                    WHERE tw_cover.work_id = w.id
+                    ORDER BY tr.side, tr.track_number, tr.release_id
+                    LIMIT 1
+                ) AS representative_release_id,
+                (
+                    SELECT GROUP_CONCAT(composer.name, ', ')
+                    FROM work_artists wa
+                    JOIN artists composer ON composer.id = wa.artist_id
+                    WHERE wa.work_id = w.id
+                    ORDER BY wa.position
+                ) AS composer_names,
+                COUNT(DISTINCT tr.release_id) AS linked_release_count
+         FROM works w
+         LEFT JOIN track_works tw ON tw.work_id = w.id
+         LEFT JOIN tracks tr ON tr.id = tw.track_id
+         ",
+    );
+    if let Some(filter) = filter {
+        query.push_str(filter);
+    }
+    query.push_str(
+        "
+         GROUP BY w.id, w.title, w.disambiguation, w.work_type, w.created_at",
+    );
+    if let Some(tail) = tail {
+        query.push('\n');
+        query.push_str(tail);
+    }
+    query
+}
+
+fn row_to_work_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbWorkSummary> {
+    Ok(DbWorkSummary {
+        work: DbWork {
+            id: row.get("work_id")?,
+            title: row.get("work_title")?,
+            disambiguation: row.get("work_disambiguation")?,
+            work_type: row.get("work_type")?,
+            created_at: rfc3339_column(row, "work_created_at")?,
+        },
+        parent_work_id: row.get("parent_work_id")?,
+        representative_release_id: row.get("representative_release_id")?,
+        composer_names: row.get("composer_names")?,
+        linked_release_count: row.get("linked_release_count")?,
+    })
+}
+
+fn row_to_composer_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbComposerSummary> {
+    Ok(DbComposerSummary {
+        artist: row_to_aliased_artist(row, "artist")?,
+        work_count: row.get("work_count")?,
+        linked_release_count: row.get("linked_release_count")?,
+        unlinked_credit_count: row.get("unlinked_credit_count")?,
+    })
+}
+
+fn work_summary_sort_key(work: &DbWorkSummary) -> String {
+    work.work.title.to_lowercase()
+}
+
+fn row_to_track_role_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbTrackRoleSummary> {
+    Ok(DbTrackRoleSummary {
+        role: DbTrackArtistRole {
+            id: row.get("track_artist_role_id")?,
+            track_id: row.get("track_id")?,
+            artist_id: row.get("artist_id")?,
+            position: row.get("position")?,
+            source: metadata_source_column(row, "role_source")?,
+            source_credit: row.get("source_credit")?,
+            created_at: rfc3339_column(row, "created_at")?,
+        },
+        track: row_to_aliased_track(row, "track")?,
+        album: row_to_aliased_album(row, "album")?,
+        artist: row_to_aliased_artist(row, "artist")?,
+    })
+}
+
+fn work_release_rows(conn: &Connection, work_id: &str) -> Result<Vec<DbReleaseSummary>, DbError> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT
+            r.id AS release_id,
+            r.album_id,
+            r.format AS release_format,
+            r.remote,
+            (SELECT rf.id FROM release_files rf WHERE rf.release_id = r.id LIMIT 1) AS any_file_id,
+            COALESCE((SELECT COUNT(*) FROM release_files rf WHERE rf.release_id = r.id), 0) AS file_count,
+            COALESCE((SELECT SUM(rf.file_size) FROM release_files rf WHERE rf.release_id = r.id), 0) AS total_size
+         FROM track_works tw
+         JOIN tracks t ON t.id = tw.track_id
+         JOIN releases r ON r.id = t.release_id
+         WHERE tw.work_id = ?
+         ORDER BY r.created_at",
+    )?;
+    let rows = stmt.query_map(params![work_id], row_to_release_summary)?;
+    rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+        .map_err(DbError::from)
+}
+
+fn row_to_release_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbReleaseSummary> {
+    Ok(DbReleaseSummary {
+        id: row.get("release_id")?,
+        album_id: row.get("album_id")?,
+        format: row.get("release_format")?,
+        remote: row.get("remote")?,
+        any_file_id: row.get("any_file_id")?,
+        file_count: row.get("file_count")?,
+        total_size: row.get("total_size")?,
+    })
+}
+
+fn composer_order_by(sort: ComposerSortCriterion) -> String {
+    let field = match sort.field {
+        ComposerSortField::Name => "composer.name",
+        ComposerSortField::WorkCount => "work_count",
+        ComposerSortField::LinkedReleaseCount => "linked_release_count",
+    };
+    let direction = match sort.direction {
+        SortDirection::Ascending => "ASC",
+        SortDirection::Descending => "DESC",
+    };
+    format!("{field} {direction}, composer.name ASC")
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -504,6 +720,69 @@ fn rfc3339_column(row: &Row, column: &str) -> coven::rusqlite::Result<DateTime<U
         })
 }
 
+fn metadata_source_column(row: &Row, column: &str) -> coven::rusqlite::Result<MetadataSource> {
+    let raw: String = row.get(column)?;
+    raw.parse::<MetadataSource>()
+        .map_err(|e| column_conversion_error(row, column, e))
+}
+
+fn row_to_aliased_artist(row: &Row, prefix: &str) -> coven::rusqlite::Result<DbArtist> {
+    let id_column = format!("{prefix}_id");
+    let name_column = format!("{prefix}_name");
+    let sort_name_column = format!("{prefix}_sort_name");
+    let discogs_id_column = format!("{prefix}_discogs_artist_id");
+    let musicbrainz_id_column = format!("{prefix}_musicbrainz_artist_id");
+    let created_at_column = format!("{prefix}_created_at");
+    Ok(DbArtist {
+        id: row.get(id_column.as_str())?,
+        name: row.get(name_column.as_str())?,
+        sort_name: row.get(sort_name_column.as_str())?,
+        discogs_artist_id: row.get(discogs_id_column.as_str())?,
+        musicbrainz_artist_id: row.get(musicbrainz_id_column.as_str())?,
+        created_at: rfc3339_column(row, &created_at_column)?,
+    })
+}
+
+fn row_to_aliased_album(row: &Row, prefix: &str) -> coven::rusqlite::Result<DbAlbum> {
+    let id_column = format!("{prefix}_id");
+    let title_column = format!("{prefix}_title");
+    let artist_id_column = format!("{prefix}_artist_id");
+    let year_column = format!("{prefix}_year");
+    let primary_release_id_column = format!("{prefix}_primary_release_id");
+    let is_compilation_column = format!("{prefix}_is_compilation");
+    let created_at_column = format!("{prefix}_created_at");
+    Ok(DbAlbum {
+        id: row.get(id_column.as_str())?,
+        title: row.get(title_column.as_str())?,
+        artist_id: row.get(artist_id_column.as_str())?,
+        year: row.get(year_column.as_str())?,
+        primary_release_id: row.get(primary_release_id_column.as_str())?,
+        is_compilation: row.get(is_compilation_column.as_str())?,
+        created_at: rfc3339_column(row, &created_at_column)?,
+    })
+}
+
+fn row_to_aliased_track(row: &Row, prefix: &str) -> coven::rusqlite::Result<DbTrack> {
+    let id_column = format!("{prefix}_id");
+    let release_id_column = format!("{prefix}_release_id");
+    let title_column = format!("{prefix}_title");
+    let side_column = format!("{prefix}_side");
+    let track_number_column = format!("{prefix}_track_number");
+    let duration_ms_column = format!("{prefix}_duration_ms");
+    let discogs_position_column = format!("{prefix}_discogs_position");
+    let created_at_column = format!("{prefix}_created_at");
+    Ok(DbTrack {
+        id: row.get(id_column.as_str())?,
+        release_id: row.get(release_id_column.as_str())?,
+        title: row.get(title_column.as_str())?,
+        side: row.get(side_column.as_str())?,
+        track_number: row.get(track_number_column.as_str())?,
+        duration_ms: row.get(duration_ms_column.as_str())?,
+        discogs_position: row.get(discogs_position_column.as_str())?,
+        created_at: rfc3339_column(row, &created_at_column)?,
+    })
+}
+
 fn row_to_release(row: &Row) -> coven::rusqlite::Result<DbRelease> {
     let metadata_source: String = row.get("metadata_source")?;
     let metadata_source = metadata_source
@@ -773,6 +1052,208 @@ fn insert_track_artist_row(
             ta.position,
             reg,
             ta.created_at.to_rfc3339()
+        ],
+    )
+    .map(|_| ())
+    .map_err(DbError::from)
+}
+
+fn insert_work_row(conn: &Connection, work: &DbWork, reg: &str) -> Result<(), DbError> {
+    conn.execute(
+        r#"
+        INSERT OR IGNORE INTO works (
+            id, title, disambiguation, work_type, _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        "#,
+        params![
+            work.id,
+            work.title,
+            work.disambiguation,
+            work.work_type,
+            reg,
+            work.created_at.to_rfc3339()
+        ],
+    )
+    .map(|_| ())
+    .map_err(DbError::from)
+}
+
+fn insert_work_artist_row(
+    conn: &Connection,
+    link: &DbWorkArtist,
+    reg: &str,
+) -> Result<(), DbError> {
+    conn.execute(
+        r#"
+        INSERT OR IGNORE INTO work_artists (id, work_id, artist_id, position, source, _updated_at, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+        params![
+            link.id,
+            link.work_id,
+            link.artist_id,
+            link.position,
+            link.source.as_str(),
+            reg,
+            link.created_at.to_rfc3339()
+        ],
+    )
+    .map(|_| ())
+    .map_err(DbError::from)
+}
+
+fn insert_work_part_row(conn: &Connection, part: &DbWorkPart, reg: &str) -> Result<(), DbError> {
+    conn.execute(
+        r#"
+        INSERT OR IGNORE INTO work_parts (
+            id, parent_work_id, child_work_id, position, source, _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+        params![
+            part.id,
+            part.parent_work_id,
+            part.child_work_id,
+            part.position,
+            part.source.as_str(),
+            reg,
+            part.created_at.to_rfc3339()
+        ],
+    )
+    .map(|_| ())
+    .map_err(DbError::from)
+}
+
+fn insert_track_work_row(conn: &Connection, link: &DbTrackWork, reg: &str) -> Result<(), DbError> {
+    conn.execute(
+        r#"
+        INSERT INTO track_works (id, track_id, work_id, position, source, _updated_at, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+        params![
+            link.id,
+            link.track_id,
+            link.work_id,
+            link.position,
+            link.source.as_str(),
+            reg,
+            link.created_at.to_rfc3339()
+        ],
+    )
+    .map(|_| ())
+    .map_err(DbError::from)
+}
+
+fn insert_release_artist_role_row(
+    conn: &Connection,
+    role: &DbReleaseArtistRole,
+    reg: &str,
+) -> Result<(), DbError> {
+    insert_artist_role_row(conn, ArtistRoleInsert::Release(role), reg)
+}
+
+fn insert_track_artist_role_row(
+    conn: &Connection,
+    role: &DbTrackArtistRole,
+    reg: &str,
+) -> Result<(), DbError> {
+    insert_artist_role_row(conn, ArtistRoleInsert::Track(role), reg)
+}
+
+enum ArtistRoleInsert<'a> {
+    Release(&'a DbReleaseArtistRole),
+    Track(&'a DbTrackArtistRole),
+}
+
+impl ArtistRoleInsert<'_> {
+    fn table(&self) -> &'static str {
+        match self {
+            Self::Release(_) => "release_artist_roles",
+            Self::Track(_) => "track_artist_roles",
+        }
+    }
+
+    fn target_column(&self) -> &'static str {
+        match self {
+            Self::Release(_) => "release_id",
+            Self::Track(_) => "track_id",
+        }
+    }
+
+    fn id(&self) -> &str {
+        match self {
+            Self::Release(role) => &role.id,
+            Self::Track(role) => &role.id,
+        }
+    }
+
+    fn target_id(&self) -> &str {
+        match self {
+            Self::Release(role) => &role.release_id,
+            Self::Track(role) => &role.track_id,
+        }
+    }
+
+    fn artist_id(&self) -> &str {
+        match self {
+            Self::Release(role) => &role.artist_id,
+            Self::Track(role) => &role.artist_id,
+        }
+    }
+
+    fn position(&self) -> i32 {
+        match self {
+            Self::Release(role) => role.position,
+            Self::Track(role) => role.position,
+        }
+    }
+
+    fn source(&self) -> MetadataSource {
+        match self {
+            Self::Release(role) => role.source,
+            Self::Track(role) => role.source,
+        }
+    }
+
+    fn source_credit(&self) -> &Option<String> {
+        match self {
+            Self::Release(role) => &role.source_credit,
+            Self::Track(role) => &role.source_credit,
+        }
+    }
+
+    fn created_at(&self) -> DateTime<Utc> {
+        match self {
+            Self::Release(role) => role.created_at,
+            Self::Track(role) => role.created_at,
+        }
+    }
+}
+
+fn insert_artist_role_row(
+    conn: &Connection,
+    row: ArtistRoleInsert<'_>,
+    reg: &str,
+) -> Result<(), DbError> {
+    let sql = format!(
+        r#"
+        INSERT INTO {} (
+            id, {}, artist_id, position, source, source_credit, _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+        row.table(),
+        row.target_column()
+    );
+    conn.execute(
+        &sql,
+        params![
+            row.id(),
+            row.target_id(),
+            row.artist_id(),
+            row.position(),
+            row.source().as_str(),
+            row.source_credit(),
+            reg,
+            row.created_at().to_rfc3339()
         ],
     )
     .map(|_| ())

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -336,15 +336,7 @@ impl Database {
             let mut rows = stmt.query(params![limit as i64, offset as i64])?;
             let mut storage_rows = Vec::new();
             while let Some(row) = rows.next()? {
-                let release = DbReleaseSummary {
-                    id: row.get("release_id")?,
-                    album_id: row.get("album_id")?,
-                    format: row.get("release_format")?,
-                    remote: row.get("remote")?,
-                    any_file_id: row.get("any_file_id")?,
-                    file_count: row.get("file_count")?,
-                    total_size: row.get("total_size")?,
-                };
+                let release = row_to_release_summary(row)?;
 
                 let release_ids_json: String = row.get("release_ids_json")?;
                 let release_ids: Vec<String> =
@@ -452,11 +444,18 @@ impl Database {
         metadata: &[DbReleaseMetadata],
         track_artists: &[DbTrackArtist],
         album_artists: &[DbAlbumArtist],
+        works: &[DbWork],
+        work_artists: &[DbWorkArtist],
+        work_parts: &[DbWorkPart],
+        track_works: &[DbTrackWork],
+        release_artist_roles: &[DbReleaseArtistRole],
+        track_artist_roles: &[DbTrackArtistRole],
         files: &[DbFile],
         audio_formats: &[DbAudioFormat],
         library_image: Option<(&DbLibraryImage, &[u8])>,
         primary_release_id: Option<(&str, &str)>, // (album_id, release_id)
         import_id: &str,
+        import_status: ImportOperationStatus,
         identities: &[crate::import::ReleaseIdentity],
         // The in-place folder this import's files live in on this device. Every
         // import lands LOCAL, so each file is registered as a coven user-provided
@@ -477,11 +476,18 @@ impl Database {
         let metadata = metadata.to_vec();
         let track_artists = track_artists.to_vec();
         let album_artists = album_artists.to_vec();
+        let works = works.to_vec();
+        let work_artists = work_artists.to_vec();
+        let work_parts = work_parts.to_vec();
+        let track_works = track_works.to_vec();
+        let release_artist_roles = release_artist_roles.to_vec();
+        let track_artist_roles = track_artist_roles.to_vec();
         let files = files.to_vec();
         let audio_formats = audio_formats.to_vec();
         let library_image = library_image.map(|(image, bytes)| (image.clone(), bytes.to_vec()));
         let primary_release_id = primary_release_id.map(|(a, r)| (a.to_string(), r.to_string()));
         let import_id = import_id.to_string();
+        let import_status = import_status.as_str().to_string();
         let identities = identities.to_vec();
         let local_path = local_path.to_string();
 
@@ -493,7 +499,7 @@ impl Database {
             .write(move |w| {
                 if let Some((image, bytes)) = &library_image {
                     w.put_blob(
-                        image_namespace(&image.image_type),
+                        image.image_type.namespace(),
                         image.id.clone(),
                         bytes.clone(),
                     );
@@ -527,24 +533,49 @@ impl Database {
                         insert_release_identity_row(tx, &release.id, identity, &reg, &now)?;
                     }
 
-                    // 3. Insert tracks. DbTracks live inside `tracks_to_files`;
+                    // 3. Insert globally identified works before their links.
+                    for work in &works {
+                        insert_work_row(tx, work, &reg)?;
+                    }
+
+                    for work_artist in &work_artists {
+                        insert_work_artist_row(tx, work_artist, &reg)?;
+                    }
+
+                    for work_part in &work_parts {
+                        insert_work_part_row(tx, work_part, &reg)?;
+                    }
+
+                    for role in &release_artist_roles {
+                        insert_release_artist_role_row(tx, role, &reg)?;
+                    }
+
+                    // 4. Insert tracks. DbTracks live inside `tracks_to_files`;
                     //    their `duration_ms` was populated by the mapper from
                     //    the CUE sheet or a standalone-file probe.
                     for track in &tracks {
                         insert_track_row(tx, track, &reg)?;
                     }
 
-                    // 4. Insert track artists
+                    // 5. Insert track artists and work/role links.
                     for ta in &track_artists {
                         insert_track_artist_row(tx, ta, &reg)?;
                     }
 
-                    // 5. Insert release metadata
+                    for track_work in &track_works {
+                        insert_track_work_row(tx, track_work, &reg)?;
+                    }
+
+                    for role in &track_artist_roles {
+                        insert_track_artist_role_row(tx, role, &reg)?;
+                    }
+
+                    // 6. Insert release metadata.
                     for meta in &metadata {
                         insert_release_metadata_row(tx, meta)?;
                     }
 
-                    // 6. Insert files, and register each as a coven
+                    // 7. Insert files, and register each as a coven
                     //    user-provided external ref (the user's own file in
                     //    place). Every import lands Local — the files ARE the
                     //    user's files at `local_path`, tracked in coven's
@@ -580,12 +611,12 @@ impl Database {
                         )?;
                     }
 
-                    // 7. Insert audio formats
+                    // 8. Insert audio formats
                     for af in &audio_formats {
                         insert_audio_format_row(tx, af, &reg)?;
                     }
 
-                    // 8. Write the cover row and its host-provided blob in one
+                    // 9. Write the cover row and its host-provided blob in one
                     //    coven write. On a browsable home its readable cloud_path
                     //    (`{album}/{release}/cover.{ext}`) is computed now,
                     //    ready when the gate flips; an opaque home leaves it
@@ -605,7 +636,7 @@ impl Database {
                         upsert_library_image_row(tx, &image, &reg)?;
                     }
 
-                    // 9. Set album primary_release_id
+                    // 10. Set album primary_release_id
                     if let Some((album_id, release_id)) = &primary_release_id {
                         tx.execute(
                             "UPDATE albums SET primary_release_id = ?, _updated_at = ? WHERE id = ?",
@@ -613,15 +644,10 @@ impl Database {
                         )?;
                     }
 
-                    // 10. Link import to release and mark complete
+                    // 11. Link import to release and mark complete
                     tx.execute(
                         "UPDATE imports SET release_id = ?, status = ?, updated_at = ? WHERE id = ?",
-                        params![
-                            release.id,
-                            ImportOperationStatus::Complete.as_str(),
-                            now_ts,
-                            import_id,
-                        ],
+                        params![release.id, import_status, now_ts, import_id,],
                     )?;
 
                     Ok(())
@@ -650,6 +676,98 @@ impl Database {
             )?;
             tx.execute("DELETE FROM releases WHERE id = ?", params![release_id])?;
             Ok(())
+        })
+        .await
+    }
+
+    /// Mark an import failed and remove the release it finalized in the same DB
+    /// operation. Used when remote import upload setup fails after finalize: the
+    /// release was never announced to the library, and its audio files are the
+    /// user's in-place source files, so this clears coven's external refs without
+    /// queuing file deletion.
+    pub async fn fail_import_and_delete_release(
+        &self,
+        import_id: &str,
+        release_id: &str,
+        error: &str,
+    ) -> Result<(), DbError> {
+        let import_id = import_id.to_string();
+        let release_id = release_id.to_string();
+        let error = error.to_string();
+        let reg = self.register_stamp().await?;
+        let now = self.inner.clock.now().timestamp();
+        self.call(move |conn| {
+            conn.execute_batch("SAVEPOINT fail_import_and_delete_release")
+                .map_err(DbError::from)?;
+
+            let result = (|| {
+                let album_id = conn
+                    .query_row(
+                        "SELECT album_id FROM releases WHERE id = ?",
+                        params![release_id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?
+                    .ok_or_else(|| DbError(format!("release not found: {release_id}")))?;
+
+                let remaining_release_count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM releases WHERE album_id = ? AND id != ?",
+                    params![album_id, release_id],
+                    |row| row.get(0),
+                )?;
+                let primary_release_id: Option<String> = conn.query_row(
+                    "SELECT primary_release_id FROM albums WHERE id = ?",
+                    params![album_id],
+                    |row| row.get(0),
+                )?;
+
+                conn.execute(
+                    "DELETE FROM local_blob_refs
+                     WHERE namespace = ?
+                       AND blob_id IN (SELECT id FROM release_files WHERE release_id = ?)",
+                    params![crate::sync::RELEASE_FILES_NAMESPACE, release_id],
+                )?;
+                conn.execute(
+                    "UPDATE imports SET release_id = NULL WHERE release_id = ?",
+                    params![release_id],
+                )?;
+                conn.execute(
+                    "UPDATE imports SET status = ?, error_message = ?, updated_at = ?, release_id = NULL WHERE id = ?",
+                    params![
+                        ImportOperationStatus::Failed.as_str(),
+                        error,
+                        now,
+                        import_id,
+                    ],
+                )?;
+                conn.execute("DELETE FROM releases WHERE id = ?", params![release_id])?;
+
+                if remaining_release_count == 0 {
+                    conn.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
+                } else if primary_release_id.as_deref() == Some(&release_id) {
+                    conn.execute(
+                        "UPDATE albums SET primary_release_id = NULL, _updated_at = ? WHERE id = ?",
+                        params![reg, album_id],
+                    )?;
+                }
+
+                Ok(())
+            })();
+
+            if let Err(error) = result {
+                if let Err(rollback_error) = conn.execute_batch(
+                    "ROLLBACK TO SAVEPOINT fail_import_and_delete_release;
+                     RELEASE SAVEPOINT fail_import_and_delete_release",
+                ) {
+                    return Err(DbError(format!(
+                        "{error}; rollback of fail_import_and_delete_release failed: {rollback_error}"
+                    )));
+                }
+                return Err(error);
+            }
+
+            conn.execute_batch("RELEASE SAVEPOINT fail_import_and_delete_release")
+                .map_err(DbError::from)
         })
         .await
     }
@@ -870,6 +988,26 @@ impl Database {
             conn.execute(
                 "UPDATE imports SET status = ?, updated_at = ? WHERE id = ?",
                 params![status, now, id],
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+    }
+    /// Mark the active import linked to a release complete after its requested
+    /// remote transition has actually finished.
+    pub async fn complete_import_for_release(&self, release_id: &str) -> Result<(), DbError> {
+        let release_id = release_id.to_string();
+        let now = self.inner.clock.now().timestamp();
+        self.call(move |conn| {
+            conn.execute(
+                "UPDATE imports SET status = ?, updated_at = ? WHERE release_id = ? AND status = ?",
+                params![
+                    ImportOperationStatus::Complete.as_str(),
+                    now,
+                    release_id,
+                    ImportOperationStatus::Importing.as_str(),
+                ],
             )
             .map(|_| ())
             .map_err(DbError::from)

--- a/bae-core/src/db/client/tests.rs
+++ b/bae-core/src/db/client/tests.rs
@@ -113,7 +113,7 @@ mod readable_cloud_path_tests {
 
     #[test]
     fn artist_key_is_artist_id() {
-        // Keyed by the artist id alone — no DB lookup.
+        // Keyed by the artist id alone -- no DB lookup.
         let key = resolve_artist_cloud_path("artist-1", &ContentType::Png);
         assert_eq!(key, "artist-1/artist.png");
     }
@@ -261,6 +261,598 @@ mod row_mapper_error_tests {
 }
 
 #[cfg(test)]
+mod outbox_items_tests {
+    use super::super::*;
+    use coven::SystemClock;
+
+    async fn empty_db() -> (Database, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        (db, tmp)
+    }
+
+    /// `cancel` rows are coven tombstone retries and render nothing in the
+    /// processing snapshot.
+    #[tokio::test]
+    async fn outbox_items_omits_cancel_operation() {
+        let (db, _tmp) = empty_db().await;
+        db.add_cloud_outbox_delete("cloud-key").await.unwrap();
+        db.call(|conn| {
+            conn.execute(
+                "UPDATE cloud_outbox SET operation = 'cancel' WHERE cloud_key = 'cloud-key'",
+                [],
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+        .unwrap();
+
+        let rows = db.outbox_items().await.unwrap();
+        assert!(rows.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod composer_mode_tests {
+    use super::super::*;
+    use coven::SystemClock;
+
+    async fn seeded_db() -> (Database, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        db.call(|conn| {
+            conn.execute_batch(
+                "
+                INSERT INTO artists (id, name, sort_name, discogs_artist_id, musicbrainz_artist_id, _updated_at, created_at)
+                VALUES
+                    ('artist-album', 'Album Artist A', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('artist-composer', 'Displayed Composer A', 'Hidden Composer Sort A', NULL, 'mb-artist-composer-a', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO albums (id, title, artist_id, year, primary_release_id, is_compilation, _updated_at, created_at)
+                VALUES ('album-a', 'Album Title A', 'artist-album', 2026, 'release-a', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO releases (id, album_id, release_name, year, disc_id, metadata_source, metadata_source_release_id, format, label, catalog_number, country, barcode, remote, source_folder_name, content_hash, album_loudness_lufs, album_peak_linear, _updated_at, created_at)
+                VALUES ('release-a', 'album-a', NULL, 2026, NULL, 'musicbrainz', 'mb-release-a', 'CD', NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO tracks (id, release_id, title, side, track_number, duration_ms, discogs_position, _updated_at, created_at)
+                VALUES ('track-a', 'release-a', 'Track Title A', 1, 1, 1000, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO works (id, title, disambiguation, work_type, _updated_at, created_at)
+                VALUES
+                    ('work-parent-a', 'Parent Work A', NULL, 'work', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('work-child-a', 'Displayed Work A', NULL, 'part', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO work_artists (id, work_id, artist_id, position, source, _updated_at, created_at)
+                VALUES ('work-artist-a', 'work-child-a', 'artist-composer', 0, 'musicbrainz', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO work_parts (id, parent_work_id, child_work_id, position, source, _updated_at, created_at)
+                VALUES ('work-part-a', 'work-parent-a', 'work-child-a', 0, 'musicbrainz', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO track_works (id, track_id, work_id, position, source, _updated_at, created_at)
+                VALUES ('track-work-a', 'track-a', 'work-child-a', 0, 'musicbrainz', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                ",
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+        .unwrap();
+        (db, tmp)
+    }
+
+    #[tokio::test]
+    async fn finalize_import_persists_composer_work_and_role_rows() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let album_artist = DbArtist {
+            id: "artist-album".to_string(),
+            name: "Album Artist A".to_string(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: now,
+        };
+        let composer = DbArtist {
+            id: "artist-composer".to_string(),
+            name: "Composer Artist A".to_string(),
+            sort_name: Some("Composer Artist A".to_string()),
+            discogs_artist_id: None,
+            musicbrainz_artist_id: Some("mb-artist-composer-a".to_string()),
+            created_at: now,
+        };
+        db.insert_artist(&album_artist).await.unwrap();
+        db.insert_artist(&composer).await.unwrap();
+
+        let album = DbAlbum {
+            id: "album-a".to_string(),
+            title: "Album Title A".to_string(),
+            artist_id: album_artist.id.clone(),
+            year: Some(2026),
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: now,
+        };
+        let release = DbRelease {
+            id: "release-a".to_string(),
+            album_id: album.id.clone(),
+            release_name: None,
+            pressing: Pressing {
+                year: Some(2026),
+                format: Some("CD".to_string()),
+                label: None,
+                catalog_number: None,
+                country: None,
+                barcode: None,
+            },
+            disc_id: None,
+            metadata_source: ReleaseMetadataSource::MusicBrainz,
+            metadata_source_release_id: Some("mb-release-a".to_string()),
+            remote: true,
+            source_folder_name: None,
+            content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
+            created_at: now,
+        };
+        let track = DbTrack {
+            id: "track-a".to_string(),
+            release_id: release.id.clone(),
+            title: "Track Title A".to_string(),
+            side: 1,
+            track_number: Some(1),
+            duration_ms: Some(1000),
+            discogs_position: None,
+            created_at: now,
+        };
+        let track_files = vec![crate::import::TrackFile::Standalone {
+            db_track: track,
+            file_path: tmp.path().join("Track.flac"),
+        }];
+        let works = vec![DbWork::new(
+            "work-a",
+            "Work Title A",
+            None,
+            Some("work".to_string()),
+            now,
+        )];
+        let work_artists = vec![DbWorkArtist::new(
+            "work-a",
+            &composer.id,
+            0,
+            crate::import::MetadataSource::MusicBrainz,
+            "work-artist-a".to_string(),
+            now,
+        )];
+        let track_works = vec![DbTrackWork::new(
+            "track-a",
+            "work-a",
+            0,
+            crate::import::MetadataSource::MusicBrainz,
+            "track-work-a".to_string(),
+            now,
+        )];
+        let release_roles = vec![DbReleaseArtistRole::new(
+            &release.id,
+            &composer.id,
+            0,
+            crate::import::MetadataSource::Discogs,
+            Some("Conducted By".to_string()),
+            "release-role-a".to_string(),
+            now,
+        )];
+        let track_roles = vec![DbTrackArtistRole::new(
+            "track-a",
+            &composer.id,
+            0,
+            crate::import::MetadataSource::MusicBrainz,
+            Some("arranger".to_string()),
+            "track-role-a".to_string(),
+            now,
+        )];
+
+        db.finalize_import_atomic(
+            Some(&album),
+            &release,
+            &track_files,
+            &[],
+            &[],
+            &[],
+            &works,
+            &work_artists,
+            &[],
+            &track_works,
+            &release_roles,
+            &track_roles,
+            &[],
+            &[],
+            None,
+            Some((&album.id, &release.id)),
+            "import-a",
+            ImportOperationStatus::Complete,
+            &[],
+            tmp.path().to_str().unwrap(),
+            crate::config::HomeStorage::Opaque,
+        )
+        .await
+        .unwrap();
+
+        let composer_detail = db
+            .find_composer_detail(&composer.id)
+            .await
+            .unwrap()
+            .expect("composer detail");
+        assert_eq!(composer_detail.work_groups.len(), 1);
+        assert_eq!(composer_detail.work_groups[0].works[0].work.id, "work-a");
+        let release_role_count = db
+            .call(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM release_artist_roles WHERE id = 'release-role-a'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(DbError::from)
+            })
+            .await
+            .unwrap();
+        assert_eq!(release_role_count, 1);
+
+        let work_detail = db
+            .find_work_detail("work-a")
+            .await
+            .unwrap()
+            .expect("work detail");
+        assert_eq!(work_detail.tracks.len(), 1);
+        let track_role_count = db
+            .call(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM track_artist_roles WHERE id = 'track-role-a'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(DbError::from)
+            })
+            .await
+            .unwrap();
+        assert_eq!(track_role_count, 1);
+    }
+
+    #[tokio::test]
+    async fn fail_import_and_delete_release_removes_finalized_import_state_atomically() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        db.insert_import(&DbImport::new(
+            "import-a",
+            "Album Title A",
+            "Artist Name A",
+            tmp.path().to_str().unwrap(),
+            now,
+        ))
+        .await
+        .unwrap();
+
+        let artist = DbArtist {
+            id: "artist-a".to_string(),
+            name: "Artist Name A".to_string(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: now,
+        };
+        db.insert_artist(&artist).await.unwrap();
+
+        let album = DbAlbum {
+            id: "album-a".to_string(),
+            title: "Album Title A".to_string(),
+            artist_id: artist.id.clone(),
+            year: Some(2026),
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: now,
+        };
+        let release = DbRelease {
+            id: "release-a".to_string(),
+            album_id: album.id.clone(),
+            release_name: None,
+            pressing: Pressing {
+                year: Some(2026),
+                format: Some("FLAC".to_string()),
+                label: None,
+                catalog_number: None,
+                country: None,
+                barcode: None,
+            },
+            disc_id: None,
+            metadata_source: ReleaseMetadataSource::FileTags,
+            metadata_source_release_id: None,
+            remote: false,
+            source_folder_name: None,
+            content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
+            created_at: now,
+        };
+        let track = DbTrack {
+            id: "track-a".to_string(),
+            release_id: release.id.clone(),
+            title: "Track Title A".to_string(),
+            side: 1,
+            track_number: Some(1),
+            duration_ms: Some(1000),
+            discogs_position: None,
+            created_at: now,
+        };
+        let file = DbFile::new(
+            &release.id,
+            "Track Title A.flac",
+            1024,
+            ContentType::Flac,
+            "file-a".to_string(),
+            now,
+        );
+        let track_files = vec![crate::import::TrackFile::Standalone {
+            db_track: track,
+            file_path: tmp.path().join("Track Title A.flac"),
+        }];
+
+        db.finalize_import_atomic(
+            Some(&album),
+            &release,
+            &track_files,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[file],
+            &[],
+            None,
+            Some((&album.id, &release.id)),
+            "import-a",
+            ImportOperationStatus::Complete,
+            &[],
+            tmp.path().to_str().unwrap(),
+            crate::config::HomeStorage::Opaque,
+        )
+        .await
+        .unwrap();
+        assert!(db.external_blob("file-a").await.unwrap().is_some());
+
+        db.fail_import_and_delete_release("import-a", "release-a", "remote upload failed")
+            .await
+            .unwrap();
+
+        assert!(db.find_release_by_id("release-a").await.unwrap().is_none());
+        assert!(db.find_album_by_id("album-a").await.unwrap().is_none());
+        assert!(db.external_blob("file-a").await.unwrap().is_none());
+        let import = db
+            .find_import_by_id("import-a")
+            .await
+            .unwrap()
+            .expect("import remains visible as failed");
+        assert_eq!(import.status, ImportOperationStatus::Failed);
+        assert!(import.release_id.is_none());
+        assert_eq!(
+            import.error_message.as_deref(),
+            Some("remote upload failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_import_for_release_marks_active_release_import_complete() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        db.insert_import(&DbImport::new(
+            "import-a",
+            "Album Title A",
+            "Artist Name A",
+            tmp.path().to_str().unwrap(),
+            now,
+        ))
+        .await
+        .unwrap();
+
+        let artist = DbArtist {
+            id: "artist-a".to_string(),
+            name: "Artist Name A".to_string(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: now,
+        };
+        db.insert_artist(&artist).await.unwrap();
+
+        let album = DbAlbum {
+            id: "album-a".to_string(),
+            title: "Album Title A".to_string(),
+            artist_id: artist.id.clone(),
+            year: Some(2026),
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: now,
+        };
+        let release = DbRelease {
+            id: "release-a".to_string(),
+            album_id: album.id.clone(),
+            release_name: None,
+            pressing: Pressing {
+                year: Some(2026),
+                format: Some("FLAC".to_string()),
+                label: None,
+                catalog_number: None,
+                country: None,
+                barcode: None,
+            },
+            disc_id: None,
+            metadata_source: ReleaseMetadataSource::FileTags,
+            metadata_source_release_id: None,
+            remote: false,
+            source_folder_name: None,
+            content_hash: None,
+            album_loudness_lufs: None,
+            album_peak_linear: None,
+            created_at: now,
+        };
+        let track = DbTrack {
+            id: "track-a".to_string(),
+            release_id: release.id.clone(),
+            title: "Track Title A".to_string(),
+            side: 1,
+            track_number: Some(1),
+            duration_ms: Some(1000),
+            discogs_position: None,
+            created_at: now,
+        };
+        let file = DbFile::new(
+            &release.id,
+            "Track Title A.flac",
+            1024,
+            ContentType::Flac,
+            "file-a".to_string(),
+            now,
+        );
+        let track_files = vec![crate::import::TrackFile::Standalone {
+            db_track: track,
+            file_path: tmp.path().join("Track Title A.flac"),
+        }];
+
+        db.finalize_import_atomic(
+            Some(&album),
+            &release,
+            &track_files,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[file],
+            &[],
+            None,
+            Some((&album.id, &release.id)),
+            "import-a",
+            ImportOperationStatus::Importing,
+            &[],
+            tmp.path().to_str().unwrap(),
+            crate::config::HomeStorage::Opaque,
+        )
+        .await
+        .unwrap();
+
+        db.complete_import_for_release("release-a").await.unwrap();
+
+        let import = db
+            .find_import_by_id("import-a")
+            .await
+            .unwrap()
+            .expect("import remains linked to release");
+        assert_eq!(import.status, ImportOperationStatus::Complete);
+        assert_eq!(import.release_id.as_deref(), Some("release-a"));
+    }
+
+    #[tokio::test]
+    async fn search_library_matches_composer_and_work_sort_names() {
+        let (db, _tmp) = seeded_db().await;
+
+        let composer_results = db.search_library("Hidden Composer", 10).await.unwrap();
+        assert_eq!(composer_results.composers.len(), 1);
+        assert_eq!(composer_results.composers[0].artist.id, "artist-composer");
+
+        let work_results = db.search_library("Displayed Work", 10).await.unwrap();
+        assert_eq!(work_results.works.len(), 1);
+        assert_eq!(work_results.works[0].work.id, "work-child-a");
+        assert_eq!(
+            work_results.works[0].parent_work_id.as_deref(),
+            Some("work-parent-a")
+        );
+        assert_eq!(
+            work_results.works[0].representative_release_id.as_deref(),
+            Some("release-a")
+        );
+    }
+
+    #[tokio::test]
+    async fn composer_detail_carries_work_parent_and_representative_release() {
+        let (db, _tmp) = seeded_db().await;
+
+        let detail = db
+            .find_composer_detail("artist-composer")
+            .await
+            .unwrap()
+            .expect("composer detail");
+
+        assert_eq!(detail.work_groups.len(), 1);
+        let group = &detail.work_groups[0];
+        assert_eq!(
+            group.parent.as_ref().map(|work| work.work.id.as_str()),
+            Some("work-parent-a")
+        );
+        assert_eq!(group.works.len(), 1);
+        assert_eq!(group.works[0].work.id, "work-child-a");
+        assert_eq!(
+            group.works[0].parent_work_id.as_deref(),
+            Some("work-parent-a")
+        );
+        assert_eq!(
+            group.works[0].representative_release_id.as_deref(),
+            Some("release-a")
+        );
+    }
+
+    #[tokio::test]
+    async fn work_detail_lists_child_works_with_their_representative_release() {
+        let (db, _tmp) = seeded_db().await;
+
+        let detail = db
+            .find_work_detail("work-parent-a")
+            .await
+            .unwrap()
+            .expect("work detail");
+
+        assert_eq!(detail.child_works.len(), 1);
+        assert_eq!(detail.child_works[0].work.id, "work-child-a");
+        assert_eq!(
+            detail.child_works[0].representative_release_id.as_deref(),
+            Some("release-a")
+        );
+    }
+}
+
+#[cfg(test)]
 mod playback_state_load_tests {
     use super::super::*;
     use coven::SystemClock;
@@ -281,7 +873,7 @@ mod playback_state_load_tests {
     async fn mismatched_source_and_cursor_discards_the_cache() {
         let (db, _tmp) = empty_db().await;
 
-        // Write a row by hand with a present source but a NULL cursor —
+        // Write a row by hand with a present source but a NULL cursor --
         // `save_playback_state` never produces this, so we insert it directly.
         db.call(|conn| {
             conn.execute(

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -107,6 +107,67 @@ pub struct DbTrackArtist {
     pub position: i32,
     pub created_at: DateTime<Utc>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DbWork {
+    pub id: String,
+    pub title: String,
+    pub disambiguation: Option<String>,
+    pub work_type: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DbWorkArtist {
+    pub id: String,
+    pub work_id: String,
+    pub artist_id: String,
+    pub position: i32,
+    pub source: MetadataSource,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DbWorkPart {
+    pub id: String,
+    pub parent_work_id: String,
+    pub child_work_id: String,
+    pub position: i32,
+    pub source: MetadataSource,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DbTrackWork {
+    pub id: String,
+    pub track_id: String,
+    pub work_id: String,
+    pub position: i32,
+    pub source: MetadataSource,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DbReleaseArtistRole {
+    pub id: String,
+    pub release_id: String,
+    pub artist_id: String,
+    pub position: i32,
+    pub source: MetadataSource,
+    pub source_credit: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DbTrackArtistRole {
+    pub id: String,
+    pub track_id: String,
+    pub artist_id: String,
+    pub position: i32,
+    pub source: MetadataSource,
+    pub source_credit: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
 /// Album metadata - represents a logical album (the "master")
 ///
 /// A logical album can have multiple physical releases (e.g., "1973 Original", "2016 Remaster").
@@ -479,6 +540,128 @@ impl DbTrackArtist {
             track_id: track_id.to_string(),
             artist_id: artist_id.to_string(),
             position,
+            created_at: now,
+        }
+    }
+}
+
+impl DbWork {
+    pub fn new(
+        work_id: &str,
+        title: &str,
+        disambiguation: Option<String>,
+        work_type: Option<String>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbWork {
+            id: work_id.to_string(),
+            title: title.to_string(),
+            disambiguation,
+            work_type,
+            created_at: now,
+        }
+    }
+}
+
+impl DbWorkArtist {
+    pub fn new(
+        work_id: &str,
+        artist_id: &str,
+        position: i32,
+        source: MetadataSource,
+        id: String,
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbWorkArtist {
+            id,
+            work_id: work_id.to_string(),
+            artist_id: artist_id.to_string(),
+            position,
+            source,
+            created_at: now,
+        }
+    }
+}
+
+impl DbWorkPart {
+    pub fn new(
+        parent_work_id: &str,
+        child_work_id: &str,
+        position: i32,
+        source: MetadataSource,
+        id: String,
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbWorkPart {
+            id,
+            parent_work_id: parent_work_id.to_string(),
+            child_work_id: child_work_id.to_string(),
+            position,
+            source,
+            created_at: now,
+        }
+    }
+}
+
+impl DbTrackWork {
+    pub fn new(
+        track_id: &str,
+        work_id: &str,
+        position: i32,
+        source: MetadataSource,
+        id: String,
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbTrackWork {
+            id,
+            track_id: track_id.to_string(),
+            work_id: work_id.to_string(),
+            position,
+            source,
+            created_at: now,
+        }
+    }
+}
+
+impl DbReleaseArtistRole {
+    pub fn new(
+        release_id: &str,
+        artist_id: &str,
+        position: i32,
+        source: MetadataSource,
+        source_credit: Option<String>,
+        id: String,
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbReleaseArtistRole {
+            id,
+            release_id: release_id.to_string(),
+            artist_id: artist_id.to_string(),
+            position,
+            source,
+            source_credit,
+            created_at: now,
+        }
+    }
+}
+
+impl DbTrackArtistRole {
+    pub fn new(
+        track_id: &str,
+        artist_id: &str,
+        position: i32,
+        source: MetadataSource,
+        source_credit: Option<String>,
+        id: String,
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbTrackArtistRole {
+            id,
+            track_id: track_id.to_string(),
+            artist_id: artist_id.to_string(),
+            position,
+            source,
+            source_credit,
             created_at: now,
         }
     }
@@ -904,7 +1087,7 @@ impl DbImport {
     }
 }
 /// Type discriminator for library images
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LibraryImageType {
     Cover,
     Artist,
@@ -915,6 +1098,13 @@ impl LibraryImageType {
         match self {
             LibraryImageType::Cover => "cover",
             LibraryImageType::Artist => "artist",
+        }
+    }
+
+    pub fn namespace(&self) -> &'static str {
+        match self {
+            LibraryImageType::Cover => crate::sync::COVERS_NAMESPACE,
+            LibraryImageType::Artist => crate::sync::ARTIST_IMAGES_NAMESPACE,
         }
     }
 }
@@ -969,6 +1159,8 @@ pub struct DbLibraryImage {
 pub struct DbLibrarySearchResults {
     pub albums: Vec<DbAlbumSearchResult>,
     pub tracks: Vec<DbTrackSearchResult>,
+    pub composers: Vec<DbComposerSummary>,
+    pub works: Vec<DbWorkSummary>,
 }
 
 /// Raw album search-result row with the primary artist name joined in SQL.
@@ -991,6 +1183,67 @@ pub struct DbTrackSearchResult {
     pub album_id: String,
     pub album_title: String,
     pub artist_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbComposerSummary {
+    pub artist: DbArtist,
+    pub work_count: i64,
+    pub linked_release_count: i64,
+    pub unlinked_credit_count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbWorkSummary {
+    pub work: DbWork,
+    pub parent_work_id: Option<String>,
+    pub representative_release_id: Option<String>,
+    pub composer_names: Option<String>,
+    pub linked_release_count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbComposerDetail {
+    pub composer: DbComposerSummary,
+    pub work_groups: Vec<DbComposerWorkGroup>,
+    pub unlinked_release_roles: Vec<DbReleaseRoleSummary>,
+    pub unlinked_track_roles: Vec<DbTrackRoleSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbComposerWorkGroup {
+    pub id: String,
+    pub parent: Option<DbWorkSummary>,
+    pub works: Vec<DbWorkSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbWorkDetail {
+    pub work: DbWorkSummary,
+    pub child_works: Vec<DbWorkSummary>,
+    pub releases: Vec<DbReleaseSummary>,
+    pub tracks: Vec<DbWorkTrackSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbReleaseRoleSummary {
+    pub role: DbReleaseArtistRole,
+    pub album: DbAlbum,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbTrackRoleSummary {
+    pub role: DbTrackArtistRole,
+    pub track: DbTrack,
+    pub album: DbAlbum,
+    pub artist: DbArtist,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbWorkTrackSummary {
+    pub link: DbTrackWork,
+    pub track: DbTrack,
+    pub album: DbAlbum,
 }
 
 /// Raw per-release storage summary assembled via a single SQL query (no
@@ -1040,6 +1293,19 @@ pub enum SortDirection {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AlbumSortCriterion {
     pub field: AlbumSortField,
+    pub direction: SortDirection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComposerSortField {
+    Name,
+    WorkCount,
+    LinkedReleaseCount,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComposerSortCriterion {
+    pub field: ComposerSortField,
     pub direction: SortDirection,
 }
 

--- a/bae-core/src/discogs/client.rs
+++ b/bae-core/src/discogs/client.rs
@@ -1,4 +1,4 @@
-use crate::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
+use crate::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsRoleArtist, DiscogsTrack};
 use crate::discogs::remote_cover_from_urls;
 use crate::import::cover_art::RemoteCover;
 use lru::LruCache;
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Mutex as StdMutex, OnceLock};
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Capacity for each request-kind cache. Sized for a typical session
 /// (a few imports, each touching 1-3 releases). Eviction costs one
@@ -117,9 +117,15 @@ pub struct DiscogsSearchResult {
     pub label: Option<Vec<String>>,
     pub catno: Option<String>,
     pub barcode: Option<Vec<String>>,
-    #[serde(default, deserialize_with = "crate::discogs::empty_string_as_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
     pub cover_image: Option<String>,
-    #[serde(default, deserialize_with = "crate::discogs::empty_string_as_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
     pub thumb: Option<String>,
     pub master_id: Option<u64>,
     #[serde(rename = "type")]
@@ -144,6 +150,22 @@ struct ArtistCredit {
     id: u64,
     name: String,
 }
+
+#[derive(Debug, Deserialize, Clone)]
+struct ExtraArtistCredit {
+    id: Option<u64>,
+    name: String,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
+    role: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
+    anv: Option<String>,
+}
 /// Detailed release response from Discogs
 #[derive(Debug, Deserialize)]
 struct ReleaseResponse {
@@ -157,6 +179,7 @@ struct ReleaseResponse {
     labels: Option<Vec<LabelResponse>>,
     images: Option<Vec<Image>>,
     artists: Option<Vec<ArtistCredit>>,
+    extraartists: Option<Vec<ExtraArtistCredit>>,
     tracklist: Option<Vec<TrackResponse>>,
     master_id: Option<u64>,
 }
@@ -178,6 +201,7 @@ struct TrackResponse {
     duration: Option<String>,
     #[serde(default)]
     artists: Vec<ArtistCredit>,
+    extraartists: Option<Vec<ExtraArtistCredit>>,
     #[serde(default)]
     type_: String,
 }
@@ -185,6 +209,23 @@ struct TrackResponse {
 struct LabelResponse {
     name: String,
     catno: Option<String>,
+}
+
+fn extra_artist_to_model(a: ExtraArtistCredit) -> Option<DiscogsRoleArtist> {
+    let Some(role) = a.role else {
+        warn!(
+            discogs_artist_id = ?a.id,
+            artist_name = %a.name,
+            "Skipping Discogs extraartist without role"
+        );
+        return None;
+    };
+    Some(DiscogsRoleArtist {
+        id: a.id.map(|id| id.to_string()),
+        name: a.name,
+        role,
+        credited_name: a.anv,
+    })
 }
 
 /// Convert raw Discogs release JSON into the public `DiscogsRelease` shape.
@@ -210,6 +251,12 @@ pub fn parse_discogs_release_json(raw_json: &str) -> Result<DiscogsRelease, Disc
                     name: a.name,
                 })
                 .collect(),
+            extraartists: t.extraartists.map(|extraartists| {
+                extraartists
+                    .into_iter()
+                    .filter_map(extra_artist_to_model)
+                    .collect()
+            }),
             type_: if t.type_.is_empty() {
                 "track".to_string()
             } else {
@@ -226,6 +273,12 @@ pub fn parse_discogs_release_json(raw_json: &str) -> Result<DiscogsRelease, Disc
             name: a.name,
         })
         .collect();
+    let extraartists = release.extraartists.map(|extraartists| {
+        extraartists
+            .into_iter()
+            .filter_map(extra_artist_to_model)
+            .collect()
+    });
     let primary_image = release.images.as_ref().and_then(|images| {
         images
             .iter()
@@ -253,6 +306,7 @@ pub fn parse_discogs_release_json(raw_json: &str) -> Result<DiscogsRelease, Disc
         cover_image,
         thumb,
         artists,
+        extraartists,
         tracklist,
         master_id,
     })

--- a/bae-core/src/discogs/mod.rs
+++ b/bae-core/src/discogs/mod.rs
@@ -14,22 +14,6 @@ pub(crate) fn split_title(title: &str) -> Option<(&str, &str)> {
     title.split_once(" - ").map(|(a, b)| (a.trim(), b.trim()))
 }
 
-/// Map `Some("")` → `None`. Discogs returns empty strings (`""`)
-/// instead of `null` for missing URL fields (`thumb`, `cover_image`,
-/// etc.); serde deserializes those into `Some(String::new())` which
-/// then leaks downstream as a "valid" URL until something tries to
-/// parse it. Apply with
-/// `#[serde(default, deserialize_with = "empty_string_as_none")]` on
-/// any `Option<String>` field where empty has only one meaning
-/// (absence).
-pub(crate) fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize;
-    Ok(Option::<String>::deserialize(deserializer)?.filter(|s| !s.is_empty()))
-}
-
 pub(crate) fn remote_cover_from_urls<I>(
     cover_image: Option<&str>,
     thumb: Option<&str>,

--- a/bae-core/src/discogs/models.rs
+++ b/bae-core/src/discogs/models.rs
@@ -8,6 +8,14 @@ pub struct DiscogsArtist {
     pub id: String,
     pub name: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DiscogsRoleArtist {
+    pub id: Option<String>,
+    pub name: String,
+    pub role: String,
+    pub credited_name: Option<String>,
+}
 /// Represents a Discogs release search result
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiscogsRelease {
@@ -19,12 +27,19 @@ pub struct DiscogsRelease {
     pub format: Vec<String>,
     pub country: Option<String>,
     pub label: Vec<String>,
-    #[serde(default, deserialize_with = "crate::discogs::empty_string_as_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
     pub cover_image: Option<String>,
-    #[serde(default, deserialize_with = "crate::discogs::empty_string_as_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
     pub thumb: Option<String>,
     pub catno: Option<String>,
     pub artists: Vec<DiscogsArtist>,
+    pub extraartists: Option<Vec<DiscogsRoleArtist>>,
     pub tracklist: Vec<DiscogsTrack>,
     pub master_id: Option<String>,
 }
@@ -48,6 +63,7 @@ pub struct DiscogsTrack {
     pub duration: Option<String>,
     #[serde(default)]
     pub artists: Vec<DiscogsArtist>,
+    pub extraartists: Option<Vec<DiscogsRoleArtist>>,
     /// Track type: "track", "heading", or "index"
     #[serde(default)]
     pub type_: String,
@@ -75,6 +91,7 @@ mod tests {
                 id: "discogs-artist-1".to_string(),
                 name: "Artist Name".to_string(),
             }],
+            extraartists: Some(vec![]),
             tracklist: vec![],
             master_id: None,
         }

--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -100,7 +100,7 @@ pub async fn resolve_release_identity(
 /// signals."
 ///
 /// The cover blob lives in coven's store (no path bae may compute), so its bytes
-/// come back through `read_image_blob` and are written into a temp dir whose
+/// come back through the cover's image ref and are written into a temp dir whose
 /// guard is returned alongside the paths: the caller holds it until the OCR pass
 /// finishes, then the staged file is cleaned up. `None` when the release has no
 /// cover.
@@ -118,8 +118,22 @@ pub async fn resolve_release_artwork_paths(
     // reader opens. The cover is one of several OCR artwork inputs (the in-folder
     // image files below are the others), so a read/staging failure logs and skips
     // just the cover rather than failing the whole resolve.
-    let cover_staging = match library_manager.read_image_blob(release_id).await {
-        Ok(Some(bytes)) => stage_cover_for_ocr(release_id, &bytes, &mut paths),
+    let cover_staging = match library_manager.cover_ref(release_id).await {
+        Ok(Some(image)) => {
+            match library_manager.read_image_blob(&image).await {
+                Ok(Some(bytes)) => stage_cover_for_ocr(release_id, &bytes, &mut paths),
+                Ok(None) => {
+                    debug!("artwork OCR: release {release_id} has no cover blob; skipping cover staging");
+                    None
+                }
+                Err(e) => {
+                    warn!(
+                    "artwork OCR: reading cover for release {release_id} failed: {e}; skipping cover"
+                );
+                    None
+                }
+            }
+        }
         Ok(None) => {
             debug!("artwork OCR: release {release_id} has no cover blob; skipping cover staging");
             None

--- a/bae-core/src/import/discogs_mapper.rs
+++ b/bae-core/src/import/discogs_mapper.rs
@@ -1,11 +1,68 @@
-use super::ParsedAlbum;
-use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
-use crate::discogs::DiscogsRelease;
+use super::{ParsedAlbum, ParsedWorkGraph};
+use crate::db::{
+    DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbReleaseArtistRole, DbTrack, DbTrackArtist,
+    DbTrackArtistRole,
+};
+use crate::discogs::{DiscogsRelease, DiscogsRoleArtist};
 use crate::import::types::ReleaseIdentity;
 use crate::import::MetadataSource;
 use crate::musicbrainz::MbReleaseResponse;
 use coven::Clock;
 use coven::IdProvider;
+use tracing::{debug, warn};
+
+fn discogs_role_is_composer(role: &str) -> bool {
+    let lowered = role
+        .chars()
+        .filter(|c| *c != '[' && *c != ']')
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let compact = lowered.replace(['-', '_'], " ");
+    compact.contains("composed by")
+        || compact.contains("written by")
+        || compact.contains("music by")
+        || compact.contains("composer")
+}
+
+fn find_or_push_discogs_role_artist(
+    artists: &mut Vec<DbArtist>,
+    credit: &DiscogsRoleArtist,
+    ids: &dyn IdProvider,
+    now: chrono::DateTime<chrono::Utc>,
+) -> String {
+    if let Some(existing) = artists.iter().find(|artist| {
+        if let Some(source_id) = credit.id.as_ref() {
+            artist.discogs_artist_id.as_ref() == Some(source_id)
+        } else {
+            artist.name.eq_ignore_ascii_case(&credit.name)
+        }
+    }) {
+        return existing.id.clone();
+    }
+
+    let name = match credit.credited_name.clone() {
+        Some(name) => name,
+        None => {
+            warn!(
+                discogs_artist_id = ?credit.id,
+                artist_name = %credit.name,
+                "Discogs role artist has no credited name; using canonical name"
+            );
+            credit.name.clone()
+        }
+    };
+    let artist = DbArtist {
+        id: ids.new_id(),
+        name: name.clone(),
+        sort_name: Some(name),
+        discogs_artist_id: credit.id.clone(),
+        musicbrainz_artist_id: None,
+        created_at: now,
+    };
+    let id = artist.id.clone();
+    artists.push(artist);
+    id
+}
 
 /// Map Discogs release metadata into database models including artist information.
 ///
@@ -73,6 +130,32 @@ pub fn map_discogs_to_db(
 
     let mut tracks = Vec::new();
     let mut track_artists = Vec::new();
+    let mut release_artist_roles = Vec::new();
+    let mut track_artist_roles = Vec::new();
+
+    if let Some(extraartists) = release.extraartists.as_ref() {
+        for (position, credit) in extraartists.iter().enumerate() {
+            if discogs_role_is_composer(&credit.role) {
+                let artist_id = find_or_push_discogs_role_artist(&mut artists, credit, ids, now);
+                release_artist_roles.push(DbReleaseArtistRole::new(
+                    &db_release.id,
+                    &artist_id,
+                    position as i32,
+                    MetadataSource::Discogs,
+                    Some(credit.role.clone()),
+                    ids.new_id(),
+                    now,
+                ));
+            } else {
+                debug!(
+                    discogs_release_id = %release.id,
+                    artist_name = %credit.name,
+                    role = %credit.role,
+                    "Skipping Discogs release-level extraartist with non-composer role"
+                );
+            }
+        }
+    }
 
     for pt in &processed {
         let track = DbTrack::from_discogs_track(
@@ -96,6 +179,47 @@ pub fn map_discogs_to_db(
                 .any(|p| p == &discogs_track.position)
                 && discogs_track.type_ != "heading"
             {
+                match discogs_track.extraartists.as_ref() {
+                    Some(extraartists) => {
+                        for (role_position, credit) in extraartists.iter().enumerate() {
+                            if discogs_role_is_composer(&credit.role) {
+                                let artist_id = find_or_push_discogs_role_artist(
+                                    &mut artists,
+                                    credit,
+                                    ids,
+                                    now,
+                                );
+                                track_artist_roles.push(DbTrackArtistRole::new(
+                                    &track.id,
+                                    &artist_id,
+                                    role_position as i32,
+                                    MetadataSource::Discogs,
+                                    Some(credit.role.clone()),
+                                    ids.new_id(),
+                                    now,
+                                ));
+                            } else {
+                                debug!(
+                                    discogs_release_id = %release.id,
+                                    discogs_track_position = %discogs_track.position,
+                                    track_title = %discogs_track.title,
+                                    artist_name = %credit.name,
+                                    role = %credit.role,
+                                    "Skipping Discogs track-level extraartist with non-composer role"
+                                );
+                            }
+                        }
+                    }
+                    None => {
+                        debug!(
+                            discogs_release_id = %release.id,
+                            discogs_track_position = %discogs_track.position,
+                            track_title = %discogs_track.title,
+                            "Discogs track has no extraartists field; skipping per-track role credits"
+                        );
+                    }
+                }
+
                 for discogs_artist in &discogs_track.artists {
                     let already_exists = artists
                         .iter()
@@ -178,6 +302,14 @@ pub fn map_discogs_to_db(
         artists,
         album_artists,
         track_artists,
+        work_graph: ParsedWorkGraph {
+            works: Vec::new(),
+            work_artists: Vec::new(),
+            work_parts: Vec::new(),
+            track_works: Vec::new(),
+        },
+        release_artist_roles,
+        track_artist_roles,
         identities,
     })
 }
@@ -372,7 +504,7 @@ fn extract_artist_name(title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::discogs::models::{DiscogsArtist, DiscogsTrack};
+    use crate::discogs::models::{DiscogsArtist, DiscogsRoleArtist, DiscogsTrack};
     use coven::FixedClock;
     use coven::SequentialIdProvider;
 
@@ -417,6 +549,7 @@ mod tests {
             duration: None,
             artists: vec![],
             type_: "track".to_string(),
+            extraartists: None,
         }
     }
 
@@ -427,13 +560,14 @@ mod tests {
             duration: None,
             artists: vec![],
             type_: "heading".to_string(),
+            extraartists: None,
         }
     }
 
     fn make_release(tracklist: Vec<DiscogsTrack>) -> DiscogsRelease {
         DiscogsRelease {
             id: "test-123".to_string(),
-            title: "Test Album".to_string(),
+            title: "Album Title A".to_string(),
             year: Some(2024),
             genre: vec![],
             style: vec![],
@@ -444,12 +578,83 @@ mod tests {
             thumb: None,
             catno: None,
             artists: vec![DiscogsArtist {
-                name: "Test Artist".to_string(),
+                name: "Artist Name A".to_string(),
                 id: "artist-1".to_string(),
             }],
             tracklist,
+            extraartists: Some(vec![]),
             master_id: None,
         }
+    }
+
+    #[test]
+    fn extraartist_roles_import_as_role_credits_not_works_or_display_artists() {
+        let mut release = make_release(vec![make_track("1", "Track Title 1")]);
+        release.extraartists = Some(vec![
+            DiscogsRoleArtist {
+                id: Some("discogs-composer-a".to_string()),
+                name: "Composer Name A".to_string(),
+                role: "Composed By".to_string(),
+                credited_name: Some("Composer Credit A".to_string()),
+            },
+            DiscogsRoleArtist {
+                id: Some("discogs-producer-a".to_string()),
+                name: "Producer Name A".to_string(),
+                role: "Producer".to_string(),
+                credited_name: Some("Producer Credit A".to_string()),
+            },
+        ]);
+        release.tracklist[0].extraartists = Some(vec![
+            DiscogsRoleArtist {
+                id: Some("discogs-composer-a".to_string()),
+                name: "Composer Name A".to_string(),
+                role: "Written-By".to_string(),
+                credited_name: Some("Composer Credit A".to_string()),
+            },
+            DiscogsRoleArtist {
+                id: Some("discogs-engineer-a".to_string()),
+                name: "Engineer Name A".to_string(),
+                role: "Engineer".to_string(),
+                credited_name: Some("Engineer Credit A".to_string()),
+            },
+        ]);
+
+        let parsed = map(&release, Some(2024), None).unwrap();
+
+        assert!(parsed.work_graph.works.is_empty());
+        assert!(parsed.work_graph.work_artists.is_empty());
+        assert!(parsed.work_graph.work_parts.is_empty());
+        assert!(parsed.work_graph.track_works.is_empty());
+
+        let composer = parsed
+            .artists
+            .iter()
+            .find(|artist| artist.discogs_artist_id.as_deref() == Some("discogs-composer-a"))
+            .expect("composer role artist imported");
+        let release_artist_roles = &parsed.release_artist_roles;
+        let track_artist_roles = &parsed.track_artist_roles;
+        assert!(release_artist_roles.iter().any(|role| {
+            role.artist_id == composer.id && role.source_credit.as_deref() == Some("Composed By")
+        }));
+        assert!(track_artist_roles.iter().any(|role| {
+            role.artist_id == composer.id && role.source_credit.as_deref() == Some("Written-By")
+        }));
+        assert!(!parsed
+            .artists
+            .iter()
+            .any(|artist| artist.discogs_artist_id.as_deref() == Some("discogs-producer-a")));
+        assert!(!parsed
+            .artists
+            .iter()
+            .any(|artist| artist.discogs_artist_id.as_deref() == Some("discogs-engineer-a")));
+        assert!(!parsed
+            .album_artists
+            .iter()
+            .any(|link| link.artist_id == composer.id));
+        assert!(!parsed
+            .track_artists
+            .iter()
+            .any(|link| link.artist_id == composer.id));
     }
 
     #[test]
@@ -531,6 +736,7 @@ mod tests {
                 duration: None,
                 artists: vec![],
                 type_: "track".to_string(),
+                extraartists: None,
             },
             DiscogsTrack {
                 position: "B1ii".to_string(),
@@ -538,6 +744,7 @@ mod tests {
                 duration: None,
                 artists: vec![],
                 type_: "track".to_string(),
+                extraartists: None,
             },
             DiscogsTrack {
                 position: "B1iii".to_string(),
@@ -545,6 +752,7 @@ mod tests {
                 duration: None,
                 artists: vec![],
                 type_: "track".to_string(),
+                extraartists: None,
             },
             make_heading("-"),
             make_track("B2", "Track Three"),
@@ -641,6 +849,7 @@ mod tests {
                 duration: None,
                 artists: vec![sub_artist.clone()],
                 type_: "track".to_string(),
+                extraartists: None,
             },
             DiscogsTrack {
                 position: "B1ii".to_string(),
@@ -648,6 +857,7 @@ mod tests {
                 duration: None,
                 artists: vec![sub_artist.clone()],
                 type_: "track".to_string(),
+                extraartists: None,
             },
         ]);
 
@@ -720,7 +930,7 @@ mod tests {
     fn mb_xref_with_group(release_id: &str, group_id: &str) -> MbReleaseResponse {
         MbReleaseResponse {
             id: release_id.to_string(),
-            title: "Test Album".to_string(),
+            title: "Album Title A".to_string(),
             date: None,
             country: None,
             barcode: None,
@@ -800,6 +1010,7 @@ mod tests {
             duration: None,
             artists: vec![],
             type_: "index".to_string(),
+            extraartists: None,
         };
         let result = process_tracklist(&[index, make_track("A1", "Real Track")]);
         assert_eq!(result.len(), 1);

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -20,7 +20,7 @@
 //! from any tag carrying a date. Both stay `None` if not determinable
 //! rather than being defaulted.
 
-use super::ParsedAlbum;
+use super::{ParsedAlbum, ParsedWorkGraph};
 use crate::db::ReleaseMetadataSource;
 use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
 use crate::util::content_type::ContentType;
@@ -281,6 +281,14 @@ pub fn map_file_tags_to_db(
         artists,
         album_artists,
         track_artists,
+        work_graph: ParsedWorkGraph {
+            works: Vec::new(),
+            work_artists: Vec::new(),
+            work_parts: Vec::new(),
+            track_works: Vec::new(),
+        },
+        release_artist_roles: Vec::new(),
+        track_artist_roles: Vec::new(),
         identities: Vec::new(),
     })
 }

--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -234,6 +234,27 @@ impl ImportServiceHandle {
     }
 }
 
+pub fn remap_artist_links<T: Clone>(
+    links: &[T],
+    artist_id_map: &HashMap<String, String>,
+    label: &str,
+    artist_id: impl Fn(&T) -> &str,
+    assign_artist_id: impl Fn(&mut T, String),
+) -> Result<Vec<T>, String> {
+    links
+        .iter()
+        .map(|link| {
+            let parsed_artist_id = artist_id(link);
+            let actual_id = artist_id_map.get(parsed_artist_id).ok_or_else(|| {
+                format!("{label} artist ID {parsed_artist_id} not found in artist map")
+            })?;
+            let mut remapped = link.clone();
+            assign_artist_id(&mut remapped, actual_id.clone());
+            Ok(remapped)
+        })
+        .collect()
+}
+
 /// Remap track artist IDs from the parsed (temporary) artist IDs to the actual DB IDs.
 ///
 /// The ParsedAlbum's track_artists reference artist IDs generated during parsing, but
@@ -243,17 +264,13 @@ pub fn remap_track_artists(
     track_artists: &[crate::db::DbTrackArtist],
     artist_id_map: &HashMap<String, String>,
 ) -> Result<Vec<crate::db::DbTrackArtist>, String> {
-    track_artists
-        .iter()
-        .map(|ta| {
-            let actual_id = artist_id_map.get(&ta.artist_id).ok_or_else(|| {
-                format!("Track artist ID {} not found in artist map", ta.artist_id)
-            })?;
-            let mut remapped = ta.clone();
-            remapped.artist_id = actual_id.clone();
-            Ok(remapped)
-        })
-        .collect()
+    remap_artist_links(
+        track_artists,
+        artist_id_map,
+        "track artist",
+        |ta| &ta.artist_id,
+        |ta, artist_id| ta.artist_id = artist_id,
+    )
 }
 
 /// Remap album artist IDs from the parsed (temporary) artist IDs to the actual DB IDs.
@@ -261,17 +278,13 @@ pub fn remap_album_artists(
     album_artists: &[crate::db::DbAlbumArtist],
     artist_id_map: &HashMap<String, String>,
 ) -> Result<Vec<crate::db::DbAlbumArtist>, String> {
-    album_artists
-        .iter()
-        .map(|aa| {
-            let actual_id = artist_id_map.get(&aa.artist_id).ok_or_else(|| {
-                format!("Album artist ID {} not found in artist map", aa.artist_id)
-            })?;
-            let mut remapped = aa.clone();
-            remapped.artist_id = actual_id.clone();
-            Ok(remapped)
-        })
-        .collect()
+    remap_artist_links(
+        album_artists,
+        artist_id_map,
+        "album artist",
+        |aa| &aa.artist_id,
+        |aa, artist_id| aa.artist_id = artist_id,
+    )
 }
 
 /// Fetch artist images for artists that have a Discogs ID but no image yet.

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -30,7 +30,18 @@ pub(crate) mod service;
 mod track_to_file_mapper;
 mod types;
 
-use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
+use crate::db::{
+    DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbReleaseArtistRole, DbTrack, DbTrackArtist,
+    DbTrackArtistRole, DbTrackWork, DbWork, DbWorkArtist, DbWorkPart,
+};
+
+#[derive(Debug, Clone)]
+pub struct ParsedWorkGraph {
+    pub works: Vec<DbWork>,
+    pub work_artists: Vec<DbWorkArtist>,
+    pub work_parts: Vec<DbWorkPart>,
+    pub track_works: Vec<DbTrackWork>,
+}
 
 /// Result of parsing a release (MusicBrainz or Discogs) into the
 /// in-memory shape that flows into commit. Carries the per-source
@@ -45,6 +56,9 @@ pub struct ParsedAlbum {
     pub artists: Vec<DbArtist>,
     pub album_artists: Vec<DbAlbumArtist>,
     pub track_artists: Vec<DbTrackArtist>,
+    pub work_graph: ParsedWorkGraph,
+    pub release_artist_roles: Vec<DbReleaseArtistRole>,
+    pub track_artist_roles: Vec<DbTrackArtistRole>,
     /// One element per source the parser resolved for this release.
     /// Empty for Unknown imports (file-tag-only).
     pub identities: Vec<crate::import::types::ReleaseIdentity>,

--- a/bae-core/src/import/musicbrainz_mapper.rs
+++ b/bae-core/src/import/musicbrainz_mapper.rs
@@ -14,14 +14,20 @@
 //! produce only a Discogs identity row at first; the reverse cross-link
 //! is resolved via MB's URL endpoint.
 
-use super::ParsedAlbum;
-use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist};
+use super::{ParsedAlbum, ParsedWorkGraph};
+use crate::db::{
+    DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbTrack, DbTrackArtist, DbTrackArtistRole,
+    DbTrackWork, DbWork, DbWorkArtist, DbWorkPart,
+};
 use crate::import::types::ReleaseIdentity;
 use crate::import::MetadataSource;
-use crate::musicbrainz::{fetch_release_group_json, ExternalUrls, MbReleaseResponse};
+use crate::musicbrainz::{
+    fetch_release_group_json, ExternalUrls, MbArtistRef, MbRelation, MbReleaseResponse, MbWork,
+};
 use coven::Clock;
 use coven::IdProvider;
-use tracing::warn;
+use std::collections::HashSet;
+use tracing::{debug, warn};
 
 /// Extract the leading numeric Discogs release ID from a Discogs release URL.
 ///
@@ -36,6 +42,199 @@ pub(crate) fn extract_discogs_release_id(url: &str) -> Option<String> {
     let last = trimmed.rsplit('/').next()?;
     let id: String = last.chars().take_while(|c| c.is_ascii_digit()).collect();
     (!id.is_empty()).then_some(id)
+}
+
+fn mb_relation_is(relation: &MbRelation, target_type: &str, relation_type: &str) -> bool {
+    relation.target_type.as_deref() == Some(target_type)
+        && relation.relation_type.as_deref() == Some(relation_type)
+}
+
+fn mb_artist_name(artist: &MbArtistRef, credit: Option<&str>) -> Option<String> {
+    credit
+        .filter(|c| !c.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| artist.name.clone())
+}
+
+fn find_or_push_mb_artist(
+    artists: &mut Vec<DbArtist>,
+    artist_ref: &MbArtistRef,
+    credit: Option<&str>,
+    ids: &(impl IdProvider + ?Sized),
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<String> {
+    let artist_name = mb_artist_name(artist_ref, credit)?;
+    let mb_artist_id = artist_ref.id.clone();
+    if let Some(existing) =
+        artists.iter().find(
+            |artist| match (&artist.musicbrainz_artist_id, &mb_artist_id) {
+                (Some(existing_id), Some(new_id)) => existing_id == new_id,
+                (None, None) => artist.name.eq_ignore_ascii_case(&artist_name),
+                _ => false,
+            },
+        )
+    {
+        return Some(existing.id.clone());
+    }
+
+    let artist = DbArtist {
+        id: ids.new_id(),
+        name: artist_name.clone(),
+        sort_name: artist_ref.sort_name.clone(),
+        discogs_artist_id: None,
+        musicbrainz_artist_id: mb_artist_id,
+        created_at: now,
+    };
+    let id = artist.id.clone();
+    artists.push(artist);
+    Some(id)
+}
+
+fn mb_relation_is_composer(relation: &MbRelation) -> bool {
+    relation.relation_type.as_deref() == Some("composer")
+}
+
+fn push_work_graph(
+    work: &MbWork,
+    parent: Option<&str>,
+    artists: &mut Vec<DbArtist>,
+    works: &mut Vec<DbWork>,
+    work_artists: &mut Vec<DbWorkArtist>,
+    work_parts: &mut Vec<DbWorkPart>,
+    seen_works: &mut HashSet<String>,
+    expanded_works: &mut HashSet<String>,
+    ids: &(impl IdProvider + ?Sized),
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    if seen_works.insert(work.id.clone()) {
+        works.push(DbWork::new(
+            &work.id,
+            &work.title,
+            work.disambiguation.clone(),
+            work.work_type.clone(),
+            now,
+        ));
+    }
+
+    if let Some(parent_work_id) = parent {
+        if !work_parts
+            .iter()
+            .any(|part| part.parent_work_id == parent_work_id && part.child_work_id == work.id)
+        {
+            work_parts.push(DbWorkPart::new(
+                parent_work_id,
+                &work.id,
+                work_parts.len() as i32,
+                MetadataSource::MusicBrainz,
+                ids.new_id(),
+                now,
+            ));
+        }
+    }
+
+    if work.relations.is_empty() || !expanded_works.insert(work.id.clone()) {
+        return;
+    }
+
+    for relation in &work.relations {
+        if relation.target_type.as_deref() == Some("artist") {
+            if mb_relation_is_composer(relation) {
+                let Some(artist_ref) = relation.artist.as_ref() else {
+                    warn!(
+                        work_id = %work.id,
+                        relation_type = ?relation.relation_type,
+                        "Skipping MusicBrainz work artist relation without artist payload"
+                    );
+                    continue;
+                };
+                let Some(artist_id) = find_or_push_mb_artist(
+                    artists,
+                    artist_ref,
+                    relation.target_credit.as_deref(),
+                    ids,
+                    now,
+                ) else {
+                    warn!(
+                        work_id = %work.id,
+                        musicbrainz_artist_id = ?artist_ref.id,
+                        "Skipping MusicBrainz work artist relation with unresolved artist"
+                    );
+                    continue;
+                };
+                if !work_artists.iter().any(|link| {
+                    link.work_id == work.id
+                        && link.artist_id == artist_id
+                        && link.source == MetadataSource::MusicBrainz
+                }) {
+                    work_artists.push(DbWorkArtist::new(
+                        &work.id,
+                        &artist_id,
+                        work_artists.len() as i32,
+                        MetadataSource::MusicBrainz,
+                        ids.new_id(),
+                        now,
+                    ));
+                }
+            } else {
+                debug!(
+                    work_id = %work.id,
+                    relation_type = ?relation.relation_type,
+                    target_type = ?relation.target_type,
+                    target_credit = ?relation.target_credit,
+                    "Skipping MusicBrainz work artist relation with non-composer relation type"
+                );
+            }
+        } else if mb_relation_is(relation, "work", "parts") {
+            let Some(child_or_parent) = relation.work.as_ref() else {
+                warn!(
+                    work_id = %work.id,
+                    relation_type = ?relation.relation_type,
+                    "Skipping MusicBrainz work parts relation without work payload"
+                );
+                continue;
+            };
+            match relation.direction.as_deref() {
+                Some("backward") => {
+                    push_work_graph(
+                        child_or_parent,
+                        None,
+                        artists,
+                        works,
+                        work_artists,
+                        work_parts,
+                        seen_works,
+                        expanded_works,
+                        ids,
+                        now,
+                    );
+                    if !work_parts.iter().any(|part| {
+                        part.parent_work_id == child_or_parent.id && part.child_work_id == work.id
+                    }) {
+                        work_parts.push(DbWorkPart::new(
+                            &child_or_parent.id,
+                            &work.id,
+                            work_parts.len() as i32,
+                            MetadataSource::MusicBrainz,
+                            ids.new_id(),
+                            now,
+                        ));
+                    }
+                }
+                _ => push_work_graph(
+                    child_or_parent,
+                    Some(&work.id),
+                    artists,
+                    works,
+                    work_artists,
+                    work_parts,
+                    seen_works,
+                    expanded_works,
+                    ids,
+                    now,
+                ),
+            }
+        }
+    }
 }
 
 /// Fetch a MusicBrainz release. Pure MB: no Discogs client, no cross-ref.
@@ -97,11 +296,6 @@ pub fn map_mb_response_to_db(
 
             let mb_artist_id = artist_obj.id.clone();
 
-            let sort_name = artist_obj
-                .sort_name
-                .clone()
-                .unwrap_or_else(|| artist_name.clone());
-
             let discogs_artist_id = discogs_release.as_ref().and_then(|dr| {
                 dr.artists
                     .iter()
@@ -112,7 +306,7 @@ pub fn map_mb_response_to_db(
             let artist = DbArtist {
                 id: ids.new_id(),
                 name: artist_name,
-                sort_name: Some(sort_name),
+                sort_name: artist_obj.sort_name.clone(),
                 discogs_artist_id,
                 musicbrainz_artist_id: mb_artist_id,
                 created_at: now,
@@ -131,7 +325,7 @@ pub fn map_mb_response_to_db(
         let artist = DbArtist {
             id: ids.new_id(),
             name: artist_name.clone(),
-            sort_name: Some(artist_name),
+            sort_name: None,
             discogs_artist_id: None,
             musicbrainz_artist_id: None,
             created_at: now,
@@ -183,6 +377,13 @@ pub fn map_mb_response_to_db(
 
     let mut tracks = Vec::new();
     let mut track_artists = Vec::new();
+    let mut works = Vec::new();
+    let mut work_artists = Vec::new();
+    let mut work_parts = Vec::new();
+    let mut track_works = Vec::new();
+    let mut track_artist_roles = Vec::new();
+    let mut seen_works = HashSet::new();
+    let mut expanded_works = HashSet::new();
 
     // Compute side base: each medium contributes 1 or 2 sides depending on format.
     let mut side_base = 0i32;
@@ -272,46 +473,27 @@ pub fn map_mb_response_to_db(
             for (credit_pos, credit) in track.artist_credit.iter().enumerate() {
                 if let Some(artist_obj) = &credit.artist {
                     let Some(artist_name) = artist_obj.name.clone() else {
+                        warn!(
+                            track_id = %db_track.id,
+                            musicbrainz_artist_id = ?artist_obj.id,
+                            "Skipping MusicBrainz track artist credit without artist name"
+                        );
                         continue;
                     };
-                    let mb_artist_id = artist_obj.id.clone();
-
-                    // Find this artist (dedup by MB artist ID, else by name),
-                    // or create and insert it — one scan, one predicate.
-                    let artist_id = if let Some(existing) = artists.iter().find(|a| {
-                        if let (Some(existing_id), Some(ref new_id)) =
-                            (&a.musicbrainz_artist_id, &mb_artist_id)
-                        {
-                            existing_id == new_id
-                        } else {
-                            a.name.eq_ignore_ascii_case(&artist_name)
-                        }
-                    }) {
-                        existing.id.clone()
-                    } else {
-                        let sort_name = artist_obj
-                            .sort_name
-                            .clone()
-                            .unwrap_or_else(|| artist_name.clone());
-
-                        let discogs_artist_id = discogs_release.as_ref().and_then(|dr| {
-                            dr.artists
-                                .iter()
-                                .find(|da| da.name.eq_ignore_ascii_case(&artist_name))
-                                .map(|da| da.id.clone())
-                        });
-
-                        let artist = DbArtist {
-                            id: ids.new_id(),
-                            name: artist_name.clone(),
-                            sort_name: Some(sort_name),
-                            discogs_artist_id,
-                            musicbrainz_artist_id: mb_artist_id.clone(),
-                            created_at: now,
-                        };
-                        let id = artist.id.clone();
-                        artists.push(artist);
-                        id
+                    let Some(artist_id) = find_or_push_mb_artist(
+                        &mut artists,
+                        artist_obj,
+                        Some(&artist_name),
+                        ids,
+                        now,
+                    ) else {
+                        warn!(
+                            track_id = %db_track.id,
+                            musicbrainz_artist_id = ?artist_obj.id,
+                            artist_name = %artist_name,
+                            "Skipping MusicBrainz track artist credit with unresolved artist"
+                        );
+                        continue;
                     };
 
                     track_artists.push(DbTrackArtist::new(
@@ -321,6 +503,83 @@ pub fn map_mb_response_to_db(
                         ids.new_id(),
                         now,
                     ));
+                }
+            }
+
+            if let Some(recording) = track.recording.as_ref() {
+                for (relation_pos, relation) in recording.relations.iter().enumerate() {
+                    if mb_relation_is(relation, "work", "performance") {
+                        let Some(work) = relation.work.as_ref() else {
+                            warn!(
+                                track_id = %db_track.id,
+                                relation_type = ?relation.relation_type,
+                                "Skipping MusicBrainz recording work relation without work payload"
+                            );
+                            continue;
+                        };
+                        push_work_graph(
+                            work,
+                            None,
+                            &mut artists,
+                            &mut works,
+                            &mut work_artists,
+                            &mut work_parts,
+                            &mut seen_works,
+                            &mut expanded_works,
+                            ids,
+                            now,
+                        );
+                        track_works.push(DbTrackWork::new(
+                            &db_track.id,
+                            &work.id,
+                            relation_pos as i32,
+                            MetadataSource::MusicBrainz,
+                            ids.new_id(),
+                            now,
+                        ));
+                    } else if relation.target_type.as_deref() == Some("artist") {
+                        if mb_relation_is_composer(relation) {
+                            let Some(artist_ref) = relation.artist.as_ref() else {
+                                warn!(
+                                    track_id = %db_track.id,
+                                    relation_type = ?relation.relation_type,
+                                    "Skipping MusicBrainz recording artist relation without artist payload"
+                                );
+                                continue;
+                            };
+                            let Some(artist_id) = find_or_push_mb_artist(
+                                &mut artists,
+                                artist_ref,
+                                relation.target_credit.as_deref(),
+                                ids,
+                                now,
+                            ) else {
+                                warn!(
+                                    track_id = %db_track.id,
+                                    musicbrainz_artist_id = ?artist_ref.id,
+                                    "Skipping MusicBrainz recording artist relation with unresolved artist"
+                                );
+                                continue;
+                            };
+                            track_artist_roles.push(DbTrackArtistRole::new(
+                                &db_track.id,
+                                &artist_id,
+                                relation_pos as i32,
+                                MetadataSource::MusicBrainz,
+                                relation.relation_type.clone(),
+                                ids.new_id(),
+                                now,
+                            ));
+                        } else {
+                            debug!(
+                                track_id = %db_track.id,
+                                relation_type = ?relation.relation_type,
+                                target_type = ?relation.target_type,
+                                target_credit = ?relation.target_credit,
+                                "Skipping MusicBrainz recording artist relation with non-composer relation type"
+                            );
+                        };
+                    }
                 }
             }
 
@@ -350,6 +609,14 @@ pub fn map_mb_response_to_db(
         artists,
         album_artists,
         track_artists,
+        work_graph: ParsedWorkGraph {
+            works,
+            work_artists,
+            work_parts,
+            track_works,
+        },
+        release_artist_roles: Vec::new(),
+        track_artist_roles,
         identities,
     })
 }
@@ -358,7 +625,7 @@ pub fn map_mb_response_to_db(
 mod tests {
     use super::*;
     use crate::musicbrainz::{
-        MbArtistCredit, MbArtistRef, MbMedium, MbRecording, MbReleaseResponse, MbTrack,
+        MbArtistCredit, MbArtistRef, MbMedium, MbRecording, MbReleaseResponse, MbTrack, MbWork,
     };
     use coven::FixedClock;
     use coven::SequentialIdProvider;
@@ -386,7 +653,10 @@ mod tests {
             title: None,
             length: None,
             recording: Some(MbRecording {
+                id: None,
                 title: Some(title.to_string()),
+                artist_credit: vec![],
+                relations: vec![],
             }),
             artist_credit: vec![],
         }
@@ -395,16 +665,16 @@ mod tests {
     fn make_response(media: Vec<MbMedium>) -> MbReleaseResponse {
         MbReleaseResponse {
             id: "test-release".to_string(),
-            title: "Test Album".to_string(),
+            title: "Album Title A".to_string(),
             date: Some("2024".to_string()),
             country: None,
             barcode: None,
             artist_credit: vec![MbArtistCredit {
-                name: "Test Artist".to_string(),
+                name: "Artist Name A".to_string(),
                 artist: Some(MbArtistRef {
                     id: Some("artist-1".to_string()),
-                    name: Some("Test Artist".to_string()),
-                    sort_name: Some("Artist, Test".to_string()),
+                    name: Some("Artist Name A".to_string()),
+                    sort_name: Some("Artist Name A".to_string()),
                 }),
             }],
             release_group: Some(crate::musicbrainz::MbReleaseGroupRef {
@@ -562,7 +832,10 @@ mod tests {
                     title: None,
                     length: None,
                     recording: Some(MbRecording {
+                        id: None,
                         title: Some("Side-less Track".to_string()),
+                        artist_credit: vec![],
+                        relations: vec![],
                     }),
                     artist_credit: vec![],
                 },
@@ -645,7 +918,7 @@ mod tests {
     fn discogs_release_with_master(master_id: Option<String>) -> crate::discogs::DiscogsRelease {
         crate::discogs::DiscogsRelease {
             id: "d-rel-99".to_string(),
-            title: "Test Album".to_string(),
+            title: "Album Title A".to_string(),
             year: Some(2024),
             genre: vec![],
             style: vec![],
@@ -657,6 +930,7 @@ mod tests {
             catno: None,
             artists: vec![],
             tracklist: vec![],
+            extraartists: Some(vec![]),
             master_id,
         }
     }
@@ -730,6 +1004,167 @@ mod tests {
     }
 
     #[test]
+    fn missing_mb_sort_names_remain_absent() {
+        let mut response = make_response(vec![{
+            let mut track = make_mb_track("1", "Track 1");
+            track.recording.as_mut().unwrap().relations = vec![MbRelation {
+                target_type: Some("artist".to_string()),
+                relation_type: Some("composer".to_string()),
+                artist: Some(MbArtistRef {
+                    id: Some("composer-artist-a".to_string()),
+                    name: Some("Composer Name A".to_string()),
+                    sort_name: None,
+                }),
+                ..MbRelation::default()
+            }];
+            MbMedium {
+                format: Some("CD".to_string()),
+                tracks: vec![track],
+            }
+        }]);
+        response.artist_credit[0].artist.as_mut().unwrap().sort_name = None;
+
+        let parsed = map(&response, Some(2024), None).unwrap();
+
+        let release_artist = parsed
+            .artists
+            .iter()
+            .find(|artist| artist.musicbrainz_artist_id.as_deref() == Some("artist-1"))
+            .expect("release artist imported");
+        let composer = parsed
+            .artists
+            .iter()
+            .find(|artist| artist.musicbrainz_artist_id.as_deref() == Some("composer-artist-a"))
+            .expect("composer artist imported");
+
+        assert_eq!(release_artist.sort_name, None);
+        assert_eq!(composer.sort_name, None);
+    }
+
+    #[test]
+    fn nested_recording_work_imports_composer_work_graph() {
+        let composer_ref = MbArtistRef {
+            id: Some("composer-artist-a".to_string()),
+            name: Some("Composer Name A".to_string()),
+            sort_name: Some("Composer Name A".to_string()),
+        };
+        let lyricist_ref = MbArtistRef {
+            id: Some("lyricist-artist-a".to_string()),
+            name: Some("Lyricist Name A".to_string()),
+            sort_name: Some("Lyricist Name A".to_string()),
+        };
+        let child_work = MbWork {
+            id: "mb-work-child-a".to_string(),
+            title: "Work Part A".to_string(),
+            disambiguation: None,
+            work_type: Some("part".to_string()),
+            relations: vec![MbRelation {
+                target_type: Some("artist".to_string()),
+                relation_type: Some("composer".to_string()),
+                artist: Some(composer_ref.clone()),
+                target_credit: Some("Composer Name A".to_string()),
+                ..MbRelation::default()
+            }],
+        };
+        let parent_work = MbWork {
+            id: "mb-work-parent-a".to_string(),
+            title: "Work Title A".to_string(),
+            disambiguation: Some("work disambiguation".to_string()),
+            work_type: Some("work".to_string()),
+            relations: vec![
+                MbRelation {
+                    target_type: Some("artist".to_string()),
+                    relation_type: Some("composer".to_string()),
+                    artist: Some(composer_ref),
+                    target_credit: Some("Composer Name A".to_string()),
+                    ..MbRelation::default()
+                },
+                MbRelation {
+                    target_type: Some("artist".to_string()),
+                    relation_type: Some("lyricist".to_string()),
+                    artist: Some(lyricist_ref),
+                    target_credit: Some("Lyricist Name A".to_string()),
+                    ..MbRelation::default()
+                },
+                MbRelation {
+                    target_type: Some("work".to_string()),
+                    relation_type: Some("parts".to_string()),
+                    direction: Some("forward".to_string()),
+                    work: Some(child_work),
+                    ..MbRelation::default()
+                },
+            ],
+        };
+        let mut track_one = make_mb_track("1", "Track Title 1");
+        track_one.recording.as_mut().unwrap().relations = vec![MbRelation {
+            target_type: Some("work".to_string()),
+            relation_type: Some("performance".to_string()),
+            work: Some(parent_work.clone()),
+            ..MbRelation::default()
+        }];
+        let mut track_two = make_mb_track("2", "Track Title 2");
+        track_two.recording.as_mut().unwrap().relations = vec![MbRelation {
+            target_type: Some("work".to_string()),
+            relation_type: Some("performance".to_string()),
+            work: Some(parent_work),
+            ..MbRelation::default()
+        }];
+        let response = make_response(vec![MbMedium {
+            format: Some("CD".to_string()),
+            tracks: vec![track_one, track_two],
+        }]);
+
+        let parsed = map(&response, Some(2024), None).unwrap();
+
+        let work_graph = &parsed.work_graph;
+        assert_eq!(work_graph.works.len(), 2);
+        assert!(work_graph
+            .works
+            .iter()
+            .any(|work| work.id == "mb-work-parent-a"));
+        assert!(work_graph
+            .works
+            .iter()
+            .any(|work| work.id == "mb-work-child-a"));
+        assert!(work_graph.track_works.iter().any(|link| {
+            link.track_id == parsed.tracks[0].id && link.work_id == "mb-work-parent-a"
+        }));
+        assert!(work_graph.work_parts.iter().any(|part| {
+            part.parent_work_id == "mb-work-parent-a" && part.child_work_id == "mb-work-child-a"
+        }));
+
+        let composer = parsed
+            .artists
+            .iter()
+            .find(|artist| artist.musicbrainz_artist_id.as_deref() == Some("composer-artist-a"))
+            .expect("composer artist imported");
+        assert!(work_graph
+            .work_artists
+            .iter()
+            .any(|link| { link.artist_id == composer.id }));
+        assert_eq!(
+            work_graph
+                .work_artists
+                .iter()
+                .filter(|link| { link.artist_id == composer.id })
+                .count(),
+            2
+        );
+        assert!(!parsed
+            .artists
+            .iter()
+            .any(|artist| artist.musicbrainz_artist_id.as_deref() == Some("lyricist-artist-a")));
+        assert!(!parsed
+            .album_artists
+            .iter()
+            .any(|link| link.artist_id == composer.id));
+        assert!(!parsed
+            .track_artists
+            .iter()
+            .any(|link| link.artist_id == composer.id));
+    }
+
+    #[test]
     fn track_level_artist_credit_creates_and_links_a_new_artist() {
         // Track 2 credits a guest distinct from the release artist. The
         // track-artist loop must create that artist once and link it to track 2
@@ -793,5 +1228,81 @@ mod tests {
             .track_artists
             .iter()
             .any(|ta| ta.track_id == parsed.tracks[0].id && ta.artist_id == matching[0].id));
+    }
+
+    #[test]
+    fn known_mb_artist_id_does_not_merge_into_same_name_artist_without_id() {
+        let mut response = make_response(vec![{
+            let mut track = make_mb_track("1", "Track 1");
+            track.recording.as_mut().unwrap().relations = vec![MbRelation {
+                target_type: Some("artist".to_string()),
+                relation_type: Some("composer".to_string()),
+                artist: Some(MbArtistRef {
+                    id: Some("composer-artist-a".to_string()),
+                    name: Some("Artist Name A".to_string()),
+                    sort_name: None,
+                }),
+                ..MbRelation::default()
+            }];
+            MbMedium {
+                format: Some("CD".to_string()),
+                tracks: vec![track],
+            }
+        }]);
+        response.artist_credit[0].artist = None;
+
+        let parsed = map(&response, Some(2024), None).unwrap();
+
+        let release_artist = parsed
+            .artists
+            .iter()
+            .find(|artist| artist.musicbrainz_artist_id.is_none())
+            .expect("release artist without MB id exists");
+        let composer = parsed
+            .artists
+            .iter()
+            .find(|artist| artist.musicbrainz_artist_id.as_deref() == Some("composer-artist-a"))
+            .expect("known composer artist exists separately");
+
+        assert_ne!(release_artist.id, composer.id);
+        assert!(parsed
+            .track_artist_roles
+            .iter()
+            .any(|role| role.artist_id == composer.id));
+    }
+
+    #[test]
+    fn known_mb_artist_ids_keep_same_name_artists_separate() {
+        let mut track = make_mb_track("1", "Track 1");
+        track.artist_credit = vec![credit("artist-1", "Artist Name A")];
+        track.recording.as_mut().unwrap().relations = vec![MbRelation {
+            target_type: Some("artist".to_string()),
+            relation_type: Some("composer".to_string()),
+            artist: Some(MbArtistRef {
+                id: Some("artist-2".to_string()),
+                name: Some("Artist Name A".to_string()),
+                sort_name: None,
+            }),
+            ..MbRelation::default()
+        }];
+        let response = make_response(vec![MbMedium {
+            format: Some("CD".to_string()),
+            tracks: vec![track],
+        }]);
+
+        let parsed = map(&response, Some(2024), None).unwrap();
+
+        let matching: Vec<_> = parsed
+            .artists
+            .iter()
+            .filter(|artist| artist.name == "Artist Name A")
+            .collect();
+        assert_eq!(matching.len(), 2);
+        assert!(matching
+            .iter()
+            .any(|artist| artist.musicbrainz_artist_id.as_deref() == Some("artist-1")));
+        assert!(matching
+            .iter()
+            .any(|artist| artist.musicbrainz_artist_id.as_deref() == Some("artist-2")));
     }
 }

--- a/bae-core/src/import/progress/handle.rs
+++ b/bae-core/src/import/progress/handle.rs
@@ -28,6 +28,7 @@ impl SubscriptionFilter {
                 ImportProgress::Started { id, .. } => id == release_id,
                 ImportProgress::Progress { id, .. } => id == release_id,
                 ImportProgress::Complete { id, .. } => id == release_id,
+                ImportProgress::RemoteUploadQueued { id, .. } => id == release_id,
                 ImportProgress::Failed { id, .. } => id == release_id,
             },
             SubscriptionFilter::Import { import_id } => match progress {
@@ -35,6 +36,7 @@ impl SubscriptionFilter {
                 ImportProgress::Started { import_id: iid, .. } => iid.as_ref() == Some(import_id),
                 ImportProgress::Progress { import_id: iid, .. } => iid.as_ref() == Some(import_id),
                 ImportProgress::Complete { import_id: iid, .. } => iid == import_id,
+                ImportProgress::RemoteUploadQueued { import_id: iid, .. } => iid == import_id,
                 ImportProgress::Failed { import_id: iid, .. } => iid.as_ref() == Some(import_id),
             },
             SubscriptionFilter::AllImports => match progress {
@@ -42,6 +44,7 @@ impl SubscriptionFilter {
                 ImportProgress::Started { import_id, .. } => import_id.is_some(),
                 ImportProgress::Progress { import_id, .. } => import_id.is_some(),
                 ImportProgress::Complete { .. } => true,
+                ImportProgress::RemoteUploadQueued { .. } => true,
                 ImportProgress::Failed { import_id, .. } => import_id.is_some(),
             },
         }
@@ -171,6 +174,11 @@ mod tests {
             import_id: "import-1".to_string(),
             album_id: "album-1".to_string(),
         },),);
+        assert!(filter.matches(&ImportProgress::RemoteUploadQueued {
+            id: "release-1".to_string(),
+            import_id: "import-1".to_string(),
+            album_id: "album-1".to_string(),
+        },),);
         assert!(!filter.matches(&ImportProgress::Progress {
             id: "release-2".to_string(),
             percent: 50,
@@ -228,6 +236,11 @@ mod tests {
             import_id: "import-1".to_string(),
             album_id: "album-1".to_string(),
         },),);
+        assert!(filter.matches(&ImportProgress::RemoteUploadQueued {
+            id: "release-1".to_string(),
+            import_id: "import-1".to_string(),
+            album_id: "album-1".to_string(),
+        },),);
         assert!(filter.matches(&ImportProgress::Failed {
             id: "release-1".to_string(),
             error: "error".to_string(),
@@ -272,6 +285,11 @@ mod tests {
             import_id: Some("import-2".to_string()),
         },),);
         assert!(filter.matches(&ImportProgress::Complete {
+            id: "release-1".to_string(),
+            import_id: "import-3".to_string(),
+            album_id: "album-1".to_string(),
+        },),);
+        assert!(filter.matches(&ImportProgress::RemoteUploadQueued {
             id: "release-1".to_string(),
             import_id: "import-3".to_string(),
             album_id: "album-1".to_string(),

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -9,7 +9,8 @@ use crate::library::LibraryManager;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 use {
     crate::db::{
-        DbAlbum, DbAlbumArtist, DbFile, DbRelease, DbReleaseMetadata, DbTrack, DbTrackArtist,
+        DbAlbum, DbAlbumArtist, DbFile, DbRelease, DbReleaseArtistRole, DbReleaseMetadata, DbTrack,
+        DbTrackArtist, DbTrackArtistRole, ImportOperationStatus,
     },
     crate::import::folder_registry::ImportFolderRegistry,
     crate::import::folder_scanner::{
@@ -17,6 +18,7 @@ use {
     },
     crate::import::track_to_file_mapper::map_tracks_to_files,
     crate::import::types::{CoverSelection, DiscoveredFile, ImportPhase, PrepareStep, TrackFile},
+    crate::import::ParsedWorkGraph,
     notify::RecursiveMode,
     notify_debouncer_full::{new_debouncer, DebounceEventResult},
     std::collections::{HashMap, HashSet},
@@ -58,6 +60,9 @@ struct PreparedMetadata {
     existing_album_id: Option<String>,
     remapped_track_artists: Vec<DbTrackArtist>,
     remapped_album_artists: Vec<DbAlbumArtist>,
+    work_graph: ParsedWorkGraph,
+    remapped_release_artist_roles: Vec<DbReleaseArtistRole>,
+    remapped_track_artist_roles: Vec<DbTrackArtistRole>,
     /// Per-source identity rows for the release. Empty for Unknown.
     /// Commit writes one `release_identities` row per element.
     identities: Vec<crate::import::types::ReleaseIdentity>,
@@ -537,6 +542,9 @@ impl ImportService {
             existing_album_id,
             remapped_track_artists,
             remapped_album_artists,
+            work_graph,
+            remapped_release_artist_roles,
+            remapped_track_artist_roles,
             identities,
             album_title,
             artist_name,
@@ -743,6 +751,9 @@ impl ImportService {
             &db_metadata,
             &remapped_track_artists,
             &remapped_album_artists,
+            &work_graph,
+            &remapped_release_artist_roles,
+            &remapped_track_artist_roles,
             existing_album_id.is_none().then_some(&db_album),
             &album_id,
             &identities,
@@ -831,6 +842,9 @@ impl ImportService {
         db_metadata: &[DbReleaseMetadata],
         remapped_track_artists: &[crate::db::DbTrackArtist],
         remapped_album_artists: &[crate::db::DbAlbumArtist],
+        work_graph: &ParsedWorkGraph,
+        remapped_release_artist_roles: &[crate::db::DbReleaseArtistRole],
+        remapped_track_artist_roles: &[crate::db::DbTrackArtistRole],
         new_album: Option<&crate::db::DbAlbum>,
         album_id: &str,
         identities: &[crate::import::types::ReleaseIdentity],
@@ -1014,6 +1028,11 @@ impl ImportService {
         );
 
         let remote_intent = matches!(storage_mode, StorageMode::Remote);
+        let finalized_import_status = if remote_intent {
+            ImportOperationStatus::Importing
+        } else {
+            ImportOperationStatus::Complete
+        };
         library_manager
             .finalize_import_atomic(
                 new_album,
@@ -1022,11 +1041,18 @@ impl ImportService {
                 db_metadata,
                 remapped_track_artists,
                 remapped_album_artists,
+                &work_graph.works,
+                &work_graph.work_artists,
+                &work_graph.work_parts,
+                &work_graph.track_works,
+                remapped_release_artist_roles,
+                remapped_track_artist_roles,
                 &db_files,
                 &audio_formats,
                 library_image,
                 cover_rel_id,
                 import_id,
+                finalized_import_status,
                 identities,
                 &local_path,
             )
@@ -1041,22 +1067,21 @@ impl ImportService {
         // already holds the upload by the time any consumer observes the release or
         // `Complete`.
         //
-        // The release is already a finalized, playable Local release, so a failure
-        // to *start* the remote transition (sync not running, a truncated source)
-        // is NOT a reason to fail the whole import and discard the imported files —
-        // the user keeps a valid Local release whose storage row shows `Local` with
-        // a "Make Remote" action to retry. But it is a genuine failure of the
-        // requested Remote import, never a silent success: it is surfaced loudly at
-        // `error` (the requested Remote outcome was not achieved), not swallowed.
-        // The release's visible `Local` storage state plus its "Make Remote" retry
-        // action are how this surfaces to the user.
         if remote_intent {
             if let Err(e) = library_manager.coven_make_remote(&db_release.id, pin).await {
-                error!(
-                    "Remote import of {} could not start its cloud upload ({e}); the release \
-                     is imported as Local and can be made Remote manually",
+                let remote_error = format!(
+                    "Remote import of {} could not start its cloud upload: {e}",
                     db_release.id
                 );
+                if let Err(import_error) = library_manager
+                    .fail_import_and_delete_release(import_id, &db_release.id, &remote_error)
+                    .await
+                {
+                    return Err(format!(
+                        "{remote_error}; removing release and marking import failed failed: {import_error}"
+                    ));
+                }
+                return Err(remote_error);
             }
         }
 
@@ -1068,18 +1093,24 @@ impl ImportService {
                 .await;
         }
 
-        // Emit Complete after the album/release events: the release is now in the
-        // library and playable (as a local release; a remote import is
-        // uploading in the background, its outbox row already queued above).
+        let progress = if remote_intent {
+            ImportProgress::RemoteUploadQueued {
+                id: db_release.id.to_string(),
+                import_id: import_id.to_string(),
+                album_id: album_id.to_string(),
+            }
+        } else {
+            ImportProgress::Complete {
+                id: db_release.id.to_string(),
+                import_id: import_id.to_string(),
+                album_id: album_id.to_string(),
+            }
+        };
         send_event(
             &self.event_tx,
             crate::import::handle::ImportEvent::ImportProgress {
                 candidate_key: candidate_key.to_string(),
-                progress: ImportProgress::Complete {
-                    id: db_release.id.to_string(),
-                    import_id: import_id.to_string(),
-                    album_id: album_id.to_string(),
-                },
+                progress,
             },
         );
 

--- a/bae-core/src/import/service/reconcile.rs
+++ b/bae-core/src/import/service/reconcile.rs
@@ -7,10 +7,12 @@
 
 use std::collections::HashMap;
 
-use crate::db::DbImport;
-use crate::import::handle::{fetch_artist_images, remap_album_artists, remap_track_artists};
-
 use super::{apply_identity_choice, apply_user_edit_to_seed, ImportService, PreparedMetadata};
+use crate::db::DbImport;
+use crate::import::handle::{
+    fetch_artist_images, remap_album_artists, remap_artist_links, remap_track_artists,
+};
+use crate::import::ParsedWorkGraph;
 
 impl ImportService {
     /// Reconcile the prepared release against existing library state,
@@ -72,6 +74,9 @@ impl ImportService {
             mut artists,
             mut album_artists,
             mut track_artists,
+            work_graph,
+            release_artist_roles,
+            track_artist_roles,
             identities: parsed_identities,
         } = parsed;
 
@@ -168,6 +173,27 @@ impl ImportService {
         } else {
             vec![]
         };
+        let remapped_work_artists = remap_artist_links(
+            &work_graph.work_artists,
+            &artist_id_map,
+            "work artist",
+            |link| &link.artist_id,
+            |link, artist_id| link.artist_id = artist_id,
+        )?;
+        let remapped_release_artist_roles = remap_artist_links(
+            &release_artist_roles,
+            &artist_id_map,
+            "release artist role",
+            |role| &role.artist_id,
+            |role, artist_id| role.artist_id = artist_id,
+        )?;
+        let remapped_track_artist_roles = remap_artist_links(
+            &track_artist_roles,
+            &artist_id_map,
+            "track artist role",
+            |role| &role.artist_id,
+            |role, artist_id| role.artist_id = artist_id,
+        )?;
 
         let discogs_client = library_manager
             .discogs_client()
@@ -184,6 +210,14 @@ impl ImportService {
             existing_album_id,
             remapped_track_artists,
             remapped_album_artists,
+            work_graph: ParsedWorkGraph {
+                works: work_graph.works,
+                work_artists: remapped_work_artists,
+                work_parts: work_graph.work_parts,
+                track_works: work_graph.track_works,
+            },
+            remapped_release_artist_roles,
+            remapped_track_artist_roles,
             identities,
             album_title,
             artist_name,

--- a/bae-core/src/import/types.rs
+++ b/bae-core/src/import/types.rs
@@ -24,10 +24,11 @@
 //! - Store track audio format records
 use crate::cue_flac::{CueSheet, FlacInfo};
 use crate::db::DbTrack;
+use serde::{Deserialize, Serialize};
 use std::{path::Path, path::PathBuf, sync::Arc};
 
 /// Metadata source for a release.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MetadataSource {
     MusicBrainz,
     Discogs,
@@ -499,6 +500,11 @@ pub enum ImportProgress {
         import_id: Option<String>,
     },
     Complete {
+        id: String,
+        import_id: String,
+        album_id: String,
+    },
+    RemoteUploadQueued {
         id: String,
         import_id: String,
         album_id: String,

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod network;
 pub mod playback;
 pub mod queue;
 pub mod retry;
+mod serde_helpers;
 // The signal-extraction machinery (OCR, disc-ID compute) is desktop-only and
 // gated submodule-by-submodule inside `signals`. The module itself stays
 // available on every target for the pure `LookupFailure` type, which the shared

--- a/bae-core/src/library/manager/album.rs
+++ b/bae-core/src/library/manager/album.rs
@@ -64,8 +64,21 @@ impl LibraryManager {
             .iter()
             .filter_map(|a| a.primary_release_id.clone())
             .collect();
-        let covers = self.cover_refs(&primary_ids).await?;
-        Ok(SearchResults::from_raw(raw, &covers))
+        let artist_ids: Vec<String> = raw.composers.iter().map(|c| c.artist.id.clone()).collect();
+        let work_release_ids: Vec<String> = raw
+            .works
+            .iter()
+            .filter_map(|w| w.representative_release_id.clone())
+            .collect();
+        let album_covers = self.cover_refs(&primary_ids).await?;
+        let composer_images = self.artist_image_refs(&artist_ids).await?;
+        let work_covers = self.cover_refs(&work_release_ids).await?;
+        Ok(SearchResults::from_raw(
+            raw,
+            &album_covers,
+            &composer_images,
+            &work_covers,
+        ))
     }
 
     /// Delete an album and all its associated data

--- a/bae-core/src/library/manager/composer.rs
+++ b/bae-core/src/library/manager/composer.rs
@@ -1,0 +1,135 @@
+//! Composer and work domain operations for [`LibraryManager`].
+
+use super::*;
+
+impl LibraryManager {
+    pub async fn get_composer_count(&self) -> Result<u64, LibraryError> {
+        Ok(self.database.get_composer_count().await?)
+    }
+
+    pub async fn get_composer_page(
+        &self,
+        sort: crate::db::ComposerSortCriterion,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<ComposerSummary>, LibraryError> {
+        let raw = self.database.get_composer_page(sort, offset, limit).await?;
+        let artist_ids: Vec<String> = raw.iter().map(|c| c.artist.id.clone()).collect();
+        let images = self.artist_image_refs(&artist_ids).await?;
+        Ok(raw
+            .into_iter()
+            .map(|composer| {
+                let image = images.get(&composer.artist.id).cloned();
+                ComposerSummary::from_raw(composer, image)
+            })
+            .collect())
+    }
+
+    pub async fn get_composer_detail(
+        &self,
+        artist_id: &str,
+    ) -> Result<Option<ComposerDetail>, LibraryError> {
+        let Some(raw) = self.database.find_composer_detail(artist_id).await? else {
+            return Ok(None);
+        };
+        let composer_images = self
+            .artist_image_refs(std::slice::from_ref(&raw.composer.artist.id))
+            .await?;
+        let release_ids: Vec<String> = raw
+            .work_groups
+            .iter()
+            .flat_map(|group| {
+                group
+                    .parent
+                    .iter()
+                    .chain(group.works.iter())
+                    .filter_map(|work| work.representative_release_id.clone())
+            })
+            .collect();
+        let covers = self.cover_refs(&release_ids).await?;
+        let work_groups: Vec<ComposerWorkGroup> = raw
+            .work_groups
+            .into_iter()
+            .map(|group| ComposerWorkGroup {
+                id: group.id,
+                parent: group
+                    .parent
+                    .map(|parent| work_summary_with_cover(parent, &covers)),
+                works: group
+                    .works
+                    .into_iter()
+                    .map(|work| work_summary_with_cover(work, &covers))
+                    .collect(),
+            })
+            .collect();
+        let default_work_id = work_groups.first().and_then(|group| {
+            group
+                .parent
+                .as_ref()
+                .map(|work| work.raw.work.id.clone())
+                .or_else(|| group.works.first().map(|work| work.raw.work.id.clone()))
+        });
+        Ok(Some(ComposerDetail {
+            composer: {
+                let image = composer_images.get(&raw.composer.artist.id).cloned();
+                ComposerSummary::from_raw(raw.composer, image)
+            },
+            work_groups,
+            unlinked_release_roles: raw.unlinked_release_roles,
+            unlinked_track_roles: raw.unlinked_track_roles,
+            default_work_id,
+        }))
+    }
+
+    pub async fn get_work_detail(&self, work_id: &str) -> Result<Option<WorkDetail>, LibraryError> {
+        let Some(raw) = self.database.find_work_detail(work_id).await? else {
+            return Ok(None);
+        };
+        let has_cloud_home = self.has_cloud_home();
+        let release_ids: Vec<String> = raw.releases.iter().map(|r| r.id.clone()).collect();
+        let covers = self.cover_refs(&release_ids).await?;
+        let work_cover = raw
+            .work
+            .representative_release_id
+            .as_ref()
+            .and_then(|id| covers.get(id).cloned());
+        let child_release_ids: Vec<String> = raw
+            .child_works
+            .iter()
+            .filter_map(|work| work.representative_release_id.clone())
+            .collect();
+        let child_covers = self.cover_refs(&child_release_ids).await?;
+        let mut releases = Vec::with_capacity(raw.releases.len());
+        for release in raw.releases {
+            let pinned = self.release_pinned(release.any_file_id.as_deref()).await?;
+            let cover = covers.get(&release.id).cloned();
+            let ctx = ReleaseResolveCtx {
+                has_cloud_home,
+                pinned,
+                cover,
+            };
+            releases.push(ReleaseSummary::from_raw(release, &ctx));
+        }
+        Ok(Some(WorkDetail {
+            work: WorkSummary::from_raw(raw.work, work_cover),
+            child_works: raw
+                .child_works
+                .into_iter()
+                .map(|work| work_summary_with_cover(work, &child_covers))
+                .collect(),
+            releases,
+            tracks: raw.tracks,
+        }))
+    }
+}
+
+fn work_summary_with_cover(
+    work: crate::db::DbWorkSummary,
+    covers: &HashMap<String, ImageRef>,
+) -> WorkSummary {
+    let cover = work
+        .representative_release_id
+        .as_ref()
+        .and_then(|id| covers.get(id).cloned());
+    WorkSummary::from_raw(work, cover)
+}

--- a/bae-core/src/library/manager/coven_blobs.rs
+++ b/bae-core/src/library/manager/coven_blobs.rs
@@ -91,7 +91,7 @@ impl LibraryManager {
 
     /// The cover [`ImageRef`] for one release — its image id paired with the
     /// `covers` row's `_updated_at` — or `None` when the release has no cover row.
-    pub(super) async fn cover_ref(
+    pub(crate) async fn cover_ref(
         &self,
         release_id: &str,
     ) -> Result<Option<ImageRef>, LibraryError> {
@@ -105,41 +105,54 @@ impl LibraryManager {
         &self,
         release_ids: &[String],
     ) -> Result<HashMap<String, ImageRef>, LibraryError> {
-        Ok(self
-            .database
-            .cover_versions(release_ids)
-            .await?
-            .into_iter()
-            .map(|(id, version)| (id.clone(), ImageRef { id, version }))
-            .collect())
+        Ok(image_ref_map(
+            self.database.cover_versions(release_ids).await?,
+            LibraryImageType::Cover,
+        ))
+    }
+
+    pub(super) async fn artist_image_refs(
+        &self,
+        artist_ids: &[String],
+    ) -> Result<HashMap<String, ImageRef>, LibraryError> {
+        Ok(image_ref_map(
+            self.database.artist_image_versions(artist_ids).await?,
+            LibraryImageType::Artist,
+        ))
     }
 
     /// Read a host-provided library image's whole bytes through coven's
-    /// locality-aware read: coven's local store while Local, the pinned/evictable
-    /// cache or the cloud while Remote. `id` is a release id (a cover) or an artist
-    /// id (an artist image); the `covers` row is probed first (the common grid
-    /// case), then `artist_images`. `None` when no such image row exists (no cover
-    /// produced); a read error surfaces rather than being masked.
-    pub async fn read_image_blob(&self, id: &str) -> Result<Option<Vec<u8>>, LibraryError> {
-        for (namespace, image_type) in [
-            (crate::sync::COVERS_NAMESPACE, LibraryImageType::Cover),
-            (
-                crate::sync::ARTIST_IMAGES_NAMESPACE,
-                LibraryImageType::Artist,
-            ),
-        ] {
-            let Some(row) = self.database.find_library_image(id, &image_type).await? else {
-                continue;
-            };
-            let blob = Self::image_blob_ref(namespace, id, row.cloud_path.clone());
-            let bytes = self
-                .handle
-                .read_blob(&blob)
-                .await
-                .map_err(|e| LibraryError::Storage(format!("read image {id}: {e}")))?;
-            return Ok(Some(bytes));
-        }
-        Ok(None)
+    /// locality-aware read. The [`ImageRef`] carries the image kind, so the read
+    /// goes directly to the table/namespace that produced the ref.
+    pub async fn read_image_blob(&self, image: &ImageRef) -> Result<Option<Vec<u8>>, LibraryError> {
+        self.read_library_image_blob(&image.id, &image.image_type)
+            .await
+    }
+
+    pub async fn read_cover_image_blob(
+        &self,
+        release_id: &str,
+    ) -> Result<Option<Vec<u8>>, LibraryError> {
+        self.read_library_image_blob(release_id, &LibraryImageType::Cover)
+            .await
+    }
+
+    async fn read_library_image_blob(
+        &self,
+        id: &str,
+        image_type: &LibraryImageType,
+    ) -> Result<Option<Vec<u8>>, LibraryError> {
+        let namespace = image_type.namespace();
+        let Some(row) = self.database.find_library_image(id, image_type).await? else {
+            return Ok(None);
+        };
+        let blob = Self::image_blob_ref(namespace, id, row.cloud_path.clone());
+        let bytes = self
+            .handle
+            .read_blob(&blob)
+            .await
+            .map_err(|e| LibraryError::Storage(format!("read image {id}: {e}")))?;
+        Ok(Some(bytes))
     }
 
     /// Whether coven holds this release pinned on this device — true iff its
@@ -193,4 +206,23 @@ impl LibraryManager {
         self.database.write_library_image_blob(image, bytes).await?;
         Ok(())
     }
+}
+
+fn image_ref_map(
+    versions: HashMap<String, String>,
+    image_type: LibraryImageType,
+) -> HashMap<String, ImageRef> {
+    versions
+        .into_iter()
+        .map(|(id, version)| {
+            (
+                id.clone(),
+                ImageRef {
+                    id,
+                    version,
+                    image_type: image_type.clone(),
+                },
+            )
+        })
+        .collect()
 }

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -60,7 +60,10 @@ impl LibraryManager {
         let year = meta.release.pressing.year.or(album.year);
 
         let cover_image_bytes = match album.primary_release_id.as_deref() {
-            Some(rid) => self.read_image_blob(rid).await?,
+            Some(rid) => match self.cover_ref(rid).await? {
+                Some(image) => self.read_image_blob(&image).await?,
+                None => None,
+            },
             None => None,
         };
 

--- a/bae-core/src/library/manager/image.rs
+++ b/bae-core/src/library/manager/image.rs
@@ -4,8 +4,8 @@ use super::*;
 
 impl LibraryManager {
     /// Bytes of one gallery slot, dispatching the read on its [`GallerySource`]
-    /// so no caller picks the byte source itself: a `Cover` is read by image id
-    /// (`read_image_blob`), a `ReleaseFile` by file id (`load_gallery_image`).
+    /// so no caller picks the byte source itself: a `Cover` is read by its image
+    /// ref, a `ReleaseFile` by file id (`load_gallery_image`).
     /// The gallery carries a cover slot only when a cover exists, so a `Cover`
     /// with no bytes here is exceptional and surfaces rather than being masked.
     pub async fn read_gallery_bytes(
@@ -14,11 +14,9 @@ impl LibraryManager {
         source: &GallerySource,
     ) -> Result<Vec<u8>, LibraryError> {
         match source {
-            GallerySource::Cover(image) => {
-                self.read_image_blob(&image.id).await?.ok_or_else(|| {
-                    LibraryError::Storage(format!("gallery cover image {} has no bytes", image.id))
-                })
-            }
+            GallerySource::Cover(image) => self.read_image_blob(image).await?.ok_or_else(|| {
+                LibraryError::Storage(format!("gallery cover image {} has no bytes", image.id))
+            }),
             GallerySource::ReleaseFile { file_id } => {
                 self.load_gallery_image(release_id, file_id).await
             }

--- a/bae-core/src/library/manager/import.rs
+++ b/bae-core/src/library/manager/import.rs
@@ -25,11 +25,18 @@ impl LibraryManager {
         metadata: &[crate::db::DbReleaseMetadata],
         track_artists: &[crate::db::DbTrackArtist],
         album_artists: &[crate::db::DbAlbumArtist],
+        works: &[crate::db::DbWork],
+        work_artists: &[crate::db::DbWorkArtist],
+        work_parts: &[crate::db::DbWorkPart],
+        track_works: &[crate::db::DbTrackWork],
+        release_artist_roles: &[crate::db::DbReleaseArtistRole],
+        track_artist_roles: &[crate::db::DbTrackArtistRole],
         files: &[DbFile],
         audio_formats: &[DbAudioFormat],
         library_image: Option<(&DbLibraryImage, &[u8])>,
         primary_release_id: Option<(&str, &str)>,
         import_id: &str,
+        import_status: ImportOperationStatus,
         identities: &[crate::import::ReleaseIdentity],
         local_path: &str,
     ) -> Result<(), LibraryError> {
@@ -45,11 +52,18 @@ impl LibraryManager {
                 metadata,
                 track_artists,
                 album_artists,
+                works,
+                work_artists,
+                work_parts,
+                track_works,
+                release_artist_roles,
+                track_artist_roles,
                 files,
                 audio_formats,
                 library_image,
                 primary_release_id,
                 import_id,
+                import_status,
                 identities,
                 local_path,
                 storage,
@@ -79,6 +93,20 @@ impl LibraryManager {
     /// Record an error for an import operation
     pub async fn update_import_error(&self, id: &str, error: &str) -> Result<(), LibraryError> {
         Ok(self.database.update_import_error(id, error).await?)
+    }
+
+    /// Mark an import failed and remove its finalized release in one DB
+    /// operation.
+    pub async fn fail_import_and_delete_release(
+        &self,
+        import_id: &str,
+        release_id: &str,
+        error: &str,
+    ) -> Result<(), LibraryError> {
+        Ok(self
+            .database
+            .fail_import_and_delete_release(import_id, release_id, error)
+            .await?)
     }
 
     /// Get all active (non-complete, non-failed) imports

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -29,9 +29,11 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
 use crate::album_detail::{
-    join_artist_names, AlbumDetail, AlbumSummary, GallerySource, ImageRef, ReleaseDetail,
-    ReleaseResolveCtx, ReleaseStorageAction, ReleaseStorageSummary, SearchResults, StorageFilter,
-    StoragePage, StorageRow, StorageSort, StorageSortDirection, StorageSortField,
+    join_artist_names, AlbumDetail, AlbumSummary, ComposerDetail, ComposerSummary,
+    ComposerWorkGroup, GallerySource, ImageRef, ReleaseDetail, ReleaseResolveCtx,
+    ReleaseStorageAction, ReleaseStorageSummary, ReleaseSummary, SearchResults, StorageFilter,
+    StoragePage, StorageRow, StorageSort, StorageSortDirection, StorageSortField, WorkDetail,
+    WorkSummary,
 };
 #[cfg(feature = "oauth-providers")]
 use crate::config::CloudProvider;
@@ -63,6 +65,7 @@ use coven::LibraryDir;
 
 mod album;
 mod artist;
+mod composer;
 mod config;
 mod coven_blobs;
 mod export;

--- a/bae-core/src/library/manager/release.rs
+++ b/bae-core/src/library/manager/release.rs
@@ -961,6 +961,7 @@ pub(crate) async fn cover_ref_for(
         .map(|version| ImageRef {
             id: release_id.to_string(),
             version,
+            image_type: LibraryImageType::Cover,
         }))
 }
 

--- a/bae-core/src/library/manager/sync.rs
+++ b/bae-core/src/library/manager/sync.rs
@@ -2,7 +2,6 @@
 //! pipeline, and pause state.
 
 use super::*;
-
 impl LibraryManager {
     /// Whether a cloud provider is connected. Reads config, not manager presence:
     /// the connected provider lives in config and is known synchronously from the

--- a/bae-core/src/musicbrainz/mod.rs
+++ b/bae-core/src/musicbrainz/mod.rs
@@ -309,7 +309,7 @@ pub async fn lookup_release_by_id(
 
     info!("MusicBrainz: Looking up release ID '{}'", release_id);
     let url = format!(
-        "https://musicbrainz.org/ws/2/release/{}?inc=recordings+artist-credits+release-groups+release-group-rels+url-rels+labels+media",
+        "https://musicbrainz.org/ws/2/release/{}?inc=recordings+artist-credits+release-groups+release-group-rels+url-rels+labels+media+recording-level-rels+work-level-rels+work-rels+artist-rels",
         release_id,
     );
     debug!("MusicBrainz API request: {}", url);
@@ -690,7 +690,7 @@ pub async fn search_releases_with_params(
     info!("   Query: {}", query);
     let url = "https://musicbrainz.org/ws/2/release";
     debug!(
-        "MusicBrainz API request: {}?query={}&limit=25&inc=recordings+artist-credits+release-groups+labels+media+url-rels",
+        "MusicBrainz API request: {}?query={}&limit=25&inc=recordings+artist-credits+release-groups+labels+media+url-rels+recording-level-rels+work-level-rels+work-rels+artist-rels",
         url, query
     );
 
@@ -703,7 +703,7 @@ pub async fn search_releases_with_params(
             ("limit", "25"),
             (
                 "inc",
-                "recordings+artist-credits+release-groups+labels+media+url-rels",
+                "recordings+artist-credits+release-groups+labels+media+url-rels+recording-level-rels+work-level-rels+work-rels+artist-rels",
             ),
         ])
         .header("Accept", "application/json")

--- a/bae-core/src/musicbrainz/tests.rs
+++ b/bae-core/src/musicbrainz/tests.rs
@@ -104,13 +104,18 @@ fn test_extract_urls_from_relations() {
             url: Some(MbUrlResource {
                 resource: Some("https://www.discogs.com/master/12345".to_string()),
             }),
+            ..Default::default()
         },
         MbRelation {
             url: Some(MbUrlResource {
                 resource: Some("https://www.discogs.com/release/67890".to_string()),
             }),
+            ..Default::default()
         },
-        MbRelation { url: None },
+        MbRelation {
+            url: None,
+            ..Default::default()
+        },
     ];
 
     let mut urls = ExternalUrls {

--- a/bae-core/src/musicbrainz/types.rs
+++ b/bae-core/src/musicbrainz/types.rs
@@ -6,10 +6,28 @@
 
 use serde::{Deserialize, Serialize};
 
-/// A URL relation from MusicBrainz (used across release and release-group responses)
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// A relation from MusicBrainz. Release/release-group URL relations fill `url`;
+/// recording and work relations fill `artist` or `work` plus typed relation fields.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct MbRelation {
     pub url: Option<MbUrlResource>,
+    #[serde(rename = "target-type")]
+    pub target_type: Option<String>,
+    #[serde(
+        rename = "type",
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
+    pub relation_type: Option<String>,
+    pub direction: Option<String>,
+    pub artist: Option<MbArtistRef>,
+    pub work: Option<MbWork>,
+    #[serde(
+        rename = "target-credit",
+        default,
+        deserialize_with = "crate::serde_helpers::empty_string_as_none"
+    )]
+    pub target_credit: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -56,10 +74,26 @@ pub struct MbReleaseGroupRef {
     pub relations: Option<Vec<MbRelation>>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MbWork {
+    pub id: String,
+    pub title: String,
+    pub disambiguation: Option<String>,
+    #[serde(rename = "type")]
+    pub work_type: Option<String>,
+    #[serde(default)]
+    pub relations: Vec<MbRelation>,
+}
+
 /// A recording within a track
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MbRecording {
+    pub id: Option<String>,
     pub title: Option<String>,
+    #[serde(rename = "artist-credit", default)]
+    pub artist_credit: Vec<MbArtistCredit>,
+    #[serde(default)]
+    pub relations: Vec<MbRelation>,
 }
 
 /// A track within a medium

--- a/bae-core/src/serde_helpers.rs
+++ b/bae-core/src/serde_helpers.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Deserializer};
+
+/// Map an absent or blank string field to `None`.
+pub(crate) fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?
+        .and_then(|value| (!value.trim().is_empty()).then_some(value)))
+}

--- a/bae-core/src/sync/mod.rs
+++ b/bae-core/src/sync/mod.rs
@@ -95,6 +95,12 @@ pub fn synced_tables() -> Vec<SyncedTable> {
         SyncedTable::new("release_identities"),
         SyncedTable::new("tracks"),
         SyncedTable::new("track_artists"),
+        SyncedTable::new("works").gated_by_descendants(),
+        SyncedTable::new("work_artists"),
+        SyncedTable::new("work_parts"),
+        SyncedTable::new("track_works"),
+        SyncedTable::new("release_artist_roles"),
+        SyncedTable::new("track_artist_roles"),
         // The user's own imported files: user-provided (Local = the file at the
         // user's path, an external ref coven holds), CacheLazy (fetched on first
         // read when Remote). coven reads the blob id off the PK and the readable
@@ -264,20 +270,20 @@ mod tests {
         }
     }
 
-    /// `albums` and `artists` are the FK-ancestors of the gated `releases` root,
-    /// declared `gated_by_descendants()` so a row drops out of sync once its gated
-    /// subtree empties (coven infers the keep-children from the FK graph). Any
-    /// other table carrying this marker — or one of these two losing it — would
+    /// `albums`, `artists`, and `works` are FK-ancestors of the gated `releases`
+    /// root, declared `gated_by_descendants()` so a row drops out of sync once its
+    /// gated subtree empties (coven infers the keep-children from the FK graph).
+    /// Any other table carrying this marker — or one of these losing it — would
     /// diverge from the schema's FK shape, which is what this test catches.
     #[test]
-    fn albums_and_artists_are_the_gated_by_descendants_ancestors() {
+    fn albums_artists_and_works_are_the_gated_by_descendants_ancestors() {
         let tables = synced_tables();
         let ancestors: BTreeSet<&str> = tables
             .iter()
             .filter(|t| t.is_gated_by_descendants())
             .map(|t| t.name())
             .collect();
-        assert_eq!(ancestors, BTreeSet::from(["albums", "artists"]));
+        assert_eq!(ancestors, BTreeSet::from(["albums", "artists", "works"]));
     }
 
     /// `release_files` carries the user's own blobs; `covers` and `artist_images`

--- a/bae-core/src/sync/upload_observer.rs
+++ b/bae-core/src/sync/upload_observer.rs
@@ -257,6 +257,9 @@ impl coven::BlobTransitionObserver for ReleaseUploadObserver {
             debug!("on_root_made_remote for non-release root {root_table:?}/{root_id}; ignoring");
             return;
         }
+        if let Err(e) = self.db().complete_import_for_release(root_id).await {
+            warn!("on_root_made_remote: marking import complete for {root_id}: {e}");
+        }
         self.emit_release_updated(root_id).await;
         self.emit_outbox_changed().await;
     }

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -327,6 +327,13 @@ impl UiEventBus {
                                     album_id,
                                 })
                             }
+                            ImportProgress::RemoteUploadQueued { id, album_id, .. } => {
+                                Some(UiBusEvent::CandidateImportComplete {
+                                    key: candidate_key.clone(),
+                                    release_id: id,
+                                    album_id,
+                                })
+                            }
                             ImportProgress::Failed { error, .. } => {
                                 // The import pipeline flattens every failure
                                 // (scan, metadata, encryption, DB) to a string;

--- a/bae-core/tests/alac_fixtures.rs
+++ b/bae-core/tests/alac_fixtures.rs
@@ -59,6 +59,7 @@ fn make_discogs_release(id: &str, title: &str, tracks: &[&str]) -> DiscogsReleas
         thumb: None,
         catno: None,
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: tracks
             .iter()
             .enumerate()
@@ -68,6 +69,7 @@ fn make_discogs_release(id: &str, title: &str, tracks: &[&str]) -> DiscogsReleas
                 title: (*title).to_string(),
                 duration: Some("0:02".to_string()),
                 artists: vec![],
+                extraartists: None,
             })
             .collect(),
         master_id: None,

--- a/bae-core/tests/support/mod.rs
+++ b/bae-core/tests/support/mod.rs
@@ -44,24 +44,32 @@ pub fn seed_discogs_test_release(release: bae_core::discogs::DiscogsRelease) -> 
     id
 }
 
-/// Wait for an import to complete, returning (release_id, album_id).
+fn import_terminal_ids(progress: &bae_core::import::ImportProgress) -> Option<(String, String)> {
+    match progress {
+        bae_core::import::ImportProgress::Complete { id, album_id, .. }
+        | bae_core::import::ImportProgress::RemoteUploadQueued { id, album_id, .. } => {
+            Some((id.clone(), album_id.clone()))
+        }
+        _ => None,
+    }
+}
+
+/// Wait for the import worker to finish, returning (release_id, album_id).
 ///
-/// Listens on a progress receiver (from subscribe_import) and waits for
-/// the release-level Complete event (release_id: None means the id IS the release).
+/// Local imports emit `Complete`. Remote imports emit `RemoteUploadQueued`: the
+/// import worker is finished, while remote completion waits for coven upload
+/// confirmation.
 /// Panics on failure.
 #[allow(dead_code)]
 pub async fn wait_for_import_complete(
     progress_rx: &mut tokio::sync::mpsc::UnboundedReceiver<bae_core::import::ImportProgress>,
 ) -> (String, String) {
     while let Some(progress) = progress_rx.recv().await {
-        match &progress {
-            bae_core::import::ImportProgress::Complete { id, album_id, .. } => {
-                return (id.clone(), album_id.clone());
-            }
-            bae_core::import::ImportProgress::Failed { error, .. } => {
-                panic!("Import failed: {}", error);
-            }
-            _ => {}
+        if let Some(ids) = import_terminal_ids(&progress) {
+            return ids;
+        }
+        if let bae_core::import::ImportProgress::Failed { error, .. } = &progress {
+            panic!("Import failed: {}", error);
         }
     }
     panic!("Progress channel closed without completion");
@@ -76,14 +84,11 @@ pub async fn try_wait_for_import_complete(
     progress_rx: &mut tokio::sync::mpsc::UnboundedReceiver<bae_core::import::ImportProgress>,
 ) -> Result<(String, String), String> {
     while let Some(progress) = progress_rx.recv().await {
-        match &progress {
-            bae_core::import::ImportProgress::Complete { id, album_id, .. } => {
-                return Ok((id.clone(), album_id.clone()));
-            }
-            bae_core::import::ImportProgress::Failed { error, .. } => {
-                return Err(error.clone());
-            }
-            _ => {}
+        if let Some(ids) = import_terminal_ids(&progress) {
+            return Ok(ids);
+        }
+        if let bae_core::import::ImportProgress::Failed { error, .. } = &progress {
+            return Err(error.clone());
         }
     }
     Err("Progress channel closed without completion".to_string())

--- a/bae-core/tests/support/mod.rs
+++ b/bae-core/tests/support/mod.rs
@@ -89,6 +89,22 @@ pub async fn try_wait_for_import_complete(
     Err("Progress channel closed without completion".to_string())
 }
 
+#[allow(dead_code)]
+pub async fn read_cover_image_blob(
+    db: &bae_core::db::Database,
+    mgr: &bae_core::library::LibraryManager,
+    release_id: &str,
+) -> Option<Vec<u8>> {
+    let version = db.cover_version(release_id).await.unwrap()?;
+    mgr.read_image_blob(&bae_core::album_detail::ImageRef {
+        id: release_id.to_string(),
+        version,
+        image_type: bae_core::db::LibraryImageType::Cover,
+    })
+    .await
+    .unwrap()
+}
+
 /// Initialize tracing for tests with proper test output handling
 #[allow(dead_code)]
 pub fn tracing_init() {

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 use tracing::info;
 
 fn start_test_import(
@@ -1598,13 +1598,37 @@ async fn wait_for_multi_disc_cue_ape_import_ready(
         StorageMode::Local => wait_for_import_complete(progress_rx).await,
         StorageMode::Remote => {
             let (release_id, album_id) = wait_for_remote_upload_queued(progress_rx).await;
-            let uploaded = library_manager
-                .drain_uploads_for_test()
+            timeout(Duration::from_secs(10), async {
+                loop {
+                    library_manager
+                        .drain_uploads_for_test()
+                        .await
+                        .expect("drain queued remote import uploads");
+                    let release = library_manager
+                        .get_release_by_id(&release_id)
+                        .await
+                        .expect("find imported release")
+                        .expect("imported release exists");
+                    let pending = library_manager
+                        .count_pending_uploads_for_release(&release_id)
+                        .await
+                        .expect("count pending release uploads");
+                    if release.remote && pending == 0 {
+                        break;
+                    }
+                    sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("remote multi-disc CUE/APE import uploads all files");
+            let files = library_manager
+                .get_files_for_release(&release_id)
                 .await
-                .expect("drain queued remote import uploads");
+                .expect("get release files");
             assert_eq!(
-                uploaded, 4,
-                "remote multi-disc CUE/APE import uploads 4 files"
+                files.len(),
+                4,
+                "remote multi-disc CUE/APE import keeps both audio files and both CUE sheets"
             );
             (release_id, album_id)
         }

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -17,9 +17,11 @@ use bae_core::import::{
 };
 use bae_core::library::LibraryManager;
 use bae_core::playback::{PlaybackProgress, PlaybackState};
+use bae_core::sync::CloudCipher;
 use bae_core::util::content_type::ContentType;
-use coven::LibraryDir;
+use coven::{EncryptionService, InMemoryCloudHome, LibraryDir};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use tokio::time::timeout;
@@ -65,6 +67,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
         thumb: None,
         catno: None,
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -72,6 +75,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track One".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -79,6 +83,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track Two".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -86,6 +91,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track Three".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master".to_string()),
@@ -1445,24 +1451,29 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
         std::fs::write(dir.join("CDImage.cue"), cue_body).expect("write cue");
     }
 
-    let db_file = db_dir.join("test.db");
-    let database = Database::new_test(
-        db_file.to_str().unwrap(),
-        std::sync::Arc::new(coven::SystemClock),
-    )
-    .await
-    .expect("database");
     let library_dir = LibraryDir::new(db_dir.clone());
     let (config_handle, key_service) = test_config_and_keys(&library_dir);
-    let library_manager = LibraryManager::new(
-        database.clone(),
-        library_dir.clone(),
+    let library_manager = LibraryManager::open(
         config_handle,
         key_service,
         std::sync::Arc::new(coven::SystemClock),
         std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
-    );
+    )
+    .expect("open library manager");
+    if storage_mode == StorageMode::Remote {
+        library_manager
+            .connect_test_cloud_home(
+                Arc::new(InMemoryCloudHome::new()),
+                CloudCipher::Encrypted(EncryptionService::new_with_key(&[7u8; 32])),
+            )
+            .await
+            .expect("connect in-memory cloud home");
+        assert!(
+            library_manager.is_sync_ready(),
+            "remote import test cloud should start sync"
+        );
+    }
 
     // Discogs multi-disc tracklist: positions "1-1".."1-3", "2-1".."2-3".
     // `parse_side_from_position` maps these to side=1 and side=2.
@@ -1479,6 +1490,7 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
         thumb: None,
         catno: None,
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: (1..=2)
             .flat_map(|disc| {
                 (1..=3).map(move |n| DiscogsTrack {
@@ -1487,6 +1499,7 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
                     title: format!("Disc {} Track {}", disc, n),
                     duration: Some("0:30".to_string()),
                     artists: vec![],
+                    extraartists: None,
                 })
             })
             .collect(),
@@ -1513,7 +1526,9 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
         .expect("send command");
 
     let mut progress_rx = import_handle.subscribe_import(import_id);
-    let (release_id, _) = wait_for_import_complete(&mut progress_rx).await;
+    let (release_id, _) =
+        wait_for_multi_disc_cue_ape_import_ready(&library_manager, storage_mode, &mut progress_rx)
+            .await;
 
     let tracks = library_manager
         .get_tracks(&release_id)
@@ -1572,6 +1587,45 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
             track.title, track.side,
         );
     }
+}
+
+async fn wait_for_multi_disc_cue_ape_import_ready(
+    library_manager: &LibraryManager,
+    storage_mode: StorageMode,
+    progress_rx: &mut tokio::sync::mpsc::UnboundedReceiver<bae_core::import::ImportProgress>,
+) -> (String, String) {
+    match storage_mode {
+        StorageMode::Local => wait_for_import_complete(progress_rx).await,
+        StorageMode::Remote => {
+            let (release_id, album_id) = wait_for_remote_upload_queued(progress_rx).await;
+            let uploaded = library_manager
+                .drain_uploads_for_test()
+                .await
+                .expect("drain queued remote import uploads");
+            assert_eq!(
+                uploaded, 4,
+                "remote multi-disc CUE/APE import uploads 4 files"
+            );
+            (release_id, album_id)
+        }
+    }
+}
+
+async fn wait_for_remote_upload_queued(
+    progress_rx: &mut tokio::sync::mpsc::UnboundedReceiver<bae_core::import::ImportProgress>,
+) -> (String, String) {
+    while let Some(progress) = progress_rx.recv().await {
+        match progress {
+            bae_core::import::ImportProgress::RemoteUploadQueued { id, album_id, .. } => {
+                return (id, album_id)
+            }
+            bae_core::import::ImportProgress::Failed { error, .. } => {
+                panic!("Import failed: {}", error);
+            }
+            _ => {}
+        }
+    }
+    panic!("Progress channel closed without remote upload being queued");
 }
 
 /// Regression: multi-disc CUE/APE imports must link each track to its OWN disc's

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -695,6 +695,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
         thumb: None,
         catno: None,
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -702,6 +703,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track One (440Hz)".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -709,6 +711,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track Two (880Hz)".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -716,6 +719,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track Three (660Hz)".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master".to_string()),

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -218,6 +218,7 @@ fn discogs_release(title: &str, tracks: &[&str]) -> DiscogsRelease {
         thumb: None,
         catno: None,
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: tracks
             .iter()
             .enumerate()
@@ -227,6 +228,7 @@ fn discogs_release(title: &str, tracks: &[&str]) -> DiscogsRelease {
                 title: t.to_string(),
                 duration: Some("3:00".to_string()),
                 artists: vec![],
+                extraartists: None,
             })
             .collect(),
         master_id: None,
@@ -279,8 +281,6 @@ async fn folder_scan_produces_candidates() {
     let names: std::collections::BTreeSet<_> = candidates.iter().map(|c| c.name.as_str()).collect();
     assert!(names.contains("Artist - First Album"));
     assert!(names.contains("Artist - Second Album"));
-
-    println!("Folder scan produced 2 independent candidates");
 }
 
 /// The watcher reconciles a folder against the candidates it last emitted: a new
@@ -499,11 +499,6 @@ async fn import_produces_audio_format_records() {
     assert!(format.is_some(), "should have audio format record");
     let format = format.unwrap();
     assert_eq!(format.content_type.as_str(), "audio/flac");
-
-    println!(
-        "Audio format records verified: {}",
-        format.content_type.as_str()
-    );
 }
 
 /// The loudness pass emits a continuous `fraction` (0 → 1) as it scans, ticking
@@ -887,8 +882,6 @@ async fn two_sequential_imports() {
             .unwrap();
     assert_eq!(album1.title, "First Album");
     assert_eq!(album2.title, "Second Album");
-
-    println!("Two sequential imports verified");
 }
 
 /// 6. Import with local cover art: covers row + the cover blob in coven's local store.
@@ -933,19 +926,11 @@ async fn import_with_cover_art() {
     let cover = cover.unwrap();
     assert_eq!(cover.source, "local");
 
-    // Cover bytes readable through the handle (coven's local store while Local).
-    let cover_bytes = f
-        .library_manager
-        .read_image_blob(&release_id)
+    // Cover bytes readable through the image ref path (coven's local store while Local).
+    let cover_bytes = support::read_cover_image_blob(&f.db, &f.library_manager, &release_id)
         .await
-        .unwrap()
         .expect("cover blob should be readable");
     assert!(!cover_bytes.is_empty(), "cover bytes should not be empty");
-
-    println!(
-        "Import with cover art verified: DB row + {} bytes",
-        cover_bytes.len()
-    );
 }
 
 /// On a browsable home the readable cloud_path is computed AT IMPORT — for every
@@ -1050,6 +1035,7 @@ fn discogs_release_rich(title: &str, master_id: &str, tracks: &[&str]) -> Discog
         thumb: None,
         catno: Some("CAT-001".to_string()),
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: tracks
             .iter()
             .enumerate()
@@ -1059,6 +1045,7 @@ fn discogs_release_rich(title: &str, master_id: &str, tracks: &[&str]) -> Discog
                 title: t.to_string(),
                 duration: Some("3:00".to_string()),
                 artists: vec![],
+                extraartists: None,
             })
             .collect(),
         master_id: Some(master_id.to_string()),
@@ -1316,12 +1303,14 @@ fn seed_discogs_for_xref(release_id: &str, master_id: &str, title: &str) -> Stri
             id: "discogs-artist-1".to_string(),
             name: "Artist Name".to_string(),
         }],
+        extraartists: Some(vec![]),
         tracklist: vec![DiscogsTrack {
             type_: "track".to_string(),
             position: "1".to_string(),
             title: "Track One".to_string(),
             duration: Some("3:00".to_string()),
             artists: vec![],
+            extraartists: None,
         }],
         master_id: Some(master_id.to_string()),
     };
@@ -1366,7 +1355,10 @@ fn seed_mb_with_discogs_xref(
                 title: None,
                 length: None,
                 recording: Some(MbRecording {
+                    id: None,
                     title: Some("Track One".to_string()),
+                    artist_credit: vec![],
+                    relations: vec![],
                 }),
                 artist_credit: vec![],
             }],
@@ -1730,11 +1722,8 @@ async fn unknown_import_seeds_embedded_cover_when_no_folder_image() {
         "cover must be sourced from the embedded picture"
     );
 
-    let bytes = f
-        .library_manager
-        .read_image_blob(&release_id)
+    let bytes = support::read_cover_image_blob(&f.db, &f.library_manager, &release_id)
         .await
-        .unwrap()
         .expect("cover blob readable");
     assert_eq!(bytes, EMBEDDED_JPEG, "cover bytes are the embedded picture");
 }

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -509,6 +509,7 @@ fn create_test_album() -> DiscogsRelease {
             name: "Test Artist".to_string(),
             id: "test-artist-1".to_string(),
         }],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -516,6 +517,7 @@ fn create_test_album() -> DiscogsRelease {
                 title: "Test Track 1".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -523,6 +525,7 @@ fn create_test_album() -> DiscogsRelease {
                 title: "Test Track 2".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -530,6 +533,7 @@ fn create_test_album() -> DiscogsRelease {
                 title: "Test Track 3".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master-123".to_string()),
@@ -625,6 +629,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
             name: "Test Artist".to_string(),
             id: "test-artist-1".to_string(),
         }],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -632,6 +637,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 title: "Track One (Silence)".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -639,6 +645,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 title: "Track Two (White Noise)".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -646,6 +653,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 title: "Track Three (Brown Noise)".to_string(),
                 duration: Some("0:10".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master-cue-flac".to_string()),
@@ -2974,12 +2982,14 @@ impl HighSampleRateTestFixture {
                 name: "Test Artist".to_string(),
                 id: "test-artist-1".to_string(),
             }],
+            extraartists: Some(vec![]),
             tracklist: vec![DiscogsTrack {
                 type_: "track".to_string(),
                 position: "1".to_string(),
                 title: "96kHz Track".to_string(),
                 duration: Some("0:03".to_string()),
                 artists: vec![],
+                extraartists: None,
             }],
             master_id: Some("test-master-96khz".to_string()),
         };

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -193,6 +193,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
             name: "Test Artist".to_string(),
             id: "test-artist-1".to_string(),
         }],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -200,6 +201,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 title: "Track One".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -207,6 +209,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 title: "Track Two".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -214,6 +217,7 @@ fn create_cue_flac_test_album() -> DiscogsRelease {
                 title: "Track Three".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master".to_string()),
@@ -238,6 +242,7 @@ fn create_mp3_test_album() -> DiscogsRelease {
             name: "Test Artist".to_string(),
             id: "test-artist-2".to_string(),
         }],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -245,6 +250,7 @@ fn create_mp3_test_album() -> DiscogsRelease {
                 title: "Track 1".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -252,6 +258,7 @@ fn create_mp3_test_album() -> DiscogsRelease {
                 title: "Track 2".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -259,6 +266,7 @@ fn create_mp3_test_album() -> DiscogsRelease {
                 title: "Track 3".to_string(),
                 duration: Some("0:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master-mp3".to_string()),

--- a/bae-core/tests/test_reset_metadata.rs
+++ b/bae-core/tests/test_reset_metadata.rs
@@ -152,7 +152,10 @@ fn mb_release_json(
                     title: Some((*t).to_string()),
                     length: None,
                     recording: Some(MbRecording {
+                        id: None,
                         title: Some((*t).to_string()),
+                        artist_credit: vec![],
+                        relations: vec![],
                     }),
                     artist_credit: vec![],
                 })

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -538,6 +538,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
         thumb: None,
         catno: None,
         artists: vec![],
+        extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -545,6 +546,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track One".to_string(),
                 duration: Some("3:00".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -552,6 +554,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track Two".to_string(),
                 duration: Some("4:00".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
             DiscogsTrack {
                 type_: "track".to_string(),
@@ -559,6 +562,7 @@ fn create_test_discogs_release() -> DiscogsRelease {
                 title: "Track Three".to_string(),
                 duration: Some("2:30".to_string()),
                 artists: vec![],
+                extraartists: None,
             },
         ],
         master_id: Some("test-master-storage".to_string()),

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -268,8 +268,8 @@ async fn make_remote_uploads_are_visible_in_snapshot_before_drain() {
 
 /// A cover is a host-provided blob: its bytes go to coven's local store
 /// store and coven owns the copy. While the release is Local the cover lives in
-/// coven's local store and `read_image_blob` serves its bytes through the handle —
-/// no cloud round-trip and no bae path into coven's store.
+/// coven's local store and `read_image_blob` serves its bytes through the image
+/// reference — no cloud round-trip and no bae path into coven's store.
 #[tokio::test]
 async fn test_cover_blob_stored_via_local_files_is_readable() {
     tracing_init();
@@ -279,7 +279,9 @@ async fn test_cover_blob_stored_via_local_files_is_readable() {
 
     // No cover row yet → no bytes.
     assert!(
-        mgr.read_image_blob(&release_id).await.unwrap().is_none(),
+        support::read_cover_image_blob(&db, &mgr, &release_id)
+            .await
+            .is_none(),
         "no cover before one is stored"
     );
 
@@ -305,10 +307,8 @@ async fn test_cover_blob_stored_via_local_files_is_readable() {
     .unwrap();
 
     // read_image_blob serves it from coven's local store, byte-for-byte.
-    let read = mgr
-        .read_image_blob(&release_id)
+    let read = support::read_cover_image_blob(&db, &mgr, &release_id)
         .await
-        .unwrap()
         .expect("cover resolves to bytes once stored");
     assert_eq!(read, bytes, "the stored cover reads back byte-for-byte");
 }

--- a/bae-ios/bae/bae/AppService.swift
+++ b/bae-ios/bae/bae/AppService.swift
@@ -63,7 +63,9 @@ final class AppService: Observable {
         // no import flow, so build `MediaPaths` without it.
         mediaPaths = MediaPaths(
             filePath: { try appHandle.filePath(fileId: $0) },
-            fetchImageBytes: { try await appHandle.fetchImageBytes(imageId: $0) },
+            fetchCoverImageBytes: {
+                try await appHandle.fetchCoverImageBytes(releaseId: $0)
+            },
             fetchGalleryBytes: {
                 try await appHandle.fetchGalleryBytes(releaseId: $0, source: $1)
             }

--- a/bae-ios/bae/bae/MediaControlService.swift
+++ b/bae-ios/bae/bae/MediaControlService.swift
@@ -351,7 +351,9 @@ extension MediaControlService {
         let bytes: Data
         do {
             guard
-                let data = try await appHandle.fetchImageBytes(imageId: imageId)
+                let data = try await appHandle.fetchCoverImageBytes(
+                    releaseId: imageId
+                )
             else {
                 logger.debug("No Now Playing artwork for \(imageId)")
                 return

--- a/bae-ios/bae/bae/Views/ImageView.swift
+++ b/bae-ios/bae/bae/Views/ImageView.swift
@@ -70,7 +70,7 @@ extension ImageView {
         pointSize: CGFloat
     ) {
         self.init(
-            source: imageRef.map { .cover(id: $0.id, version: $0.version) },
+            source: imageRef.map { .image($0) },
             pointSize: pointSize,
             contentMode: contentMode
         )

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -172,7 +172,10 @@ struct LibraryView: View {
                 for row in rows {
                     _ = libraryStore.internAlbumSummary(row)
                 }
-            }
+            },
+            onError: { error in
+                configStore.showError(error)
+            },
         )
         list = albumList
         await albumList.loadInitial()

--- a/bae-macos/bae/bae/BaeApp.swift
+++ b/bae-macos/bae/bae/BaeApp.swift
@@ -4,6 +4,23 @@ import SwiftUI
 import os.log
 
 private let logger = Logger.bae("BaeApp")
+private let appProcessEnvironment = ProcessInfo.processInfo.environment
+
+private enum AppRuntime {
+    static func skipsApplicationServices(environment: [String: String]) -> Bool
+    {
+        isPreview(environment: environment)
+            || isTestHost(environment: environment)
+    }
+
+    private static func isPreview(environment: [String: String]) -> Bool {
+        environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
+    private static func isTestHost(environment: [String: String]) -> Bool {
+        environment["XCTestConfigurationFilePath"] != nil
+    }
+}
 
 enum AppScreen {
     case loading
@@ -24,12 +41,10 @@ struct BaeApp: App {
     @ObservedObject
     private var checkForUpdatesViewModel: CheckForUpdatesViewModel
 
-    private static var isPreview: Bool {
-        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
-    }
-
     init() {
-        let startUpdater = !Self.isPreview
+        let startUpdater = !AppRuntime.skipsApplicationServices(
+            environment: appProcessEnvironment
+        )
         #if DEBUG
             _ = startUpdater  // suppress unused warning
             let controller = SPUStandardUpdaterController(
@@ -442,12 +457,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     @ObservationIgnored
     private var lockTask: Task<Void, Never>?
 
-    private static var isPreview: Bool {
-        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    private var skipsApplicationServices: Bool {
+        AppRuntime.skipsApplicationServices(
+            environment: appProcessEnvironment
+        )
     }
 
     func applicationDidFinishLaunching(_: Notification) {
-        if !Self.isPreview {
+        if !skipsApplicationServices {
             BaeCrashReporting.configure()
             BaeDiagnostics.configure(source: "macos")
             logger.info("application launched")
@@ -505,14 +522,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         // Open Library submenu reflects libraries created, renamed, or removed
         // elsewhere while we were in the background. Only meaningful once a
         // library is open — the menu that consumes the list exists only then.
-        guard !Self.isPreview, appService != nil else { return }
+        guard !skipsApplicationServices, appService != nil else {
+            return
+        }
         reloadLibraries()
     }
 
     // MARK: - Library lifecycle
 
     private func loadInitialState() {
-        if Self.isPreview {
+        if skipsApplicationServices {
             screen = .welcome
             return
         }

--- a/bae-macos/bae/bae/BridgeComposerSortField+CaseIterable.swift
+++ b/bae-macos/bae/bae/BridgeComposerSortField+CaseIterable.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension BridgeComposerSortField: CaseIterable {
+    public static var allCases: [BridgeComposerSortField] {
+        [.name, .workCount, .linkedReleaseCount]
+    }
+
+    var displayName: String {
+        switch self {
+        case .name: String(localized: "Name")
+        case .workCount: String(localized: "Works")
+        case .linkedReleaseCount: String(localized: "Releases")
+        }
+    }
+}

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -82841,6 +82841,1532 @@
           }
         }
       }
+    },
+    "Composers": {
+      "comment": "Library/search composer section and mode label",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        }
+      }
+    },
+    "Works": {
+      "comment": "Library/search works section and composer work count label",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Works"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        }
+      }
+    },
+    "No composers": {
+      "comment": "Empty composer library message title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No composers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        }
+      }
+    },
+    "Releases": {
+      "comment": "Composer work detail release section header",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Releases"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        }
+      }
+    },
+    "Credits": {
+      "comment": "Composer sort field and unlinked credits section header",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credits"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        }
+      }
+    },
+    "Recordings": {
+      "comment": "Composer work detail recording section header",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recordings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        }
+      }
+    },
+    "Composer detail not found": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer detail not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        }
+      }
+    },
+    "Work detail not found": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Work detail not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-macos/bae/bae/PreviewData.swift
+++ b/bae-macos/bae/bae/PreviewData.swift
@@ -68,53 +68,76 @@ enum PreviewData {
 
     // MARK: - Search
 
-    /// Search results — three album hits and two track hits — for the
-    /// SearchView "With results" preview.
+    /// Search results for the SearchView "With results" preview.
     static let searchResults = SearchResults(
         bridge: BridgeSearchResults(
             albums: [
                 BridgeAlbumSearchResult(
                     id: "a-02",
-                    title: "Pacific Standard",
+                    title: "Album Title B",
                     year: 2019,
-                    artistName: "Glass Harbor",
+                    artistName: "Artist Name A",
                     cover: nil
                 ),
                 BridgeAlbumSearchResult(
                     id: "a-14",
-                    title: "Landlocked",
+                    title: "Album Title N",
                     year: 2022,
-                    artistName: "Glass Harbor",
+                    artistName: "Artist Name A",
                     cover: nil
                 ),
                 BridgeAlbumSearchResult(
                     id: "a-03",
-                    title: "Proof by Induction",
+                    title: "Album Title C",
                     year: 2021,
-                    artistName: "Velvet Mathematics",
+                    artistName: "Artist Name B",
                     cover: nil
                 ),
             ],
             tracks: [
                 BridgeTrackSearchResult(
                     id: "t-03",
-                    title: "Tide Pool",
+                    title: "Track Title 3",
                     durationMs: 198_000,
                     albumId: "a-02",
-                    albumTitle: "Pacific Standard",
-                    artistName: "Glass Harbor"
+                    albumTitle: "Album Title B",
+                    artistName: "Artist Name A"
                 ),
                 BridgeTrackSearchResult(
                     id: "t-05",
-                    title: "Axiom",
+                    title: "Track Title 5",
                     durationMs: 187_000,
                     albumId: "a-03",
-                    albumTitle: "Proof by Induction",
-                    artistName: "Velvet Mathematics"
+                    albumTitle: "Album Title C",
+                    artistName: "Artist Name B"
                 ),
             ],
+            composers: [
+                BridgeComposerSummary(
+                    artistId: "artist-composer-a",
+                    name: "Composer Name A",
+                    sortName: "Composer Name A",
+                    workCount: 2,
+                    linkedReleaseCount: 3,
+                    unlinkedCreditCount: 0,
+                    image: nil
+                )
+            ],
+            works: [
+                BridgeWorkSummary(
+                    workId: "work-a",
+                    title: "Work Title A",
+                    disambiguation: nil,
+                    workType: "work",
+                    parentWorkId: nil,
+                    composerNames: "Composer Name A",
+                    linkedReleaseCount: 2,
+                    representativeReleaseId: "release-a",
+                    representativeCover: nil
+                )
+            ],
         ),
-        query: "glass"
+        query: "placeholder"
     )
 
     // MARK: - Cover sheet

--- a/bae-macos/bae/bae/Services/Library.swift
+++ b/bae-macos/bae/bae/Services/Library.swift
@@ -11,6 +11,15 @@ final class Library: Sendable, Observable {
             _ sortCriteria: [BridgeSortCriterion], _ offset: UInt64,
             _ limit: UInt64
         ) throws -> [BridgeAlbum]
+    let getComposerCount: @Sendable () throws -> UInt64
+    let getComposerPage:
+        @Sendable (
+            _ sortCriterion: BridgeComposerSortCriterion, _ offset: UInt64,
+            _ limit: UInt64
+        ) throws -> [BridgeComposerSummary]
+    let getComposerDetail:
+        @Sendable (_ artistId: String) throws -> BridgeComposerDetail?
+    let getWorkDetail: @Sendable (_ workId: String) throws -> BridgeWorkDetail?
     let searchLibrary:
         @Sendable (_ query: String) async throws -> BridgeSearchResults
     let storageCount: @Sendable (_ filter: BridgeStorageFilter) throws -> UInt64
@@ -33,9 +42,27 @@ final class Library: Sendable, Observable {
         getAlbumPage:
             @escaping @Sendable ([BridgeSortCriterion], UInt64, UInt64) throws
             -> [BridgeAlbum] = { _, _, _ in [] },
+        getComposerCount: @escaping @Sendable () throws -> UInt64 = {
+            throw StubError.notImplemented
+        },
+        getComposerPage:
+            @escaping @Sendable (BridgeComposerSortCriterion, UInt64, UInt64)
+            throws
+            -> [BridgeComposerSummary] = { _, _, _ in
+                throw StubError.notImplemented
+            },
+        getComposerDetail:
+            @escaping @Sendable (String) throws -> BridgeComposerDetail? = {
+                _ in throw StubError.notImplemented
+            },
+        getWorkDetail:
+            @escaping @Sendable (String) throws -> BridgeWorkDetail? = { _ in
+                throw StubError.notImplemented
+            },
         searchLibrary:
             @escaping @Sendable (String) async throws -> BridgeSearchResults = {
-                _ in BridgeSearchResults(albums: [], tracks: [])
+                _ in
+                throw StubError.notImplemented
             },
         storageCount:
             @escaping @Sendable (BridgeStorageFilter) throws -> UInt64 = { _ in
@@ -61,6 +88,10 @@ final class Library: Sendable, Observable {
     ) {
         self.getAlbumCount = getAlbumCount
         self.getAlbumPage = getAlbumPage
+        self.getComposerCount = getComposerCount
+        self.getComposerPage = getComposerPage
+        self.getComposerDetail = getComposerDetail
+        self.getWorkDetail = getWorkDetail
         self.searchLibrary = searchLibrary
         self.storageCount = storageCount
         self.storagePage = storagePage
@@ -85,6 +116,18 @@ final class Library: Sendable, Observable {
                         limit: $2
                     )
                 },
+                getComposerCount: { try handle.getComposerCount() },
+                getComposerPage: {
+                    try handle.getComposerPage(
+                        sortCriterion: $0,
+                        offset: $1,
+                        limit: $2
+                    )
+                },
+                getComposerDetail: {
+                    try handle.getComposerDetail(artistId: $0)
+                },
+                getWorkDetail: { try handle.getWorkDetail(workId: $0) },
                 searchLibrary: { try await handle.searchLibrary(query: $0) },
                 storageCount: { try handle.storageCount(filter: $0) },
                 storagePage: {

--- a/bae-macos/bae/bae/Services/LibraryStore.swift
+++ b/bae-macos/bae/bae/Services/LibraryStore.swift
@@ -60,6 +60,23 @@ struct AlbumPreviewPageSource: PageSource {
     }
 }
 
+struct LibraryComposerPageSource: PageSource {
+    let library: Library
+    let sort: BridgeComposerSortCriterion
+
+    func count() async throws -> Int {
+        try Int(library.getComposerCount())
+    }
+
+    func page(offset: Int, limit: Int) async throws -> [BridgeComposerSummary] {
+        try library.getComposerPage(sort, UInt64(offset), UInt64(limit))
+    }
+}
+
+extension BridgeComposerSummary: Identifiable {
+    public var id: String { artistId }
+}
+
 // MARK: - Storage page source
 
 /// Page source backed by `AppHandle` for the Storage Manager table.
@@ -102,6 +119,7 @@ extension BridgeStorageRow: Identifiable {
 /// the ingest closure interns each one as an `AlbumSummary` in the
 /// store. Views resolve slots by reading `libraryStore.albumSummaries[id]`.
 typealias AlbumList = PaginatedList<BridgeAlbum>
+typealias ComposerList = PaginatedList<BridgeComposerSummary>
 
 // MARK: - StorageList
 
@@ -135,6 +153,7 @@ extension AlbumList {
                     _ = store.internAlbumSummary(row)
                 }
             },
+            onError: { _ in },
         )
         list.preloadForPreview(ids: sorted.map(\.id))
         return list
@@ -219,6 +238,7 @@ final class LibraryStore {
     /// - `internReleaseDetail` (album-detail ingest)
     /// - `loadReleaseDetail` / `reloadReleaseDetail` (on-demand loaders)
     private(set) var releaseDetails: [String: ReleaseDetail] = [:]
+    private(set) var composerSummaries: [String: BridgeComposerSummary] = [:]
 
     /// Fires when the library's *shape* changes — anything that could
     /// alter the total row count or ordering of a library- or
@@ -256,6 +276,14 @@ final class LibraryStore {
         let summary = AlbumSummary(from: bridge)
         albumSummaries[bridge.id] = summary
         return summary
+    }
+
+    @discardableResult
+    func internComposerSummary(_ bridge: BridgeComposerSummary)
+        -> BridgeComposerSummary
+    {
+        composerSummaries[bridge.artistId] = bridge
+        return bridge
     }
 
     /// Upsert the canonical `ReleaseSummary` for this bridge payload.
@@ -423,6 +451,7 @@ final class LibraryStore {
     /// invalidating any visible lists.
     func handleAlbumRemoved(albumId: String, releaseIds: [String]) {
         albumSummaries.removeValue(forKey: albumId)
+        composerSummaries.removeAll()
         for id in releaseIds {
             releaseSummaries.removeValue(forKey: id)
             releaseDetails.removeValue(forKey: id)
@@ -438,6 +467,7 @@ final class LibraryStore {
     func handleReleaseAdded(album: BridgeAlbum, release: BridgeRelease) {
         _ = internReleaseDetail(release)
         _ = internAlbumSummary(album)
+        composerSummaries.removeAll()
     }
 
     /// Reducer target for `ReleaseUpdated`. Same slice writes as
@@ -445,6 +475,7 @@ final class LibraryStore {
     /// for the summary and replaces the detail wholesale.
     func handleReleaseUpdated(release: BridgeRelease) {
         _ = internReleaseDetail(release)
+        composerSummaries.removeAll()
     }
 
     /// Reducer target for `ReleaseRemoved`. Drops the release from both
@@ -461,6 +492,7 @@ final class LibraryStore {
     ) {
         releaseSummaries.removeValue(forKey: releaseId)
         releaseDetails.removeValue(forKey: releaseId)
+        composerSummaries.removeAll()
         if let album {
             _ = internAlbumSummary(album)
         }

--- a/bae-macos/bae/bae/Services/MediaControlService.swift
+++ b/bae-macos/bae/bae/Services/MediaControlService.swift
@@ -382,7 +382,9 @@ extension MediaControlService {
         let bytes: Data
         do {
             guard
-                let data = try await appHandle.fetchImageBytes(imageId: imageId)
+                let data = try await appHandle.fetchCoverImageBytes(
+                    releaseId: imageId
+                )
             else {
                 logger.debug("No Now Playing artwork for \(imageId)")
                 return

--- a/bae-macos/bae/bae/Services/MediaPaths.swift
+++ b/bae-macos/bae/bae/Services/MediaPaths.swift
@@ -1,17 +1,19 @@
 import CoreGraphics
 import Foundation
+import os.log
 
-/// Which library image to fetch and how. A `cover` (a release cover or an
-/// artist image) is read by image id via `fetchImageBytes` and cached under its
-/// content `version`. A `gallery` slot (the lightbox's view of a release's cover
-/// or one of its image files) is read via `fetchGalleryBytes`, which takes the
-/// whole `BridgeGallerySource` and dispatches the read in core — the UI never
-/// picks the byte source. `cacheId` is the gallery item's stable list identity,
-/// the decode-cache key, not a fetch decision.
+private let logger = Logger.bae("MediaPaths")
+
+/// Which library image to fetch and how. A `cover` is a release cover addressed
+/// by release id; an `image` is a release cover or artist image with a full
+/// `BridgeImageRef`. A `gallery` slot is read via `fetchGalleryBytes`, which
+/// takes the whole
+/// `BridgeGallerySource` and dispatches the read in core — the UI never picks
+/// the byte source. `cacheId` is the gallery item's stable list identity, the
+/// decode-cache key, not a fetch decision.
 enum LibraryImageSource: Equatable, Hashable, Sendable {
-    /// `version` is nil for now-playing/queue covers, which carry only an id;
-    /// those cache by id alone, accepted on those single/small surfaces.
     case cover(id: String, version: String?)
+    case image(BridgeImageRef)
     case gallery(
         releaseId: String,
         source: BridgeGallerySource,
@@ -24,7 +26,10 @@ enum LibraryImageSource: Equatable, Hashable, Sendable {
     /// release scope keeps two releases' covers distinct in the shared cache).
     var cacheToken: String {
         switch self {
-        case .cover(let id, let version): "cover:\(id):\(version ?? "")"
+        case .cover(let id, let version):
+            "cover:\(id):\(version ?? id)"
+        case .image(let image):
+            "image:\(image.imageType):\(image.id):\(image.version)"
         case .gallery(let releaseId, _, let cacheId):
             "gallery:\(releaseId):\(cacheId)"
         }
@@ -38,11 +43,15 @@ enum LibraryImageSource: Equatable, Hashable, Sendable {
 final class MediaPaths: Sendable, Observable {
     /// Filesystem path for the user's own external file behind a library file
     /// (the DiscID re-read of a rip's LOG/CUE/audio). NOT for images — library
-    /// images are read through `fetchImageBytes` / `fetchGalleryBytes`.
+    /// images are read through `fetchImageBytes` and `fetchGalleryBytes`.
     let filePath: @Sendable (_ fileId: String) throws -> String?
+    /// Bytes of a release cover by release id, or nil when no such cover exists.
+    let fetchCoverImageBytes:
+        @Sendable (_ releaseId: String) async throws -> Data?
     /// Bytes of a host-provided library image (a cover or an artist image) by
-    /// id, or nil when no such image exists.
-    let fetchImageBytes: @Sendable (_ imageId: String) async throws -> Data?
+    /// full image ref, or nil when no such image exists.
+    let fetchImageBytes:
+        @Sendable (_ image: BridgeImageRef) async throws -> Data?
     /// Bytes of one of a release's gallery slots (its cover or an image file),
     /// dispatched in core on the `BridgeGallerySource` and downloaded from the
     /// release's cloud home (and decrypted) when it isn't on disk here.
@@ -61,9 +70,12 @@ final class MediaPaths: Sendable, Observable {
 
     init(
         filePath: @escaping @Sendable (String) throws -> String? = { _ in nil },
-        fetchImageBytes: @escaping @Sendable (String) async throws -> Data? = {
-            _ in nil
-        },
+        fetchCoverImageBytes:
+            @escaping @Sendable (String) async throws -> Data? = { _ in nil },
+        fetchImageBytes:
+            @escaping @Sendable (BridgeImageRef) async throws -> Data? = {
+                _ in nil
+            },
         fetchGalleryBytes:
             @escaping @Sendable (String, BridgeGallerySource) async throws ->
             Data = { _, _ in throw MediaPathsUnavailable() },
@@ -72,6 +84,7 @@ final class MediaPaths: Sendable, Observable {
         }
     ) {
         self.filePath = filePath
+        self.fetchCoverImageBytes = fetchCoverImageBytes
         self.fetchImageBytes = fetchImageBytes
         self.fetchGalleryBytes = fetchGalleryBytes
         self.fetchCoverBytes = fetchCoverBytes
@@ -81,8 +94,11 @@ final class MediaPaths: Sendable, Observable {
         convenience init(handle: any AppHandleProtocol) {
             self.init(
                 filePath: { try handle.filePath(fileId: $0) },
+                fetchCoverImageBytes: {
+                    try await handle.fetchCoverImageBytes(releaseId: $0)
+                },
                 fetchImageBytes: {
-                    try await handle.fetchImageBytes(imageId: $0)
+                    try await handle.fetchImageBytes(image: $0)
                 },
                 fetchGalleryBytes: {
                     try await handle.fetchGalleryBytes(
@@ -101,7 +117,7 @@ final class MediaPaths: Sendable, Observable {
     static let stub = MediaPaths()
 
     /// Decoded library image for `source` at `pointSize`, reading from the cache
-    /// when present and otherwise fetching the bytes (a cover by id, a gallery
+    /// when present and otherwise fetching the bytes (an image ref or a gallery
     /// slot via the bridge), decoding off the main thread, and caching the
     /// result. Returns nil when no
     /// such image exists (a `cover` with no bytes); a fetch/decode error
@@ -121,7 +137,16 @@ final class MediaPaths: Sendable, Observable {
         let bytes: Data
         switch source {
         case .cover(let id, _):
-            guard let data = try await fetchImageBytes(id) else {
+            guard let data = try await fetchCoverImageBytes(id) else {
+                logger.warning("Missing cover image bytes for \(id)")
+                return nil
+            }
+            bytes = data
+        case .image(let image):
+            guard let data = try await fetchImageBytes(image) else {
+                logger.warning(
+                    "Missing library image bytes for \(image.imageType) \(image.id)"
+                )
                 return nil
             }
             bytes = data

--- a/bae-macos/bae/bae/Services/PaginatedList.swift
+++ b/bae-macos/bae/bae/Services/PaginatedList.swift
@@ -99,6 +99,8 @@ final class PaginatedList<Row: Identifiable & Sendable> where Row.ID: Sendable {
     @ObservationIgnored
     private let ingest: ([Row]) -> Void
     @ObservationIgnored
+    private let onError: (DisplayError) -> Void
+    @ObservationIgnored
     private var reloadTask: Task<Void, Never>?
     // In-flight `loadRange` fetches, keyed "offset:end:generation", so concurrent
     // callers asking for the same range coalesce onto one DB query instead of
@@ -106,9 +108,14 @@ final class PaginatedList<Row: Identifiable & Sendable> where Row.ID: Sendable {
     @ObservationIgnored
     private var inFlight: [String: Task<Void, Never>] = [:]
 
-    init(pageSource: any PageSource<Row>, ingest: @escaping ([Row]) -> Void) {
+    init(
+        pageSource: any PageSource<Row>,
+        ingest: @escaping ([Row]) -> Void,
+        onError: @escaping (DisplayError) -> Void
+    ) {
         self.pageSource = pageSource
         self.ingest = ingest
+        self.onError = onError
     }
 
     // MARK: - Queries
@@ -155,6 +162,7 @@ final class PaginatedList<Row: Identifiable & Sendable> where Row.ID: Sendable {
         }
         catch {
             logger.error("Failed to load count: \(error.localizedDescription)")
+            onError(DisplayError(line: error.localizedDescription))
         }
     }
 
@@ -225,6 +233,7 @@ final class PaginatedList<Row: Identifiable & Sendable> where Row.ID: Sendable {
             logger.error(
                 "Failed to load range [\(offset) ..< \(end)]: \(error.localizedDescription)"
             )
+            onError(DisplayError(line: error.localizedDescription))
         }
     }
 
@@ -258,6 +267,7 @@ final class PaginatedList<Row: Identifiable & Sendable> where Row.ID: Sendable {
                 logger.error(
                     "invalidate() failed: \(error.localizedDescription)"
                 )
+                onError(DisplayError(line: error.localizedDescription))
             }
         }
     }

--- a/bae-macos/bae/bae/Services/Store/SearchResults.swift
+++ b/bae-macos/bae/bae/Services/Store/SearchResults.swift
@@ -4,11 +4,15 @@ struct SearchResults: Equatable {
     let query: String
     let albums: [AlbumSearchResult]
     let tracks: [TrackSearchResult]
+    let composers: [BridgeComposerSummary]
+    let works: [BridgeWorkSummary]
 
     init(bridge: BridgeSearchResults, query: String) {
         self.query = query
         albums = bridge.albums.map(AlbumSearchResult.init(bridge:))
         tracks = bridge.tracks.map(TrackSearchResult.init(bridge:))
+        composers = bridge.composers
+        works = bridge.works
     }
 }
 
@@ -46,4 +50,8 @@ struct TrackSearchResult: Equatable, Identifiable {
         albumTitle = bridge.albumTitle
         artistName = bridge.artistName
     }
+}
+
+extension BridgeWorkSummary: Identifiable {
+    public var id: String { workId }
 }

--- a/bae-macos/bae/bae/Services/UiStore.swift
+++ b/bae-macos/bae/bae/Services/UiStore.swift
@@ -15,6 +15,11 @@ struct NavigationCommand {
     let trackId: String?
 }
 
+enum LibraryNavigationTarget {
+    case composer(String)
+    case work(String)
+}
+
 // MARK: - UiStore
 
 /// Shared UI-originated state. Views read properties, call methods to mutate.
@@ -31,6 +36,11 @@ class UiStore: @unchecked Sendable {
     /// what the UI *is*; this subject carries what should *happen once*.
     @ObservationIgnored
     let navigationSubject = PassthroughSubject<NavigationCommand, Never>()
+
+    @ObservationIgnored
+    let libraryNavigationSubject = PassthroughSubject<
+        LibraryNavigationTarget, Never
+    >()
 
     // ── Shared selections ───────────────────────────────────────────────
 
@@ -84,7 +94,21 @@ class UiStore: @unchecked Sendable {
         activeSection = .importing
     }
 
+    func navigateToComposer(_ artistId: String) {
+        activeSection = .library
+        libraryNavigationSubject.send(.composer(artistId))
+    }
+
+    func navigateToWork(_ workId: String) {
+        activeSection = .library
+        libraryNavigationSubject.send(.work(workId))
+    }
+
     func selectAlbum(_ albumId: String) {
+        selectedAlbumId = albumId
+    }
+
+    func selectAlbumFromGrid(_ albumId: String?) {
         selectedAlbumId = albumId
     }
 

--- a/bae-macos/bae/bae/Views/AlbumGridView.swift
+++ b/bae-macos/bae/bae/Views/AlbumGridView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+import os.log
 
+private let albumGridLogger = Logger.bae("AlbumGridView")
 private let albumCardSize: CGFloat = 180
 private let gridSpacing: CGFloat = 24
 private let loadBatchSize = 50
@@ -10,8 +12,6 @@ struct AlbumGridView<ExpansionContent: View>: View {
     @Environment(LibraryStore.self)
     private var libraryStore
     let list: AlbumList
-    @Binding
-    var selectedAlbumId: String?
     @Binding
     var sortCriteria: [BridgeSortCriterion]
     let availableFields: [BridgeSortField]
@@ -78,7 +78,8 @@ struct AlbumGridView<ExpansionContent: View>: View {
                                                         .artistNames,
                                                     year: summary.year,
                                                     cover: summary.cover,
-                                                    isSelected: selectedAlbumId
+                                                    isSelected: uiStore
+                                                        .selectedAlbumId
                                                         == summary.id,
                                                     size: cardWidth,
                                                     onPlay: {
@@ -111,18 +112,16 @@ struct AlbumGridView<ExpansionContent: View>: View {
                                                                 0.85
                                                         )
                                                     ) {
-                                                        if uiStore
-                                                            .selectedAlbumId
-                                                            == summary.id
-                                                        {
-                                                            uiStore
-                                                                .closeAlbumDetail()
-                                                        }
-                                                        else {
-                                                            uiStore.selectAlbum(
-                                                                summary.id
+                                                        uiStore
+                                                            .selectAlbumFromGrid(
+                                                                uiStore
+                                                                    .selectedAlbumId
+                                                                    == summary
+                                                                    .id
+                                                                    ? nil
+                                                                    : summary
+                                                                        .id
                                                             )
-                                                        }
                                                     }
                                                 }
                                             }
@@ -168,18 +167,13 @@ struct AlbumGridView<ExpansionContent: View>: View {
                                         limit: batchEnd - firstAlbum
                                     )
                                 }
-                                if let selectedId = selectedAlbumId,
-                                    (0..<columnCount)
-                                        .contains(where: { col in
-                                            let idx =
-                                                rowIndex * columnCount + col
-                                            return idx < list.totalCount
-                                                && list.idAt(idx) == selectedId
-                                        })
-                                {
-                                    expansionContent(selectedId)
-                                        .transition(.opacity)
-                                }
+                                AlbumExpansionSlot(
+                                    selectedId: selectedAlbumId(
+                                        rowIndex: rowIndex,
+                                        columnCount: columnCount
+                                    ),
+                                    expansionContent: expansionContent
+                                )
                             }
                         }
                         .padding(.horizontal, Self.contentPadding)
@@ -192,6 +186,9 @@ struct AlbumGridView<ExpansionContent: View>: View {
                     guard let albumIndex = list.position(of: command.albumId),
                         columnCount > 0
                     else {
+                        albumGridLogger.warning(
+                            "Dropping album navigation command for unloaded album \(command.albumId)"
+                        )
                         return
                     }
 
@@ -206,6 +203,20 @@ struct AlbumGridView<ExpansionContent: View>: View {
             }
         }
         .background(Theme.background)
+    }
+}
+
+extension AlbumGridView {
+    private func selectedAlbumId(rowIndex: Int, columnCount: Int) -> String? {
+        guard let selectedId = uiStore.selectedAlbumId else {
+            return nil
+        }
+        let rowContainsSelection = (0..<columnCount)
+            .contains { col in
+                let index = rowIndex * columnCount + col
+                return index < list.totalCount && list.idAt(index) == selectedId
+            }
+        return rowContainsSelection ? selectedId : nil
     }
 
     private var libraryHeader: some View {
@@ -321,6 +332,21 @@ private struct SortCriterionChip: View {
     }
 }
 
+private struct AlbumExpansionSlot<ExpansionContent: View>: View {
+    let selectedId: String?
+    let expansionContent: (String) -> ExpansionContent
+
+    var body: some View {
+        ZStack {
+            Color.clear.frame(height: 0)
+            selectedId.map { id in
+                expansionContent(id)
+                    .transition(.opacity)
+            }
+        }
+    }
+}
+
 // MARK: - Album Card
 
 struct AlbumCardView: View {
@@ -371,11 +397,12 @@ struct AlbumCardView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-            if let year {
-                Text(String(year))
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
+            StableOptionalText(
+                text: year.map(String.init),
+                font: .caption2,
+                foreground: .tertiary,
+                lineHeight: 12
+            )
         }
         .contextMenu {
             Button("Play") { onPlay() }
@@ -472,8 +499,6 @@ private class MenuItem: NSMenuItem {
         /// `AlbumDetailView` chain's environment from one place.
         let store: LibraryStore
         @State
-        private var selectedAlbumId: String? = "a-04"
-        @State
         private var sortCriteria: [BridgeSortCriterion] = [
             BridgeSortCriterion(field: .dateAdded, direction: .descending)
         ]
@@ -486,7 +511,6 @@ private class MenuItem: NSMenuItem {
             )
             AlbumGridView(
                 list: list,
-                selectedAlbumId: $selectedAlbumId,
                 sortCriteria: $sortCriteria,
                 availableFields: BridgeSortField.allCases,
                 onPlay: { _ in },

--- a/bae-macos/bae/bae/Views/ImageView.swift
+++ b/bae-macos/bae/bae/Views/ImageView.swift
@@ -197,15 +197,13 @@ extension ImageView {
     ) {
         self.init(
             content: imageRef.map {
-                .library(.cover(id: $0.id, version: $0.version))
+                .library(.image($0))
             },
             contentMode: contentMode,
             pointSize: pointSize
         )
     }
 
-    /// A now-playing/queue cover, which carries only an image id (no content
-    /// version). Cached by id alone — accepted on these single/small surfaces.
     init(
         coverImageId: String?,
         contentMode: ContentMode = .fill,

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -1,5 +1,42 @@
 import SwiftUI
 
+private let composerLoadBatchSize = 50
+
+private enum LibraryBrowserMode {
+    case albums
+    case composers
+}
+
+private enum ComposerPaneSelection: Equatable {
+    case none
+    case composer(artistId: String, workId: String?)
+    case work(workId: String)
+
+    var composerId: String? {
+        if case .composer(let artistId, _) = self {
+            return artistId
+        }
+        return nil
+    }
+
+    var workId: String? {
+        switch self {
+        case .none:
+            return nil
+        case .composer(_, let workId):
+            return workId
+        case .work(let workId):
+            return workId
+        }
+    }
+}
+
+private enum ComposerPaneDetail {
+    case empty
+    case composer(BridgeComposerDetail, work: BridgeWorkDetail?)
+    case work(BridgeWorkDetail)
+}
+
 struct LibraryView: View {
     @Environment(Playback.self)
     var playback
@@ -13,16 +50,95 @@ struct LibraryView: View {
     var uiStore
 
     @State
-    private var list: AlbumList?
+    private var mode: LibraryBrowserMode = .albums
+    @State
+    private var albumList: AlbumList?
+    @State
+    private var composerList: ComposerList?
     @State
     private var sortCriteria: [BridgeSortCriterion] = Self.loadSortCriteria()
+    @State
+    private var composerSortCriterion =
+        BridgeComposerSortCriterion(field: .name, direction: .ascending)
+    @State
+    private var composerPaneDetail: ComposerPaneDetail = .empty
+    @State
+    private var detailSelection: ComposerPaneSelection = .none
 
     var body: some View {
         @Bindable
         var uiStore = uiStore
+        VStack(spacing: 0) {
+            modePicker
+                .padding(.top, 14)
+                .padding(.horizontal, 16)
+            Group {
+                switch mode {
+                case .albums:
+                    albumContent
+                case .composers:
+                    composerContent
+                }
+            }
+        }
+        .background(Theme.background)
+        .task(id: sortCriteria) {
+            Self.saveSortCriteria(sortCriteria)
+            await reloadAlbumList(sort: sortCriteria)
+        }
+        .task(id: mode) {
+            if mode == .composers {
+                await ensureComposerListLoaded()
+            }
+        }
+        .task(id: detailSelection.composerId) {
+            await loadComposerDetail()
+        }
+        .task(id: detailSelection) {
+            await loadWorkDetail()
+        }
+        .task(id: composerSortCriterion) {
+            if mode == .composers {
+                await reloadComposerList(sort: composerSortCriterion)
+            }
+        }
+        .onReceive(libraryStore.libraryShapeSubject) { change in
+            switch change {
+            case .albumAdded, .albumUpdated, .albumRemoved:
+                albumList?.invalidate()
+                composerList?.invalidate()
+            case .releaseAdded, .releaseUpdated, .releaseRemoved:
+                composerList?.invalidate()
+            }
+        }
+        .onReceive(uiStore.libraryNavigationSubject) { target in
+            mode = .composers
+            switch target {
+            case .composer(let artistId):
+                detailSelection = .composer(artistId: artistId, workId: nil)
+                composerPaneDetail = .empty
+            case .work(let workId):
+                detailSelection = .work(workId: workId)
+                composerPaneDetail = .empty
+            }
+        }
+    }
+}
+
+extension LibraryView {
+    private var modePicker: some View {
+        Picker("Library", selection: $mode) {
+            Text("Albums").tag(LibraryBrowserMode.albums)
+            Text("Composers").tag(LibraryBrowserMode.composers)
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 260)
+    }
+
+    private var albumContent: some View {
         Group {
-            if let list {
-                if list.totalCount == 0 {
+            if let albumList {
+                if albumList.totalCount == 0 {
                     ContentUnavailableView(
                         "No albums",
                         systemImage: "square.stack",
@@ -31,8 +147,7 @@ struct LibraryView: View {
                 }
                 else {
                     AlbumGridView(
-                        list: list,
-                        selectedAlbumId: $uiStore.selectedAlbumId,
+                        list: albumList,
                         sortCriteria: $sortCriteria,
                         availableFields: BridgeSortField.allCases,
                         onPlay: { releaseId in
@@ -55,34 +170,321 @@ struct LibraryView: View {
                 ProgressView()
             }
         }
-        .task {
-            if list == nil {
-                let newList = makeList(sort: sortCriteria)
-                await newList.loadInitial()
-                list = newList
+    }
+
+    private var composerContent: some View {
+        Group {
+            if let composerList {
+                if composerList.totalCount == 0 {
+                    ContentUnavailableView(
+                        "No composers",
+                        systemImage: "person.wave.2",
+                        description: Text("Import some music to get started"),
+                    )
+                }
+                else {
+                    HSplitView {
+                        composerListView(composerList)
+                            .frame(minWidth: 260, idealWidth: 320)
+                        composerDetailView
+                            .frame(minWidth: 420)
+                    }
+                }
             }
-        }
-        .onChange(of: sortCriteria) { _, newValue in
-            Self.saveSortCriteria(newValue)
-            let newList = makeList(sort: newValue)
-            Task {
-                await newList.loadInitial()
-                list = newList
-            }
-        }
-        .onReceive(libraryStore.libraryShapeSubject) { change in
-            // Library grid rows are albums; release-level shape changes
-            // don't move rows.
-            switch change {
-            case .albumAdded, .albumUpdated, .albumRemoved:
-                list?.invalidate()
-            case .releaseAdded, .releaseUpdated, .releaseRemoved:
-                break
+            else {
+                ProgressView()
             }
         }
     }
 
-    private func makeList(sort: [BridgeSortCriterion]) -> AlbumList {
+    private func composerListView(_ list: ComposerList) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            composerHeader
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            List {
+                ForEach(0..<list.totalCount, id: \.self) { index in
+                    composerRow(at: index, list: list)
+                        .task(
+                            id: RowLoadID(
+                                epoch: list.loadEpoch,
+                                index: index
+                            )
+                        ) {
+                            let first = max(
+                                0,
+                                index - composerLoadBatchSize / 2
+                            )
+                            let end = min(
+                                first + composerLoadBatchSize,
+                                list.totalCount
+                            )
+                            await list.loadRange(
+                                offset: first,
+                                limit: end - first
+                            )
+                        }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+        }
+    }
+
+    private var composerHeader: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Composers")
+                .font(.title.bold())
+            Spacer()
+            composerSortControls
+        }
+    }
+
+    private var composerSortControls: some View {
+        HStack(spacing: 8) {
+            Menu {
+                ForEach(BridgeComposerSortField.allCases, id: \.self) { field in
+                    Button(field.displayName) {
+                        composerSortCriterion = BridgeComposerSortCriterion(
+                            field: field,
+                            direction: composerSortCriterion.direction
+                        )
+                    }
+                }
+            } label: {
+                Text(composerSortCriterion.field.displayName)
+            }
+            .menuStyle(.borderlessButton)
+            Button {
+                let nextDirection: BridgeSortDirection =
+                    composerSortCriterion.direction == .ascending
+                    ? .descending : .ascending
+                composerSortCriterion = BridgeComposerSortCriterion(
+                    field: composerSortCriterion.field,
+                    direction: nextDirection
+                )
+            } label: {
+                Image(
+                    systemName: composerSortCriterion.direction == .ascending
+                        ? "arrow.up" : "arrow.down"
+                )
+            }
+            .buttonStyle(.borderless)
+            .help(
+                composerSortCriterion.direction == .ascending
+                    ? String(localized: "Sort Descending")
+                    : String(localized: "Sort Ascending")
+            )
+        }
+    }
+
+    private func composerRow(at index: Int, list: ComposerList) -> some View {
+        let id = list.idAt(index)
+        return ComposerListRow(
+            id: id,
+            isSelected: id != nil && detailSelection.composerId == id,
+            select: { id in
+                detailSelection = .composer(artistId: id, workId: nil)
+                composerPaneDetail = .empty
+            }
+        )
+    }
+
+    private var composerDetailView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                if case .composer(let composerDetail, let loadedWorkDetail) =
+                    composerPaneDetail
+                {
+                    ComposerDetailHeader(summary: composerDetail.composer)
+                    if !composerDetail.workGroups.isEmpty {
+                        SectionHeader(title: String(localized: "Works"))
+                        ForEach(composerDetail.workGroups) { group in
+                            ComposerWorkGroupView(group: group) { workId in
+                                if let artistId = detailSelection.composerId {
+                                    detailSelection = .composer(
+                                        artistId: artistId,
+                                        workId: workId
+                                    )
+                                    composerPaneDetail = .composer(
+                                        composerDetail,
+                                        work: nil
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    if !composerDetail.unlinkedReleaseRoles.isEmpty {
+                        SectionHeader(title: String(localized: "Credits"))
+                        ForEach(
+                            composerDetail.unlinkedReleaseRoles,
+                            id: \.releaseId
+                        ) { role in
+                            CreditRow(
+                                title: role.albumTitle,
+                                subtitle: role.sourceCredit
+                            )
+                        }
+                    }
+                    if !composerDetail.unlinkedTrackRoles.isEmpty {
+                        ForEach(
+                            composerDetail.unlinkedTrackRoles,
+                            id: \.trackId
+                        ) { role in
+                            CreditRow(
+                                title: role.trackTitle,
+                                subtitle: role.albumTitle
+                            )
+                        }
+                    }
+                    if let loadedWorkDetail {
+                        Divider()
+                        WorkDetailView(
+                            detail: loadedWorkDetail,
+                            openWork: { workId in
+                                if case .composer(let artistId, _) =
+                                    detailSelection
+                                {
+                                    detailSelection = .composer(
+                                        artistId: artistId,
+                                        workId: workId
+                                    )
+                                    composerPaneDetail = .composer(
+                                        composerDetail,
+                                        work: nil
+                                    )
+                                }
+                            },
+                            openAlbum: { albumId in
+                                uiStore.selectAlbum(albumId)
+                                mode = .albums
+                            }
+                        )
+                    }
+                }
+                if case .work(let loadedWorkDetail) = composerPaneDetail {
+                    WorkDetailView(
+                        detail: loadedWorkDetail,
+                        openWork: { workId in
+                            detailSelection = .work(workId: workId)
+                            composerPaneDetail = .empty
+                        },
+                        openAlbum: { albumId in
+                            uiStore.selectAlbum(albumId)
+                            mode = .albums
+                        }
+                    )
+                }
+                if detailSelection == .none {
+                    ContentUnavailableView(
+                        "Composers",
+                        systemImage: "person.wave.2"
+                    )
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Theme.surface)
+    }
+
+    private func ensureComposerListLoaded() async {
+        guard composerList == nil else {
+            return
+        }
+        let newList = makeComposerList(sort: composerSortCriterion)
+        await newList.loadInitial()
+        composerList = newList
+    }
+
+    private func loadComposerDetail() async {
+        guard let selectedComposerId = detailSelection.composerId else {
+            return
+        }
+        do {
+            let getComposerDetail = library.getComposerDetail
+            let detail =
+                try await DetachedWork.run {
+                    try getComposerDetail(selectedComposerId)
+                }
+            guard !Task.isCancelled else {
+                return
+            }
+            guard let detail else {
+                uiStore.showError(
+                    DisplayError(
+                        line: String(localized: "Composer detail not found")
+                    )
+                )
+                return
+            }
+            composerPaneDetail = .composer(detail, work: nil)
+            if case .composer(let artistId, nil) = detailSelection,
+                artistId == selectedComposerId,
+                let defaultWorkId = detail.defaultWorkId
+            {
+                detailSelection = .composer(
+                    artistId: selectedComposerId,
+                    workId: defaultWorkId
+                )
+            }
+        }
+        catch {
+            uiStore.showError(DisplayError(line: error.localizedDescription))
+        }
+    }
+
+    private func loadWorkDetail() async {
+        let selectedDetail = detailSelection
+        guard let selectedWorkId = selectedDetail.workId else {
+            return
+        }
+        do {
+            let getWorkDetail = library.getWorkDetail
+            let detail =
+                try await DetachedWork.run {
+                    try getWorkDetail(selectedWorkId)
+                }
+            guard !Task.isCancelled else {
+                return
+            }
+            guard detailSelection == selectedDetail else {
+                return
+            }
+            guard let detail else {
+                uiStore.showError(
+                    DisplayError(
+                        line: String(localized: "Work detail not found")
+                    )
+                )
+                return
+            }
+            switch selectedDetail {
+            case .composer(let artistId, .some):
+                guard
+                    case .composer(let composerDetail, _) = composerPaneDetail,
+                    composerDetail.composer.artistId == artistId
+                else {
+                    uiStore.showError(
+                        DisplayError(
+                            line: String(localized: "Composer detail not found")
+                        )
+                    )
+                    return
+                }
+                composerPaneDetail = .composer(composerDetail, work: detail)
+            case .work:
+                composerPaneDetail = .work(detail)
+            case .none, .composer(_, .none):
+                return
+            }
+        }
+        catch {
+            uiStore.showError(DisplayError(line: error.localizedDescription))
+        }
+    }
+
+    private func makeAlbumList(sort: [BridgeSortCriterion]) -> AlbumList {
         AlbumList(
             pageSource: LibraryAlbumPageSource(
                 library: library,
@@ -93,7 +495,41 @@ struct LibraryView: View {
                     _ = libraryStore.internAlbumSummary(row)
                 }
             },
+            onError: { [uiStore] error in
+                uiStore.showError(error)
+            },
         )
+    }
+
+    private func makeComposerList(
+        sort: BridgeComposerSortCriterion
+    ) -> ComposerList {
+        ComposerList(
+            pageSource: LibraryComposerPageSource(
+                library: library,
+                sort: sort
+            ),
+            ingest: { [libraryStore] rows in
+                for row in rows {
+                    _ = libraryStore.internComposerSummary(row)
+                }
+            },
+            onError: { [uiStore] error in
+                uiStore.showError(error)
+            },
+        )
+    }
+
+    private func reloadComposerList(sort: BridgeComposerSortCriterion) async {
+        let newList = makeComposerList(sort: sort)
+        await newList.loadInitial()
+        composerList = newList
+    }
+
+    private func reloadAlbumList(sort: [BridgeSortCriterion]) async {
+        let newList = makeAlbumList(sort: sort)
+        await newList.loadInitial()
+        albumList = newList
     }
 
     private static let sortCriteriaKey = "librarySortCriteria"
@@ -113,6 +549,289 @@ struct LibraryView: View {
     private static func saveSortCriteria(_ criteria: [BridgeSortCriterion]) {
         if let data = criteria.toJSON() {
             UserDefaults.standard.set(data, forKey: sortCriteriaKey)
+        }
+    }
+
+}
+
+extension BridgeComposerWorkGroup: Identifiable {}
+
+private struct ComposerListRow: View {
+    @Environment(LibraryStore.self)
+    private var libraryStore
+
+    let id: String?
+    let isSelected: Bool
+    let select: (String) -> Void
+
+    var body: some View {
+        let summary = id.flatMap { libraryStore.composerSummaries[$0] }
+        Button(action: {
+            guard let id else {
+                return
+            }
+            select(id)
+        }) {
+            ZStack(alignment: .leading) {
+                ComposerSummaryPlaceholder()
+                    .opacity(summary == nil ? 1 : 0)
+                    .allowsHitTesting(summary == nil)
+                ComposerSummaryRow(summary: summary, isSelected: isSelected)
+                    .opacity(summary == nil ? 0 : 1)
+                    .allowsHitTesting(summary != nil)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(summary == nil)
+    }
+}
+
+private struct ComposerSummaryRow: View {
+    let summary: BridgeComposerSummary?
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: summary?.image, pointSize: 36)
+                .frame(width: 36, height: 36)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading, spacing: 3) {
+                OptionalLineText(
+                    text: summary?.name,
+                    font: .body,
+                    foreground: .primary
+                )
+                OptionalLineText(
+                    text: workCountText,
+                    font: .caption,
+                    foreground: .secondary
+                )
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isSelected ? Color.accentColor.opacity(0.18) : .clear)
+        )
+    }
+
+    private var workCountText: String? {
+        guard let summary else {
+            return nil
+        }
+        return "\(summary.workCount) \(String(localized: "Works"))"
+    }
+}
+
+private struct OptionalLineText: View {
+    let text: String?
+    let font: Font
+    let foreground: StableOptionalTextForeground
+
+    var body: some View {
+        StableOptionalText(
+            text: text,
+            font: font,
+            foreground: foreground,
+            lineHeight: lineHeight,
+            lineLimit: 1
+        )
+    }
+
+    private var lineHeight: CGFloat {
+        switch font {
+        case .caption:
+            12
+        default:
+            16
+        }
+    }
+}
+
+private struct ComposerSummaryPlaceholder: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.secondary.opacity(0.15))
+                .frame(width: 36, height: 36)
+            VStack(alignment: .leading, spacing: 6) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.secondary.opacity(0.15))
+                    .frame(width: 140, height: 12)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.secondary.opacity(0.12))
+                    .frame(width: 80, height: 10)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct ComposerDetailHeader: View {
+    let summary: BridgeComposerSummary
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ImageView(imageRef: summary.image, pointSize: 72)
+                .frame(width: 72, height: 72)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            VStack(alignment: .leading, spacing: 6) {
+                Text(summary.name)
+                    .font(.title.bold())
+                    .lineLimit(2)
+                Text("\(summary.workCount) \(String(localized: "Works"))")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct WorkSummaryRow: View {
+    let summary: BridgeWorkSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: summary.representativeCover, pointSize: 42)
+                .frame(width: 42, height: 42)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(summary.title)
+                    .font(.body)
+                    .lineLimit(1)
+                OptionalLineText(
+                    text: summary.composerNames,
+                    font: .caption,
+                    foreground: .secondary
+                )
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct ComposerWorkGroupView: View {
+    let group: BridgeComposerWorkGroup
+    let openWork: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(parentRows, id: \.workId) { parent in
+                Button(action: { openWork(parent.workId) }) {
+                    WorkSummaryRow(summary: parent)
+                }
+                .buttonStyle(.plain)
+            }
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(group.works, id: \.workId) { work in
+                    Button(action: { openWork(work.workId) }) {
+                        WorkSummaryRow(summary: work)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.leading, group.parent == nil ? 0 : 18)
+        }
+    }
+
+    private var parentRows: [BridgeWorkSummary] {
+        guard let parent = group.parent else {
+            return []
+        }
+        return [parent]
+    }
+}
+
+private struct SectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.headline)
+            .padding(.top, 4)
+    }
+}
+
+private struct CreditRow: View {
+    let title: String
+    let subtitle: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.body)
+                .lineLimit(1)
+            StableOptionalText(
+                text: subtitle,
+                font: .caption,
+                foreground: .secondary,
+                lineHeight: 12,
+                lineLimit: 1
+            )
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct WorkDetailView: View {
+    let detail: BridgeWorkDetail
+    let openWork: (String) -> Void
+    let openAlbum: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(detail.work.title)
+                .font(.title2.bold())
+                .lineLimit(2)
+            if !detail.childWorks.isEmpty {
+                SectionHeader(title: String(localized: "Works"))
+                ForEach(detail.childWorks, id: \.workId) { work in
+                    Button(action: { openWork(work.workId) }) {
+                        WorkSummaryRow(summary: work)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            if !detail.releases.isEmpty {
+                SectionHeader(title: String(localized: "Releases"))
+                ForEach(detail.releases, id: \.id) { release in
+                    Button(action: { openAlbum(release.albumId) }) {
+                        HStack(spacing: 12) {
+                            ImageView(imageRef: release.cover, pointSize: 42)
+                                .frame(width: 42, height: 42)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(release.id)
+                                    .font(.body)
+                                    .lineLimit(1)
+                                OptionalLineText(
+                                    text: release.format,
+                                    font: .caption,
+                                    foreground: .secondary
+                                )
+                            }
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            if !detail.tracks.isEmpty {
+                SectionHeader(title: String(localized: "Recordings"))
+                ForEach(detail.tracks, id: \.trackId) { track in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(track.trackTitle)
+                            .font(.body)
+                            .lineLimit(1)
+                        Text(track.albumTitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
         }
     }
 }

--- a/bae-macos/bae/bae/Views/MainAppView.swift
+++ b/bae-macos/bae/bae/Views/MainAppView.swift
@@ -96,6 +96,8 @@ struct MainAppView: View {
                     SearchView(
                         results: uiStore.searchResults,
                         onSelectAlbum: selectAlbum,
+                        onSelectComposer: selectComposer,
+                        onSelectWork: selectWork,
                     )
                     .frame(width: 400, height: 350, alignment: .topTrailing)
                     .position(x: rect.maxX - 200, y: rect.maxY + 180)
@@ -112,11 +114,25 @@ struct MainAppView: View {
     // MARK: - Search selection
 
     private func selectAlbum(_ albumId: String) {
+        closeSearchPopover()
+        uiStore.selectAlbum(albumId)
+    }
+
+    private func selectComposer(_ artistId: String) {
+        closeSearchPopover()
+        uiStore.navigateToComposer(artistId)
+    }
+
+    private func selectWork(_ workId: String) {
+        closeSearchPopover()
+        uiStore.navigateToWork(workId)
+    }
+
+    private func closeSearchPopover() {
         uiStore.showSearchPopover = false
         searchText = ""
         NSApp.keyWindow?.makeFirstResponder(nil)
         uiStore.searchResults = nil
-        uiStore.selectAlbum(albumId)
     }
 
     // MARK: - Queue drop handling

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -21,12 +21,11 @@ struct NowPlayingBarContainer: View {
         var uiStore = uiStore
         let np = playbackStore.nowPlaying
         let track = np.track
-        // The now-playing/queue cover is id-only by design: load by image id and
-        // cache by id alone. No store lookup to backfill a content version —
-        // these single/small surfaces don't need the reload-on-replace the grid
-        // covers get from their versioned refs.
         let cover: ImageContent? =
-            track?.coverImageId.map { .library(.cover(id: $0, version: nil)) }
+            track?.coverImageId
+            .map {
+                .library(.cover(id: $0, version: nil))
+            }
         NowPlayingBar(
             trackTitle: track?.trackTitle,
             secondaryLine: np.secondaryLine,

--- a/bae-macos/bae/bae/Views/SearchView.swift
+++ b/bae-macos/bae/bae/Views/SearchView.swift
@@ -3,11 +3,15 @@ import SwiftUI
 struct SearchView: View {
     let results: SearchResults?
     let onSelectAlbum: (String) -> Void
+    let onSelectComposer: (String) -> Void
+    let onSelectWork: (String) -> Void
 
     var body: some View {
         Group {
             if let results {
-                if results.albums.isEmpty, results.tracks.isEmpty {
+                if results.albums.isEmpty, results.tracks.isEmpty,
+                    results.composers.isEmpty, results.works.isEmpty
+                {
                     ContentUnavailableView.search(text: results.query)
                 }
                 else {
@@ -38,6 +42,22 @@ struct SearchView: View {
                     }
                 }
             }
+
+            Section("Composers") {
+                ForEach(results.composers, id: \.id) { composer in
+                    composerRow(composer)
+                }
+            }
+            .opacity(results.composers.isEmpty ? 0 : 1)
+            .allowsHitTesting(!results.composers.isEmpty)
+
+            Section("Works") {
+                ForEach(results.works, id: \.id) { work in
+                    workRow(work)
+                }
+            }
+            .opacity(results.works.isEmpty ? 0 : 1)
+            .allowsHitTesting(!results.works.isEmpty)
         }
         .scrollContentBackground(.hidden)
         .background(Theme.background)
@@ -87,10 +107,16 @@ struct SearchView: View {
                         .font(.body)
                         .lineLimit(1)
 
-                    Text("\(track.artistName) - \(track.albumTitle)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                    Text(
+                        String(
+                            format: String(localized: "%@ - %@"),
+                            track.artistName,
+                            track.albumTitle
+                        )
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
                 }
 
                 Spacer()
@@ -99,6 +125,53 @@ struct SearchView: View {
                     Text(track.durationLabel)
                         .font(.callout.monospacedDigit())
                         .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func composerRow(_ composer: BridgeComposerSummary) -> some View {
+        libraryEntityRow(
+            systemImage: "person.wave.2",
+            title: composer.name,
+            subtitle: "\(composer.workCount) \(String(localized: "Works"))",
+            action: { onSelectComposer(composer.id) }
+        )
+    }
+
+    private func workRow(_ work: BridgeWorkSummary) -> some View {
+        libraryEntityRow(
+            systemImage: "music.quarternote.3",
+            title: work.title,
+            subtitle: work.composerNames,
+            action: { onSelectWork(work.id) }
+        )
+    }
+
+    private func libraryEntityRow(
+        systemImage: String,
+        title: String,
+        subtitle: String?,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .frame(width: 32, height: 32)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+                        .lineLimit(1)
+                    StableOptionalText(
+                        text: subtitle,
+                        font: .caption,
+                        foreground: .secondary,
+                        lineHeight: 12,
+                        lineLimit: 1
+                    )
                 }
             }
         }
@@ -116,6 +189,8 @@ struct SearchView: View {
     SearchView(
         results: PreviewData.searchResults,
         onSelectAlbum: { _ in },
+        onSelectComposer: { _ in },
+        onSelectWork: { _ in },
     )
     .frame(width: 600, height: 500)
     .environment(MediaPaths.stub)
@@ -124,10 +199,17 @@ struct SearchView: View {
 #Preview("No results") {
     SearchView(
         results: SearchResults(
-            bridge: BridgeSearchResults(albums: [], tracks: []),
-            query: "nonexistent"
+            bridge: BridgeSearchResults(
+                albums: [],
+                tracks: [],
+                composers: [],
+                works: []
+            ),
+            query: "placeholder"
         ),
         onSelectAlbum: { _ in },
+        onSelectComposer: { _ in },
+        onSelectWork: { _ in },
     )
     .frame(width: 600, height: 400)
     .environment(MediaPaths.stub)

--- a/bae-macos/bae/bae/Views/StableOptionalText.swift
+++ b/bae-macos/bae/bae/Views/StableOptionalText.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+enum StableOptionalTextForeground {
+    case primary
+    case secondary
+    case tertiary
+}
+
+struct StableOptionalText: View {
+    let text: String?
+    let font: Font
+    let foreground: StableOptionalTextForeground
+    let lineHeight: CGFloat
+    let lineLimit: Int?
+
+    init(
+        text: String?,
+        font: Font,
+        foreground: StableOptionalTextForeground = .primary,
+        lineHeight: CGFloat,
+        lineLimit: Int? = nil
+    ) {
+        self.text = text
+        self.font = font
+        self.foreground = foreground
+        self.lineHeight = lineHeight
+        self.lineLimit = lineLimit
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Color.clear
+                .frame(height: lineHeight)
+                .accessibilityHidden(true)
+            styledText
+                .opacity(hasText ? 1 : 0)
+                .allowsHitTesting(hasText)
+                .accessibilityHidden(!hasText)
+        }
+    }
+
+    @ViewBuilder
+    private var styledText: some View {
+        switch foreground {
+        case .primary:
+            baseText
+        case .secondary:
+            baseText.foregroundStyle(.secondary)
+        case .tertiary:
+            baseText.foregroundStyle(.tertiary)
+        }
+    }
+
+    private var baseText: some View {
+        Text(displayText)
+            .font(font)
+            .lineLimit(lineLimit)
+    }
+
+    private var hasText: Bool {
+        text != nil
+    }
+
+    private var displayText: String {
+        switch text {
+        case .some(let text):
+            text
+        case .none:
+            " "
+        }
+    }
+}

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -122,6 +122,9 @@ struct StorageManagerView: View {
                     _ = libraryStore.internReleaseSummary(row.release)
                 }
             },
+            onError: { [uiStore] error in
+                uiStore.showError(error)
+            },
         )
         Task {
             await newList.loadInitial()

--- a/bae-macos/bae/baeTests/LibraryStoreTests.swift
+++ b/bae-macos/bae/baeTests/LibraryStoreTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import bae
@@ -110,7 +111,8 @@ private func makeList(store: LibraryStore, albums: [BridgeAlbum]) -> AlbumList {
             for row in rows {
                 _ = store.internAlbumSummary(row)
             }
-        }
+        },
+        onError: { _ in },
     )
 }
 
@@ -134,7 +136,76 @@ final class CountingAlbumPageSource: PageSource, @unchecked Sendable {
         pageCallCount += 1
         let start = min(offset, albums.count)
         let end = min(start + limit, albums.count)
-        return Array(albums[start ..< end])
+        return Array(albums[start..<end])
+    }
+}
+
+private struct PaginatedListTestError: LocalizedError, Sendable {
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+private final class ThrowingAlbumPageSource: PageSource, @unchecked Sendable {
+    var albums: [BridgeAlbum]
+    var countError: PaginatedListTestError?
+    var pageError: PaginatedListTestError?
+
+    init(
+        albums: [BridgeAlbum],
+        countError: PaginatedListTestError? = nil,
+        pageError: PaginatedListTestError? = nil
+    ) {
+        self.albums = albums
+        self.countError = countError
+        self.pageError = pageError
+    }
+
+    func count() async throws -> Int {
+        if let countError {
+            throw countError
+        }
+        return albums.count
+    }
+
+    func page(offset: Int, limit: Int) async throws -> [BridgeAlbum] {
+        if let pageError {
+            throw pageError
+        }
+        let start = min(offset, albums.count)
+        let end = min(start + limit, albums.count)
+        return Array(albums[start..<end])
+    }
+}
+
+@Suite("SearchResults")
+struct SearchResultsTests {
+
+    @Test("work results carry linked release count")
+    func workResultsCarryLinkedReleaseCount() {
+        let results = SearchResults(
+            bridge: BridgeSearchResults(
+                albums: [],
+                tracks: [],
+                composers: [],
+                works: [
+                    BridgeWorkSummary(
+                        workId: "work-child-a",
+                        title: "Work Title A",
+                        disambiguation: nil,
+                        workType: "part",
+                        parentWorkId: "work-parent-a",
+                        composerNames: "Composer Name A",
+                        linkedReleaseCount: 1,
+                        representativeReleaseId: "release-a",
+                        representativeCover: nil
+                    )
+                ]
+            ),
+            query: "work"
+        )
+
+        #expect(results.works.first?.linkedReleaseCount == 1)
     }
 }
 
@@ -190,19 +261,41 @@ struct InternAlbumSummaryTests {
         let store = LibraryStore()
         let first = store.internAlbumSummary(
             makeBridgeAlbum(
-                cover: BridgeImageRef(id: "cover-1", version: "1000")))
+                cover: BridgeImageRef(
+                    id: "cover-1",
+                    version: "1000",
+                    imageType: .cover
+                )
+            )
+        )
         #expect(
             first.cover
-                == ImageRef(bridge: BridgeImageRef(id: "cover-1", version: "1000")))
+                == BridgeImageRef(
+                    id: "cover-1",
+                    version: "1000",
+                    imageType: .cover
+                )
+        )
 
         let second = store.internAlbumSummary(
             makeBridgeAlbum(
-                cover: BridgeImageRef(id: "cover-1", version: "2000")))
+                cover: BridgeImageRef(
+                    id: "cover-1",
+                    version: "2000",
+                    imageType: .cover
+                )
+            )
+        )
 
         #expect(first === second)
         #expect(
             first.cover
-                == ImageRef(bridge: BridgeImageRef(id: "cover-1", version: "2000")))
+                == BridgeImageRef(
+                    id: "cover-1",
+                    version: "2000",
+                    imageType: .cover
+                )
+        )
     }
 }
 
@@ -257,7 +350,11 @@ struct InternReleaseSummaryTests {
             pinned: true,
             fileCount: 12,
             totalSize: 5_000_000,
-            cover: BridgeImageRef(id: "release-1", version: "7")
+            cover: BridgeImageRef(
+                id: "release-1",
+                version: "7",
+                imageType: .cover
+            )
         )
 
         let summary = store.internReleaseSummary(bridge)
@@ -271,7 +368,12 @@ struct InternReleaseSummaryTests {
         #expect(summary.totalSize == 5_000_000)
         #expect(
             summary.cover
-                == ImageRef(bridge: BridgeImageRef(id: "release-1", version: "7")))
+                == BridgeImageRef(
+                    id: "release-1",
+                    version: "7",
+                    imageType: .cover
+                )
+        )
     }
 
     @MainActor
@@ -280,22 +382,42 @@ struct InternReleaseSummaryTests {
         let store = LibraryStore()
         let first = store.internReleaseSummary(
             makeBridgeReleaseSummary(
-                cover: BridgeImageRef(id: "release-1", version: "1"))
+                cover: BridgeImageRef(
+                    id: "release-1",
+                    version: "1",
+                    imageType: .cover
+                )
+            )
         )
         #expect(
             first.cover
-                == ImageRef(bridge: BridgeImageRef(id: "release-1", version: "1")))
+                == BridgeImageRef(
+                    id: "release-1",
+                    version: "1",
+                    imageType: .cover
+                )
+        )
 
         // Re-interning with a bumped cover version updates the existing
         // instance in place rather than replacing it.
         let second = store.internReleaseSummary(
             makeBridgeReleaseSummary(
-                cover: BridgeImageRef(id: "release-1", version: "2"))
+                cover: BridgeImageRef(
+                    id: "release-1",
+                    version: "2",
+                    imageType: .cover
+                )
+            )
         )
         #expect(first === second)
         #expect(
             first.cover
-                == ImageRef(bridge: BridgeImageRef(id: "release-1", version: "2")))
+                == BridgeImageRef(
+                    id: "release-1",
+                    version: "2",
+                    imageType: .cover
+                )
+        )
     }
 }
 
@@ -317,7 +439,9 @@ struct InternReleaseDetailTests {
     }
 
     @MainActor
-    @Test("detail wraps the identity-stable summary from releaseSummaries slice")
+    @Test(
+        "detail wraps the identity-stable summary from releaseSummaries slice"
+    )
     func detailWrapsCanonicalSummary() {
         let store = LibraryStore()
         let bridge = makeBridgeRelease()
@@ -402,13 +526,18 @@ struct AlbumEventTests {
     @Test("handleAlbumAdded does not mutate live lists")
     func albumAddedDoesNotMutateList() async {
         let store = LibraryStore()
-        let list = makeList(store: store, albums: [makeBridgeAlbum(id: "a1", title: "Existing")])
+        let list = makeList(
+            store: store,
+            albums: [makeBridgeAlbum(id: "a1", title: "Existing")]
+        )
         await list.loadInitial()
         await list.loadRange(offset: 0, limit: 1)
 
         let preCount = list.totalCount
 
-        store.handleAlbumAdded(album: makeBridgeAlbumDetail(albumId: "a2", title: "New"))
+        store.handleAlbumAdded(
+            album: makeBridgeAlbumDetail(albumId: "a2", title: "New")
+        )
 
         // Slice holds the new summary, but the list's segments are untouched.
         #expect(store.albumSummaries["a2"] != nil)
@@ -451,7 +580,9 @@ struct AlbumEventTests {
     }
 
     @MainActor
-    @Test("handleAlbumUpdated replaces releaseDetails and updates release summary identity")
+    @Test(
+        "handleAlbumUpdated replaces releaseDetails and updates release summary identity"
+    )
     func albumUpdatedRefreshesSlices() {
         let store = LibraryStore()
         let r1 = makeBridgeRelease(
@@ -492,9 +623,14 @@ struct AlbumEventTests {
         let store = LibraryStore()
         let r1 = makeBridgeRelease(id: "r-1", albumId: "album-1")
         let r2 = makeBridgeRelease(id: "r-2", albumId: "album-1")
-        store.handleAlbumAdded(album: makeBridgeAlbumDetail(releases: [r1, r2]))
+        store.handleAlbumAdded(
+            album: makeBridgeAlbumDetail(releases: [r1, r2])
+        )
 
-        store.handleAlbumRemoved(albumId: "album-1", releaseIds: ["r-1", "r-2"])
+        store.handleAlbumRemoved(
+            albumId: "album-1",
+            releaseIds: ["r-1", "r-2"]
+        )
 
         #expect(store.albumSummaries["album-1"] == nil)
         #expect(store.releaseSummaries["r-1"] == nil)
@@ -512,16 +648,23 @@ struct AlbumEventTests {
         let a2r1 = makeBridgeRelease(id: "a2-r1", albumId: "album-2")
         let a2r2 = makeBridgeRelease(id: "a2-r2", albumId: "album-2")
 
-        store.handleAlbumAdded(album: makeBridgeAlbumDetail(
-            albumId: "album-1",
-            releases: [a1r1, a1r2]
-        ))
-        store.handleAlbumAdded(album: makeBridgeAlbumDetail(
-            albumId: "album-2",
-            releases: [a2r1, a2r2]
-        ))
+        store.handleAlbumAdded(
+            album: makeBridgeAlbumDetail(
+                albumId: "album-1",
+                releases: [a1r1, a1r2]
+            )
+        )
+        store.handleAlbumAdded(
+            album: makeBridgeAlbumDetail(
+                albumId: "album-2",
+                releases: [a2r1, a2r2]
+            )
+        )
 
-        store.handleAlbumRemoved(albumId: "album-1", releaseIds: ["a1-r1", "a1-r2"])
+        store.handleAlbumRemoved(
+            albumId: "album-1",
+            releaseIds: ["a1-r1", "a1-r2"]
+        )
 
         // album-1 and both of its releases are gone.
         #expect(store.albumSummaries["album-1"] == nil)
@@ -542,10 +685,13 @@ struct AlbumEventTests {
     @Test("handleAlbumRemoved does not mutate live lists")
     func albumRemovedDoesNotMutateList() async {
         let store = LibraryStore()
-        let list = makeList(store: store, albums: [
-            makeBridgeAlbum(id: "a1", title: "Alpha"),
-            makeBridgeAlbum(id: "a2", title: "Beta"),
-        ])
+        let list = makeList(
+            store: store,
+            albums: [
+                makeBridgeAlbum(id: "a1", title: "Alpha"),
+                makeBridgeAlbum(id: "a2", title: "Beta"),
+            ]
+        )
         await list.loadInitial()
         await list.loadRange(offset: 0, limit: 2)
 
@@ -567,11 +713,16 @@ struct AlbumEventTests {
 struct ReleaseEventTests {
 
     @MainActor
-    @Test("handleReleaseAdded interns the release and updates parent album releaseIds from event")
+    @Test(
+        "handleReleaseAdded interns the release and updates parent album releaseIds from event"
+    )
     func releaseAddedInternsSlices() {
         let store = LibraryStore()
         store.handleAlbumAdded(album: makeBridgeAlbumDetail(albumId: "album-1"))
-        let newRelease = makeBridgeRelease(id: "release-2", displayName: "Second Release")
+        let newRelease = makeBridgeRelease(
+            id: "release-2",
+            displayName: "Second Release"
+        )
         let updatedAlbum = makeBridgeAlbum(
             id: "album-1",
             releaseIds: ["release-1", "release-2"]
@@ -580,8 +731,13 @@ struct ReleaseEventTests {
         store.handleReleaseAdded(album: updatedAlbum, release: newRelease)
 
         #expect(store.releaseSummaries["release-2"]?.id == "release-2")
-        #expect(store.releaseDetails["release-2"]?.displayName == "Second Release")
-        #expect(store.albumSummaries["album-1"]?.releaseIds.contains("release-2") == true)
+        #expect(
+            store.releaseDetails["release-2"]?.displayName == "Second Release"
+        )
+        #expect(
+            store.albumSummaries["album-1"]?.releaseIds.contains("release-2")
+                == true
+        )
     }
 
     @MainActor
@@ -607,7 +763,9 @@ struct ReleaseEventTests {
     }
 
     @MainActor
-    @Test("handleReleaseRemoved drops the release and interns the event's post-removal album")
+    @Test(
+        "handleReleaseRemoved drops the release and interns the event's post-removal album"
+    )
     func releaseRemoved() {
         let store = LibraryStore()
         store.handleAlbumAdded(
@@ -619,7 +777,9 @@ struct ReleaseEventTests {
                 ]
             )
         )
-        store.albumSummaries["album-1"]?.releaseIds = ["release-1", "release-2"]
+        store.albumSummaries["album-1"]?.releaseIds = [
+            "release-1", "release-2",
+        ]
         #expect(store.releaseSummaries["release-1"] != nil)
         #expect(store.releaseDetails["release-1"] != nil)
 
@@ -636,11 +796,16 @@ struct ReleaseEventTests {
     }
 
     @MainActor
-    @Test("handleReleaseRemoved leaves the album untouched when the event carries no summary")
+    @Test(
+        "handleReleaseRemoved leaves the album untouched when the event carries no summary"
+    )
     func releaseRemovedWithoutAlbum() {
         let store = LibraryStore()
         store.handleAlbumAdded(
-            album: makeBridgeAlbumDetail(albumId: "album-1", releases: [makeBridgeRelease()])
+            album: makeBridgeAlbumDetail(
+                albumId: "album-1",
+                releases: [makeBridgeRelease()]
+            )
         )
 
         // album: nil mirrors the cascade-delete case where AlbumRemoved already
@@ -661,11 +826,14 @@ struct PaginatedListTests {
     @Test("loadInitial sets totalCount, no positions loaded until loadRange")
     func loadInitialAllocates() async {
         let store = LibraryStore()
-        let list = makeList(store: store, albums: [
-            makeBridgeAlbum(id: "a1"),
-            makeBridgeAlbum(id: "a2"),
-            makeBridgeAlbum(id: "a3"),
-        ])
+        let list = makeList(
+            store: store,
+            albums: [
+                makeBridgeAlbum(id: "a1"),
+                makeBridgeAlbum(id: "a2"),
+                makeBridgeAlbum(id: "a3"),
+            ]
+        )
 
         await list.loadInitial()
 
@@ -678,11 +846,14 @@ struct PaginatedListTests {
     @Test("loadRange populates ids at correct positions and interns via ingest")
     func loadRangePopulatesPositions() async {
         let store = LibraryStore()
-        let list = makeList(store: store, albums: [
-            makeBridgeAlbum(id: "a1", title: "Alpha"),
-            makeBridgeAlbum(id: "a2", title: "Beta"),
-            makeBridgeAlbum(id: "a3", title: "Gamma"),
-        ])
+        let list = makeList(
+            store: store,
+            albums: [
+                makeBridgeAlbum(id: "a1", title: "Alpha"),
+                makeBridgeAlbum(id: "a2", title: "Beta"),
+                makeBridgeAlbum(id: "a3", title: "Gamma"),
+            ]
+        )
         await list.loadInitial()
 
         await list.loadRange(offset: 0, limit: 3)
@@ -703,9 +874,13 @@ struct PaginatedListTests {
             makeBridgeAlbum(id: "a1", title: "Alpha"),
             makeBridgeAlbum(id: "a2", title: "Beta"),
         ])
-        let list = AlbumList(pageSource: source, ingest: { rows in
-            for row in rows { _ = store.internAlbumSummary(row) }
-        })
+        let list = AlbumList(
+            pageSource: source,
+            ingest: { rows in
+                for row in rows { _ = store.internAlbumSummary(row) }
+            },
+            onError: { _ in },
+        )
         await list.loadInitial()
         await list.loadRange(offset: 0, limit: 2)
         #expect(source.pageCallCount == 1)
@@ -719,9 +894,10 @@ struct PaginatedListTests {
     @Test("rowCount computes correctly")
     func rowCountComputation() async {
         let store = LibraryStore()
-        let albums = (0..<7).map {
-            makeBridgeAlbum(id: "a\($0)", title: "Album \($0)")
-        }
+        let albums = (0..<7)
+            .map {
+                makeBridgeAlbum(id: "a\($0)", title: "Album \($0)")
+            }
         let list = makeList(store: store, albums: albums)
         await list.loadInitial()
 
@@ -744,14 +920,79 @@ struct PaginatedListTests {
     }
 
     @MainActor
-    @Test("invalidate keeps old state visible, then atomically swaps in refreshed shape")
+    @Test("loadInitial reports count errors")
+    func loadInitialReportsCountErrors() async {
+        let source = ThrowingAlbumPageSource(
+            albums: [],
+            countError: PaginatedListTestError(message: "count failed")
+        )
+        var errors: [DisplayError] = []
+        let list = AlbumList(
+            pageSource: source,
+            ingest: { _ in },
+            onError: { errors.append($0) },
+        )
+
+        await list.loadInitial()
+
+        #expect(errors == [DisplayError(line: "count failed")])
+    }
+
+    @MainActor
+    @Test("loadRange reports page errors")
+    func loadRangeReportsPageErrors() async {
+        let source = ThrowingAlbumPageSource(
+            albums: [makeBridgeAlbum(id: "a1")],
+            pageError: PaginatedListTestError(message: "page failed")
+        )
+        var errors: [DisplayError] = []
+        let list = AlbumList(
+            pageSource: source,
+            ingest: { _ in },
+            onError: { errors.append($0) },
+        )
+
+        await list.loadInitial()
+        await list.loadRange(offset: 0, limit: 1)
+
+        #expect(errors == [DisplayError(line: "page failed")])
+    }
+
+    @MainActor
+    @Test("invalidate reports count errors")
+    func invalidateReportsCountErrors() async {
+        let source = ThrowingAlbumPageSource(albums: [
+            makeBridgeAlbum(id: "a1")
+        ])
+        var errors: [DisplayError] = []
+        let list = AlbumList(
+            pageSource: source,
+            ingest: { _ in },
+            onError: { errors.append($0) },
+        )
+        await list.loadInitial()
+        source.countError = PaginatedListTestError(message: "reload failed")
+
+        list.invalidate()
+        await list.awaitReload()
+
+        #expect(errors == [DisplayError(line: "reload failed")])
+    }
+
+    @MainActor
+    @Test(
+        "invalidate keeps old state visible, then atomically swaps in refreshed shape"
+    )
     func invalidateRefetches() async {
         let store = LibraryStore()
-        let list = makeList(store: store, albums: [
-            makeBridgeAlbum(id: "a1", title: "Alpha"),
-            makeBridgeAlbum(id: "a2", title: "Beta"),
-            makeBridgeAlbum(id: "a3", title: "Gamma"),
-        ])
+        let list = makeList(
+            store: store,
+            albums: [
+                makeBridgeAlbum(id: "a1", title: "Alpha"),
+                makeBridgeAlbum(id: "a2", title: "Beta"),
+                makeBridgeAlbum(id: "a3", title: "Gamma"),
+            ]
+        )
         await list.loadInitial()
         await list.loadRange(offset: 0, limit: 3)
         #expect(list.idAt(0) == "a1")
@@ -776,16 +1017,22 @@ struct PaginatedListTests {
     }
 
     @MainActor
-    @Test("invalidate re-fetches previously loaded ranges and surfaces new rows")
+    @Test(
+        "invalidate re-fetches previously loaded ranges and surfaces new rows"
+    )
     func invalidateSurfacesNewRows() async {
         let store = LibraryStore()
         // Start with one album; load it.
         let source = MutablePageSource(albums: [
-            makeBridgeAlbum(id: "a1", title: "Alpha"),
+            makeBridgeAlbum(id: "a1", title: "Alpha")
         ])
-        let list = AlbumList(pageSource: source, ingest: { rows in
-            for row in rows { _ = store.internAlbumSummary(row) }
-        })
+        let list = AlbumList(
+            pageSource: source,
+            ingest: { rows in
+                for row in rows { _ = store.internAlbumSummary(row) }
+            },
+            onError: { _ in },
+        )
         await list.loadInitial()
         await list.loadRange(offset: 0, limit: 1)
         #expect(list.idAt(0) == "a1")
@@ -826,7 +1073,7 @@ final class MutablePageSource: PageSource, @unchecked Sendable {
     func page(offset: Int, limit: Int) async throws -> [BridgeAlbum] {
         let start = min(offset, albums.count)
         let end = min(start + limit, albums.count)
-        return Array(albums[start ..< end])
+        return Array(albums[start..<end])
     }
 }
 

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1417,6 +1417,30 @@ pub unsafe extern "C" fn bae_album_count(handle: *const BaeHandle) -> i64 {
 struct FfiImageRef {
     id: String,
     version: String,
+    image_type: FfiLibraryImageType,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FfiLibraryImageType {
+    Cover,
+    Artist,
+}
+
+impl FfiLibraryImageType {
+    fn from_core(image_type: bae_core::db::LibraryImageType) -> Self {
+        match image_type {
+            bae_core::db::LibraryImageType::Cover => Self::Cover,
+            bae_core::db::LibraryImageType::Artist => Self::Artist,
+        }
+    }
+
+    fn into_core(self) -> bae_core::db::LibraryImageType {
+        match self {
+            Self::Cover => bae_core::db::LibraryImageType::Cover,
+            Self::Artist => bae_core::db::LibraryImageType::Artist,
+        }
+    }
 }
 
 impl FfiImageRef {
@@ -1424,6 +1448,7 @@ impl FfiImageRef {
         Self {
             id: r.id,
             version: r.version,
+            image_type: FfiLibraryImageType::from_core(r.image_type),
         }
     }
 
@@ -1431,6 +1456,7 @@ impl FfiImageRef {
         bae_core::album_detail::ImageRef {
             id: self.id,
             version: self.version,
+            image_type: self.image_type.into_core(),
         }
     }
 }
@@ -3011,10 +3037,11 @@ pub unsafe extern "C" fn bae_image_bytes(
         return BaeBytes::error();
     };
     let app = &handle.0;
-    match app
-        .runtime
-        .block_on(app.services.library_manager().read_image_blob(&image_id))
-    {
+    match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .read_cover_image_blob(&image_id),
+    ) {
         Ok(Some(bytes)) => BaeBytes::from_vec(bytes),
         Ok(None) => BaeBytes::absent(),
         Err(e) => {


### PR DESCRIPTION
This implements composer mode as a source-backed library view: releases can now import composer/work relationships from MusicBrainz and composer role credits from Discogs, store them as first-class rows, and expose composer/work browsing through the core, bridge, and macOS UI. The model keeps composer identity and work identity separate from release titles, so classical browsing is driven by source relations instead of title parsing.

Remote imports now distinguish a release being added with its upload queued from a completed local import; the import row is marked complete when coven reports the release has actually become remote. Legitimate non-composer contributor skips are logged with their source context instead of disappearing silently.

Fixes #157

Test plan:
- cargo test -p bae-core --lib
- cargo test -p bae-core db::client::tests::composer_mode_tests --lib
- cargo test -p bae-core import::musicbrainz_mapper::tests --lib
- cargo test -p bae-core import::discogs_mapper::tests --lib
- cargo test -p bae-core import::progress::handle::tests --lib
- CARGO_BUILD_RUSTC_WRAPPER= cargo clippy --lib -p bae-core -- -D warnings -A unexpected_cfgs -A deprecated
- CARGO_BUILD_RUSTC_WRAPPER= cargo clippy --tests -p bae-core --features test-utils -- -D warnings -A unexpected_cfgs -A deprecated
- CARGO_BUILD_RUSTC_WRAPPER= cargo clippy -p bae-bridge -- -D warnings -A unexpected_cfgs -A deprecated
- focused Codex rule review: never-mask-errors-with-defaults, no-self-heal-make-state-correct-or-fail-loud, use-the-project-s-logger-for-real-logs, set-state-don-t-toggle