### PR TITLE
Start remote tracks in one round-trip, and verify every track decodes at import

### DIFF
--- a/bae-core/migrations/001_initial.sql
+++ b/bae-core/migrations/001_initial.sql
@@ -248,6 +248,13 @@ CREATE TABLE IF NOT EXISTS audio_formats (
     start_sample INTEGER NOT NULL,
     end_sample INTEGER,
     end_byte INTEGER,
+    -- Byte this track's audio begins at within its backing file: the seektable
+    -- checkpoint the playback seek lands on (computed at import by seeking to
+    -- start_sample). NULL for a track starting at byte 0 (album's first track /
+    -- whole-file track) — nothing to prefetch, the header read covers it.
+    -- Playback fetches this window in parallel with the header probe so the
+    -- track-start seek lands on buffered bytes instead of a second round-trip.
+    start_byte INTEGER,
     -- Per-track loudness measured at import (EBU R128 integrated loudness over
     -- this track's sample window), in LUFS. NULL = not measured (decode/measure
     -- failure, or a near-silent track that has no usable loudness). Playback

--- a/bae-core/src/audio_codec/decode.rs
+++ b/bae-core/src/audio_codec/decode.rs
@@ -528,6 +528,7 @@ unsafe fn read_sample(
 pub fn decode_audio_streaming(
     buffer: SharedSparseBuffer,
     sink: &mut TrackSink,
+    seek_to_byte: Option<u64>,
     seek_to_sample: Option<u64>,
     start_at_sample: Option<u64>,
     stop_at_sample: Option<u64>,
@@ -541,6 +542,7 @@ pub fn decode_audio_streaming(
         decode_audio_streaming_impl(
             buffer,
             sink,
+            seek_to_byte,
             seek_to_sample,
             start_at_sample,
             stop_at_sample,
@@ -554,6 +556,7 @@ pub fn decode_audio_streaming(
 unsafe fn decode_audio_streaming_impl(
     buffer: SharedSparseBuffer,
     sink: &mut TrackSink,
+    seek_to_byte: Option<u64>,
     seek_to_sample: Option<u64>,
     start_at_sample: Option<u64>,
     stop_at_sample: Option<u64>,
@@ -760,7 +763,29 @@ unsafe fn decode_audio_streaming_impl(
     // from the start (then trimming to the target) is the only way to play such a
     // file -- correct here, but wasteful over a cloud home, which is why every
     // CUE/FLAC should carry a seektable (issue #226). Keep the bail-out logged.
-    if let Some(sample_pos) = seek_to_sample {
+    //
+    // A by-byte seek (AVSEEK_FLAG_BYTE) jumps straight to a known frame offset --
+    // no seektable consulted, no binary search reading the file's end -- and the
+    // landed frame's sample is read from its header, so the `start_at_sample`
+    // trim below still reaches the exact sample. Used for FLAC, where the frame
+    // byte is recorded at import; APE has no per-frame byte positions, so it
+    // sample-seeks via its mandatory index instead.
+    if let Some(byte_pos) = seek_to_byte {
+        let ret = av_seek_frame(
+            fmt_ctx,
+            stream_index,
+            byte_pos as i64,
+            AVSEEK_FLAG_BYTE as c_int,
+        );
+        if ret < 0 {
+            warn!(
+                "byte seek to {byte_pos} failed ({}); decoding from the start",
+                av_err_str(ret)
+            );
+        } else {
+            avcodec_flush_buffers(codec_ctx);
+        }
+    } else if let Some(sample_pos) = seek_to_sample {
         let target_ts = sample_pos as i64;
         let ret = avformat_seek_file(fmt_ctx, stream_index, i64::MIN, target_ts, target_ts, 0);
         if ret < 0 {

--- a/bae-core/src/audio_codec/decode.rs
+++ b/bae-core/src/audio_codec/decode.rs
@@ -146,6 +146,14 @@ unsafe fn decode_audio_avio(
 ) -> Result<(), String> {
     use ffmpeg_sys_next::*;
 
+    // Count fatal FFmpeg errors for this decode, so the sink can flag a track
+    // whose audio bytes fail to decode (import decode-verify rides this pass).
+    // The counter is reset after `find_stream_info` below, not here: probing an
+    // attached-picture stream (an embedded cover) emits its own fatal-level logs
+    // that say nothing about the audio, so only errors from the audio decode loop
+    // should count.
+    install_ffmpeg_log_callback();
+
     // Create our context for callbacks
     let mut avio_ctx = Box::new(AvioContext {
         data: data.as_ptr(),
@@ -196,6 +204,10 @@ unsafe fn decode_audio_avio(
         avformat_close_input(&mut fmt_ctx);
         return Err(format!("Failed to find stream info: {}", av_err_str(ret)));
     }
+
+    // Only count fatal errors from the audio decode below -- probing an embedded
+    // cover during `find_stream_info` above may have logged its own.
+    reset_ffmpeg_errors();
 
     // Find best audio stream
     let stream_index = av_find_best_stream(
@@ -402,6 +414,9 @@ unsafe fn decode_audio_avio(
 
     // Keep avio_ctx alive until here (prevent drop during FFmpeg operations)
     drop(avio_ctx);
+
+    // Report the fatal-error count so a verifying sink can flag a broken decode.
+    sink.set_decode_error_count(get_ffmpeg_errors());
 
     Ok(())
 }

--- a/bae-core/src/audio_codec/decode.rs
+++ b/bae-core/src/audio_codec/decode.rs
@@ -13,6 +13,7 @@ use std::cell::Cell;
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{debug, info, warn};
 
 // Thread-local FFmpeg error counter for per-decode error tracking
@@ -561,6 +562,11 @@ unsafe fn decode_audio_streaming_impl(
 ) -> Result<(), StreamingDecodeError> {
     use ffmpeg_sys_next::*;
 
+    // Wall-clock origin for the first-sample latency log below: spans the probe
+    // (open_input + find_stream_info), the seek, and the decode up to the first
+    // audio sample -- the whole "how long before playback starts" window.
+    let decode_start = Instant::now();
+
     // Create streaming AVIO context. The reader's read-ahead ceiling is set
     // after the seek below, once it sits at the track's start -- so the fill
     // buffers the rest of the current track, not from byte 0 during probe.
@@ -804,6 +810,7 @@ unsafe fn decode_audio_streaming_impl(
     let mut samples_output: u64 = 0;
     let mut reached_stop = false;
     let mut tracked_sample_pos: i64 = -1;
+    let mut first_sample_logged = false;
 
     // Read and decode packets
     while av_read_frame(fmt_ctx, packet) >= 0 {
@@ -903,8 +910,19 @@ unsafe fn decode_audio_streaming_impl(
 
             samples_output += samples_to_output.len() as u64;
 
-            if !samples_to_output.is_empty() && !push_samples_to_sink(sink, samples_to_output) {
-                break;
+            if !samples_to_output.is_empty() {
+                if !first_sample_logged {
+                    first_sample_logged = true;
+                    info!(
+                        "first audio sample: buffer={} fetched {}B from coven in {}ms",
+                        buffer.id(),
+                        buffer.bytes_fetched(),
+                        decode_start.elapsed().as_millis(),
+                    );
+                }
+                if !push_samples_to_sink(sink, samples_to_output) {
+                    break;
+                }
             }
         }
     }

--- a/bae-core/src/audio_codec/mod.rs
+++ b/bae-core/src/audio_codec/mod.rs
@@ -19,7 +19,7 @@ use avio::{avio_write_callback, avio_write_seek_callback, WriteAvioContext};
 
 pub use decode::{decode_audio, decode_audio_streaming, decode_audio_to_sink};
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
-pub use probe::frame_byte_offsets;
+pub use probe::{frame_byte_offsets, seek_landing_bytes};
 pub use probe::{probe_audio_from_path, ProbeResult};
 
 /// Buffer size for FFmpeg custom-IO (`avio`) contexts. The standard 32 KiB

--- a/bae-core/src/audio_codec/mod.rs
+++ b/bae-core/src/audio_codec/mod.rs
@@ -96,6 +96,10 @@ pub trait DecodedSink {
     /// One interleaved-i32 chunk, already trimmed to the requested
     /// `[start_sample, end_sample)` window.
     fn on_samples(&mut self, samples: &[i32]);
+    /// The count of fatal FFmpeg errors during the decode, reported once after the
+    /// stream ends. Default: ignore it. A verifying sink captures it to flag a
+    /// track whose bytes failed to decode. `0` for a clean decode.
+    fn set_decode_error_count(&mut self, _count: u32) {}
 }
 
 /// Initialize FFmpeg (call once at startup)

--- a/bae-core/src/audio_codec/probe.rs
+++ b/bae-core/src/audio_codec/probe.rs
@@ -275,3 +275,100 @@ pub fn frame_byte_offsets(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
         }
     }
 }
+
+/// The byte the demuxer reads from after seeking to each of `samples` -- read
+/// from the AVIO position (`avio_tell`) right after the seek, the way the demuxer
+/// itself positions. Recorded at import as each track's start byte.
+///
+/// Two reasons this is robust where `frame_byte_offsets` (which reads the packet
+/// `pos`) returns `None` or a wrong value:
+/// - The AVIO position is defined for every format. APE packets carry no byte
+///   position; a FLAC with placeholder seektable points returns none either.
+/// - It does *not* set `AVFMT_FLAG_FAST_SEEK`, so a FLAC seek binary-searches the
+///   real frames instead of trusting the file's seektable -- which lands
+///   accurately even when that seektable is coarse or full of placeholder points.
+///   (APE ignores the flag and uses its mandatory index either way.)
+///
+/// Binary-searching a FLAC reads the file's end here, once at import. Playback
+/// never does: it byte-seeks straight to the recorded byte (FLAC) or sample-seeks
+/// and prefetches it (APE). `None` only if the file can't be opened or a seek
+/// fails outright.
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+pub fn seek_landing_bytes(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
+    unsafe {
+        use ffmpeg_sys_next::*;
+
+        let c_path = std::ffi::CString::new(path).ok()?;
+        let mut fmt_ctx = avformat_alloc_context();
+        if fmt_ctx.is_null() {
+            return None;
+        }
+        if avformat_open_input(
+            &mut fmt_ctx,
+            c_path.as_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        ) < 0
+        {
+            warn!("seek_landing_bytes: failed to open input {path}");
+            return None;
+        }
+        if avformat_find_stream_info(fmt_ctx, ptr::null_mut()) < 0 {
+            warn!("seek_landing_bytes: failed to read stream info for {path}");
+            avformat_close_input(&mut fmt_ctx);
+            return None;
+        }
+        let stream_index = av_find_best_stream(
+            fmt_ctx,
+            AVMediaType::AVMEDIA_TYPE_AUDIO,
+            -1,
+            -1,
+            ptr::null_mut(),
+            0,
+        );
+        if stream_index < 0 {
+            warn!("seek_landing_bytes: no audio stream in {path}");
+            avformat_close_input(&mut fmt_ctx);
+            return None;
+        }
+        let stream = *(*fmt_ctx).streams.add(stream_index as usize);
+        let time_base = (*stream).time_base;
+        let sample_rate = (*(*stream).codecpar).sample_rate as i64;
+
+        let mut offsets = Vec::with_capacity(samples.len());
+        let mut failed: Option<String> = None;
+        for &sample in samples {
+            let target_ts = if time_base.num == 1 && time_base.den as i64 == sample_rate {
+                sample as i64
+            } else if sample_rate > 0 && time_base.num > 0 {
+                (sample as i128 * time_base.den as i128
+                    / (time_base.num as i128 * sample_rate as i128)) as i64
+            } else {
+                failed = Some(format!("invalid time base for sample {sample}"));
+                break;
+            };
+            if avformat_seek_file(fmt_ctx, stream_index, i64::MIN, target_ts, target_ts, 0) < 0 {
+                failed = Some(format!("seek to sample {sample} failed"));
+                break;
+            }
+            // Where the demuxer left the read cursor = the frame it will read next.
+            // `avio_seek(.., 0, SEEK_CUR)` is `avio_tell`: returns the position
+            // without moving it.
+            let pos = avio_seek((*fmt_ctx).pb, 0, 1 /* SEEK_CUR */);
+            if pos < 0 {
+                failed = Some(format!("avio_tell after seek to sample {sample} failed"));
+                break;
+            }
+            offsets.push(pos as u64);
+        }
+
+        avformat_close_input(&mut fmt_ctx);
+        match failed {
+            Some(reason) => {
+                warn!("seek_landing_bytes: {reason} in {path}");
+                None
+            }
+            None => Some(offsets),
+        }
+    }
+}

--- a/bae-core/src/audio_codec/probe.rs
+++ b/bae-core/src/audio_codec/probe.rs
@@ -188,6 +188,29 @@ pub fn probe_audio_from_path(path: &str) -> Option<ProbeResult> {
     }
 }
 
+/// Convert a sample number to a timestamp in the stream's time base. For
+/// FLAC/APE the time base is `1/sample_rate`, so the timestamp is the sample
+/// number; otherwise scale by the time base. `None` when the time base is
+/// unusable (non-positive numerator, or a zero sample rate) -- the caller then
+/// bails out of the seek loop.
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+fn sample_to_timestamp(
+    sample: u64,
+    time_base: ffmpeg_sys_next::AVRational,
+    sample_rate: i64,
+) -> Option<i64> {
+    if time_base.num == 1 && time_base.den as i64 == sample_rate {
+        Some(sample as i64)
+    } else if sample_rate > 0 && time_base.num > 0 {
+        Some(
+            (sample as i128 * time_base.den as i128 / (time_base.num as i128 * sample_rate as i128))
+                as i64,
+        )
+    } else {
+        None
+    }
+}
+
 /// The byte offset in the file of the frame containing each of `samples`, found
 /// by seeking -- not decoding. For each sample the demuxer is seeked to it and
 /// the next frame's byte position is read back: the frame at or before the
@@ -220,14 +243,7 @@ pub fn frame_byte_offsets(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
         let mut offsets = Vec::with_capacity(samples.len());
         let mut failed: Option<String> = None;
         for &sample in samples {
-            // Sample number -> timestamp in the stream's time base (1/sample_rate
-            // for FLAC/APE, so the timestamp is the sample number).
-            let target_ts = if time_base.num == 1 && time_base.den as i64 == sample_rate {
-                sample as i64
-            } else if sample_rate > 0 && time_base.num > 0 {
-                (sample as i128 * time_base.den as i128
-                    / (time_base.num as i128 * sample_rate as i128)) as i64
-            } else {
+            let Some(target_ts) = sample_to_timestamp(sample, time_base, sample_rate) else {
                 failed = Some(format!("invalid time base for sample {sample}"));
                 break;
             };
@@ -280,14 +296,15 @@ pub fn frame_byte_offsets(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
 /// from the AVIO position (`avio_tell`) right after the seek, the way the demuxer
 /// itself positions. Recorded at import as each track's start byte.
 ///
-/// Two reasons this is robust where `frame_byte_offsets` (which reads the packet
+/// Two reasons this lands where `frame_byte_offsets` (which reads the packet
 /// `pos`) returns `None` or a wrong value:
 /// - The AVIO position is defined for every format. APE packets carry no byte
 ///   position; a FLAC with placeholder seektable points returns none either.
-/// - It does *not* set `AVFMT_FLAG_FAST_SEEK`, so a FLAC seek binary-searches the
-///   real frames instead of trusting the file's seektable -- which lands
-///   accurately even when that seektable is coarse or full of placeholder points.
-///   (APE ignores the flag and uses its mandatory index either way.)
+/// - It does *not* set `AVFMT_FLAG_FAST_SEEK` (`open_best_audio_stream` leaves it
+///   unset), so a FLAC seek binary-searches the real frames instead of trusting
+///   the file's seektable -- landing accurately even when that seektable is coarse
+///   or full of placeholder points. (APE ignores the flag and uses its mandatory
+///   index either way.)
 ///
 /// Binary-searching a FLAC reads the file's end here, once at import. Playback
 /// never does: it byte-seeks straight to the recorded byte (FLAC) or sample-seeks
@@ -298,39 +315,9 @@ pub fn seek_landing_bytes(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
     unsafe {
         use ffmpeg_sys_next::*;
 
-        let c_path = std::ffi::CString::new(path).ok()?;
-        let mut fmt_ctx = avformat_alloc_context();
-        if fmt_ctx.is_null() {
-            return None;
-        }
-        if avformat_open_input(
-            &mut fmt_ctx,
-            c_path.as_ptr(),
-            ptr::null_mut(),
-            ptr::null_mut(),
-        ) < 0
-        {
-            warn!("seek_landing_bytes: failed to open input {path}");
-            return None;
-        }
-        if avformat_find_stream_info(fmt_ctx, ptr::null_mut()) < 0 {
-            warn!("seek_landing_bytes: failed to read stream info for {path}");
-            avformat_close_input(&mut fmt_ctx);
-            return None;
-        }
-        let stream_index = av_find_best_stream(
-            fmt_ctx,
-            AVMediaType::AVMEDIA_TYPE_AUDIO,
-            -1,
-            -1,
-            ptr::null_mut(),
-            0,
-        );
-        if stream_index < 0 {
-            warn!("seek_landing_bytes: no audio stream in {path}");
-            avformat_close_input(&mut fmt_ctx);
-            return None;
-        }
+        // Opens without AVFMT_FLAG_FAST_SEEK, so a FLAC seek binary-searches the
+        // real frames (see the doc comment) rather than trusting the seektable.
+        let (mut fmt_ctx, stream_index) = open_best_audio_stream(path, "seek_landing_bytes")?;
         let stream = *(*fmt_ctx).streams.add(stream_index as usize);
         let time_base = (*stream).time_base;
         let sample_rate = (*(*stream).codecpar).sample_rate as i64;
@@ -338,12 +325,7 @@ pub fn seek_landing_bytes(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
         let mut offsets = Vec::with_capacity(samples.len());
         let mut failed: Option<String> = None;
         for &sample in samples {
-            let target_ts = if time_base.num == 1 && time_base.den as i64 == sample_rate {
-                sample as i64
-            } else if sample_rate > 0 && time_base.num > 0 {
-                (sample as i128 * time_base.den as i128
-                    / (time_base.num as i128 * sample_rate as i128)) as i64
-            } else {
+            let Some(target_ts) = sample_to_timestamp(sample, time_base, sample_rate) else {
                 failed = Some(format!("invalid time base for sample {sample}"));
                 break;
             };

--- a/bae-core/src/audio_codec/tests.rs
+++ b/bae-core/src/audio_codec/tests.rs
@@ -658,8 +658,16 @@ fn seek_landing_bytes_lands_in_file_at_or_before_the_frame() {
 /// The load-bearing accuracy guarantee: a by-byte seek to the recorded landing,
 /// trimmed to the track's start sample, produces output whose *first* sample is
 /// exactly the start sample. The by-byte jump lands on the frame boundary at or
-/// before the target; `start_at_sample` trims the sub-frame remainder. A window
-/// one frame earlier correlates worse, so the trim really landed on the target.
+/// before the target; `start_at_sample` trims the sub-frame remainder.
+///
+/// Two assertions prove the byte drives the landing, not the trim alone (over a
+/// full in-memory buffer the trim would reach the target from a decode-from-zero
+/// too, so accuracy on its own proves nothing):
+/// - The correct landing byte yields the exact target sample, and a window one
+///   frame earlier correlates worse.
+/// - A *wrong* landing byte (a later track's, past the target) yields output that
+///   is NOT the target sample -- so the byte-seek target, not the trim, decides
+///   where output begins.
 #[test]
 fn byte_seek_to_landing_is_sample_exact() {
     use crate::playback::create_track_stream_pair_with_capacity;
@@ -675,49 +683,56 @@ fn byte_seek_to_landing_is_sample_exact() {
     let sample_rate = 44100u64;
     let channels = 2u32;
     // Track 2 start (white noise) -- random content correlates precisely, unlike
-    // the silent track 1.
+    // the silent track 1. Track 3's landing (20s) is the deliberately wrong byte,
+    // well past track 2's target.
     let start = 10 * sample_rate;
-    let landing = seek_landing_bytes(path, &[start]).expect("landing")[0];
+    let landings = seek_landing_bytes(path, &[start, 20 * sample_rate]).expect("landings");
+    let landing = landings[0];
+    let wrong_landing = landings[1];
 
     let ground = decode_audio(&flac, None, None).expect("ground-truth decode");
     let scale = i16::MAX as f32; // 16-bit fixture
 
-    let buffer = create_sparse_buffer(flac.len() as u64);
-    buffer.append_at(0, &flac);
-    let (mut sink, mut source, _ready) =
-        create_track_stream_pair_with_capacity(sample_rate as u32, channels, 500_000);
-    let decode_buffer = buffer.clone();
-    let handle = thread::spawn(move || {
-        let token = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        decode_audio_streaming(
-            decode_buffer,
-            &mut sink,
-            Some(landing),                  // by-byte seek to the landing
-            None,                           // no sample seek
-            Some(start),                    // trim lead-in to the start sample
-            Some(start + sample_rate / 10), // stop ~0.1s later
-            None,
-            token,
-        )
-    });
-    assert!(handle.join().unwrap().is_ok(), "byte-seek decode failed");
-
-    let mut seeked = Vec::new();
-    let mut buf = [0.0f32; 1024];
-    loop {
-        let n = source.pull_samples(&mut buf);
-        if n == 0 && source.is_finished() {
-            break;
+    // Decode track 2 with a given by-byte seek target, trimming to `start` and
+    // stopping ~0.1s later; return the interleaved output samples.
+    let decode_from = |seek_to_byte: Option<u64>| -> Vec<f32> {
+        let buffer = create_sparse_buffer(flac.len() as u64);
+        buffer.append_at(0, &flac);
+        let (mut sink, mut source, _ready) =
+            create_track_stream_pair_with_capacity(sample_rate as u32, channels, 500_000);
+        let decode_buffer = buffer.clone();
+        let handle = thread::spawn(move || {
+            let token = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            decode_audio_streaming(
+                decode_buffer,
+                &mut sink,
+                seek_to_byte,
+                None,                           // no sample seek
+                Some(start),                    // trim lead-in to the start sample
+                Some(start + sample_rate / 10), // stop ~0.1s later
+                None,
+                token,
+            )
+        });
+        assert!(handle.join().unwrap().is_ok(), "byte-seek decode failed");
+        let mut out = Vec::new();
+        let mut buf = [0.0f32; 1024];
+        loop {
+            let n = source.pull_samples(&mut buf);
+            if n == 0 && source.is_finished() {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
         }
-        seeked.extend_from_slice(&buf[..n]);
-    }
-    assert!(seeked.len() > 200, "not enough samples: {}", seeked.len());
+        out
+    };
 
-    // Mean squared error of the first `window` output samples against the ground
+    let target = start as usize * channels as usize;
+    // Mean squared error of the first `window` samples of `out` against the ground
     // truth starting at interleaved offset `off`.
-    let window = 256usize.min(seeked.len());
-    let mse_at = |off: usize| -> f64 {
-        let e: f64 = seeked[..window]
+    let mse = |out: &[f32], off: usize| -> f64 {
+        let window = 256usize.min(out.len());
+        let e: f64 = out[..window]
             .iter()
             .zip(&ground.samples[off..off + window])
             .map(|(&s, &t)| {
@@ -727,20 +742,42 @@ fn byte_seek_to_landing_is_sample_exact() {
             .sum();
         e / window as f64
     };
+    // The output's first sample is the target sample: enough samples, and the
+    // first window matches the ground truth at exactly `target`.
+    let is_sample_exact = |out: &[f32]| out.len() > 200 && mse(out, target) < 1e-4;
 
-    let target = start as usize * channels as usize;
-    let mse_target = mse_at(target);
+    // Correct landing -> exact target sample.
+    let seeked = decode_from(Some(landing));
     assert!(
-        mse_target < 1e-4,
-        "first output sample is not the target sample (mse {mse_target:.6}); \
-         byte-seek + trim did not land on start_sample",
+        is_sample_exact(&seeked),
+        "the correct landing byte must land on start_sample (len {}, mse {:.6})",
+        seeked.len(),
+        mse(&seeked, target),
     );
-    // One frame earlier must correlate worse -- proves the trim landed on the
-    // target, not a frame short of it. (A wrong/None seek byte fails this too.)
+    // One frame earlier correlates worse -- the trim landed on the target, not a
+    // frame short of it.
     let earlier = target.saturating_sub(4096 * channels as usize);
     assert!(
-        mse_at(earlier) > mse_target,
+        mse(&seeked, earlier) > mse(&seeked, target),
         "output aligns at least as well one frame before the target -- the trim \
          did not land exactly on start_sample",
+    );
+
+    // Wrong landing (track 3's, past the target) -> NOT the target sample. This
+    // isolates the byte-seek as the mechanism: with the trim alone the output
+    // would be identical regardless of the byte. The seek is a valid in-file
+    // offset (so it doesn't fail and fall back to decode-from-zero); it just lands
+    // past the stop window, yielding empty/misaligned output.
+    let sabotaged = decode_from(Some(wrong_landing));
+    assert!(
+        !is_sample_exact(&sabotaged),
+        "a wrong landing byte still produced the target sample (len {}, mse {:.6}) -- \
+         the byte-seek target is not driving where output begins",
+        sabotaged.len(),
+        if sabotaged.len() >= 256 {
+            mse(&sabotaged, target)
+        } else {
+            f64::NAN
+        },
     );
 }

--- a/bae-core/src/audio_codec/tests.rs
+++ b/bae-core/src/audio_codec/tests.rs
@@ -281,7 +281,16 @@ fn test_streaming_decode() {
     let decoder_buffer = buffer.clone();
     let decoder_handle = thread::spawn(move || {
         let token = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        decode_audio_streaming(decoder_buffer, &mut sink, None, None, None, None, token)
+        decode_audio_streaming(
+            decoder_buffer,
+            &mut sink,
+            None,
+            None,
+            None,
+            None,
+            None,
+            token,
+        )
     });
 
     // Feed data to buffer (simulating download)
@@ -324,7 +333,7 @@ fn test_streaming_decode_treats_cancelled_input_as_normal_stop() {
     let (mut sink, source, _ready) = create_track_stream_pair_with_capacity(44100, 1, 4096);
     let token = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-    let result = decode_audio_streaming(buffer, &mut sink, None, None, None, None, token);
+    let result = decode_audio_streaming(buffer, &mut sink, None, None, None, None, None, token);
 
     assert_eq!(result, Err(StreamingDecodeError::InputCancelled));
     assert!(!source.producer_finished());
@@ -379,6 +388,7 @@ fn check_seek_to_produces_correct_samples(sample_rate: u32, channels: u32, bits_
         decode_audio_streaming(
             buffer,
             &mut sink,
+            None,
             Some(seek_sample),
             None,
             None,
@@ -560,6 +570,7 @@ fn flac_seek_uses_seektable_not_binary_search() {
         decode_audio_streaming(
             decode_buffer,
             &mut sink,
+            None,
             Some(seek_sample),
             None,
             Some(stop_sample),
@@ -595,5 +606,141 @@ fn flac_seek_uses_seektable_not_binary_search() {
     assert!(
         reads.iter().any(|&o| o >= file_len / 8),
         "no read past the header; the seek did not advance into the file: {reads:?}"
+    );
+}
+
+/// `seek_landing_bytes` returns, for each deep track start of the real CUE/FLAC
+/// fixture, a byte within the file at or before the exact frame byte
+/// `frame_byte_offsets` reports for the same sample -- the landing recorded per
+/// track at import and byte-seeked to at playback. Both open without
+/// `AVFMT_FLAG_FAST_SEEK`, so they binary-search the frames and land together.
+#[test]
+fn seek_landing_bytes_lands_in_file_at_or_before_the_frame() {
+    init();
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/cue_flac/Test Album.flac"
+    );
+    let sr = probe_audio_from_path(path)
+        .expect("probe fixture")
+        .sample_rate as u64;
+    let file_size = std::fs::metadata(path).unwrap().len();
+
+    // Deep track starts from the CUE (10s white noise, 20s brown noise).
+    let starts = [10 * sr, 20 * sr];
+    let landings = seek_landing_bytes(path, &starts).expect("seek_landing_bytes");
+    let frames = frame_byte_offsets(path, &starts).expect("frame_byte_offsets");
+    assert_eq!(landings.len(), starts.len());
+
+    for i in 0..starts.len() {
+        assert!(
+            landings[i] > 0,
+            "a deep track start lands past byte 0: {landings:?}"
+        );
+        assert!(
+            landings[i] < file_size,
+            "landing stays within the file: {} of {file_size}",
+            landings[i]
+        );
+        assert!(
+            landings[i] <= frames[i],
+            "landing sits at or before the exact frame byte: {} vs {}",
+            landings[i],
+            frames[i]
+        );
+    }
+    assert!(
+        landings[1] > landings[0],
+        "a later track lands later in the file: {landings:?}"
+    );
+}
+
+/// The load-bearing accuracy guarantee: a by-byte seek to the recorded landing,
+/// trimmed to the track's start sample, produces output whose *first* sample is
+/// exactly the start sample. The by-byte jump lands on the frame boundary at or
+/// before the target; `start_at_sample` trims the sub-frame remainder. A window
+/// one frame earlier correlates worse, so the trim really landed on the target.
+#[test]
+fn byte_seek_to_landing_is_sample_exact() {
+    use crate::playback::create_track_stream_pair_with_capacity;
+    use crate::playback::sparse_buffer::create_sparse_buffer;
+    use std::thread;
+
+    init();
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/cue_flac/Test Album.flac"
+    );
+    let flac = std::fs::read(path).expect("read fixture");
+    let sample_rate = 44100u64;
+    let channels = 2u32;
+    // Track 2 start (white noise) -- random content correlates precisely, unlike
+    // the silent track 1.
+    let start = 10 * sample_rate;
+    let landing = seek_landing_bytes(path, &[start]).expect("landing")[0];
+
+    let ground = decode_audio(&flac, None, None).expect("ground-truth decode");
+    let scale = i16::MAX as f32; // 16-bit fixture
+
+    let buffer = create_sparse_buffer(flac.len() as u64);
+    buffer.append_at(0, &flac);
+    let (mut sink, mut source, _ready) =
+        create_track_stream_pair_with_capacity(sample_rate as u32, channels, 500_000);
+    let decode_buffer = buffer.clone();
+    let handle = thread::spawn(move || {
+        let token = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        decode_audio_streaming(
+            decode_buffer,
+            &mut sink,
+            Some(landing),                  // by-byte seek to the landing
+            None,                           // no sample seek
+            Some(start),                    // trim lead-in to the start sample
+            Some(start + sample_rate / 10), // stop ~0.1s later
+            None,
+            token,
+        )
+    });
+    assert!(handle.join().unwrap().is_ok(), "byte-seek decode failed");
+
+    let mut seeked = Vec::new();
+    let mut buf = [0.0f32; 1024];
+    loop {
+        let n = source.pull_samples(&mut buf);
+        if n == 0 && source.is_finished() {
+            break;
+        }
+        seeked.extend_from_slice(&buf[..n]);
+    }
+    assert!(seeked.len() > 200, "not enough samples: {}", seeked.len());
+
+    // Mean squared error of the first `window` output samples against the ground
+    // truth starting at interleaved offset `off`.
+    let window = 256usize.min(seeked.len());
+    let mse_at = |off: usize| -> f64 {
+        let e: f64 = seeked[..window]
+            .iter()
+            .zip(&ground.samples[off..off + window])
+            .map(|(&s, &t)| {
+                let d = s as f64 - t as f64 / scale as f64;
+                d * d
+            })
+            .sum();
+        e / window as f64
+    };
+
+    let target = start as usize * channels as usize;
+    let mse_target = mse_at(target);
+    assert!(
+        mse_target < 1e-4,
+        "first output sample is not the target sample (mse {mse_target:.6}); \
+         byte-seek + trim did not land on start_sample",
+    );
+    // One frame earlier must correlate worse -- proves the trim landed on the
+    // target, not a frame short of it. (A wrong/None seek byte fails this too.)
+    let earlier = target.saturating_sub(4096 * channels as usize);
+    assert!(
+        mse_at(earlier) > mse_target,
+        "output aligns at least as well one frame before the target -- the trim \
+         did not land exactly on start_sample",
     );
 }

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -215,6 +215,14 @@ fn default_replay_gain_mode() -> ReplayGainMode {
     ReplayGainMode::Off
 }
 
+/// The serde default for `ConfigYaml.verify_decode_on_import`: on. Import fully
+/// decodes every track for loudness anyway, so the verify rides that pass for
+/// free; defaulting on means a truncated/corrupt track is caught at import
+/// instead of failing at play time.
+fn default_verify_decode_on_import() -> bool {
+    true
+}
+
 /// Whether a usable Discogs API key is configured. Folds the no-key case and
 /// the validation state into the four states a UI shows, so each binding
 /// doesn't re-derive the precedence.
@@ -355,6 +363,11 @@ pub struct ConfigYaml {
     /// Whether playback pauses between vinyl/cassette sides.
     #[serde(default)]
     pub pause_between_sides: bool,
+    /// Whether import fully decodes each track to verify it (fatal-error / frame
+    /// shortfall), failing the import for a broken track rather than importing it
+    /// and failing at play time. Rides the loudness decode, so it adds no work.
+    #[serde(default = "default_verify_decode_on_import")]
+    pub verify_decode_on_import: bool,
     /// Local automation server configuration. Required so missing/stale config
     /// files fail to load instead of silently taking an implicit value.
     pub mcp: McpConfig,
@@ -382,6 +395,7 @@ impl ConfigYaml {
             discogs: self.discogs,
             replay_gain_mode: self.replay_gain_mode,
             pause_between_sides: self.pause_between_sides,
+            verify_decode_on_import: self.verify_decode_on_import,
             mcp: self.mcp,
         }
     }
@@ -398,6 +412,7 @@ impl From<&Config> for ConfigYaml {
             encryption_key_fingerprint: config.encryption_key_fingerprint.clone(),
             replay_gain_mode: config.replay_gain_mode,
             pause_between_sides: config.pause_between_sides,
+            verify_decode_on_import: config.verify_decode_on_import,
             mcp: config.mcp,
             cloud_home: config.cloud_home.clone(),
         }
@@ -432,6 +447,9 @@ pub struct Config {
     pub replay_gain_mode: ReplayGainMode,
     /// Whether playback pauses between vinyl/cassette sides.
     pub pause_between_sides: bool,
+    /// Whether import verifies each track by fully decoding it, failing the import
+    /// for a broken (truncated/corrupt) track. Defaults to `true`.
+    pub verify_decode_on_import: bool,
     /// Local automation server configuration. The bearer token is keyring-only.
     pub mcp: McpConfig,
 }
@@ -682,6 +700,7 @@ impl Config {
             discogs: None,
             replay_gain_mode: default_replay_gain_mode(),
             pause_between_sides: false,
+            verify_decode_on_import: default_verify_decode_on_import(),
             mcp: McpConfig::disabled_default(),
         }
     }

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -874,6 +874,7 @@ fn row_to_audio_format(row: &Row) -> coven::rusqlite::Result<DbAudioFormat> {
         start_sample: row.get("start_sample")?,
         end_sample: row.get("end_sample")?,
         end_byte: row.get("end_byte")?,
+        start_byte: row.get("start_byte")?,
         track_loudness_lufs: row.get("track_loudness_lufs")?,
         track_peak_linear: row.get("track_peak_linear")?,
         created_at: rfc3339_column(row, "created_at")?,
@@ -1290,8 +1291,8 @@ fn insert_audio_format_row(
     conn.execute(
         r#"
         INSERT INTO audio_formats (
-            id, track_id, content_type, pregap_ms, sample_rate, bits_per_sample, channels, file_id, start_sample, end_sample, end_byte, track_loudness_lufs, track_peak_linear, _updated_at, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            id, track_id, content_type, pregap_ms, sample_rate, bits_per_sample, channels, file_id, start_sample, end_sample, end_byte, start_byte, track_loudness_lufs, track_peak_linear, _updated_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
         params![
             af.id,
@@ -1305,6 +1306,7 @@ fn insert_audio_format_row(
             af.start_sample,
             af.end_sample,
             af.end_byte,
+            af.start_byte,
             af.track_loudness_lufs,
             af.track_peak_linear,
             reg,

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -499,6 +499,13 @@ pub struct DbAudioFormat {
     /// Playback buffers the rest of the current track up to here, ahead of the
     /// playhead, rather than a fixed window.
     pub end_byte: Option<i64>,
+    /// Byte this track's audio begins at within its backing file: the seektable
+    /// checkpoint the playback seek lands on, computed at import by seeking to
+    /// `start_sample` (see `seek_landing_bytes`). `None` for a track starting at
+    /// byte 0 (the album's first track, or a whole-file track). Playback fetches
+    /// this window in parallel with the header probe so the track-start seek lands
+    /// on buffered bytes rather than paying a second serial round-trip.
+    pub start_byte: Option<i64>,
     /// Per-track integrated loudness (EBU R128) in LUFS, measured at import over
     /// this track's sample window. `None` = not measured (decode/measure failure
     /// or a near-silent track with no usable loudness). Playback derives a gain
@@ -962,6 +969,7 @@ impl DbAudioFormat {
             start_sample,
             end_sample,
             end_byte: None,
+            start_byte: None,
             track_loudness_lufs: None,
             track_peak_linear: None,
             created_at: now,
@@ -979,6 +987,16 @@ impl DbAudioFormat {
     /// track sets its own end byte, computed at import.
     pub fn with_end_byte(mut self, end_byte: Option<i64>) -> Self {
         self.end_byte = end_byte;
+        self
+    }
+
+    /// Set the track's start byte within its backing file (the seektable
+    /// checkpoint the playback seek lands on). The default `None` is byte 0 —
+    /// correct for the album's first track and a whole-file per-track source; a
+    /// deep track of a single-file album sets its own start byte, computed at
+    /// import.
+    pub fn with_start_byte(mut self, start_byte: Option<i64>) -> Self {
+        self.start_byte = start_byte;
         self
     }
 

--- a/bae-core/src/import/loudness.rs
+++ b/bae-core/src/import/loudness.rs
@@ -15,6 +15,24 @@ use tracing::{debug, warn};
 use crate::import::handle::send_event;
 use crate::import::types::TrackFile;
 
+/// The album loudness/peak plus the tracks whose decode looked broken (import
+/// decode-verify). `broken` carries a human-readable line per broken track (its
+/// path, track number, and reason); the caller fails the import on it when
+/// `verify_decode_on_import` is on.
+pub(super) struct LoudnessResult {
+    pub album_loudness_lufs: Option<f64>,
+    pub album_peak_linear: Option<f64>,
+    pub broken: Vec<String>,
+}
+
+/// One track's decode outcome from the blocking measure task: the measurement
+/// (absent when unmeasured/silent/failed) and the broken-decode reason (absent
+/// when the decode produced the full window cleanly).
+struct TrackOutcome {
+    measured: Option<(ebur128::EbuR128, f64, f64)>,
+    broken: Option<String>,
+}
+
 /// The meter and the format-derived constants it needs, set together once the
 /// decode probes the format. Held as one `Option` so "no format yet" is a single
 /// absence, not several fields each separately nullable.
@@ -41,6 +59,10 @@ struct LoudnessProgressSink {
     /// only advances at the post-track tick.
     total_frames: Option<u64>,
     done_frames: u64,
+    /// Fatal FFmpeg errors reported by the decoder after the stream ends (0 for a
+    /// clean decode). Set once via `set_decode_error_count`; a non-zero count
+    /// flags the track as broken for import decode-verify.
+    decode_error_count: u32,
     frames_since_emit: u64,
     event_tx: broadcast::Sender<crate::import::handle::ImportEvent>,
     candidate_key: String,
@@ -70,6 +92,31 @@ impl LoudnessProgressSink {
         );
     }
 
+    /// Why this track's decode looks broken, if it does: a fatal FFmpeg error, or
+    /// output frames far short of the expected window (a valid header over a
+    /// truncated body — the decode stops early). `None` = the decode produced the
+    /// full window cleanly. The caller asserts on this only when
+    /// `verify_decode_on_import` is on; otherwise it's advisory (logged).
+    fn broken_reason(&self) -> Option<String> {
+        if self.decode_error_count > 0 {
+            return Some(format!("{} fatal decode error(s)", self.decode_error_count));
+        }
+        // A duration-derived `total_frames` (a whole-file / last track with no
+        // end_sample) is approximate, so require a gross shortfall: a truncated
+        // body decodes a fraction of the window, far past this 5% slack, while
+        // boundary rounding on the expected count stays well under it.
+        if let Some(total) = self.total_frames {
+            let complete_floor = total - total / 20;
+            if total > 0 && self.done_frames < complete_floor {
+                return Some(format!(
+                    "decoded {} of {} expected frames (truncated body)",
+                    self.done_frames, total
+                ));
+            }
+        }
+        None
+    }
+
     /// Finish the meter, surfacing any stored decode/measure failure.
     fn into_result(
         self,
@@ -97,6 +144,10 @@ impl crate::audio_codec::DecodedSink for LoudnessProgressSink {
             }
             Err(e) => self.error = Some(e),
         }
+    }
+
+    fn set_decode_error_count(&mut self, count: u32) {
+        self.decode_error_count = count;
     }
 
     fn on_samples(&mut self, samples: &[i32]) {
@@ -140,12 +191,17 @@ impl crate::audio_codec::DecodedSink for LoudnessProgressSink {
 ///
 /// Per-track progress ticks (and the sub-track ticks from the sink) are
 /// published on `event_tx`, the import event channel the service owns.
+///
+/// The full decode also verifies each track: a fatal decode error or output
+/// frames far short of the expected window (a truncated body under a valid
+/// header) marks the track broken. Broken tracks are always logged and returned;
+/// the caller decides whether to fail the import (per `verify_decode_on_import`).
 pub(super) async fn measure_loudness(
     event_tx: &broadcast::Sender<crate::import::handle::ImportEvent>,
     audio_formats: &mut [crate::db::DbAudioFormat],
     tracks_to_files: &[TrackFile],
     candidate_key: &str,
-) -> (Option<f64>, Option<f64>) {
+) -> LoudnessResult {
     use ebur128::EbuR128;
 
     // Source bytes per file, read once and shared across that file's tracks
@@ -185,6 +241,9 @@ pub(super) async fn measure_loudness(
     // formats are built from the same tracks), so `idx` keys both.
     let mut meters: Vec<EbuR128> = Vec::new();
     let mut track_peaks: Vec<f64> = Vec::new();
+    // Tracks whose decode looked broken (fatal errors / truncated body). Always
+    // collected; the caller fails the import on these when verify is on.
+    let mut broken_tracks: Vec<String> = Vec::new();
     for (idx, tf) in tracks_to_files.iter().enumerate() {
         let path = tf.file_path().to_path_buf();
         let Some(bytes) = file_bytes.get(&path).and_then(|b| b.clone()) else {
@@ -219,50 +278,70 @@ pub(super) async fn measure_loudness(
         // `idx`/`tracks_total` place this track's scan in the bar.
         let task_event_tx = event_tx.clone();
         let key = candidate_key.to_string();
-        let measured = tokio::task::spawn_blocking(move || {
+        let task_path = path.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
             let mut sink = LoudnessProgressSink {
                 source_bits,
                 state: None,
                 error: None,
                 total_frames,
                 done_frames: 0,
+                decode_error_count: 0,
                 frames_since_emit: 0,
                 event_tx: task_event_tx,
                 candidate_key: key,
                 idx: idx as u32,
                 tracks_total,
             };
+            // A decode that fails outright is broken; one that returns Ok can still
+            // be broken (fatal errors / a truncated body) — `broken_reason` reads
+            // the error count and frame shortfall the sink captured.
             if let Err(e) = crate::audio_codec::decode_audio_to_sink(
                 &bytes,
                 Some(start_sample),
                 end_sample,
                 &mut sink,
             ) {
-                warn!("loudness: decode failed for {path:?}: {e}; track stays unmeasured");
-                return None;
+                warn!("loudness: decode failed for {task_path:?}: {e}; track stays unmeasured");
+                return TrackOutcome {
+                    measured: None,
+                    broken: Some(format!("decode failed: {e}")),
+                };
             }
-            match sink.into_result() {
+            let broken = sink.broken_reason();
+            let measured = match sink.into_result() {
                 Ok((meter, Some(m))) => Some((meter, m.loudness_lufs, m.peak_linear)),
                 Ok((_, None)) => {
-                    debug!("loudness: {path:?} has no usable loudness (silent); unmeasured");
+                    debug!("loudness: {task_path:?} has no usable loudness (silent); unmeasured");
                     None
                 }
                 Err(e) => {
-                    warn!("loudness: measure failed for {path:?}: {e}; track stays unmeasured");
+                    warn!(
+                        "loudness: measure failed for {task_path:?}: {e}; track stays unmeasured"
+                    );
                     None
                 }
-            }
+            };
+            TrackOutcome { measured, broken }
         })
         .await;
 
-        match measured {
-            Ok(Some((meter, loudness_lufs, peak_linear))) => {
-                audio_formats[idx].track_loudness_lufs = Some(loudness_lufs);
-                audio_formats[idx].track_peak_linear = Some(peak_linear);
-                meters.push(meter);
-                track_peaks.push(peak_linear);
+        match outcome {
+            Ok(TrackOutcome { measured, broken }) => {
+                if let Some((meter, loudness_lufs, peak_linear)) = measured {
+                    audio_formats[idx].track_loudness_lufs = Some(loudness_lufs);
+                    audio_formats[idx].track_peak_linear = Some(peak_linear);
+                    meters.push(meter);
+                    track_peaks.push(peak_linear);
+                }
+                if let Some(reason) = broken {
+                    warn!(
+                        "import verify: {path:?} (track {}) looks broken: {reason}",
+                        idx + 1
+                    );
+                    broken_tracks.push(format!("{} (track {}): {reason}", path.display(), idx + 1));
+                }
             }
-            Ok(None) => {}
             Err(e) => warn!("loudness: measurement task panicked: {e}; track stays unmeasured"),
         }
         tracks_done += 1;
@@ -272,7 +351,11 @@ pub(super) async fn measure_loudness(
 
     let album_loudness = crate::loudness::album_loudness(&meters);
     let album_peak = crate::loudness::album_peak(&track_peaks);
-    (album_loudness, album_peak)
+    LoudnessResult {
+        album_loudness_lufs: album_loudness,
+        album_peak_linear: album_peak,
+        broken: broken_tracks,
+    }
 }
 
 /// Emit a loudness-measurement tick for the candidate's confirm pane. Routed
@@ -295,4 +378,95 @@ fn emit_loudness_progress(
             fraction,
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sink_with(total: Option<u64>, done: u64, errors: u32) -> LoudnessProgressSink {
+        let (event_tx, _rx) = broadcast::channel(16);
+        LoudnessProgressSink {
+            source_bits: Some(16),
+            state: None,
+            error: None,
+            total_frames: total,
+            done_frames: done,
+            decode_error_count: errors,
+            frames_since_emit: 0,
+            event_tx,
+            candidate_key: "test".to_string(),
+            idx: 0,
+            tracks_total: 1,
+        }
+    }
+
+    /// The broken signature: a gross frame shortfall (a truncated body under a
+    /// valid header) or any fatal decode error. A full-window decode and small
+    /// boundary rounding on a duration-derived expected count are not broken.
+    #[test]
+    fn broken_reason_flags_shortfall_and_errors_not_clean() {
+        assert!(
+            sink_with(Some(1000), 1000, 0).broken_reason().is_none(),
+            "a full-window decode is clean"
+        );
+        assert!(
+            sink_with(Some(1000), 970, 0).broken_reason().is_none(),
+            "a 3% shortfall is boundary rounding, within slack"
+        );
+        assert!(
+            sink_with(Some(1000), 100, 0).broken_reason().is_some(),
+            "a 90% shortfall is a truncated body"
+        );
+        assert!(
+            sink_with(Some(1000), 1000, 1).broken_reason().is_some(),
+            "a fatal decode error is broken even with the full window"
+        );
+        assert!(
+            sink_with(None, 0, 0).broken_reason().is_none(),
+            "with no expected count, a shortfall can't be asserted"
+        );
+    }
+
+    /// End-to-end over the real decoder: a window that falls in a truncated
+    /// FLAC's missing tail is flagged broken (the decode errors out or produces
+    /// far too few frames), while the same window of the intact fixture decodes
+    /// clean. Rides the same `set_decode_error_count` + frame count the import
+    /// verify uses.
+    #[test]
+    fn truncated_flac_decode_is_flagged_broken_intact_is_not() {
+        crate::audio_codec::init();
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/cue_flac/Test Album.flac"
+        );
+        let clean = std::fs::read(path).expect("read fixture");
+        let sr = 44100u64;
+        // A one-second window deep in the file (25s, brown noise near the end).
+        let start = 25 * sr;
+        let end = 26 * sr;
+        let total = end - start;
+
+        let mut sink = sink_with(Some(total), 0, 0);
+        let ok =
+            crate::audio_codec::decode_audio_to_sink(&clean, Some(start), Some(end), &mut sink);
+        assert!(ok.is_ok(), "intact decode should succeed: {ok:?}");
+        assert!(
+            sink.broken_reason().is_none(),
+            "intact fixture window is not broken (decoded {} of {total})",
+            sink.done_frames
+        );
+
+        // Truncated to 60% of its bytes: the 25s window is past the surviving
+        // audio, so the decode errors out or yields far too few frames.
+        let truncated = &clean[..clean.len() * 6 / 10];
+        let mut sink = sink_with(Some(total), 0, 0);
+        let res =
+            crate::audio_codec::decode_audio_to_sink(truncated, Some(start), Some(end), &mut sink);
+        assert!(
+            res.is_err() || sink.broken_reason().is_some(),
+            "truncated fixture window must be flagged broken (decode {res:?}, decoded {} of {total})",
+            sink.done_frames,
+        );
+    }
 }

--- a/bae-core/src/import/service/format_prep.rs
+++ b/bae-core/src/import/service/format_prep.rs
@@ -196,6 +196,29 @@ fn cue_track_byte_ends(file_path: &Path, cue_pair: &CueFlacAnalysis) -> Option<V
     crate::audio_codec::frame_byte_offsets(path, &end_samples)
 }
 
+/// Byte each CUE track's audio *starts* on within the shared file: the seektable
+/// checkpoint the playback seek lands on when seeking to that track's
+/// `start_sample`, found via `seek_landing_bytes` (one open per file, no decode).
+/// `starts[i]` is track `i`'s start byte, index-aligned to the CUE tracks. The
+/// first track starts at byte 0 (nothing to prefetch), so the caller stores
+/// `None` for it. `None` here means the offsets couldn't be read (non-UTF-8 path
+/// or a failed seek), distinct from a real result; the caller then stores no
+/// start byte for that file's tracks.
+fn cue_track_start_bytes(file_path: &Path, cue_pair: &CueFlacAnalysis) -> Option<Vec<u64>> {
+    let sample_rate = cue_analysis_format(cue_pair).sample_rate;
+    let start_samples: Vec<u64> = cue_pair
+        .cue_sheet
+        .tracks
+        .iter()
+        .map(|t| t.audio_start_sample(sample_rate))
+        .collect();
+    let Some(path) = file_path.to_str() else {
+        warn!("cue_track_start_bytes: non-UTF-8 path, cannot seek byte offsets: {file_path:?}");
+        return None;
+    };
+    crate::audio_codec::seek_landing_bytes(path, &start_samples)
+}
+
 impl ImportService {
     /// Build audio format records for all tracks. CUE-backed tracks already hold
     /// their shared analysis + index; standalone tracks are probed here.
@@ -211,6 +234,10 @@ impl ImportService {
         // across that file's tracks (one ffmpeg open per file, not per track).
         // `None` means the offsets couldn't be read for that file.
         let mut cue_ends_by_file: HashMap<PathBuf, Option<Vec<u64>>> = HashMap::new();
+        // Track start byte offsets per shared CUE file, same caching as the ends:
+        // the seektable landing for each track's `start_sample`, computed once per
+        // file. `None` means the offsets couldn't be read for that file.
+        let mut cue_starts_by_file: HashMap<PathBuf, Option<Vec<u64>>> = HashMap::new();
 
         for track_file in tracks_to_files {
             // Each track carries the absolute path to its source file; that path
@@ -255,7 +282,29 @@ impl ImportService {
                         .as_ref()
                         .and_then(|e| e.get(*cue_index))
                         .map(|&b| b as i64);
-                    af.with_end_byte(end_byte)
+                    // The first track (start_sample 0) begins at byte 0 — nothing
+                    // to prefetch, so it keeps the default `None` start byte. A
+                    // deep track records the seektable landing for its start.
+                    let start_byte = if af.start_sample > 0 {
+                        let starts =
+                            cue_starts_by_file.entry(file_path.clone()).or_insert_with(|| {
+                                let computed = cue_track_start_bytes(file_path, cue_pair);
+                                if computed.is_none() {
+                                    warn!(
+                                        "track start offsets unavailable for {:?}; its tracks lose the parallel prefetch",
+                                        file_path
+                                    );
+                                }
+                                computed
+                            });
+                        starts
+                            .as_ref()
+                            .and_then(|s| s.get(*cue_index))
+                            .map(|&b| b as i64)
+                    } else {
+                        None
+                    };
+                    af.with_end_byte(end_byte).with_start_byte(start_byte)
                 }
                 TrackFile::Standalone {
                     db_track,

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -965,15 +965,28 @@ impl ImportService {
                 ImportPhase::MeasuringLoudness,
                 import_id,
             );
-            let (album_loudness, album_peak) = crate::import::loudness::measure_loudness(
+            let loudness = crate::import::loudness::measure_loudness(
                 &self.event_tx,
                 &mut audio_formats,
                 tracks_to_files,
                 candidate_key,
             )
             .await;
-            db_release.album_loudness_lufs = album_loudness;
-            db_release.album_peak_linear = album_peak;
+            db_release.album_loudness_lufs = loudness.album_loudness_lufs;
+            db_release.album_peak_linear = loudness.album_peak_linear;
+
+            // A track that failed to decode fully (fatal errors / truncated body)
+            // would import fine but fail at play time. When verify is on, fail the
+            // import now instead — before finalize commits anything to the library.
+            if self.library_manager.get_config().verify_decode_on_import
+                && !loudness.broken.is_empty()
+            {
+                return Err(format!(
+                    "decode verification failed for {} track(s): {}",
+                    loudness.broken.len(),
+                    loudness.broken.join("; ")
+                ));
+            }
         }
 
         let local_cover_image = if !remote_cover_set {

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -188,10 +188,20 @@ pub struct ResolvedTrackAudio {
     /// whole-file track, `end_sample` is `None` when the track runs to EOF.
     pub start_sample: u64,
     pub end_sample: Option<u64>,
+    /// This track's audio codec, as stored at import. Playback dispatches the
+    /// track-start seek on it: FLAC/lossless byte-seek to `start_byte`; APE
+    /// sample-seeks its mandatory index and also prefetches the file's end (its
+    /// demuxer reads the tail on open).
+    pub content_type: crate::util::content_type::ContentType,
     /// One past this track's last byte in its backing file (frame-granular, from
     /// import; `None` when the track runs to EOF / a whole-file track). Playback
     /// buffers the rest of the current track up to here instead of a fixed window.
     pub end_byte: Option<u64>,
+    /// The byte this track's audio begins at within its backing file: the
+    /// seektable landing recorded at import (`audio_format.start_byte`). `None`
+    /// for a track starting at byte 0. Lets playback prefetch the track's audio
+    /// in parallel with the header probe.
+    pub start_byte: Option<u64>,
     /// Raw loudness/peak measurements (LUFS + linear peak) for this track and its
     /// album, as stored at import. `None` = not measured. Playback derives the
     /// replay gain from these against a constant target; nothing here is a gain.
@@ -219,7 +229,9 @@ impl ResolvedTrackAudio {
             channels: meta.audio_format.channels as u32,
             start_sample: meta.audio_format.start_sample as u64,
             end_sample: meta.audio_format.end_sample.map(|s| s as u64),
+            content_type: meta.audio_format.content_type.clone(),
             end_byte: meta.audio_format.end_byte.map(|b| b as u64),
+            start_byte: meta.audio_format.start_byte.map(|b| b as u64),
             track_loudness_lufs: meta.audio_format.track_loudness_lufs,
             track_peak_linear: meta.audio_format.track_peak_linear,
             album_loudness_lufs: meta.release.album_loudness_lufs,

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -336,12 +336,16 @@ impl AudioDataReader for CovenBlobReader {
 // readahead and per-track memory modest while cutting the call rate.
 const CLOUD_STREAM_READ_SIZE: u64 = coven::CHUNK_SIZE as u64 * 64;
 
-/// The minimum the fill keeps buffered ahead of a reader, regardless of its
-/// track ceiling. A few windows so the decoder's ring can't underrun: it's the
-/// backstop when a reader's track ceiling isn't set yet (during probe). The
-/// reader's track ceiling normally reaches much further (the rest of the current
-/// track).
-const MIN_READAHEAD: u64 = CLOUD_STREAM_READ_SIZE * 4;
+/// The minimum the fill keeps buffered ahead of a reader whose track ceiling
+/// isn't set yet -- the brief probe phase before the decoder reads the header
+/// and seeks to the track's start. One window: the demuxer reads only the front
+/// metadata (header + seektable, ~100 KB for a FLAC) before it seeks, so keeping
+/// more than a window ahead of byte 0 just speculatively fetches front bytes the
+/// decoder abandons the instant it seeks away -- a wasted ranged fetch (~1 s over
+/// a cloud home) on every track that doesn't start at byte 0. Once the decoder
+/// seeks and sets its real ceiling (the track's end byte), read-ahead is bounded
+/// by that instead and reaches the rest of the track.
+const MIN_READAHEAD: u64 = CLOUD_STREAM_READ_SIZE;
 
 /// How far behind a reader's position buffered bytes are retained before being
 /// evicted. A margin for the decoder's brief backward reads; everything older is

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -6,10 +6,75 @@
 
 use crate::playback::progress::{emit_progress, PlaybackProgress};
 use crate::playback::sparse_buffer::{ReaderDemand, SharedSparseBuffer, SparseStreamingBuffer};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
+use std::time::Instant;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::sync::Notify;
 use tracing::{debug, error, info};
+
+/// Prioritizes audio byte fetches so the track the user is waiting to hear gets
+/// the bandwidth. One foreground track is designated at a time -- the playing
+/// track -- and its fetches run immediately. A next-track preload's fetches wait
+/// while the foreground track has a fetch in flight, so preloading the next
+/// track can't take bandwidth from the current track's start. One arbiter is
+/// shared by every reader through the playback service; the service designates
+/// the foreground via [`FetchArbiter::set_foreground`] whenever a track becomes
+/// current.
+pub struct FetchArbiter {
+    /// The [`SparseStreamingBuffer::id`] of the foreground (playing) track, or
+    /// `u64::MAX` for none.
+    foreground_buffer: AtomicU64,
+    /// Count of foreground fetches currently awaiting bytes. A preload fetch
+    /// waits while this is non-zero.
+    foreground_inflight: AtomicU64,
+    /// Wakes waiting preload fetches when the foreground goes idle or changes.
+    idle: Notify,
+}
+
+impl FetchArbiter {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            foreground_buffer: AtomicU64::new(u64::MAX),
+            foreground_inflight: AtomicU64::new(0),
+            idle: Notify::new(),
+        })
+    }
+
+    /// Designate `buffer_id` as the foreground (playing) track. Wakes any
+    /// waiting preload in case the previous foreground is gone.
+    pub fn set_foreground(&self, buffer_id: u64) {
+        self.foreground_buffer.store(buffer_id, Ordering::Release);
+        self.idle.notify_waiters();
+    }
+
+    fn is_foreground(&self, buffer_id: u64) -> bool {
+        self.foreground_buffer.load(Ordering::Acquire) == buffer_id
+    }
+
+    fn begin_foreground_fetch(&self) {
+        self.foreground_inflight.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn end_foreground_fetch(&self) {
+        if self.foreground_inflight.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.idle.notify_waiters();
+        }
+    }
+
+    /// Wait until no foreground fetch is in flight. Arms the wake before reading
+    /// the count so a foreground fetch finishing between the check and the await
+    /// isn't missed.
+    async fn await_foreground_idle(&self) {
+        loop {
+            let waited = self.idle.notified();
+            if self.foreground_inflight.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            waited.await;
+        }
+    }
+}
 
 /// Reads audio data into a sparse buffer for streaming playback.
 ///
@@ -168,6 +233,7 @@ pub fn create_audio_reader(
     file_id: &str,
     cloud_path: Option<&str>,
     source_size: u64,
+    arbiter: Arc<FetchArbiter>,
 ) -> Box<dyn AudioDataReader> {
     let blob = coven::BlobRef {
         namespace: crate::sync::RELEASE_FILES_NAMESPACE.to_string(),
@@ -181,6 +247,7 @@ pub fn create_audio_reader(
         handle: library_manager.handle().clone(),
         blob,
         source_size,
+        arbiter,
     })
 }
 
@@ -192,6 +259,7 @@ pub struct CovenBlobReader {
     handle: coven::CovenHandle,
     blob: coven::BlobRef,
     source_size: u64,
+    arbiter: Arc<FetchArbiter>,
 }
 
 impl AudioDataReader for CovenBlobReader {
@@ -204,14 +272,47 @@ impl AudioDataReader for CovenBlobReader {
             handle,
             blob,
             source_size,
+            arbiter,
         } = *self;
+        let buffer_id = buffer.id();
         let (wake, buffer) = prepare_fill(buffer);
 
         tokio::spawn(async move {
-            info!("CovenBlobReader: source_size={source_size}");
+            info!("CovenBlobReader: buffer={buffer_id} source_size={source_size}");
+            // This reader's running fetch total and the wall-clock origin, so
+            // each window's log shows how many bytes have been pulled from coven
+            // and how long into the stream -- the visibility into start-up
+            // bandwidth and into a preload competing with the playing track.
+            let fetched = AtomicU64::new(0);
+            let started = Instant::now();
             let result = fill_buffer_on_demand(buffer.clone(), wake, |src_off, len| {
                 let fut = handle.open_blob_stream(&blob, source_size, src_off, len);
-                async move { fut.await.map_err(|e| e.to_string()) }
+                let arbiter = &arbiter;
+                let fetched = &fetched;
+                async move {
+                    // The playing track fetches immediately; a preload waits
+                    // while the playing track has a fetch in flight so it can't
+                    // slow the current track's start.
+                    let foreground = arbiter.is_foreground(buffer_id);
+                    let data = if foreground {
+                        arbiter.begin_foreground_fetch();
+                        let r = fut.await;
+                        arbiter.end_foreground_fetch();
+                        r
+                    } else {
+                        arbiter.await_foreground_idle().await;
+                        fut.await
+                    };
+                    let data = data.map_err(|e| e.to_string())?;
+                    let total =
+                        fetched.fetch_add(data.len() as u64, Ordering::Relaxed) + data.len() as u64;
+                    info!(
+                        "fetch buffer={buffer_id} {} off={src_off} len={len} total={total}B {}ms",
+                        if foreground { "playing" } else { "preload" },
+                        started.elapsed().as_millis(),
+                    );
+                    Ok(data)
+                }
             })
             .await;
 
@@ -464,6 +565,42 @@ mod tests {
     }
 
     const WINDOW: u64 = CLOUD_STREAM_READ_SIZE;
+
+    /// A preload reader's fetch waits while the playing track has a fetch in
+    /// flight, and proceeds once the playing track goes idle. This is the gate
+    /// that keeps preloading the next track from taking bandwidth from the track
+    /// the user just started. Sabotage — make `await_foreground_idle` return
+    /// immediately — and the waiter finishes while the playing track is still
+    /// fetching, failing the `!is_finished` assertion.
+    #[tokio::test]
+    async fn preload_fetch_yields_while_the_playing_track_is_fetching() {
+        let arbiter = FetchArbiter::new();
+        let playing = 1u64;
+        let preload = 2u64;
+
+        arbiter.set_foreground(playing);
+        assert!(arbiter.is_foreground(playing));
+        assert!(!arbiter.is_foreground(preload));
+
+        // The playing track has a fetch in flight.
+        arbiter.begin_foreground_fetch();
+
+        // A preload waiting for the foreground to idle must not proceed yet.
+        let waiting = arbiter.clone();
+        let waiter = tokio::spawn(async move { waiting.await_foreground_idle().await });
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "a preload must wait while the playing track is fetching"
+        );
+
+        // Once the playing track's fetch finishes, the preload proceeds.
+        arbiter.end_foreground_fetch();
+        timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("a preload must unblock once the playing track goes idle")
+            .expect("waiter task");
+    }
 
     /// Spawn the production `fill_buffer_on_demand` loop over an in-memory
     /// `blob`, filling `buffer`. The fetch serves `blob[start..end]` directly —

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -74,6 +74,24 @@ impl FetchArbiter {
             waited.await;
         }
     }
+
+    /// Run one fetch `fut` under the gate. A foreground (playing) fetch runs
+    /// immediately, tracked so preloads yield to it; a preload fetch waits until
+    /// no foreground fetch is in flight, then runs. `foreground` is the caller's
+    /// `is_foreground(buffer_id)`, taken once so the caller can reuse it (a log
+    /// label). Keeping the begin/end accounting here means it can't drift between
+    /// the fill and the prefetch.
+    async fn run_gated<F: std::future::Future>(&self, foreground: bool, fut: F) -> F::Output {
+        if foreground {
+            self.begin_foreground_fetch();
+            let out = fut.await;
+            self.end_foreground_fetch();
+            out
+        } else {
+            self.await_foreground_idle().await;
+            fut.await
+        }
+    }
 }
 
 /// Reads audio data into a sparse buffer for streaming playback.
@@ -349,15 +367,7 @@ impl AudioDataReader for CovenBlobReader {
                     // while the playing track has a fetch in flight so it can't
                     // slow the current track's start.
                     let foreground = arbiter.is_foreground(buffer_id);
-                    let data = if foreground {
-                        arbiter.begin_foreground_fetch();
-                        let r = fut.await;
-                        arbiter.end_foreground_fetch();
-                        r
-                    } else {
-                        arbiter.await_foreground_idle().await;
-                        fut.await
-                    };
+                    let data = arbiter.run_gated(foreground, fut).await;
                     let data = data.map_err(|e| e.to_string())?;
                     let total =
                         fetched.fetch_add(data.len() as u64, Ordering::Relaxed) + data.len() as u64;
@@ -430,19 +440,12 @@ fn spawn_window_prefetch(
     let started = Instant::now();
     tokio::spawn(async move {
         let foreground = arbiter.is_foreground(buffer_id);
-        let result = if foreground {
-            arbiter.begin_foreground_fetch();
-            let r = handle
-                .open_blob_stream(&blob, source_size, off, window)
-                .await;
-            arbiter.end_foreground_fetch();
-            r
-        } else {
-            arbiter.await_foreground_idle().await;
-            handle
-                .open_blob_stream(&blob, source_size, off, window)
-                .await
-        };
+        let result = arbiter
+            .run_gated(
+                foreground,
+                handle.open_blob_stream(&blob, source_size, off, window),
+            )
+            .await;
         match result {
             Ok(data) => {
                 if let Some(buf) = weak.upgrade() {

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -306,7 +306,7 @@ impl AudioDataReader for CovenBlobReader {
                     let data = data.map_err(|e| e.to_string())?;
                     let total =
                         fetched.fetch_add(data.len() as u64, Ordering::Relaxed) + data.len() as u64;
-                    info!(
+                    debug!(
                         "fetch buffer={buffer_id} {} off={src_off} len={len} total={total}B {}ms",
                         if foreground { "playing" } else { "preload" },
                         started.elapsed().as_millis(),

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -234,6 +234,8 @@ pub fn create_audio_reader(
     cloud_path: Option<&str>,
     source_size: u64,
     arbiter: Arc<FetchArbiter>,
+    prefetch_byte: Option<u64>,
+    prefetch_file_end: bool,
 ) -> Box<dyn AudioDataReader> {
     let blob = coven::BlobRef {
         namespace: crate::sync::RELEASE_FILES_NAMESPACE.to_string(),
@@ -248,6 +250,8 @@ pub fn create_audio_reader(
         blob,
         source_size,
         arbiter,
+        prefetch_byte,
+        prefetch_file_end,
     })
 }
 
@@ -260,6 +264,17 @@ pub struct CovenBlobReader {
     blob: coven::BlobRef,
     source_size: u64,
     arbiter: Arc<FetchArbiter>,
+    /// The byte the playing track's audio starts at, when it's past the header
+    /// (a track that seeks into the file). The reader fetches this window up
+    /// front, in parallel with the demuxer's header probe, so the decoder's seek
+    /// finds the bytes already buffered instead of paying a second serial
+    /// round-trip. `None` for a track that starts at byte 0.
+    prefetch_byte: Option<u64>,
+    /// Whether to also prefetch the file's end window. `true` for APE, whose
+    /// demuxer reads the tail (its mandatory index lives there) when it opens, so
+    /// the open would otherwise stall on a serial ranged fetch. The shared album
+    /// buffer keeps the window, so it's pulled once per image.
+    prefetch_file_end: bool,
 }
 
 impl AudioDataReader for CovenBlobReader {
@@ -273,8 +288,48 @@ impl AudioDataReader for CovenBlobReader {
             blob,
             source_size,
             arbiter,
+            prefetch_byte,
+            prefetch_file_end,
         } = *self;
         let buffer_id = buffer.id();
+
+        // Prefetch the track's start window in parallel with the demuxer's header
+        // probe. The decoder reads the header at byte 0, then seeks to the track;
+        // that seek is a second serial round-trip over a cloud home. Since the
+        // stored `start_byte` is the exact seektable landing (the playback seek
+        // lands there — a by-byte FLAC seek jumps straight to it, and APE
+        // sample-seeks its index to it), pull that window now, concurrent with the
+        // probe, so the seek lands on buffered bytes.
+        if let Some(start) = prefetch_byte {
+            if start < source_size {
+                spawn_window_prefetch(
+                    handle.clone(),
+                    blob.clone(),
+                    arbiter.clone(),
+                    &buffer,
+                    source_size,
+                    start,
+                    "track-start",
+                );
+            }
+        }
+
+        // APE reads the file's end when its demuxer opens (its index lives in the
+        // tail), so prefetch that window too — otherwise the open stalls on a
+        // serial ranged fetch of the end. Skipped when the file is a single window
+        // (the fill covers it).
+        if prefetch_file_end && source_size > CLOUD_STREAM_READ_SIZE {
+            spawn_window_prefetch(
+                handle.clone(),
+                blob.clone(),
+                arbiter.clone(),
+                &buffer,
+                source_size,
+                source_size - CLOUD_STREAM_READ_SIZE,
+                "file-end",
+            );
+        }
+
         let (wake, buffer) = prepare_fill(buffer);
 
         tokio::spawn(async move {
@@ -351,6 +406,57 @@ const MIN_READAHEAD: u64 = CLOUD_STREAM_READ_SIZE;
 /// evicted. A margin for the decoder's brief backward reads; everything older is
 /// dropped so memory stays bounded to a window around the playhead.
 const KEEP_BEHIND: u64 = CLOUD_STREAM_READ_SIZE;
+
+/// Fetch one window starting at `off` up front, in parallel with the demuxer's
+/// header probe, and append it to `buffer` so a later read finds it buffered
+/// instead of paying a serial round-trip over a cloud home. Arbiter-gated exactly
+/// like the fill: the playing track fetches immediately; a preload yields while
+/// the playing track has a fetch in flight, so preloading the next track can't
+/// steal the current track's startup bandwidth. Best-effort — a failed prefetch
+/// just leaves the fill to fetch the window on demand. `what` labels the window
+/// (track-start / file-end) in the log.
+fn spawn_window_prefetch(
+    handle: coven::CovenHandle,
+    blob: coven::BlobRef,
+    arbiter: Arc<FetchArbiter>,
+    buffer: &SharedSparseBuffer,
+    source_size: u64,
+    off: u64,
+    what: &'static str,
+) {
+    let buffer_id = buffer.id();
+    let weak = Arc::downgrade(buffer);
+    let window = CLOUD_STREAM_READ_SIZE.min(source_size - off);
+    let started = Instant::now();
+    tokio::spawn(async move {
+        let foreground = arbiter.is_foreground(buffer_id);
+        let result = if foreground {
+            arbiter.begin_foreground_fetch();
+            let r = handle
+                .open_blob_stream(&blob, source_size, off, window)
+                .await;
+            arbiter.end_foreground_fetch();
+            r
+        } else {
+            arbiter.await_foreground_idle().await;
+            handle
+                .open_blob_stream(&blob, source_size, off, window)
+                .await
+        };
+        match result {
+            Ok(data) => {
+                if let Some(buf) = weak.upgrade() {
+                    debug!(
+                        "prefetch buffer={buffer_id} {what} off={off} len={window} {}ms",
+                        started.elapsed().as_millis()
+                    );
+                    buf.append_at(off, &data);
+                }
+            }
+            Err(e) => debug!("prefetch buffer={buffer_id} {what} off={off} failed: {e}"),
+        }
+    });
+}
 
 /// The next region to fetch, given each live reader's demand ascending by
 /// position: serve the lowest-position reader first so the playing track stays
@@ -694,6 +800,68 @@ mod tests {
             WINDOW,
             6 * WINDOW,
             log,
+        );
+    }
+
+    /// The parallel prefetch removes the serial fetch at the track's start byte:
+    /// with the landing window already buffered (the prefetch completed), the fill
+    /// serves the seek target without fetching it; with a cold buffer the fill must
+    /// fetch that window. This is the whole point of pulling the start byte in
+    /// parallel with the header probe -- the decoder's seek lands on buffered bytes
+    /// instead of a second round-trip.
+    #[tokio::test]
+    async fn prefetched_start_window_removes_the_seek_target_fetch() {
+        let source_size = 8 * WINDOW;
+        let blob: Vec<u8> = (0..source_size).map(|i| (i % 251) as u8).collect();
+        let start_byte = 3 * WINDOW; // a deep track's landing
+
+        // Read one byte at `start_byte` and return the fill's fetch log.
+        async fn seek_and_log(
+            buffer: SharedSparseBuffer,
+            blob: Vec<u8>,
+            start_byte: u64,
+        ) -> Vec<(u64, u64)> {
+            let mut reader = buffer.new_reader();
+            assert!(reader.seek(start_byte));
+            let read_log = start_recording_fill(blob, None, &buffer);
+            let served = tokio::task::spawn_blocking(move || {
+                let mut b = [0u8; 1];
+                let n = reader.read(&mut b);
+                drop(reader);
+                n
+            })
+            .await
+            .expect("seek read task");
+            assert_eq!(served, Some(1), "the seek target byte must be served");
+            // Let the fill settle so its read-ahead fetches are recorded.
+            for _ in 0..100 {
+                tokio::task::yield_now().await;
+            }
+            buffer.cancel();
+            let log = read_log.lock().unwrap().clone();
+            log
+        }
+
+        // With the landing window already buffered (the prefetch completed), the
+        // fill must not fetch it.
+        let prefetched = create_sparse_buffer(source_size);
+        prefetched.append_at(
+            start_byte,
+            &blob[start_byte as usize..(start_byte + WINDOW) as usize],
+        );
+        let with = seek_and_log(prefetched, blob.clone(), start_byte).await;
+        assert!(
+            !with.iter().any(|&(start, _)| start == start_byte),
+            "prefetched: the fill must not re-fetch the already-buffered start \
+             window; log: {with:?}"
+        );
+
+        // Cold buffer: the fill must fetch the start window to serve the seek.
+        let cold = create_sparse_buffer(source_size);
+        let without = seek_and_log(cold, blob, start_byte).await;
+        assert!(
+            without.iter().any(|&(start, _)| start == start_byte),
+            "cold: the fill must fetch the start window; log: {without:?}"
         );
     }
 

--- a/bae-core/src/playback/preview_player.rs
+++ b/bae-core/src/playback/preview_player.rs
@@ -364,6 +364,7 @@ impl PreviewPlayer {
             if let Err(e) = crate::audio_codec::decode_audio_streaming(
                 decoder_buffer,
                 &mut sink,
+                None,
                 seek_to_sample,
                 None,
                 None,

--- a/bae-core/src/playback/service/advance.rs
+++ b/bae-core/src/playback/service/advance.rs
@@ -54,6 +54,7 @@ impl PlaybackService {
             track_id,
             &mut self.shared_file_buffer,
             self.progress_tx.clone(),
+            self.fetch_arbiter.clone(),
         )
         .await;
         let prepared = match prepared {
@@ -372,6 +373,9 @@ impl PlaybackService {
         }
 
         self.current_prepared = Some(next_prepared);
+        // The crossed-into track is now playing: hand its reader fetch priority
+        // over the track preloaded below.
+        self.mark_current_foreground();
 
         // Advance the queue position to the now-playing track.
         self.advance_to_preloaded();
@@ -483,6 +487,9 @@ impl PlaybackService {
         // decoder was cancelled above via the source.
         self.current_decoder_handle = self.next_decoder_handle.take();
         self.current_prepared = Some(next_prepared);
+        // The preloaded track is now the playing one: hand its reader fetch
+        // priority over whatever gets preloaded next.
+        self.mark_current_foreground();
 
         // Natural transition: start at position 0 (INDEX 00, pregap plays).
         let fmt = self

--- a/bae-core/src/playback/service/mod.rs
+++ b/bae-core/src/playback/service/mod.rs
@@ -483,7 +483,20 @@ impl PlaybackPreparedTrack {
     /// advance, the pregap skip or a seek position otherwise. Shared by the
     /// play/preload/seek paths so they can't drift on the seek/trim mapping.
     fn decode_params(&self, offset: u64) -> StreamDecodeParams {
+        use crate::util::content_type::ContentType;
+        // Byte-seek only at the natural track start (offset 0): the stored
+        // `start_byte` is the seektable landing for `start_sample`, not for an
+        // arbitrary in-track seek. A mid-track seek (offset > 0) has no recorded
+        // byte, so it sample-seeks. APE carries no per-frame byte position, so it
+        // always sample-seeks its mandatory index. Everything else (FLAC/lossless)
+        // byte-seeks straight to the landing, avoiding the seektable round-trip.
+        let seek_to_byte = if offset == 0 && self.content_type != ContentType::Ape {
+            self.start_byte
+        } else {
+            None
+        };
         StreamDecodeParams {
+            seek_to_byte,
             target_sample: self.start_sample + offset,
             stop_at_sample: self.end_sample,
             end_byte: self.end_byte,
@@ -513,6 +526,13 @@ struct PlaybackPreparedTrack {
     /// This track's sample window in its backing file (start 0 / end None = whole file).
     start_sample: u64,
     end_sample: Option<u64>,
+    /// This track's audio codec. Selects the track-start seek: FLAC/lossless
+    /// byte-seek to `start_byte`; APE sample-seeks its index.
+    content_type: crate::util::content_type::ContentType,
+    /// The byte this track's audio begins at within its backing file (the
+    /// seektable landing recorded at import). `None` = starts at byte 0. Used as
+    /// the by-byte seek target for a lossless track's natural start.
+    start_byte: Option<u64>,
     /// This track's byte span in its backing file (frame-granular; end None =
     /// whole file). The decoder hands `end_byte` to its reader as the read-ahead
     /// ceiling so the fill buffers the rest of the current track.
@@ -555,6 +575,8 @@ fn finalize_playback_track(
         duration,
         start_sample: resolved.start_sample,
         end_sample: resolved.end_sample,
+        content_type: resolved.content_type,
+        start_byte: resolved.start_byte,
         end_byte: resolved.end_byte,
         replay_gain_linear,
     }
@@ -597,6 +619,8 @@ async fn prepare_track_for_playback(
             resolved.cloud_path.as_deref(),
             source_size,
             fetch_arbiter,
+            resolved.start_byte,
+            resolved.content_type == crate::util::content_type::ContentType::Ape,
         );
         reader.start_reading(buffer.clone(), progress_tx);
         *shared_file_buffer = Some((cache_key, buffer.clone()));
@@ -864,10 +888,17 @@ pub(crate) async fn teardown_decoder_for_seek(
     }
 }
 
-/// The sample-space decoder window for one stream: `target_sample` is where
-/// FFmpeg seeks and trims lead-in (the track's start plus any pregap/seek
-/// offset); `stop_at_sample` ends output at the track's end (`None` = to EOF).
+/// The decoder window for one stream. `target_sample` is where FFmpeg trims
+/// lead-in (the track's start plus any pregap/seek offset). The seek to it is
+/// either a by-byte jump (`seek_to_byte`, a lossless track's natural start) or a
+/// sample seek (APE, or a mid-track seek); the `target_sample` trim makes the
+/// first output sample exact either way. `stop_at_sample` ends output at the
+/// track's end (`None` = to EOF).
 struct StreamDecodeParams {
+    /// When set, byte-seek straight to this offset (a lossless track's natural
+    /// start, the recorded seektable landing). `None` sample-seeks to
+    /// `target_sample` instead (APE's index, or a mid-track seek).
+    seek_to_byte: Option<u64>,
     target_sample: u64,
     stop_at_sample: Option<u64>,
     /// The track's end byte offset -- the read-ahead ceiling. `None` = whole file.
@@ -875,19 +906,29 @@ struct StreamDecodeParams {
 }
 
 impl StreamDecodeParams {
-    /// Run the streaming decoder for this window: FFmpeg seeks and trims at
-    /// `target_sample` and stops at `stop_at_sample`. Shared by the play/seek and
-    /// preload paths so they can't drift on the seek/trim mapping.
+    /// Run the streaming decoder for this window: FFmpeg seeks (by byte or by
+    /// sample), trims lead-in at `target_sample`, and stops at `stop_at_sample`.
+    /// Shared by the play/seek and preload paths so they can't drift on the
+    /// seek/trim mapping.
     fn run_decoder(
         &self,
         buffer: SharedSparseBuffer,
         sink: &mut crate::playback::track_stream::TrackSink,
         cancel: Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<(), StreamingDecodeError> {
+        // Byte seek and sample seek are mutually exclusive: with a byte landing we
+        // jump to it, else we sample-seek. `start_at_sample` trims lead-in either
+        // way so the first output sample is exactly `target_sample`.
+        let seek_to_sample = if self.seek_to_byte.is_some() {
+            None
+        } else {
+            Some(self.target_sample)
+        };
         crate::audio_codec::decode_audio_streaming(
             buffer,
             sink,
-            Some(self.target_sample),
+            self.seek_to_byte,
+            seek_to_sample,
             Some(self.target_sample),
             self.stop_at_sample,
             self.end_byte,

--- a/bae-core/src/playback/service/mod.rs
+++ b/bae-core/src/playback/service/mod.rs
@@ -32,7 +32,7 @@ use crate::library::LibraryEvent;
 use crate::library::LibraryManager;
 use crate::library::ResolvedTrackAudio;
 use crate::playback::audio_output::{AudioOutput, AudioStream, CompletionEvent, PositionEvent};
-use crate::playback::data_source::create_audio_reader;
+use crate::playback::data_source::{create_audio_reader, FetchArbiter};
 use crate::playback::error::PlaybackError;
 use crate::playback::progress::emit_progress;
 use crate::playback::progress::{PlaybackProgress, PlaybackProgressHandle};
@@ -565,6 +565,7 @@ async fn prepare_track_for_playback(
     track_id: &str,
     shared_file_buffer: &mut Option<(String, SharedSparseBuffer)>,
     progress_tx: tokio_mpsc::UnboundedSender<PlaybackProgress>,
+    fetch_arbiter: Arc<FetchArbiter>,
 ) -> Result<PlaybackPreparedTrack, PlaybackError> {
     let (resolved, track_info) = library_manager
         .resolve_track_audio_and_info(track_id)
@@ -595,6 +596,7 @@ async fn prepare_track_for_playback(
             &resolved.file_id,
             resolved.cloud_path.as_deref(),
             source_size,
+            fetch_arbiter,
         );
         reader.start_reading(buffer.clone(), progress_tx);
         *shared_file_buffer = Some((cache_key, buffer.clone()));
@@ -667,6 +669,22 @@ pub struct PlaybackService {
     /// Bridged to `TrackCrossed`.
     boundary_tx: tokio_mpsc::UnboundedSender<TrackCrossing>,
     pending_side_pause: Option<SidePauseDecision>,
+    /// Prioritizes byte fetches across tracks: the current track's reader fetches
+    /// immediately, a next-track preload's reader yields to it. Shared into every
+    /// reader; the current track is designated foreground via
+    /// `mark_current_foreground` whenever it becomes current.
+    fetch_arbiter: Arc<FetchArbiter>,
+}
+
+impl PlaybackService {
+    /// Designate the current track's buffer as the foreground for fetch
+    /// priority, so its reader fetches immediately and a next-track preload's
+    /// reader yields to it. Called wherever a track becomes the current one.
+    fn mark_current_foreground(&self) {
+        if let Some(prepared) = &self.current_prepared {
+            self.fetch_arbiter.set_foreground(prepared.buffer.id());
+        }
+    }
 }
 
 fn side_pause_prompt_between(
@@ -1007,6 +1025,7 @@ impl PlaybackService {
                     last_position_display,
                     boundary_tx,
                     pending_side_pause: None,
+                    fetch_arbiter: FetchArbiter::new(),
                 };
                 match service.library_manager.load_playback_state().await {
                     Ok(Some(state)) => match PersistedPlayback::from_row(state) {

--- a/bae-core/src/playback/service/pipeline.rs
+++ b/bae-core/src/playback/service/pipeline.rs
@@ -297,6 +297,7 @@ impl PlaybackService {
             track_id,
             &mut self.shared_file_buffer,
             self.progress_tx.clone(),
+            self.fetch_arbiter.clone(),
         )
         .await;
         let prepared = match prepared {
@@ -356,6 +357,9 @@ impl PlaybackService {
         // Store prepared track state so the shared tail reads this load's buffer
         // and cancel token.
         self.current_prepared = Some(prepared);
+        // This track is now the one the user is waiting to hear: its reader
+        // fetches with priority, the next-track preload below yields to it.
+        self.mark_current_foreground();
         if !self
             .start_decoder_and_watch(decode, fmt, sample_rate, channels, track_id.to_string())
             .await

--- a/bae-core/src/playback/sparse_buffer.rs
+++ b/bae-core/src/playback/sparse_buffer.rs
@@ -14,6 +14,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use tokio::sync::Notify;
 
+/// Hands each buffer a small process-unique id so the fill's per-window fetch
+/// logs and the decoder's first-sample log can be tied to one track's stream.
+static NEXT_BUFFER_ID: AtomicU64 = AtomicU64::new(0);
+
 /// A contiguous range of buffered data.
 #[derive(Debug, Clone)]
 struct BufferedRange {
@@ -109,6 +113,14 @@ pub struct SparseStreamingBuffer {
     /// Hands out a unique id per reader so each reader's demand has its own slot
     /// in `SparseInner::demands`.
     next_reader_id: AtomicU64,
+    /// Process-unique id for this buffer, for log correlation (the fill's
+    /// per-window fetch logs and the decoder's first-sample log carry it) and as
+    /// the [`crate::playback::data_source::FetchArbiter`] foreground designation.
+    id: u64,
+    /// Total bytes appended into this buffer (every fill window that landed,
+    /// including a window re-fetched after a backward seek). Lets the decoder
+    /// report how much was fetched from coven to reach the first audio sample.
+    bytes_fetched: AtomicU64,
     /// Every byte offset a reader was positioned at when `read()` served bytes,
     /// in call order. Lets a test see the demuxer's actual read pattern -- e.g.
     /// whether a seek jumped near the target (seektable) or read the file's end
@@ -131,9 +143,24 @@ impl SparseStreamingBuffer {
             data_available: Condvar::new(),
             fill_wake: Arc::new(Notify::new()),
             next_reader_id: AtomicU64::new(0),
+            id: NEXT_BUFFER_ID.fetch_add(1, Ordering::Relaxed),
+            bytes_fetched: AtomicU64::new(0),
             #[cfg(test)]
             read_log: Mutex::new(Vec::new()),
         }
+    }
+
+    /// This buffer's process-unique id, used to correlate fetch/first-sample
+    /// logs for one track and to designate the foreground track in the
+    /// [`crate::playback::data_source::FetchArbiter`].
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Total bytes appended into this buffer so far. Read by the decoder to
+    /// report how much was fetched from coven before the first audio sample.
+    pub fn bytes_fetched(&self) -> u64 {
+        self.bytes_fetched.load(Ordering::Relaxed)
     }
 
     /// Test-only: the byte offsets `read()` served, in call order.
@@ -180,6 +207,9 @@ impl SparseStreamingBuffer {
         if bytes.is_empty() {
             return;
         }
+
+        self.bytes_fetched
+            .fetch_add(bytes.len() as u64, Ordering::Relaxed);
 
         let mut inner = self.inner.lock().unwrap();
         let new_end = offset + bytes.len() as u64;

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -71,6 +71,23 @@ async fn test_cue_flac_records_track_positions() {
                 audio_format.start_sample, 0,
                 "the first CUE/FLAC track starts at sample 0",
             );
+            assert_eq!(
+                audio_format.start_byte, None,
+                "the first CUE/FLAC track starts at byte 0 (no prefetch, header covers it)",
+            );
+        } else {
+            // A deep track records the seektable landing for its start_sample --
+            // the byte playback byte-seeks to. Contiguous tracks share a boundary,
+            // so it equals the prior track's end byte (both are the same seek
+            // landing computed by a binary search over the frames).
+            let start_byte = audio_format.start_byte.unwrap_or_else(|| {
+                panic!("deep CUE/FLAC track {} should record a start byte", i + 1)
+            });
+            assert!(
+                start_byte > 0,
+                "track {} start byte should be a real file offset, got {start_byte}",
+                i + 1,
+            );
         }
         // Every track but the last carries an end sample; the last runs to EOF.
         if i < tracks.len() - 1 {
@@ -124,6 +141,17 @@ async fn test_cue_flac_records_track_positions() {
                     i,
                 );
             }
+            // Tracks of one file are back-to-back byte ranges: this track's start
+            // sample is the prior track's end sample, and both the start-byte seek
+            // and the end-byte seek binary-search to that same frame. So the stored
+            // start byte equals the prior track's end byte.
+            assert_eq!(
+                audio_format.start_byte,
+                prev_format.end_byte,
+                "track {} start byte should equal track {} end byte (contiguous seek landing)",
+                i + 1,
+                i,
+            );
         }
         info!(
             "Track {} '{}': samples {}..{:?}",

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -2087,7 +2087,8 @@ async fn import_truncated_album(verify: bool) -> Result<(String, String), String
 async fn verify_decode_on_import_gates_a_broken_track() {
     support::tracing_init();
 
-    // Flag off: today's behavior -- the broken album still imports.
+    // Flag off: the import does not assert on decode integrity, so the broken
+    // album still imports.
     let off = import_truncated_album(false).await;
     assert!(
         off.is_ok(),

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -1990,3 +1990,115 @@ async fn unknown_import_with_no_tags_seeds_title_from_folder_name() {
     let tracks = f.db.get_tracks_for_release(&release_id).await.unwrap();
     assert_eq!(tracks.len(), 2, "both untagged files import as tracks");
 }
+
+/// Truncate a FLAC's body on disk while keeping its header and tags: a valid
+/// STREAMINFO (declaring the full sample count) over a short audio body. Kept
+/// size stays above the scanner's gross-size floor (10% of the raw PCM size, ~44
+/// KB for the 5s mono fixture) so the file passes scan and reaches the loudness
+/// loop, but far too little audio to decode the declared samples -- the
+/// decode-verify shortfall signature.
+fn truncate_flac_body(path: &Path) {
+    let bytes = fs::read(path).expect("read flac to truncate");
+    // The 5s/44.1k/mono/16-bit fixture declares 220_500 samples => 441_000 raw
+    // bytes; the scan rejects below 44_100. 46_000 clears that while cutting the
+    // bulk of the ~68 KB audio body.
+    let keep = 46_000usize.min(bytes.len());
+    assert!(
+        bytes.len() > keep,
+        "fixture is smaller than the truncation target ({} bytes)",
+        bytes.len(),
+    );
+    fs::write(path, &bytes[..keep]).expect("write truncated flac");
+}
+
+/// Import a one-track album whose FLAC is truncated (valid header, short body),
+/// with `verify_decode_on_import` set to `verify`. Returns the import outcome.
+async fn import_truncated_album(verify: bool) -> Result<(String, String), String> {
+    let temp = TempDir::new().unwrap();
+    let db_dir = temp.path().join("db");
+    fs::create_dir_all(&db_dir).unwrap();
+    let db = Database::new_test(
+        db_dir.join("test.db").to_str().unwrap(),
+        std::sync::Arc::new(coven::SystemClock),
+    )
+    .await
+    .unwrap();
+    let library_dir = LibraryDir::new(db_dir.clone());
+    let (config_handle, key_service) = support::test_config_and_keys(&library_dir);
+    config_handle
+        .update(|c| c.verify_decode_on_import = verify)
+        .expect("set verify_decode_on_import");
+    let library_manager = LibraryManager::new(
+        db.clone(),
+        library_dir,
+        config_handle,
+        key_service,
+        std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
+        tokio::runtime::Handle::current(),
+    );
+    let handle = ImportService::start(
+        tokio::runtime::Handle::current(),
+        library_manager,
+        bae_core::import::cover_art::CoverArtArchiveClient::new(),
+    );
+
+    let album_dir = temp.path().join("album");
+    fs::create_dir_all(&album_dir).unwrap();
+    generate_tagged_album_files(
+        &album_dir,
+        "Broken Album",
+        "Broken Artist",
+        None,
+        &[TaggedTrack {
+            filename: "01.flac",
+            title: "Broken Track",
+            track_number: 1,
+        }],
+    );
+    truncate_flac_body(&album_dir.join("01.flac"));
+
+    let import_id = uuid::Uuid::new_v4().to_string();
+    handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: None,
+            storage_mode: StorageMode::Local,
+            pin: false,
+            identity_choice: IdentityChoice::Unknown,
+            user_edit: None,
+        })
+        .unwrap();
+    let mut progress_rx = handle.subscribe_import(import_id);
+    let result = support::try_wait_for_import_complete(&mut progress_rx).await;
+    // Keep the temp dir (and its files) alive until the import has finished.
+    drop(temp);
+    result
+}
+
+/// `verify_decode_on_import` gates a broken track end to end: a truncated FLAC
+/// (valid header, short body) that decodes short imports fine with the flag off,
+/// and fails at the decode-verify gate -- before finalize commits anything -- with
+/// the flag on. Proves the flag drives the outcome, not the fixture.
+#[tokio::test]
+#[serial]
+async fn verify_decode_on_import_gates_a_broken_track() {
+    support::tracing_init();
+
+    // Flag off: today's behavior -- the broken album still imports.
+    let off = import_truncated_album(false).await;
+    assert!(
+        off.is_ok(),
+        "with verify_decode_on_import off, a broken album must still import, got: {off:?}",
+    );
+
+    // Flag on (the default): the same album fails at the decode-verify gate.
+    let on = import_truncated_album(true).await;
+    let err = on.expect_err("with verify_decode_on_import on, a broken album must fail the import");
+    assert!(
+        err.contains("decode verification failed"),
+        "the failure must come from decode-verify, got: {err}",
+    );
+}


### PR DESCRIPTION
Starting a track that lives partway into a single-file cloud album used to cost two or more *serial* ranged fetches: read the header at byte 0, wait for the demuxer's seek to resolve, then fetch the track's audio. coven round-trips are latency-bound (~0.5–1s each regardless of size), so a deep track on a 243 MB release took ~2.8s to make a sound. This fetches the pieces in parallel instead — roughly one round-trip, ~1.2s.

The mechanism is a landing byte computed once at import (`seek_landing_bytes`: an AVIO position read after a non-fast-seek, so it binary-searches real frames and works for APE and FLACs with an unusable or placeholder seektable) and stored per track as `start_byte`. At play time FLAC jumps straight there with a by-byte seek — no seektable needed, which also fixes seektable-less vinyl rips — and the decoder's existing lead-in trim keeps it sample-exact. APE can't byte-seek (no per-frame positions, and its demuxer reads the file end on open), so it sample-seeks via its index and we prefetch the end-of-file slice alongside the landing. A mid-track user seek still sample-seeks to the real target rather than byte-seeking to the track start. The `FetchArbiter` keeps next-track preload from stealing the playing track's bandwidth.

The same change verifies every track actually decodes, riding the full decode the loudness pass already does at import (no second decode). A track with decode-loop errors or a frame count short of its declared length is flagged broken; with `verify_decode_on_import` on (default), an album with a broken track fails the import instead of importing silently and failing at play time. The error counter is reset after `find_stream_info` so an embedded cover's mjpeg probe doesn't false-positive a clean track.

Greenfield: the `start_byte` column requires `rm -rf ~/.bae` and a re-import to populate.

## Test plan
- `cargo test -p bae-core --features test-utils` — green.
- Byte-seek accuracy + causation (wrong byte → not sample-exact), prefetch removes the seek-target fetch, `start_byte` persisted per track, truncated FLAC flagged broken, and `verify_decode_on_import` on/off gating the import end to end.
- Not yet verified on device/cloud: the ~2.8s → ~1.2s startup win and real fetch counts (only the bae-core suite ran in this worktree).