### PR TITLE
Compute CUE track end bytes from the AVIO landing, not the packet pos

### DIFF
--- a/bae-core/src/audio_codec/mod.rs
+++ b/bae-core/src/audio_codec/mod.rs
@@ -19,7 +19,7 @@ use avio::{avio_write_callback, avio_write_seek_callback, WriteAvioContext};
 
 pub use decode::{decode_audio, decode_audio_streaming, decode_audio_to_sink};
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
-pub use probe::{frame_byte_offsets, seek_landing_bytes};
+pub use probe::seek_landing_bytes;
 pub use probe::{probe_audio_from_path, ProbeResult};
 
 /// Buffer size for FFmpeg custom-IO (`avio`) contexts. The standard 32 KiB

--- a/bae-core/src/audio_codec/probe.rs
+++ b/bae-core/src/audio_codec/probe.rs
@@ -1,6 +1,6 @@
 //! Probing and format detection: open a file by path, inspect its best audio
-//! stream, and report container/codec properties (`ProbeResult`) or per-sample
-//! frame byte offsets (`frame_byte_offsets`).
+//! stream, and report container/codec properties (`ProbeResult`) or the byte the
+//! demuxer lands on when seeking to each of a set of samples (`seek_landing_bytes`).
 
 use crate::util::content_type::ContentType;
 use std::os::raw::c_int;
@@ -211,93 +211,12 @@ fn sample_to_timestamp(
     }
 }
 
-/// The byte offset in the file of the frame containing each of `samples`, found
-/// by seeking -- not decoding. For each sample the demuxer is seeked to it and
-/// the next frame's byte position is read back: the frame at or before the
-/// sample, since FLAC and APE frames are independently seekable. Frame-granular
-/// (the offset is at or just before the exact sample), which is all the read-ahead
-/// ceiling needs. Used at import to record where each track of a single-file
-/// album begins in the file. `samples` should be ascending. Returns `None` if the
-/// file can't be opened, has no audio stream, or any sample's frame position
-/// can't be read -- the caller then treats the whole file as one span.
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
-pub fn frame_byte_offsets(path: &str, samples: &[u64]) -> Option<Vec<u64>> {
-    unsafe {
-        use ffmpeg_sys_next::*;
-
-        let (mut fmt_ctx, stream_index) = open_best_audio_stream(path, "frame_byte_offsets")?;
-        let stream = *(*fmt_ctx).streams.add(stream_index as usize);
-        let time_base = (*stream).time_base;
-        let sample_rate = (*(*stream).codecpar).sample_rate as i64;
-
-        let packet = av_packet_alloc();
-        if packet.is_null() {
-            warn!("frame_byte_offsets: failed to allocate packet for {path}");
-            avformat_close_input(&mut fmt_ctx);
-            return None;
-        }
-
-        // Compute every offset, or bail out (returning None) if any sample's
-        // frame position can't be read -- a half-faked boundary list is worse
-        // than falling back to the whole file.
-        let mut offsets = Vec::with_capacity(samples.len());
-        let mut failed: Option<String> = None;
-        for &sample in samples {
-            let Some(target_ts) = sample_to_timestamp(sample, time_base, sample_rate) else {
-                failed = Some(format!("invalid time base for sample {sample}"));
-                break;
-            };
-            if av_seek_frame(
-                fmt_ctx,
-                stream_index,
-                target_ts,
-                AVSEEK_FLAG_BACKWARD as c_int,
-            ) < 0
-            {
-                failed = Some(format!("seek to sample {sample} failed"));
-                break;
-            }
-
-            // The next packet for our stream carries its byte position in `pos`.
-            let mut pos = None;
-            while av_read_frame(fmt_ctx, packet) >= 0 {
-                let is_audio = (*packet).stream_index == stream_index;
-                let p = (*packet).pos;
-                av_packet_unref(packet);
-                if is_audio {
-                    if p >= 0 {
-                        pos = Some(p as u64);
-                    }
-                    break;
-                }
-            }
-            match pos {
-                Some(p) => offsets.push(p),
-                None => {
-                    failed = Some(format!("no frame position at sample {sample}"));
-                    break;
-                }
-            }
-        }
-
-        av_packet_free(&mut (packet as *mut _));
-        avformat_close_input(&mut fmt_ctx);
-        match failed {
-            Some(reason) => {
-                warn!("frame_byte_offsets: {reason} in {path}");
-                None
-            }
-            None => Some(offsets),
-        }
-    }
-}
-
 /// The byte the demuxer reads from after seeking to each of `samples` -- read
 /// from the AVIO position (`avio_tell`) right after the seek, the way the demuxer
 /// itself positions. Recorded at import as each track's start byte.
 ///
-/// Two reasons this lands where `frame_byte_offsets` (which reads the packet
-/// `pos`) returns `None` or a wrong value:
+/// Two reasons this reads a byte where reading the demuxer packet's `pos` returns
+/// `None` or a wrong value:
 /// - The AVIO position is defined for every format. APE packets carry no byte
 ///   position; a FLAC with placeholder seektable points returns none either.
 /// - It does *not* set `AVFMT_FLAG_FAST_SEEK` (`open_best_audio_stream` leaves it

--- a/bae-core/src/audio_codec/tests.rs
+++ b/bae-core/src/audio_codec/tests.rs
@@ -3,11 +3,11 @@ use super::*;
 use crate::util::content_type::ContentType;
 use std::sync::Arc;
 
-/// `frame_byte_offsets` actually opens the file, seeks (no decode), and
+/// `seek_landing_bytes` actually opens the file, seeks (no decode), and
 /// reports ascending byte positions within the file that follow the sample
 /// positions -- what the import-time byte boundary computation relies on.
 #[test]
-fn frame_byte_offsets_track_sample_positions() {
+fn seek_landing_bytes_track_sample_positions() {
     init();
     let sample_rate = 44100u32;
     let seconds = 4usize;
@@ -28,7 +28,7 @@ fn frame_byte_offsets_track_sample_positions() {
     let probes: Vec<u64> = (0..seconds as u64)
         .map(|s| s * sample_rate as u64)
         .collect();
-    let offsets = frame_byte_offsets(path, &probes).expect("frame_byte_offsets");
+    let offsets = seek_landing_bytes(path, &probes).expect("seek_landing_bytes");
     assert_eq!(offsets.len(), probes.len());
 
     // Non-decreasing and within the file.
@@ -52,7 +52,7 @@ fn frame_byte_offsets_track_sample_positions() {
     );
 }
 
-/// `frame_byte_offsets` against the real single-file CUE/FLAC fixture:
+/// `seek_landing_bytes` against the real single-file CUE/FLAC fixture:
 /// silence -> white noise -> brown noise, so the bitrate swings widely from
 /// track to track. The seek offsets follow the *content*, not time -- the
 /// silence track compresses to almost nothing, so the 10s track-2 boundary
@@ -60,7 +60,7 @@ fn frame_byte_offsets_track_sample_positions() {
 /// estimate puts it. That gap is why the offsets are computed at import by
 /// seeking rather than estimated from time at playback.
 #[test]
-fn frame_byte_offsets_follow_content_not_time_when_bitrate_swings() {
+fn seek_landing_bytes_follow_content_not_time_when_bitrate_swings() {
     init();
     let path = concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -73,7 +73,7 @@ fn frame_byte_offsets_follow_content_not_time_when_bitrate_swings() {
 
     // Track starts from the CUE: 0s (silence), 10s (white noise), 20s (brown).
     let starts = [0u64, 10 * sr, 20 * sr];
-    let exact = frame_byte_offsets(path, &starts).expect("offsets");
+    let exact = seek_landing_bytes(path, &starts).expect("offsets");
 
     // Time-proportional estimate -- what we'd get without seeking.
     let proportional: Vec<u64> = starts
@@ -97,6 +97,14 @@ fn frame_byte_offsets_follow_content_not_time_when_bitrate_swings() {
     );
     // Ascending and within the file.
     assert!(exact[0] <= exact[1] && exact[1] <= exact[2] && exact[2] < file_size);
+    // The brown-noise track (20s start) lands deep in the file -- it compresses
+    // far worse than the silence, so most of the file is its bytes. Confirms the
+    // landings track content in both directions, not just the silent-track dip.
+    assert!(
+        exact[2] as f64 > file_size as f64 * 0.4,
+        "brown-noise track start lands deep in the file: {} of {file_size}",
+        exact[2]
+    );
 }
 
 #[test]
@@ -606,52 +614,6 @@ fn flac_seek_uses_seektable_not_binary_search() {
     assert!(
         reads.iter().any(|&o| o >= file_len / 8),
         "no read past the header; the seek did not advance into the file: {reads:?}"
-    );
-}
-
-/// `seek_landing_bytes` returns, for each deep track start of the real CUE/FLAC
-/// fixture, a byte within the file at or before the exact frame byte
-/// `frame_byte_offsets` reports for the same sample -- the landing recorded per
-/// track at import and byte-seeked to at playback. Both open without
-/// `AVFMT_FLAG_FAST_SEEK`, so they binary-search the frames and land together.
-#[test]
-fn seek_landing_bytes_lands_in_file_at_or_before_the_frame() {
-    init();
-    let path = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/fixtures/cue_flac/Test Album.flac"
-    );
-    let sr = probe_audio_from_path(path)
-        .expect("probe fixture")
-        .sample_rate as u64;
-    let file_size = std::fs::metadata(path).unwrap().len();
-
-    // Deep track starts from the CUE (10s white noise, 20s brown noise).
-    let starts = [10 * sr, 20 * sr];
-    let landings = seek_landing_bytes(path, &starts).expect("seek_landing_bytes");
-    let frames = frame_byte_offsets(path, &starts).expect("frame_byte_offsets");
-    assert_eq!(landings.len(), starts.len());
-
-    for i in 0..starts.len() {
-        assert!(
-            landings[i] > 0,
-            "a deep track start lands past byte 0: {landings:?}"
-        );
-        assert!(
-            landings[i] < file_size,
-            "landing stays within the file: {} of {file_size}",
-            landings[i]
-        );
-        assert!(
-            landings[i] <= frames[i],
-            "landing sits at or before the exact frame byte: {} vs {}",
-            landings[i],
-            frames[i]
-        );
-    }
-    assert!(
-        landings[1] > landings[0],
-        "a later track lands later in the file: {landings:?}"
     );
 }
 

--- a/bae-core/src/import/service/format_prep.rs
+++ b/bae-core/src/import/service/format_prep.rs
@@ -164,46 +164,19 @@ fn cue_analysis_format(cue_pair: &CueFlacAnalysis) -> CueAnalysisFormat {
     }
 }
 
-/// Byte offset of each CUE track's end within the shared file, found by seeking
-/// (no decode) -- computed once per file. `ends[i]` is track `i`'s end byte; the
-/// last track has no entry and runs to EOF. The boundary is each track's
-/// `end_sample` -- the same sample `cue_backed_audio_format` trims to -- so the
-/// read-ahead ceiling and the decode window can't drift. `None` when the offsets
-/// can't be read (non-UTF-8 path, a non-last track missing its end sample, or a
-/// failed seek), distinct from a real empty result; the caller then spans the
-/// whole file.
-fn cue_track_byte_ends(file_path: &Path, cue_pair: &CueFlacAnalysis) -> Option<Vec<u64>> {
-    let sample_rate = cue_analysis_format(cue_pair).sample_rate;
-    let tracks = &cue_pair.cue_sheet.tracks;
-    // Seek to each non-last track's end sample (the last track runs to EOF, so it
-    // has no end sample); every other track must have one.
-    let end_samples = match tracks
-        .iter()
-        .take(tracks.len().saturating_sub(1))
-        .map(|t| t.end_sample(sample_rate))
-        .collect::<Option<Vec<u64>>>()
-    {
-        Some(samples) => samples,
-        None => {
-            warn!("cue_track_byte_ends: a non-last track has no end sample in {file_path:?}");
-            return None;
-        }
-    };
-    let Some(path) = file_path.to_str() else {
-        warn!("cue_track_byte_ends: non-UTF-8 path, cannot seek byte offsets: {file_path:?}");
-        return None;
-    };
-    crate::audio_codec::frame_byte_offsets(path, &end_samples)
-}
-
-/// Byte each CUE track's audio *starts* on within the shared file: the seektable
-/// checkpoint the playback seek lands on when seeking to that track's
-/// `start_sample`, found via `seek_landing_bytes` (one open per file, no decode).
-/// `starts[i]` is track `i`'s start byte, index-aligned to the CUE tracks. The
-/// first track starts at byte 0 (nothing to prefetch), so the caller stores
-/// `None` for it. `None` here means the offsets couldn't be read (non-UTF-8 path
-/// or a failed seek), distinct from a real result; the caller then stores no
-/// start byte for that file's tracks.
+/// Byte each CUE track's audio *starts* on within the shared file: the byte the
+/// demuxer lands on when seeking to that track's `start_sample`, found via
+/// `seek_landing_bytes` (one open per file, no decode). `starts[i]` is track
+/// `i`'s start byte, index-aligned to the CUE tracks.
+///
+/// This one list gives both boundaries of every track, because a CUE track's
+/// byte range is `[start[i], start[i + 1])`: track `i` ends exactly where track
+/// `i + 1`'s audio begins, so its read-ahead ceiling is the next track's start
+/// byte. The last track has no next start and runs to EOF. The first track starts
+/// at byte 0 (nothing to prefetch), so the caller stores `None` for it. `None`
+/// here means the offsets couldn't be read (non-UTF-8 path or a failed seek),
+/// distinct from a real result; the caller then stores no start or end byte for
+/// that file's tracks and they keep the whole-file read-ahead span.
 fn cue_track_start_bytes(file_path: &Path, cue_pair: &CueFlacAnalysis) -> Option<Vec<u64>> {
     let sample_rate = cue_analysis_format(cue_pair).sample_rate;
     let start_samples: Vec<u64> = cue_pair
@@ -230,13 +203,10 @@ impl ImportService {
     ) -> Result<Vec<crate::db::DbAudioFormat>, String> {
         let now = clock.now();
         let mut audio_formats = Vec::with_capacity(tracks_to_files.len());
-        // Track end byte offsets per shared CUE file, computed once and reused
-        // across that file's tracks (one ffmpeg open per file, not per track).
-        // `None` means the offsets couldn't be read for that file.
-        let mut cue_ends_by_file: HashMap<PathBuf, Option<Vec<u64>>> = HashMap::new();
-        // Track start byte offsets per shared CUE file, same caching as the ends:
-        // the seektable landing for each track's `start_sample`, computed once per
-        // file. `None` means the offsets couldn't be read for that file.
+        // Seektable landing byte for each track's `start_sample` per shared CUE
+        // file, computed once per file (one ffmpeg open, not per track) and reused
+        // for both boundaries: a track starts at its own landing and ends at the
+        // next track's. `None` means the offsets couldn't be read for that file.
         let mut cue_starts_by_file: HashMap<PathBuf, Option<Vec<u64>>> = HashMap::new();
 
         for track_file in tracks_to_files {
@@ -265,38 +235,24 @@ impl ImportService {
                         ids.new_id(),
                         now,
                     )?;
-                    // The last track (no entry) runs to EOF, as does any track
-                    // whose offsets couldn't be read -- both keep the default
-                    // whole-file span.
-                    let ends = cue_ends_by_file.entry(file_path.clone()).or_insert_with(|| {
-                        let computed = cue_track_byte_ends(file_path, cue_pair);
+                    // One seek pass per file gives every track's start byte; the
+                    // range of track N is [start[N], start[N+1]). When the offsets
+                    // can't be read, all this file's tracks keep the default
+                    // whole-file span and lose the parallel prefetch.
+                    let starts = cue_starts_by_file.entry(file_path.clone()).or_insert_with(|| {
+                        let computed = cue_track_start_bytes(file_path, cue_pair);
                         if computed.is_none() {
                             warn!(
-                                "track byte offsets unavailable for {:?}; its tracks keep the whole-file read-ahead span",
+                                "track start offsets unavailable for {:?}; its tracks keep the whole-file read-ahead span and lose the parallel prefetch",
                                 file_path
                             );
                         }
                         computed
                     });
-                    let end_byte = ends
-                        .as_ref()
-                        .and_then(|e| e.get(*cue_index))
-                        .map(|&b| b as i64);
                     // The first track (start_sample 0) begins at byte 0 — nothing
                     // to prefetch, so it keeps the default `None` start byte. A
                     // deep track records the seektable landing for its start.
                     let start_byte = if af.start_sample > 0 {
-                        let starts =
-                            cue_starts_by_file.entry(file_path.clone()).or_insert_with(|| {
-                                let computed = cue_track_start_bytes(file_path, cue_pair);
-                                if computed.is_none() {
-                                    warn!(
-                                        "track start offsets unavailable for {:?}; its tracks lose the parallel prefetch",
-                                        file_path
-                                    );
-                                }
-                                computed
-                            });
                         starts
                             .as_ref()
                             .and_then(|s| s.get(*cue_index))
@@ -304,6 +260,13 @@ impl ImportService {
                     } else {
                         None
                     };
+                    // The read-ahead ceiling is where the next track's audio
+                    // starts. The last track has no next start, so it stays `None`
+                    // and runs to EOF.
+                    let end_byte = starts
+                        .as_ref()
+                        .and_then(|s| s.get(*cue_index + 1))
+                        .map(|&b| b as i64);
                     af.with_end_byte(end_byte).with_start_byte(start_byte)
                 }
                 TrackFile::Standalone {

--- a/bae-core/src/import/service/tests.rs
+++ b/bae-core/src/import/service/tests.rs
@@ -539,3 +539,103 @@ fn user_edit_renaming_album_artist_rebuilds_credits() {
     assert!(new_artist.discogs_artist_id.is_none());
     assert_eq!(album.artist_id, new_artist.id);
 }
+
+// ── build_audio_formats: CUE track byte windows ────────────────────
+
+/// Build the `TrackFile::CueBacked` list for a single-file CUE album, reusing
+/// the import pipeline's own analysis (`analyze_cue_audio`) so the container is
+/// probed exactly as a real import probes it.
+fn cue_backed_tracks(dir: &str) -> Vec<TrackFile> {
+    let audio_path = PathBuf::from(format!("{dir}/Test Album.ape"));
+    let cue_path = PathBuf::from(format!("{dir}/Test Album.cue"));
+    let cue_sheet =
+        crate::cue_flac::CueFlacProcessor::parse_cue_sheet(&cue_path).expect("parse cue");
+    let analysis =
+        crate::import::track_to_file_mapper::analyze_cue_audio(&audio_path).expect("analyze ape");
+    let cue_pair = Arc::new(crate::import::types::CueFlacAnalysis {
+        cue_sheet,
+        analysis,
+    });
+    (0..cue_pair.cue_sheet.tracks.len())
+        .map(|index| TrackFile::CueBacked {
+            db_track: DbTrack {
+                id: format!("track-{index}"),
+                release_id: "rel".to_string(),
+                title: format!("Track {index}"),
+                side: 1,
+                track_number: Some(index as i32 + 1),
+                duration_ms: None,
+                discogs_position: None,
+                created_at: test_clock().0,
+            },
+            file_path: audio_path.clone(),
+            cue_pair: Arc::clone(&cue_pair),
+            cue_index: index,
+        })
+        .collect()
+}
+
+/// A CUE track's read-ahead ceiling is its `end_byte`; playback fills up to it
+/// and stops, so every non-last track must carry a real end byte or the fill
+/// streams the whole rest of the shared file. Ends derive from the next track's
+/// start byte (`start[N+1]`), computed via `seek_landing_bytes` -- the AVIO
+/// landing, defined for every format, including APE whose packets carry no byte
+/// position. This drives `build_audio_formats` over the APE CUE fixture and
+/// asserts the user-visible outcome: the two non-last tracks get `Some`,
+/// ascending, in-file end bytes and the last track runs to EOF (`None`).
+#[test]
+fn build_audio_formats_gives_ape_cue_tracks_real_end_bytes() {
+    crate::audio_codec::init();
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/cue_ape");
+    let tracks = cue_backed_tracks(dir);
+    assert_eq!(
+        tracks.len(),
+        3,
+        "fixture is a 3-track single-file CUE album"
+    );
+
+    let file_size = std::fs::metadata(format!("{dir}/Test Album.ape"))
+        .unwrap()
+        .len() as i64;
+    let mut file_ids = HashMap::new();
+    file_ids.insert(
+        PathBuf::from(format!("{dir}/Test Album.ape")),
+        "file-1".to_string(),
+    );
+
+    let formats = ImportService::build_audio_formats(
+        &tracks,
+        &file_ids,
+        &test_clock(),
+        &SequentialIdProvider::new("seed"),
+    )
+    .expect("build_audio_formats");
+
+    let ends: Vec<Option<i64>> = formats.iter().map(|f| f.end_byte).collect();
+    // Non-last tracks carry a real, ascending, in-file end byte.
+    let e0 = ends[0].expect("track 1 (non-last) must have an end byte");
+    let e1 = ends[1].expect("track 2 (non-last) must have an end byte");
+    assert!(
+        e0 > 0 && e0 < file_size,
+        "track 1 end within file: {e0} of {file_size}"
+    );
+    assert!(
+        e1 > 0 && e1 < file_size,
+        "track 2 end within file: {e1} of {file_size}"
+    );
+    assert!(e1 > e0, "end bytes ascend track to track: {ends:?}");
+    // The last track runs to EOF.
+    assert_eq!(ends[2], None, "the last track runs to EOF");
+
+    // Each track's end is the next track's start byte -- one boundary, not two.
+    assert_eq!(
+        formats[1].start_byte,
+        Some(e0),
+        "track 2 starts where track 1 ends"
+    );
+    assert_eq!(
+        formats[2].start_byte,
+        Some(e1),
+        "track 3 starts where track 2 ends"
+    );
+}

--- a/bae-core/src/import/track_to_file_mapper.rs
+++ b/bae-core/src/import/track_to_file_mapper.rs
@@ -192,7 +192,7 @@ fn extract_duration_from_file(file_path: &std::path::Path) -> Option<i64> {
 /// info, ALAC is probed via FFmpeg. Bytes are read once (for APE / FLAC) or
 /// opened by path (for ALAC, whose probe already streams through FFmpeg) and
 /// dropped on return.
-fn analyze_cue_audio(audio_path: &std::path::Path) -> Result<CueAudioAnalysis, String> {
+pub(crate) fn analyze_cue_audio(audio_path: &std::path::Path) -> Result<CueAudioAnalysis, String> {
     let ext = audio_path
         .extension()
         .and_then(|e| e.to_str())


### PR DESCRIPTION
A single-file CUE album stores each non-last track's end byte in `audio_formats`, and playback uses it as the read-ahead ceiling: the fill buffers up to that byte and stops. The end byte was computed at import by seeking to the track's end sample and reading the demuxer packet's `pos` (`frame_byte_offsets`).

APE packets carry no byte position -- the `pos` is -1 -- so that read returned `None` for every non-last APE track. With no end byte, the ceiling fell back to EOF and the fill streamed the entire rest of the file. Over a cloud home that is the whole tail of a single-file rip fetched to play one track (observed on-device: an APE track that should have stopped around 154 MB fetched all the way to EOF at 305 MB). FLAC was unaffected because its packets carry a real `pos`.

A CUE track's byte range is `[start[N], start[N+1])` -- track N ends exactly where track N+1's audio begins. `cue_track_start_bytes` already computes the seek landing for every track's start sample via `seek_landing_bytes`, which reads the AVIO position (`avio_tell`) after the seek; that is defined for every format, APE included. So the end byte is simply the next track's start byte. This drops the separate end-byte pass entirely: `cue_track_byte_ends` and its per-file cache are gone, the start bytes are computed once per file, and both boundaries come from that one list. The packet-`pos` reader had no other caller and is removed.

Deriving ends from starts also removes the conflated `None`: a non-last track whose starts computed always gets a real end byte, so `None` now means only a genuine seek/path failure. That case is logged as a degradation and the tracks keep the whole-file span -- a read-ahead optimization must not fail the whole import.

The `end_byte` column already exists; only how it's populated changes. Existing APE libraries keep their NULL `end_byte` until re-import, which repopulates it.

## Test plan
- New `build_audio_formats_gives_ape_cue_tracks_real_end_bytes` drives the real `build_audio_formats` over the APE CUE fixture (reusing the import pipeline's own `analyze_cue_audio`) and asserts the user-visible outcome: the two non-last APE tracks get `Some`, ascending, in-file end bytes (they were `None` before), the last track runs to EOF, and each track's end equals the next track's start byte.
- Reworked the former `frame_byte_offsets` tests onto `seek_landing_bytes` (monotonic + within-file, and the content-not-time property on the FLAC fixture); consolidated the redundant third into the content-not-time test.
- Full `cargo test -p bae-core --features test-utils` green (838 lib tests + integration suites, 0 failures); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah9ynZs5bTFQ26rrc4bSeP