### PR TITLE
Add composer-mode browser parity

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/data/Library.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/Library.kt
@@ -3,8 +3,12 @@ package fm.bae.app.data
 import uniffi.bae_bridge.AppHandle
 import uniffi.bae_bridge.BridgeAlbum
 import uniffi.bae_bridge.BridgeAlbumDetail
+import uniffi.bae_bridge.BridgeComposerDetail
+import uniffi.bae_bridge.BridgeComposerSortCriterion
+import uniffi.bae_bridge.BridgeComposerSummary
 import uniffi.bae_bridge.BridgeSearchResults
 import uniffi.bae_bridge.BridgeSortCriterion
+import uniffi.bae_bridge.BridgeWorkDetail
 
 /**
  * Narrow projection of [AppHandle] for library browse and detail reads — DB
@@ -24,6 +28,18 @@ class Library(
     ): List<BridgeAlbum> = handle.getAlbumPage(sortCriteria, offset, limit)
 
     fun albumDetail(albumId: String): BridgeAlbumDetail = handle.getAlbumDetail(albumId)
+
+    fun composerCount(): ULong = handle.getComposerCount()
+
+    fun composerPage(
+        sortCriterion: BridgeComposerSortCriterion,
+        offset: ULong,
+        limit: ULong,
+    ): List<BridgeComposerSummary> = handle.getComposerPage(sortCriterion, offset, limit)
+
+    fun composerDetail(artistId: String): BridgeComposerDetail? = handle.getComposerDetail(artistId)
+
+    fun workDetail(workId: String): BridgeWorkDetail? = handle.getWorkDetail(workId)
 
     /** Bytes of a release cover by release id, read through coven's
      *  locality-aware store, or null when no such cover exists. */

--- a/bae-android/app/src/main/java/fm/bae/app/data/LibraryStore.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/LibraryStore.kt
@@ -36,6 +36,9 @@ class LibraryStore {
     private val _generation = MutableStateFlow(0L)
     val generation: StateFlow<Long> = _generation.asStateFlow()
 
+    private val _composerGeneration = MutableStateFlow(0L)
+    val composerGeneration: StateFlow<Long> = _composerGeneration.asStateFlow()
+
     fun albumDetail(albumId: String): BridgeAlbumDetail? = _albumDetails.value[albumId]
 
     /**
@@ -58,21 +61,28 @@ class LibraryStore {
         _generation.update { it + 1 }
     }
 
+    private fun bumpComposerGeneration() {
+        _composerGeneration.update { it + 1 }
+    }
+
     // ── Album event handlers ──────────────────────────────────────────────
 
     fun handleAlbumAdded(album: BridgeAlbumDetail) {
         _albumDetails.update { it + (album.album.id to album) }
         bumpGeneration()
+        bumpComposerGeneration()
     }
 
     fun handleAlbumUpdated(album: BridgeAlbumDetail) {
         _albumDetails.update { it + (album.album.id to album) }
         bumpGeneration()
+        bumpComposerGeneration()
     }
 
     fun handleAlbumRemoved(albumId: String) {
         _albumDetails.update { it - albumId }
         bumpGeneration()
+        bumpComposerGeneration()
     }
 
     // ── Release event handlers ────────────────────────────────────────────
@@ -93,6 +103,7 @@ class LibraryStore {
             val releases = (existing?.releases.orEmpty().filter { it.id != release.id }) + release
             details + (album.id to BridgeAlbumDetail(album = album, releases = releases))
         }
+        bumpComposerGeneration()
     }
 
     fun handleReleaseUpdated(
@@ -108,6 +119,7 @@ class LibraryStore {
             val releases = existing.releases.map { if (it.id == release.id) release else it }
             details + (albumId to existing.copy(releases = releases))
         }
+        bumpComposerGeneration()
     }
 
     fun handleReleaseRemoved(
@@ -129,5 +141,6 @@ class LibraryStore {
             // authoritative DB-ordered list, not the stale interned one.
             details + (albumId to BridgeAlbumDetail(album = album, releases = releases))
         }
+        bumpComposerGeneration()
     }
 }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/AddDeviceFlow.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/AddDeviceFlow.kt
@@ -70,6 +70,7 @@ private sealed interface AddDeviceStep {
     data class Confirm(
         val pubkey: String,
         val fingerprint: String,
+        val providerAccountEmail: String?,
     ) : AddDeviceStep
 
     /** Approving — calling the bridge to mint the invite code. */
@@ -110,7 +111,7 @@ private class AddDeviceModel(
         error = null
         try {
             val request = decodeJoinRequest(code)
-            step = AddDeviceStep.Confirm(request.pubkey, request.fingerprint)
+            step = AddDeviceStep.Confirm(request.pubkey, request.fingerprint, request.email)
         } catch (e: Exception) {
             logger.error("Failed to decode join request", e)
             error = e.message ?: appContext.getString(R.string.members_add_decode_failed)
@@ -121,7 +122,12 @@ private class AddDeviceModel(
         step = AddDeviceStep.Inviting
         val inviteCode =
             try {
-                withContext(Dispatchers.IO) { session.appHandle.inviteMember(device.pubkey) }
+                withContext(Dispatchers.IO) {
+                    session.appHandle.inviteMember(
+                        publicKeyHex = device.pubkey,
+                        providerAccountEmail = device.providerAccountEmail,
+                    )
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/AlbumDetailScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/AlbumDetailScreen.kt
@@ -91,13 +91,14 @@ private data class AlbumDetailCallbacks(
 fun AlbumDetailScreen(
     session: OpenLibrary,
     albumId: String,
+    initialReleaseId: String? = null,
     onBack: () -> Unit,
 ) {
     val details by session.libraryStore.albumDetails.collectAsState()
     val detail = details[albumId]
     val nowPlaying by session.playback.nowPlaying.collectAsState()
     val isPlaying by session.playback.isPlaying.collectAsState()
-    var selectedReleaseId by remember { mutableStateOf<String?>(null) }
+    var selectedReleaseId by remember(albumId, initialReleaseId) { mutableStateOf(initialReleaseId) }
     var retryToken by remember(albumId) { mutableStateOf(0) }
     var loadError by remember(albumId) { mutableStateOf<String?>(null) }
     val appContext = LocalContext.current

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ComposerBrowser.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ComposerBrowser.kt
@@ -1,0 +1,294 @@
+package fm.bae.app.ui
+
+import android.content.Context
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import fm.bae.app.BaeLogger
+import fm.bae.app.OpenLibrary
+import fm.bae.app.R
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import uniffi.bae_bridge.BridgeComposerSortCriterion
+import uniffi.bae_bridge.BridgeComposerSortField
+import uniffi.bae_bridge.BridgeComposerSummary
+import uniffi.bae_bridge.BridgeSortDirection
+
+private const val TAG = "bae.ComposerBrowser"
+private val logger = BaeLogger(TAG)
+
+internal class ComposerPage(
+    private val session: OpenLibrary,
+    private val sortCriterion: BridgeComposerSortCriterion,
+    private val appContext: Context,
+    private val onRetry: () -> Unit,
+) {
+    val composers = mutableStateMapOf<String, BridgeComposerSummary>()
+    val order = mutableStateListOf<String>()
+    var totalCount by mutableStateOf(0)
+        private set
+    var loading by mutableStateOf(true)
+        private set
+    var error by mutableStateOf<PageError?>(null)
+        private set
+    private var loadedOffset = 0
+
+    private fun ingest(page: List<BridgeComposerSummary>) {
+        page.forEach { composer ->
+            if (!composers.containsKey(composer.artistId)) order.add(composer.artistId)
+            composers[composer.artistId] = composer
+        }
+    }
+
+    suspend fun loadFirst() {
+        loading = true
+        error = null
+        try {
+            val (count, page) =
+                withContext(Dispatchers.IO) {
+                    val c = session.library.composerCount().toInt()
+                    val p = session.library.composerPage(sortCriterion, 0u, PAGE_SIZE.toULong())
+                    c to p
+                }
+            totalCount = count
+            ingest(page)
+            loadedOffset = PAGE_SIZE
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to load first composer page", e)
+            error = PageError(appContext.getString(R.string.library_load_failed), onRetry)
+        } finally {
+            loading = false
+        }
+    }
+
+    suspend fun loadMore() {
+        if (order.size >= totalCount) return
+        val offset = loadedOffset
+        try {
+            val more =
+                withContext(Dispatchers.IO) {
+                    session.library.composerPage(sortCriterion, offset.toULong(), PAGE_SIZE.toULong())
+                }
+            ingest(more)
+            loadedOffset = offset + PAGE_SIZE
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to load composer page at offset $offset", e)
+            error = PageError(appContext.getString(R.string.library_load_more_failed), onRetry)
+        }
+    }
+}
+
+@Composable
+internal fun rememberComposerPage(
+    session: OpenLibrary,
+    generation: Long,
+    sortCriterion: BridgeComposerSortCriterion,
+    appContext: Context,
+): ComposerPage {
+    var retryToken by remember(generation, sortCriterion) { mutableStateOf(0) }
+    val page =
+        remember(generation, sortCriterion, retryToken) {
+            ComposerPage(session, sortCriterion, appContext) { retryToken++ }
+        }
+    LaunchedEffect(page) { page.loadFirst() }
+    return page
+}
+
+@Composable
+internal fun ComposerListContent(
+    page: ComposerPage,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onSelectComposer: (String) -> Unit,
+) {
+    val pageError = page.error
+    when {
+        pageError != null && page.order.isEmpty() -> {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(text = pageError.message, color = MaterialTheme.colorScheme.error)
+                TextButton(onClick = pageError.onRetry) { Text(stringResource(R.string.retry)) }
+            }
+        }
+
+        page.loading && page.order.isEmpty() -> {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+        }
+
+        page.totalCount == 0 -> {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Text(
+                    text = stringResource(R.string.library_empty_composers),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.align(Alignment.Center).padding(32.dp),
+                )
+            }
+        }
+
+        else -> {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(page.order, key = { it }) { artistId ->
+                    val composer = page.composers[artistId] ?: return@items
+                    ComposerSummaryRow(
+                        composer = composer,
+                        loadImage = loadImage,
+                        onClick = { onSelectComposer(artistId) },
+                    )
+                }
+                item {
+                    LaunchedEffect(page.order.size, page.totalCount) {
+                        page.loadMore()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val COMPOSER_SORT_FIELDS =
+    listOf(
+        BridgeComposerSortField.NAME,
+        BridgeComposerSortField.WORK_COUNT,
+        BridgeComposerSortField.LINKED_RELEASE_COUNT,
+    )
+
+@Composable
+internal fun ComposerSortMenu(
+    criterion: BridgeComposerSortCriterion,
+    onChange: (BridgeComposerSortCriterion) -> Unit,
+) {
+    fun BridgeComposerSortField.labelRes(): Int =
+        when (this) {
+            BridgeComposerSortField.NAME -> R.string.sort_name
+            BridgeComposerSortField.WORK_COUNT -> R.string.search_section_works
+            BridgeComposerSortField.LINKED_RELEASE_COUNT -> R.string.search_section_releases
+        }
+    var expanded by remember { mutableStateOf(false) }
+    val ascending = criterion.direction == BridgeSortDirection.ASCENDING
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = stringResource(R.string.sort))
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            COMPOSER_SORT_FIELDS.forEach { field ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(field.labelRes())) },
+                    onClick = {
+                        onChange(BridgeComposerSortCriterion(field, criterion.direction))
+                        expanded = false
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = null,
+                            modifier = Modifier.alpha(if (field == criterion.field) 1f else 0f),
+                        )
+                    },
+                )
+            }
+            HorizontalDivider()
+            DropdownMenuItem(
+                text = {
+                    Text(stringResource(if (ascending) R.string.sort_ascending else R.string.sort_descending))
+                },
+                onClick = {
+                    val direction = if (ascending) BridgeSortDirection.DESCENDING else BridgeSortDirection.ASCENDING
+                    onChange(BridgeComposerSortCriterion(criterion.field, direction))
+                    expanded = false
+                },
+                leadingIcon = {
+                    val icon = if (ascending) Icons.Filled.ArrowUpward else Icons.Filled.ArrowDownward
+                    Icon(imageVector = icon, contentDescription = null)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun ComposerSummaryRow(
+    composer: BridgeComposerSummary,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CoverImage(
+            coverId = composer.image?.id,
+            coverVersion = composer.image?.version,
+            loadImage = loadImage,
+            cornerRadius = 6.dp,
+            iconPadding = 12.dp,
+            modifier = Modifier.size(48.dp),
+            contentDescription = composer.name,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = composer.name,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+            )
+            Text(
+                text = stringResource(R.string.work_count, composer.workCount.toLong()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+    }
+}

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ComposerBrowser.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ComposerBrowser.kt
@@ -175,7 +175,10 @@ internal fun ComposerListContent(
         else -> {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(page.order, key = { it }) { artistId ->
-                    val composer = page.composers[artistId] ?: return@items
+                    val composer =
+                        checkNotNull(page.composers[artistId]) {
+                            "composer page order referenced missing composer: $artistId"
+                        }
                     ComposerSummaryRow(
                         composer = composer,
                         loadImage = loadImage,
@@ -256,13 +259,13 @@ internal fun ComposerSortMenu(
 internal fun ComposerSummaryRow(
     composer: BridgeComposerSummary,
     loadImage: suspend (imageId: String) -> ByteArray?,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
 ) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ComposerDetailScreens.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ComposerDetailScreens.kt
@@ -51,7 +51,7 @@ internal fun ComposerDetailScreen(
     artistId: String,
     onBack: () -> Unit,
     onSelectWork: (String) -> Unit,
-    onSelectAlbum: (String) -> Unit,
+    onSelectAlbum: (String, String) -> Unit,
 ) {
     var detail by remember(artistId) { mutableStateOf<BridgeComposerDetail?>(null) }
     var loadError by remember(artistId) { mutableStateOf<String?>(null) }
@@ -107,14 +107,14 @@ private fun ComposerDetailContent(
     detail: BridgeComposerDetail,
     loadImage: suspend (imageId: String) -> ByteArray?,
     onSelectWork: (String) -> Unit,
-    onSelectAlbum: (String) -> Unit,
+    onSelectAlbum: (String, String) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         item {
             ComposerSummaryRow(
                 composer = detail.composer,
                 loadImage = loadImage,
-                onClick = {},
+                onClick = null,
             )
         }
         if (detail.workGroups.isNotEmpty()) {
@@ -146,7 +146,7 @@ private fun ComposerDetailContent(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { onSelectAlbum(role.albumId) }
+                            .clickable { onSelectAlbum(role.albumId, role.releaseId) }
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                     style = MaterialTheme.typography.bodyLarge,
                     maxLines = 1,
@@ -227,7 +227,7 @@ private fun WorkDetailContent(
     onSelectAlbum: (String, String) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        item { WorkSummaryRow(work = detail.work, loadImage = loadImage, onClick = {}) }
+        item { WorkSummaryRow(work = detail.work, loadImage = loadImage, onClick = null) }
         if (detail.childWorks.isNotEmpty()) {
             item { LibrarySectionHeader(stringResource(R.string.search_section_works)) }
             items(detail.childWorks, key = { it.workId }) { work ->
@@ -273,21 +273,26 @@ private fun WorkDetailContent(
 }
 
 private fun workReleaseMetadata(release: BridgeWorkReleaseSummary): String =
-    listOfNotNull(release.displayName, release.format)
-        .filter { it.isNotEmpty() }
-        .joinToString(" · ")
+    if (release.format.isNullOrEmpty()) {
+        check(release.displayName.isNotEmpty()) {
+            "work release display name is empty for ${release.releaseId}"
+        }
+        release.displayName
+    } else {
+        "${release.displayName} · ${release.format}"
+    }
 
 @Composable
 private fun WorkSummaryRow(
     work: BridgeWorkSummary,
     loadImage: suspend (imageId: String) -> ByteArray?,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
 ) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ComposerDetailScreens.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ComposerDetailScreens.kt
@@ -1,0 +1,350 @@
+package fm.bae.app.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import fm.bae.app.BaeLogger
+import fm.bae.app.OpenLibrary
+import fm.bae.app.R
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import uniffi.bae_bridge.BridgeComposerDetail
+import uniffi.bae_bridge.BridgeWorkDetail
+import uniffi.bae_bridge.BridgeWorkReleaseSummary
+import uniffi.bae_bridge.BridgeWorkSummary
+
+private const val TAG = "bae.ComposerDetailScreens"
+private val logger = BaeLogger(TAG)
+
+@Composable
+internal fun ComposerDetailScreen(
+    session: OpenLibrary,
+    artistId: String,
+    onBack: () -> Unit,
+    onSelectWork: (String) -> Unit,
+    onSelectAlbum: (String) -> Unit,
+) {
+    var detail by remember(artistId) { mutableStateOf<BridgeComposerDetail?>(null) }
+    var loadError by remember(artistId) { mutableStateOf<String?>(null) }
+    val appContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(artistId) {
+        loadError = null
+        try {
+            detail = withContext(Dispatchers.IO) { session.library.composerDetail(artistId) }
+            if (detail == null) {
+                loadError = appContext.getString(R.string.composer_detail_not_found)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to load composer detail $artistId", e)
+            loadError = appContext.getString(R.string.composer_detail_load_failed)
+        }
+    }
+    Column(modifier = Modifier.fillMaxSize()) {
+        LibraryDetailTopBar(onBack = onBack)
+        val loaded = detail
+        val error = loadError
+        when {
+            error != null -> {
+                Text(
+                    text = error,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(32.dp),
+                )
+            }
+
+            loaded == null -> {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+            }
+
+            else -> {
+                ComposerDetailContent(
+                    detail = loaded,
+                    loadImage = session.library::imageBytes,
+                    onSelectWork = onSelectWork,
+                    onSelectAlbum = onSelectAlbum,
+                )
+            }
+        }
+        NowPlayingBar(session = session)
+    }
+}
+
+@Composable
+private fun ComposerDetailContent(
+    detail: BridgeComposerDetail,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onSelectWork: (String) -> Unit,
+    onSelectAlbum: (String) -> Unit,
+) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            ComposerSummaryRow(
+                composer = detail.composer,
+                loadImage = loadImage,
+                onClick = {},
+            )
+        }
+        if (detail.workGroups.isNotEmpty()) {
+            item { LibrarySectionHeader(stringResource(R.string.search_section_works)) }
+            detail.workGroups.forEach { group ->
+                group.parent?.let { parent ->
+                    item(key = "parent:${parent.workId}") {
+                        WorkSummaryRow(
+                            work = parent,
+                            loadImage = loadImage,
+                            onClick = { onSelectWork(parent.workId) },
+                        )
+                    }
+                }
+                items(group.works, key = { "work:${it.workId}" }) { work ->
+                    WorkSummaryRow(
+                        work = work,
+                        loadImage = loadImage,
+                        onClick = { onSelectWork(work.workId) },
+                    )
+                }
+            }
+        }
+        if (detail.unlinkedReleaseRoles.isNotEmpty()) {
+            item { LibrarySectionHeader(stringResource(R.string.search_section_credits)) }
+            items(detail.unlinkedReleaseRoles, key = { it.releaseId }) { role ->
+                Text(
+                    text = role.albumTitle,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelectAlbum(role.albumId) }
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                )
+            }
+        }
+        if (detail.unlinkedTrackRoles.isNotEmpty()) {
+            item { LibrarySectionHeader(stringResource(R.string.search_section_recordings)) }
+            items(detail.unlinkedTrackRoles, key = { it.trackId }) { role ->
+                TwoLineText(title = role.trackTitle, subtitle = role.albumTitle)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun WorkDetailScreen(
+    session: OpenLibrary,
+    workId: String,
+    onBack: () -> Unit,
+    onSelectWork: (String) -> Unit,
+    onSelectAlbum: (String, String) -> Unit,
+) {
+    var detail by remember(workId) { mutableStateOf<BridgeWorkDetail?>(null) }
+    var loadError by remember(workId) { mutableStateOf<String?>(null) }
+    val appContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(workId) {
+        loadError = null
+        try {
+            detail = withContext(Dispatchers.IO) { session.library.workDetail(workId) }
+            if (detail == null) {
+                loadError = appContext.getString(R.string.work_detail_not_found)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to load work detail $workId", e)
+            loadError = appContext.getString(R.string.work_detail_load_failed)
+        }
+    }
+    Column(modifier = Modifier.fillMaxSize()) {
+        LibraryDetailTopBar(onBack = onBack)
+        val loaded = detail
+        val error = loadError
+        when {
+            error != null -> {
+                Text(
+                    text = error,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(32.dp),
+                )
+            }
+
+            loaded == null -> {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+            }
+
+            else -> {
+                WorkDetailContent(
+                    detail = loaded,
+                    loadImage = session.library::imageBytes,
+                    onSelectWork = onSelectWork,
+                    onSelectAlbum = onSelectAlbum,
+                )
+            }
+        }
+        NowPlayingBar(session = session)
+    }
+}
+
+@Composable
+private fun WorkDetailContent(
+    detail: BridgeWorkDetail,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onSelectWork: (String) -> Unit,
+    onSelectAlbum: (String, String) -> Unit,
+) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item { WorkSummaryRow(work = detail.work, loadImage = loadImage, onClick = {}) }
+        if (detail.childWorks.isNotEmpty()) {
+            item { LibrarySectionHeader(stringResource(R.string.search_section_works)) }
+            items(detail.childWorks, key = { it.workId }) { work ->
+                WorkSummaryRow(
+                    work = work,
+                    loadImage = loadImage,
+                    onClick = { onSelectWork(work.workId) },
+                )
+            }
+        }
+        if (detail.releases.isNotEmpty()) {
+            item { LibrarySectionHeader(stringResource(R.string.search_section_releases)) }
+            items(detail.releases, key = { it.releaseId }) { release ->
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelectAlbum(release.albumId, release.releaseId) }
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CoverImage(
+                        coverId = release.cover?.id,
+                        coverVersion = release.cover?.version,
+                        loadImage = loadImage,
+                        cornerRadius = 6.dp,
+                        iconPadding = 12.dp,
+                        modifier = Modifier.size(48.dp),
+                        contentDescription = release.albumTitle,
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    TwoLineText(title = release.albumTitle, subtitle = workReleaseMetadata(release))
+                }
+            }
+        }
+        if (detail.tracks.isNotEmpty()) {
+            item { LibrarySectionHeader(stringResource(R.string.search_section_recordings)) }
+            items(detail.tracks, key = { it.trackId }) { track ->
+                TwoLineText(title = track.trackTitle, subtitle = track.albumTitle)
+            }
+        }
+    }
+}
+
+private fun workReleaseMetadata(release: BridgeWorkReleaseSummary): String =
+    listOfNotNull(release.displayName, release.format)
+        .filter { it.isNotEmpty() }
+        .joinToString(" · ")
+
+@Composable
+private fun WorkSummaryRow(
+    work: BridgeWorkSummary,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CoverImage(
+            coverId = work.representativeCover?.id,
+            coverVersion = work.representativeCover?.version,
+            loadImage = loadImage,
+            cornerRadius = 6.dp,
+            iconPadding = 12.dp,
+            modifier = Modifier.size(48.dp),
+            contentDescription = work.title,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        TwoLineText(title = work.title, subtitle = work.composerNames)
+    }
+}
+
+@Composable
+private fun TwoLineText(
+    title: String,
+    subtitle: String?,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Text(text = title, style = MaterialTheme.typography.bodyLarge, maxLines = 1)
+        if (!subtitle.isNullOrBlank()) {
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LibraryDetailTopBar(onBack: () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.surface, tonalElevation = 2.dp) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+            }
+            Text(text = "bae", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun LibrarySectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ErrorBanner.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ErrorBanner.kt
@@ -1,0 +1,38 @@
+package fm.bae.app.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fm.bae.app.R
+
+@Composable
+internal fun ErrorBanner(
+    message: String,
+    onRetry: (() -> Unit)? = null,
+) {
+    Surface(color = MaterialTheme.colorScheme.errorContainer, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.weight(1f),
+            )
+            if (onRetry != null) {
+                TextButton(onClick = onRetry) { Text(stringResource(R.string.retry)) }
+            }
+        }
+    }
+}

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
@@ -1,10 +1,11 @@
 package fm.bae.app.ui
 
+import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
@@ -54,9 +55,7 @@ internal fun LibraryBrowser(
     val syncError by session.configStore.syncError.collectAsState()
     val appError by session.configStore.error.collectAsState()
     val gridState = rememberLazyGridState()
-    val libraryActionFailed = stringResource(R.string.library_load_failed)
-    val page = rememberLibraryPage(session, generation, sortCriterion, LocalContext.current, gridState)
-    val composerPage = rememberComposerPage(session, composerGeneration, composerSortCriterion, LocalContext.current)
+    val appContext = LocalContext.current
 
     Column(modifier = Modifier.fillMaxSize()) {
         LibraryBrowserChrome(
@@ -75,29 +74,160 @@ internal fun LibraryBrowser(
             composerSortCriterion = composerSortCriterion,
             onComposerSortChange = { composerSortCriterion = it },
             syncing = syncing,
-            onShuffleLibrary = {
-                try {
-                    session.appHandle.playLibraryShuffled()
-                } catch (e: Exception) {
-                    logger.error("playLibraryShuffled failed", e)
-                    session.configStore.showError(libraryActionFailed)
-                }
-            },
+            onShuffleLibrary = { session.playLibraryShuffledOrReport(appContext) },
             onSettings = onSettings,
         )
-        LibraryErrorBanner(page = page, appError = appError, syncError = syncError, session = session)
         LibraryBrowserContent(
+            modifier = Modifier.fillMaxWidth().weight(1f),
             session = session,
             searchQuery = searchQuery,
             mode = mode,
-            page = page,
-            composerPage = composerPage,
+            generation = generation,
+            composerGeneration = composerGeneration,
+            sortCriterion = sortCriterion,
+            composerSortCriterion = composerSortCriterion,
+            appError = appError,
+            syncError = syncError,
             gridState = gridState,
             onSelectAlbum = onSelectAlbum,
             onSelectComposer = onSelectComposer,
             onSelectWork = onSelectWork,
+            appContext = appContext,
         )
         NowPlayingBar(session = session)
+    }
+}
+
+private fun OpenLibrary.playLibraryShuffledOrReport(appContext: Context) {
+    try {
+        appHandle.playLibraryShuffled()
+    } catch (e: Exception) {
+        logger.error("playLibraryShuffled failed", e)
+        configStore.showError(appContext.getString(R.string.library_load_failed))
+    }
+}
+
+@Composable
+private fun LibraryBrowserContent(
+    modifier: Modifier,
+    session: OpenLibrary,
+    searchQuery: String,
+    mode: LibraryBrowserMode,
+    generation: Long,
+    composerGeneration: Long,
+    sortCriterion: BridgeSortCriterion,
+    composerSortCriterion: BridgeComposerSortCriterion,
+    appError: String?,
+    syncError: String?,
+    gridState: LazyGridState,
+    onSelectAlbum: (String) -> Unit,
+    onSelectComposer: (String) -> Unit,
+    onSelectWork: (String) -> Unit,
+    appContext: Context,
+) {
+    Box(modifier = modifier) {
+        if (searchQuery.isNotBlank()) {
+            SearchResultsScreen(
+                session = session,
+                query = searchQuery,
+                onSelectAlbum = onSelectAlbum,
+                onSelectComposer = onSelectComposer,
+                onSelectWork = onSelectWork,
+            )
+        } else {
+            when (mode) {
+                LibraryBrowserMode.ALBUMS -> {
+                    AlbumBrowserContent(
+                        session = session,
+                        generation = generation,
+                        sortCriterion = sortCriterion,
+                        appError = appError,
+                        syncError = syncError,
+                        gridState = gridState,
+                        onSelectAlbum = onSelectAlbum,
+                        appContext = appContext,
+                    )
+                }
+
+                LibraryBrowserMode.COMPOSERS -> {
+                    ComposerBrowserContent(
+                        session = session,
+                        generation = composerGeneration,
+                        sortCriterion = composerSortCriterion,
+                        appError = appError,
+                        syncError = syncError,
+                        onSelectComposer = onSelectComposer,
+                        appContext = appContext,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumBrowserContent(
+    session: OpenLibrary,
+    generation: Long,
+    sortCriterion: BridgeSortCriterion,
+    appError: String?,
+    syncError: String?,
+    gridState: LazyGridState,
+    onSelectAlbum: (String) -> Unit,
+    appContext: Context,
+) {
+    val page =
+        rememberLibraryPage(
+            session = session,
+            generation = generation,
+            sortCriterion = sortCriterion,
+            appContext = appContext,
+            gridState = gridState,
+        )
+    Column(modifier = Modifier.fillMaxSize()) {
+        LibraryErrorBanner(
+            page = page,
+            appError = appError,
+            syncError = syncError,
+            session = session,
+        )
+        LibraryGridContent(
+            session = session,
+            page = page,
+            gridState = gridState,
+            onSelectAlbum = onSelectAlbum,
+        )
+    }
+}
+
+@Composable
+private fun ComposerBrowserContent(
+    session: OpenLibrary,
+    generation: Long,
+    sortCriterion: BridgeComposerSortCriterion,
+    appError: String?,
+    syncError: String?,
+    onSelectComposer: (String) -> Unit,
+    appContext: Context,
+) {
+    val page =
+        rememberComposerPage(
+            session = session,
+            generation = generation,
+            sortCriterion = sortCriterion,
+            appContext = appContext,
+        )
+    Column(modifier = Modifier.fillMaxSize()) {
+        LibraryGlobalErrorBanner(
+            appError = appError,
+            syncError = syncError,
+            session = session,
+        )
+        ComposerListContent(
+            page = page,
+            loadImage = session.library::imageBytes,
+            onSelectComposer = onSelectComposer,
+        )
     }
 }
 
@@ -143,49 +273,5 @@ private fun LibraryBrowserChrome(
             color = MaterialTheme.colorScheme.primary,
             trackColor = MaterialTheme.colorScheme.surface,
         )
-    }
-}
-
-@Composable
-private fun ColumnScope.LibraryBrowserContent(
-    session: OpenLibrary,
-    searchQuery: String,
-    mode: LibraryBrowserMode,
-    page: LibraryPage,
-    composerPage: ComposerPage,
-    gridState: androidx.compose.foundation.lazy.grid.LazyGridState,
-    onSelectAlbum: (String) -> Unit,
-    onSelectComposer: (String) -> Unit,
-    onSelectWork: (String) -> Unit,
-) {
-    Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
-        if (searchQuery.isNotBlank()) {
-            SearchResultsScreen(
-                session = session,
-                query = searchQuery,
-                onSelectAlbum = onSelectAlbum,
-                onSelectComposer = onSelectComposer,
-                onSelectWork = onSelectWork,
-            )
-        } else {
-            when (mode) {
-                LibraryBrowserMode.ALBUMS -> {
-                    LibraryGridContent(
-                        session = session,
-                        page = page,
-                        gridState = gridState,
-                        onSelectAlbum = onSelectAlbum,
-                    )
-                }
-
-                LibraryBrowserMode.COMPOSERS -> {
-                    ComposerListContent(
-                        page = composerPage,
-                        loadImage = session.library::imageBytes,
-                        onSelectComposer = onSelectComposer,
-                    )
-                }
-            }
-        }
     }
 }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
@@ -1,0 +1,191 @@
+package fm.bae.app.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import fm.bae.app.BaeLogger
+import fm.bae.app.OpenLibrary
+import fm.bae.app.R
+import uniffi.bae_bridge.BridgeComposerSortCriterion
+import uniffi.bae_bridge.BridgeComposerSortField
+import uniffi.bae_bridge.BridgeSortCriterion
+import uniffi.bae_bridge.BridgeSortDirection
+import uniffi.bae_bridge.BridgeSortField
+
+private const val TAG = "bae.LibraryBrowser"
+private val logger = BaeLogger(TAG)
+private val DEFAULT_ALBUM_SORT =
+    BridgeSortCriterion(BridgeSortField.DATE_ADDED, BridgeSortDirection.DESCENDING)
+private val DEFAULT_COMPOSER_SORT =
+    BridgeComposerSortCriterion(BridgeComposerSortField.NAME, BridgeSortDirection.ASCENDING)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LibraryBrowser(
+    session: OpenLibrary,
+    onSelectAlbum: (String) -> Unit,
+    onSelectComposer: (String) -> Unit,
+    onSelectWork: (String) -> Unit,
+    onSettings: () -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    var searchOpen by remember { mutableStateOf(false) }
+    var mode by remember { mutableStateOf(LibraryBrowserMode.ALBUMS) }
+    var sortCriterion by remember { mutableStateOf(DEFAULT_ALBUM_SORT) }
+    var composerSortCriterion by remember { mutableStateOf(DEFAULT_COMPOSER_SORT) }
+    val generation by session.libraryStore.generation.collectAsState()
+    val composerGeneration by session.libraryStore.composerGeneration.collectAsState()
+    val syncing by session.configStore.syncing.collectAsState()
+    val syncError by session.configStore.syncError.collectAsState()
+    val appError by session.configStore.error.collectAsState()
+    val gridState = rememberLazyGridState()
+    val libraryActionFailed = stringResource(R.string.library_load_failed)
+    val page = rememberLibraryPage(session, generation, sortCriterion, LocalContext.current, gridState)
+    val composerPage = rememberComposerPage(session, composerGeneration, composerSortCriterion, LocalContext.current)
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        LibraryBrowserChrome(
+            searchOpen = searchOpen,
+            searchQuery = searchQuery,
+            onSearchQueryChange = { searchQuery = it },
+            onOpenSearch = { searchOpen = true },
+            onCloseSearch = {
+                searchOpen = false
+                searchQuery = ""
+            },
+            mode = mode,
+            onModeChange = { mode = it },
+            sortCriterion = sortCriterion,
+            onSortChange = { sortCriterion = it },
+            composerSortCriterion = composerSortCriterion,
+            onComposerSortChange = { composerSortCriterion = it },
+            syncing = syncing,
+            onShuffleLibrary = {
+                try {
+                    session.appHandle.playLibraryShuffled()
+                } catch (e: Exception) {
+                    logger.error("playLibraryShuffled failed", e)
+                    session.configStore.showError(libraryActionFailed)
+                }
+            },
+            onSettings = onSettings,
+        )
+        LibraryErrorBanner(page = page, appError = appError, syncError = syncError, session = session)
+        LibraryBrowserContent(
+            session = session,
+            searchQuery = searchQuery,
+            mode = mode,
+            page = page,
+            composerPage = composerPage,
+            gridState = gridState,
+            onSelectAlbum = onSelectAlbum,
+            onSelectComposer = onSelectComposer,
+            onSelectWork = onSelectWork,
+        )
+        NowPlayingBar(session = session)
+    }
+}
+
+@Composable
+private fun LibraryBrowserChrome(
+    searchOpen: Boolean,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onOpenSearch: () -> Unit,
+    onCloseSearch: () -> Unit,
+    mode: LibraryBrowserMode,
+    onModeChange: (LibraryBrowserMode) -> Unit,
+    sortCriterion: BridgeSortCriterion,
+    onSortChange: (BridgeSortCriterion) -> Unit,
+    composerSortCriterion: BridgeComposerSortCriterion,
+    onComposerSortChange: (BridgeComposerSortCriterion) -> Unit,
+    syncing: Boolean,
+    onShuffleLibrary: () -> Unit,
+    onSettings: () -> Unit,
+) {
+    if (searchOpen) {
+        LibrarySearchBar(
+            query = searchQuery,
+            onQueryChange = onSearchQueryChange,
+            onClose = onCloseSearch,
+        )
+    } else {
+        LibraryTopBar(
+            onOpenSearch = onOpenSearch,
+            onShuffleLibrary = onShuffleLibrary,
+            mode = mode,
+            sortCriterion = sortCriterion,
+            onSortChange = onSortChange,
+            composerSortCriterion = composerSortCriterion,
+            onComposerSortChange = onComposerSortChange,
+            onSettings = onSettings,
+        )
+    }
+    LibraryModeBar(mode = mode, onModeChange = onModeChange)
+    if (syncing) {
+        LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surface,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.LibraryBrowserContent(
+    session: OpenLibrary,
+    searchQuery: String,
+    mode: LibraryBrowserMode,
+    page: LibraryPage,
+    composerPage: ComposerPage,
+    gridState: androidx.compose.foundation.lazy.grid.LazyGridState,
+    onSelectAlbum: (String) -> Unit,
+    onSelectComposer: (String) -> Unit,
+    onSelectWork: (String) -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+        if (searchQuery.isNotBlank()) {
+            SearchResultsScreen(
+                session = session,
+                query = searchQuery,
+                onSelectAlbum = onSelectAlbum,
+                onSelectComposer = onSelectComposer,
+                onSelectWork = onSelectWork,
+            )
+        } else {
+            when (mode) {
+                LibraryBrowserMode.ALBUMS -> {
+                    LibraryGridContent(
+                        session = session,
+                        page = page,
+                        gridState = gridState,
+                        onSelectAlbum = onSelectAlbum,
+                    )
+                }
+
+                LibraryBrowserMode.COMPOSERS -> {
+                    ComposerListContent(
+                        page = composerPage,
+                        loadImage = session.library::imageBytes,
+                        onSelectComposer = onSelectComposer,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Sort
@@ -35,7 +34,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -45,7 +43,6 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -60,7 +57,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -75,7 +71,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.bae_bridge.BridgeAlbum
 import uniffi.bae_bridge.BridgeComposerSortCriterion
-import uniffi.bae_bridge.BridgeComposerSortField
 import uniffi.bae_bridge.BridgeSortCriterion
 import uniffi.bae_bridge.BridgeSortDirection
 import uniffi.bae_bridge.BridgeSortField
@@ -100,6 +95,24 @@ private data class AlbumTarget(
     val albumId: String,
     val initialReleaseId: String? = null,
 )
+
+private sealed interface LibraryDestination {
+    data class Album(
+        val target: AlbumTarget,
+    ) : LibraryDestination
+
+    data class Work(
+        val workId: String,
+    ) : LibraryDestination
+
+    data class Composer(
+        val artistId: String,
+    ) : LibraryDestination
+
+    data object Members : LibraryDestination
+
+    data object Settings : LibraryDestination
+}
 
 /**
  * Loads and accumulates the album grid one page at a time. Owns the loaded
@@ -207,65 +220,62 @@ fun LibraryScreen(
     session: OpenLibrary,
     onLeaveLibrary: () -> Unit,
 ) {
-    var selectedAlbum by remember { mutableStateOf<AlbumTarget?>(null) }
-    var selectedComposerId by remember { mutableStateOf<String?>(null) }
-    var selectedWorkId by remember { mutableStateOf<String?>(null) }
-    var showSettings by remember { mutableStateOf(false) }
-    var showMembers by remember { mutableStateOf(false) }
-    val selected = selectedAlbum
-    when {
-        selected != null -> {
+    var destination by remember { mutableStateOf<LibraryDestination?>(null) }
+    when (val activeDestination = destination) {
+        is LibraryDestination.Album -> {
+            val selected = activeDestination.target
             AlbumDetailScreen(
                 session = session,
                 albumId = selected.albumId,
                 initialReleaseId = selected.initialReleaseId,
-                onBack = { selectedAlbum = null },
+                onBack = { destination = null },
             )
         }
 
-        selectedWorkId != null -> {
-            val workId = selectedWorkId ?: return
+        is LibraryDestination.Work -> {
             WorkDetailScreen(
                 session = session,
-                workId = workId,
-                onBack = { selectedWorkId = null },
-                onSelectWork = { selectedWorkId = it },
+                workId = activeDestination.workId,
+                onBack = { destination = null },
+                onSelectWork = { destination = LibraryDestination.Work(it) },
                 onSelectAlbum = { albumId, releaseId ->
-                    selectedAlbum = AlbumTarget(albumId, releaseId)
+                    destination = LibraryDestination.Album(AlbumTarget(albumId, releaseId))
                 },
             )
         }
 
-        selectedComposerId != null -> {
+        is LibraryDestination.Composer -> {
             ComposerDetailScreen(
                 session = session,
-                artistId = selectedComposerId,
-                onBack = { selectedComposerId = null },
-                onSelectWork = { selectedWorkId = it },
-                onSelectAlbum = { selectedAlbum = AlbumTarget(it) },
+                artistId = activeDestination.artistId,
+                onBack = { destination = null },
+                onSelectWork = { destination = LibraryDestination.Work(it) },
+                onSelectAlbum = { albumId, releaseId ->
+                    destination = LibraryDestination.Album(AlbumTarget(albumId, releaseId))
+                },
             )
         }
 
-        showMembers -> {
-            MembersScreen(session = session, onBack = { showMembers = false })
+        LibraryDestination.Members -> {
+            MembersScreen(session = session, onBack = { destination = null })
         }
 
-        showSettings -> {
+        LibraryDestination.Settings -> {
             SettingsScreen(
                 session = session,
-                onBack = { showSettings = false },
-                onManageDevices = { showMembers = true },
+                onBack = { destination = null },
+                onManageDevices = { destination = LibraryDestination.Members },
                 onLeaveLibrary = onLeaveLibrary,
             )
         }
 
-        else -> {
+        null -> {
             LibraryBrowser(
                 session = session,
-                onSelectAlbum = { selectedAlbum = AlbumTarget(it) },
-                onSelectComposer = { selectedComposerId = it },
-                onSelectWork = { selectedWorkId = it },
-                onSettings = { showSettings = true },
+                onSelectAlbum = { destination = LibraryDestination.Album(AlbumTarget(it)) },
+                onSelectComposer = { destination = LibraryDestination.Composer(it) },
+                onSelectWork = { destination = LibraryDestination.Work(it) },
+                onSettings = { destination = LibraryDestination.Settings },
             )
         }
     }
@@ -354,6 +364,19 @@ internal fun LibraryErrorBanner(
                 appError == null && syncError != null -> ({ session.appHandle.triggerSync() })
                 else -> null
             },
+    )
+}
+
+@Composable
+internal fun LibraryGlobalErrorBanner(
+    appError: String?,
+    syncError: String?,
+    session: OpenLibrary,
+) {
+    val banner = appError ?: syncError ?: return
+    ErrorBanner(
+        message = banner,
+        onRetry = if (appError == null && syncError != null) ({ session.appHandle.triggerSync() }) else null,
     )
 }
 
@@ -529,29 +552,6 @@ private fun SortMenu(
                     Icon(imageVector = icon, contentDescription = null)
                 },
             )
-        }
-    }
-}
-
-@Composable
-private fun ErrorBanner(
-    message: String,
-    onRetry: (() -> Unit)? = null,
-) {
-    Surface(color = MaterialTheme.colorScheme.errorContainer, modifier = Modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = message,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onErrorContainer,
-                modifier = Modifier.weight(1f),
-            )
-            if (onRetry != null) {
-                TextButton(onClick = onRetry) { Text(stringResource(R.string.retry)) }
-            }
         }
     }
 }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
@@ -74,19 +74,31 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.bae_bridge.BridgeAlbum
+import uniffi.bae_bridge.BridgeComposerSortCriterion
+import uniffi.bae_bridge.BridgeComposerSortField
 import uniffi.bae_bridge.BridgeSortCriterion
 import uniffi.bae_bridge.BridgeSortDirection
 import uniffi.bae_bridge.BridgeSortField
 
 private const val TAG = "bae.LibraryScreen"
 private val logger = BaeLogger(TAG)
-private const val PAGE_SIZE = 60
+internal const val PAGE_SIZE = 60
 private const val GRID_PREFETCH_AHEAD = 12
 private const val PULL_REFRESH_SETTLE_MS = 900L
 
-private class PageError(
+internal class PageError(
     val message: String,
     val onRetry: () -> Unit,
+)
+
+internal enum class LibraryBrowserMode {
+    ALBUMS,
+    COMPOSERS,
+}
+
+private data class AlbumTarget(
+    val albumId: String,
+    val initialReleaseId: String? = null,
 )
 
 /**
@@ -96,7 +108,7 @@ private class PageError(
  * in composition recompose on change. (Each album carries its own cover
  * reference; the grid cards fetch the bytes by id.)
  */
-private class LibraryPage(
+internal class LibraryPage(
     private val session: OpenLibrary,
     private val sortCriterion: BridgeSortCriterion,
     private val appContext: Context,
@@ -162,7 +174,7 @@ private class LibraryPage(
 }
 
 @Composable
-private fun rememberLibraryPage(
+internal fun rememberLibraryPage(
     session: OpenLibrary,
     generation: Long,
     sortCriterion: BridgeSortCriterion,
@@ -195,13 +207,43 @@ fun LibraryScreen(
     session: OpenLibrary,
     onLeaveLibrary: () -> Unit,
 ) {
-    var selectedAlbumId by remember { mutableStateOf<String?>(null) }
+    var selectedAlbum by remember { mutableStateOf<AlbumTarget?>(null) }
+    var selectedComposerId by remember { mutableStateOf<String?>(null) }
+    var selectedWorkId by remember { mutableStateOf<String?>(null) }
     var showSettings by remember { mutableStateOf(false) }
     var showMembers by remember { mutableStateOf(false) }
-    val selected = selectedAlbumId
+    val selected = selectedAlbum
     when {
         selected != null -> {
-            AlbumDetailScreen(session = session, albumId = selected, onBack = { selectedAlbumId = null })
+            AlbumDetailScreen(
+                session = session,
+                albumId = selected.albumId,
+                initialReleaseId = selected.initialReleaseId,
+                onBack = { selectedAlbum = null },
+            )
+        }
+
+        selectedWorkId != null -> {
+            val workId = selectedWorkId ?: return
+            WorkDetailScreen(
+                session = session,
+                workId = workId,
+                onBack = { selectedWorkId = null },
+                onSelectWork = { selectedWorkId = it },
+                onSelectAlbum = { albumId, releaseId ->
+                    selectedAlbum = AlbumTarget(albumId, releaseId)
+                },
+            )
+        }
+
+        selectedComposerId != null -> {
+            ComposerDetailScreen(
+                session = session,
+                artistId = selectedComposerId,
+                onBack = { selectedComposerId = null },
+                onSelectWork = { selectedWorkId = it },
+                onSelectAlbum = { selectedAlbum = AlbumTarget(it) },
+            )
         }
 
         showMembers -> {
@@ -220,7 +262,9 @@ fun LibraryScreen(
         else -> {
             LibraryBrowser(
                 session = session,
-                onSelectAlbum = { selectedAlbumId = it },
+                onSelectAlbum = { selectedAlbum = AlbumTarget(it) },
+                onSelectComposer = { selectedComposerId = it },
+                onSelectWork = { selectedWorkId = it },
                 onSettings = { showSettings = true },
             )
         }
@@ -229,74 +273,7 @@ fun LibraryScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun LibraryBrowser(
-    session: OpenLibrary,
-    onSelectAlbum: (String) -> Unit,
-    onSettings: () -> Unit,
-) {
-    var searchQuery by remember { mutableStateOf("") }
-    var searchOpen by remember { mutableStateOf(false) }
-    var sortCriterion by
-        remember { mutableStateOf(BridgeSortCriterion(BridgeSortField.DATE_ADDED, BridgeSortDirection.DESCENDING)) }
-    val generation by session.libraryStore.generation.collectAsState()
-    val syncing by session.configStore.syncing.collectAsState()
-    val syncError by session.configStore.syncError.collectAsState()
-    val appError by session.configStore.error.collectAsState()
-    val gridState = rememberLazyGridState()
-    val page = rememberLibraryPage(session, generation, sortCriterion, LocalContext.current, gridState)
-
-    Column(modifier = Modifier.fillMaxSize()) {
-        if (searchOpen) {
-            LibrarySearchBar(
-                query = searchQuery,
-                onQueryChange = { searchQuery = it },
-                onClose = {
-                    searchOpen = false
-                    searchQuery = ""
-                },
-            )
-        } else {
-            LibraryTopBar(
-                onOpenSearch = { searchOpen = true },
-                onShuffleLibrary = {
-                    try {
-                        session.appHandle.playLibraryShuffled()
-                    } catch (e: Exception) {
-                        logger.error("playLibraryShuffled failed", e)
-                    }
-                },
-                sortCriterion = sortCriterion,
-                onSortChange = { sortCriterion = it },
-                onSettings = onSettings,
-            )
-        }
-        if (syncing) {
-            LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.surface,
-            )
-        }
-        LibraryErrorBanner(page = page, appError = appError, syncError = syncError, session = session)
-        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-            if (searchQuery.isNotBlank()) {
-                SearchResultsScreen(session = session, query = searchQuery, onSelectAlbum = onSelectAlbum)
-            } else {
-                LibraryGridContent(
-                    session = session,
-                    page = page,
-                    gridState = gridState,
-                    onSelectAlbum = onSelectAlbum,
-                )
-            }
-        }
-        NowPlayingBar(session = session)
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun LibraryGridContent(
+internal fun LibraryGridContent(
     session: OpenLibrary,
     page: LibraryPage,
     gridState: LazyGridState,
@@ -361,7 +338,7 @@ private fun LibraryGridContent(
 }
 
 @Composable
-private fun LibraryErrorBanner(
+internal fun LibraryErrorBanner(
     page: LibraryPage,
     appError: String?,
     syncError: String?,
@@ -381,11 +358,14 @@ private fun LibraryErrorBanner(
 }
 
 @Composable
-private fun LibraryTopBar(
+internal fun LibraryTopBar(
     onOpenSearch: () -> Unit,
     onShuffleLibrary: () -> Unit,
+    mode: LibraryBrowserMode,
     sortCriterion: BridgeSortCriterion,
     onSortChange: (BridgeSortCriterion) -> Unit,
+    composerSortCriterion: BridgeComposerSortCriterion,
+    onComposerSortChange: (BridgeComposerSortCriterion) -> Unit,
     onSettings: () -> Unit,
 ) {
     Surface(color = MaterialTheme.colorScheme.surface, tonalElevation = 2.dp) {
@@ -404,7 +384,18 @@ private fun LibraryTopBar(
                     contentDescription = stringResource(R.string.shuffle_library),
                 )
             }
-            SortMenu(criterion = sortCriterion, onChange = onSortChange)
+            when (mode) {
+                LibraryBrowserMode.ALBUMS -> {
+                    SortMenu(criterion = sortCriterion, onChange = onSortChange)
+                }
+
+                LibraryBrowserMode.COMPOSERS -> {
+                    ComposerSortMenu(
+                        criterion = composerSortCriterion,
+                        onChange = onComposerSortChange,
+                    )
+                }
+            }
             IconButton(onClick = onSettings) {
                 Icon(imageVector = Icons.Filled.Settings, contentDescription = stringResource(R.string.settings))
             }
@@ -413,7 +404,31 @@ private fun LibraryTopBar(
 }
 
 @Composable
-private fun LibrarySearchBar(
+internal fun LibraryModeBar(
+    mode: LibraryBrowserMode,
+    onModeChange: (LibraryBrowserMode) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TextButton(onClick = { onModeChange(LibraryBrowserMode.ALBUMS) }) {
+            Text(
+                text = stringResource(R.string.library_mode_albums),
+                fontWeight = if (mode == LibraryBrowserMode.ALBUMS) FontWeight.Bold else FontWeight.Normal,
+            )
+        }
+        TextButton(onClick = { onModeChange(LibraryBrowserMode.COMPOSERS) }) {
+            Text(
+                text = stringResource(R.string.library_mode_composers),
+                fontWeight = if (mode == LibraryBrowserMode.COMPOSERS) FontWeight.Bold else FontWeight.Normal,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun LibrarySearchBar(
     query: String,
     onQueryChange: (String) -> Unit,
     onClose: () -> Unit,

--- a/bae-android/app/src/main/java/fm/bae/app/ui/SearchResultsScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/SearchResultsScreen.kt
@@ -27,16 +27,27 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import fm.bae.app.BaeLogger
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
 import fm.bae.app.formatDurationMs
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import uniffi.bae_bridge.BridgeAlbumSearchResult
+import uniffi.bae_bridge.BridgeComposerSummary
 import uniffi.bae_bridge.BridgeSearchResults
 import uniffi.bae_bridge.BridgeTrackSearchResult
+import uniffi.bae_bridge.BridgeWorkSummary
 
 private const val DEBOUNCE_MS = 300L
+private const val TAG = "bae.SearchResultsScreen"
+private val logger = BaeLogger(TAG)
+
+internal fun BridgeSearchResults.hasNoResults(): Boolean =
+    albums.isEmpty() &&
+        tracks.isEmpty() &&
+        composers.isEmpty() &&
+        works.isEmpty()
 
 private suspend fun fetchSearchResults(
     session: OpenLibrary,
@@ -59,6 +70,8 @@ fun SearchResultsScreen(
     session: OpenLibrary,
     query: String,
     onSelectAlbum: (String) -> Unit,
+    onSelectComposer: (String) -> Unit,
+    onSelectWork: (String) -> Unit,
 ) {
     var results by remember { mutableStateOf<BridgeSearchResults?>(null) }
     var loading by remember { mutableStateOf(true) }
@@ -77,7 +90,8 @@ fun SearchResultsScreen(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            error = e.message ?: appContext.getString(R.string.search_failed)
+            logger.error("Search failed", e)
+            error = appContext.getString(R.string.search_failed)
         } finally {
             loading = false
         }
@@ -99,7 +113,8 @@ fun SearchResultsScreen(
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
 
-            current != null && current.albums.isEmpty() && current.tracks.isEmpty() -> {
+            current != null &&
+                current.hasNoResults() -> {
                 Text(
                     text = stringResource(R.string.search_no_results, query),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -112,6 +127,8 @@ fun SearchResultsScreen(
                     results = current,
                     loadImage = session.library::imageBytes,
                     onSelectAlbum = onSelectAlbum,
+                    onSelectComposer = onSelectComposer,
+                    onSelectWork = onSelectWork,
                 )
             }
         }
@@ -123,6 +140,8 @@ private fun SearchResultsList(
     results: BridgeSearchResults,
     loadImage: suspend (imageId: String) -> ByteArray?,
     onSelectAlbum: (String) -> Unit,
+    onSelectComposer: (String) -> Unit,
+    onSelectWork: (String) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         if (results.albums.isNotEmpty()) {
@@ -141,6 +160,26 @@ private fun SearchResultsList(
                 TrackResultRow(
                     track = track,
                     onClick = { onSelectAlbum(track.albumId) },
+                )
+            }
+        }
+        if (results.composers.isNotEmpty()) {
+            item { SectionHeader(stringResource(R.string.search_section_composers)) }
+            items(results.composers, key = { "composer:${it.artistId}" }) { composer ->
+                ComposerResultRow(
+                    composer = composer,
+                    loadImage = loadImage,
+                    onClick = { onSelectComposer(composer.artistId) },
+                )
+            }
+        }
+        if (results.works.isNotEmpty()) {
+            item { SectionHeader(stringResource(R.string.search_section_works)) }
+            items(results.works, key = { "work:${it.workId}" }) { work ->
+                WorkResultRow(
+                    work = work,
+                    loadImage = loadImage,
+                    onClick = { onSelectWork(work.workId) },
                 )
             }
         }
@@ -233,6 +272,90 @@ private fun TrackResultRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+    }
+}
+
+@Composable
+private fun ComposerResultRow(
+    composer: BridgeComposerSummary,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CoverImage(
+            coverId = composer.image?.id,
+            coverVersion = composer.image?.version,
+            loadImage = loadImage,
+            cornerRadius = 4.dp,
+            iconPadding = 12.dp,
+            modifier = Modifier.size(48.dp),
+            contentDescription = composer.name,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = composer.name,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+            )
+            Text(
+                text = stringResource(R.string.work_count, composer.workCount.toLong()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WorkResultRow(
+    work: BridgeWorkSummary,
+    loadImage: suspend (imageId: String) -> ByteArray?,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CoverImage(
+            coverId = work.representativeCover?.id,
+            coverVersion = work.representativeCover?.version,
+            loadImage = loadImage,
+            cornerRadius = 4.dp,
+            iconPadding = 12.dp,
+            modifier = Modifier.size(48.dp),
+            contentDescription = work.title,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = work.title,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+            )
+            val composerNames = work.composerNames
+            if (!composerNames.isNullOrBlank()) {
+                Text(
+                    text = composerNames,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
         }
     }
 }

--- a/bae-android/app/src/main/res/values-ar/strings.xml
+++ b/bae-android/app/src/main/res/values-ar/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">مفتاح التشفير (64 حرفًا سداسيًا عشريًا)</string>
     <string name="unlock_failed">فشل إلغاء القفل</string>
     <string name="unlock_action">إلغاء القفل</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/bae-android/app/src/main/res/values-b+pt+BR/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Chave de criptografia (64 caracteres hexadecimais)</string>
     <string name="unlock_failed">Falha ao desbloquear</string>
     <string name="unlock_action">Desbloquear</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/bae-android/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">加密密钥（64 位十六进制）</string>
     <string name="unlock_failed">解锁失败</string>
     <string name="unlock_action">解锁</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/bae-android/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">加密 (64 hex)</string>
     <string name="unlock_failed">解鎖 · 錯誤</string>
     <string name="unlock_action">解鎖</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-bg/strings.xml
+++ b/bae-android/app/src/main/res/values-bg/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Ключ за шифроване (64 шестнадесетични знака)</string>
     <string name="unlock_failed">Отключването не бе успешно</string>
     <string name="unlock_action">Отключване</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-bn/strings.xml
+++ b/bae-android/app/src/main/res/values-bn/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">এনক্রিপশন (64 hex)</string>
     <string name="unlock_failed">আনলক · ত্রুটি</string>
     <string name="unlock_action">আনলক</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-cs/strings.xml
+++ b/bae-android/app/src/main/res/values-cs/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Šifrovací klíč (64 šestnáctkových znaků)</string>
     <string name="unlock_failed">Odemčení selhalo</string>
     <string name="unlock_action">Odemknout</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-de/strings.xml
+++ b/bae-android/app/src/main/res/values-de/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Verschlüsselungsschlüssel (64 Hex-Zeichen)</string>
     <string name="unlock_failed">Entsperren fehlgeschlagen</string>
     <string name="unlock_action">Entsperren</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-es/strings.xml
+++ b/bae-android/app/src/main/res/values-es/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Clave de cifrado (64 caracteres hexadecimales)</string>
     <string name="unlock_failed">Error al desbloquear</string>
     <string name="unlock_action">Desbloquear</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-fr/strings.xml
+++ b/bae-android/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="settings">Réglages</string>
     <string name="close_search">Fermer la recherche</string>
     <string name="clear_search">Effacer la recherche</string>
-    <string name="search_placeholder">Rechercher des albums et des pistes</string>
+    <string name="search_placeholder">Search albums, tracks, composers, and works</string>
     <string name="sort">Trier</string>
     <string name="sort_title">Titre</string>
     <string name="sort_artist">Artiste</string>
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Clé de chiffrement (64 caractères hex)</string>
     <string name="unlock_failed">Échec du déverrouillage</string>
     <string name="unlock_action">Déverrouiller</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-gu/strings.xml
+++ b/bae-android/app/src/main/res/values-gu/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">એન્ક્રિપ્શન (64 hex)</string>
     <string name="unlock_failed">અનલોક · ભૂલ</string>
     <string name="unlock_action">અનલોક</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-he/strings.xml
+++ b/bae-android/app/src/main/res/values-he/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">מפתח הצפנה (64 תווים הקסדצימליים)</string>
     <string name="unlock_failed">פתיחת הנעילה נכשלה</string>
     <string name="unlock_action">פתח נעילה</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-hi/strings.xml
+++ b/bae-android/app/src/main/res/values-hi/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">एन्क्रिप्शन (64 hex)</string>
     <string name="unlock_failed">अनलॉक · त्रुटि</string>
     <string name="unlock_action">अनलॉक</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-hr/strings.xml
+++ b/bae-android/app/src/main/res/values-hr/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Ključ za šifriranje (64 heksadecimalna znaka)</string>
     <string name="unlock_failed">Otključavanje nije uspjelo</string>
     <string name="unlock_action">Otključaj</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-it/strings.xml
+++ b/bae-android/app/src/main/res/values-it/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Crittografia (64 hex)</string>
     <string name="unlock_failed">Sblocca · Errore</string>
     <string name="unlock_action">Sblocca</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-ja/strings.xml
+++ b/bae-android/app/src/main/res/values-ja/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">暗号化キー（16進数64文字）</string>
     <string name="unlock_failed">ロック解除に失敗しました</string>
     <string name="unlock_action">ロック解除</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-kn/strings.xml
+++ b/bae-android/app/src/main/res/values-kn/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">ಎನ್‌ಕ್ರಿಪ್ಷನ್ (64 hex)</string>
     <string name="unlock_failed">ಅನ್‌ಲಾಕ್ · ದೋಷ</string>
     <string name="unlock_action">ಅನ್‌ಲಾಕ್</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-ko/strings.xml
+++ b/bae-android/app/src/main/res/values-ko/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">암호화 키(64자 16진수)</string>
     <string name="unlock_failed">잠금 해제 실패</string>
     <string name="unlock_action">잠금 해제</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-ml/strings.xml
+++ b/bae-android/app/src/main/res/values-ml/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">എൻക്രിപ്ഷൻ (64 hex)</string>
     <string name="unlock_failed">അൺലോക്ക് · പിശക്</string>
     <string name="unlock_action">അൺലോക്ക്</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-mr/strings.xml
+++ b/bae-android/app/src/main/res/values-mr/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">कूटबद्धीकरण (64 hex)</string>
     <string name="unlock_failed">अनलॉक · त्रुटी</string>
     <string name="unlock_action">अनलॉक</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-nl/strings.xml
+++ b/bae-android/app/src/main/res/values-nl/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Versleuteling (64 hex)</string>
     <string name="unlock_failed">Ontgrendelen · Fout</string>
     <string name="unlock_action">Ontgrendelen</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-pa/strings.xml
+++ b/bae-android/app/src/main/res/values-pa/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">ਇਨਕ੍ਰਿਪਸ਼ਨ (64 hex)</string>
     <string name="unlock_failed">ਅਨਲਾਕ · ਗਲਤੀ</string>
     <string name="unlock_action">ਅਨਲਾਕ</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-pl/strings.xml
+++ b/bae-android/app/src/main/res/values-pl/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Klucz szyfrujący (64 znaki szesnastkowe)</string>
     <string name="unlock_failed">Nie udało się odblokować</string>
     <string name="unlock_action">Odblokuj</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-ta/strings.xml
+++ b/bae-android/app/src/main/res/values-ta/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">குறியாக்கம் (64 hex)</string>
     <string name="unlock_failed">திற · பிழை</string>
     <string name="unlock_action">திற</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-te/strings.xml
+++ b/bae-android/app/src/main/res/values-te/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">ఎన్‌క్రిప్షన్ (64 hex)</string>
     <string name="unlock_failed">అన్‌లాక్ · లోపం</string>
     <string name="unlock_action">అన్‌లాక్</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-th/strings.xml
+++ b/bae-android/app/src/main/res/values-th/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">การเข้ารหัส (64 hex)</string>
     <string name="unlock_failed">ปลดล็อก · ข้อผิดพลาด</string>
     <string name="unlock_action">ปลดล็อก</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-tr/strings.xml
+++ b/bae-android/app/src/main/res/values-tr/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Şifreleme (64 hex)</string>
     <string name="unlock_failed">Kilidi aç · Hata</string>
     <string name="unlock_action">Kilidi aç</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-uk/strings.xml
+++ b/bae-android/app/src/main/res/values-uk/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Ключ шифрування (64 шістнадцяткові символи)</string>
     <string name="unlock_failed">Не вдалося розблокувати</string>
     <string name="unlock_action">Розблокувати</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-ur/strings.xml
+++ b/bae-android/app/src/main/res/values-ur/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">خفیہ کاری (64 hex)</string>
     <string name="unlock_failed">کھولیں · خرابی</string>
     <string name="unlock_action">کھولیں</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values-vi/strings.xml
+++ b/bae-android/app/src/main/res/values-vi/strings.xml
@@ -76,4 +76,18 @@
     <string name="unlock_key_label">Mã hóa (64 hex)</string>
     <string name="unlock_failed">Mở khóa · Lỗi</string>
     <string name="unlock_action">Mở khóa</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 </resources>

--- a/bae-android/app/src/main/res/values/strings.xml
+++ b/bae-android/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="settings">Settings</string>
     <string name="close_search">Close search</string>
     <string name="clear_search">Clear search</string>
-    <string name="search_placeholder">Search albums and tracks</string>
+    <string name="search_placeholder">Search albums, tracks, composers, and works</string>
     <string name="sort">Sort</string>
     <string name="sort_title">Title</string>
     <string name="sort_artist">Artist</string>
@@ -76,6 +76,20 @@
     <string name="search_no_results">No results for “%1$s”</string>
     <string name="search_section_albums">Albums</string>
     <string name="search_section_tracks">Tracks</string>
+    <string name="work_count">%1$d Works</string>
+    <string name="work_detail_load_failed">Couldn\'t load this work.</string>
+    <string name="work_detail_not_found">Work detail not found</string>
+    <string name="composer_detail_load_failed">Couldn\'t load this composer.</string>
+    <string name="composer_detail_not_found">Composer detail not found</string>
+    <string name="search_section_recordings">Recordings</string>
+    <string name="search_section_credits">Credits</string>
+    <string name="search_section_releases">Releases</string>
+    <string name="search_section_works">Works</string>
+    <string name="search_section_composers">Composers</string>
+    <string name="library_empty_composers">No composers</string>
+    <string name="library_mode_composers">Composers</string>
+    <string name="library_mode_albums">Albums</string>
+    <string name="sort_name">Name</string>
 
     <!-- Gallery -->
     <string name="gallery_load_failed">Couldn\'t load image</string>

--- a/bae-android/app/src/test/java/fm/bae/app/BridgeFixtures.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/BridgeFixtures.kt
@@ -2,6 +2,10 @@ package fm.bae.app
 
 import uniffi.bae_bridge.BridgeAlbum
 import uniffi.bae_bridge.BridgeAlbumDetail
+import uniffi.bae_bridge.BridgeAlbumSearchResult
+import uniffi.bae_bridge.BridgeComposerDetail
+import uniffi.bae_bridge.BridgeComposerSummary
+import uniffi.bae_bridge.BridgeComposerWorkGroup
 import uniffi.bae_bridge.BridgeConfig
 import uniffi.bae_bridge.BridgeDiscogsTokenStatus
 import uniffi.bae_bridge.BridgeExportLocation
@@ -9,7 +13,13 @@ import uniffi.bae_bridge.BridgeGalleryItem
 import uniffi.bae_bridge.BridgeMcpConfig
 import uniffi.bae_bridge.BridgeRelease
 import uniffi.bae_bridge.BridgeReleaseStorageState
+import uniffi.bae_bridge.BridgeSearchResults
 import uniffi.bae_bridge.BridgeTrackGroup
+import uniffi.bae_bridge.BridgeTrackSearchResult
+import uniffi.bae_bridge.BridgeWorkDetail
+import uniffi.bae_bridge.BridgeWorkReleaseSummary
+import uniffi.bae_bridge.BridgeWorkSummary
+import uniffi.bae_bridge.BridgeWorkTrackSummary
 
 /**
  * Plain `Bridge*` data-class constructors for the JVM unit tests. These build
@@ -68,6 +78,135 @@ object BridgeFixtures {
         album: BridgeAlbum,
         releases: List<BridgeRelease> = listOf(release(id = album.primaryReleaseId, albumId = album.id)),
     ): BridgeAlbumDetail = BridgeAlbumDetail(album = album, releases = releases)
+
+    fun albumSearchResult(
+        id: String = "alb-1",
+        title: String = "Album Title",
+    ): BridgeAlbumSearchResult =
+        BridgeAlbumSearchResult(
+            id = id,
+            title = title,
+            year = null,
+            artistName = "Artist Name",
+            cover = null,
+        )
+
+    fun trackSearchResult(
+        id: String = "trk-1",
+        albumId: String = "alb-1",
+    ): BridgeTrackSearchResult =
+        BridgeTrackSearchResult(
+            id = id,
+            title = "Track Title",
+            durationMs = null,
+            albumId = albumId,
+            albumTitle = "Album Title",
+            artistName = "Artist Name",
+        )
+
+    fun composerSummary(
+        artistId: String = "artist-1",
+        name: String = "Composer Name",
+    ): BridgeComposerSummary =
+        BridgeComposerSummary(
+            artistId = artistId,
+            name = name,
+            sortName = null,
+            workCount = 1L,
+            linkedReleaseCount = 1L,
+            unlinkedCreditCount = 0L,
+            image = null,
+        )
+
+    fun workSummary(
+        workId: String = "work-1",
+        title: String = "Work Title",
+    ): BridgeWorkSummary =
+        BridgeWorkSummary(
+            workId = workId,
+            title = title,
+            disambiguation = null,
+            workType = null,
+            parentWorkId = null,
+            composerNames = "Composer Name",
+            linkedReleaseCount = 1L,
+            representativeReleaseId = "rel-1",
+            representativeCover = null,
+        )
+
+    fun composerWorkGroup(
+        id: String = "group-1",
+        parent: BridgeWorkSummary? = null,
+        works: List<BridgeWorkSummary> = listOf(workSummary()),
+    ): BridgeComposerWorkGroup =
+        BridgeComposerWorkGroup(
+            id = id,
+            parent = parent,
+            works = works,
+        )
+
+    fun composerDetail(
+        composer: BridgeComposerSummary = composerSummary(),
+        workGroups: List<BridgeComposerWorkGroup> = listOf(composerWorkGroup()),
+    ): BridgeComposerDetail =
+        BridgeComposerDetail(
+            composer = composer,
+            workGroups = workGroups,
+            unlinkedReleaseRoles = emptyList(),
+            unlinkedTrackRoles = emptyList(),
+            defaultWorkId = null,
+        )
+
+    fun workReleaseSummary(
+        releaseId: String = "rel-1",
+        albumId: String = "alb-1",
+    ): BridgeWorkReleaseSummary =
+        BridgeWorkReleaseSummary(
+            releaseId = releaseId,
+            albumId = albumId,
+            albumTitle = "Album Title",
+            displayName = "Release",
+            format = "Format",
+            cover = null,
+        )
+
+    fun workTrackSummary(
+        trackId: String = "trk-1",
+        releaseId: String = "rel-1",
+        albumId: String = "alb-1",
+    ): BridgeWorkTrackSummary =
+        BridgeWorkTrackSummary(
+            trackId = trackId,
+            trackTitle = "Track Title",
+            releaseId = releaseId,
+            albumId = albumId,
+            albumTitle = "Album Title",
+        )
+
+    fun workDetail(
+        work: BridgeWorkSummary = workSummary(),
+        releases: List<BridgeWorkReleaseSummary> = listOf(workReleaseSummary()),
+        tracks: List<BridgeWorkTrackSummary> = listOf(workTrackSummary()),
+    ): BridgeWorkDetail =
+        BridgeWorkDetail(
+            work = work,
+            childWorks = emptyList(),
+            releases = releases,
+            tracks = tracks,
+        )
+
+    fun searchResults(
+        albums: List<BridgeAlbumSearchResult> = emptyList(),
+        tracks: List<BridgeTrackSearchResult> = emptyList(),
+        composers: List<BridgeComposerSummary> = emptyList(),
+        works: List<BridgeWorkSummary> = emptyList(),
+    ): BridgeSearchResults =
+        BridgeSearchResults(
+            albums = albums,
+            tracks = tracks,
+            composers = composers,
+            works = works,
+        )
 
     fun config(libraryId: String = "lib-1"): BridgeConfig =
         BridgeConfig(

--- a/bae-android/app/src/test/java/fm/bae/app/BridgeFixtures.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/BridgeFixtures.kt
@@ -3,9 +3,7 @@ package fm.bae.app
 import uniffi.bae_bridge.BridgeAlbum
 import uniffi.bae_bridge.BridgeAlbumDetail
 import uniffi.bae_bridge.BridgeAlbumSearchResult
-import uniffi.bae_bridge.BridgeComposerDetail
 import uniffi.bae_bridge.BridgeComposerSummary
-import uniffi.bae_bridge.BridgeComposerWorkGroup
 import uniffi.bae_bridge.BridgeConfig
 import uniffi.bae_bridge.BridgeDiscogsTokenStatus
 import uniffi.bae_bridge.BridgeExportLocation
@@ -16,10 +14,7 @@ import uniffi.bae_bridge.BridgeReleaseStorageState
 import uniffi.bae_bridge.BridgeSearchResults
 import uniffi.bae_bridge.BridgeTrackGroup
 import uniffi.bae_bridge.BridgeTrackSearchResult
-import uniffi.bae_bridge.BridgeWorkDetail
-import uniffi.bae_bridge.BridgeWorkReleaseSummary
 import uniffi.bae_bridge.BridgeWorkSummary
-import uniffi.bae_bridge.BridgeWorkTrackSummary
 
 /**
  * Plain `Bridge*` data-class constructors for the JVM unit tests. These build
@@ -132,67 +127,6 @@ object BridgeFixtures {
             linkedReleaseCount = 1L,
             representativeReleaseId = "rel-1",
             representativeCover = null,
-        )
-
-    fun composerWorkGroup(
-        id: String = "group-1",
-        parent: BridgeWorkSummary? = null,
-        works: List<BridgeWorkSummary> = listOf(workSummary()),
-    ): BridgeComposerWorkGroup =
-        BridgeComposerWorkGroup(
-            id = id,
-            parent = parent,
-            works = works,
-        )
-
-    fun composerDetail(
-        composer: BridgeComposerSummary = composerSummary(),
-        workGroups: List<BridgeComposerWorkGroup> = listOf(composerWorkGroup()),
-    ): BridgeComposerDetail =
-        BridgeComposerDetail(
-            composer = composer,
-            workGroups = workGroups,
-            unlinkedReleaseRoles = emptyList(),
-            unlinkedTrackRoles = emptyList(),
-            defaultWorkId = null,
-        )
-
-    fun workReleaseSummary(
-        releaseId: String = "rel-1",
-        albumId: String = "alb-1",
-    ): BridgeWorkReleaseSummary =
-        BridgeWorkReleaseSummary(
-            releaseId = releaseId,
-            albumId = albumId,
-            albumTitle = "Album Title",
-            displayName = "Release",
-            format = "Format",
-            cover = null,
-        )
-
-    fun workTrackSummary(
-        trackId: String = "trk-1",
-        releaseId: String = "rel-1",
-        albumId: String = "alb-1",
-    ): BridgeWorkTrackSummary =
-        BridgeWorkTrackSummary(
-            trackId = trackId,
-            trackTitle = "Track Title",
-            releaseId = releaseId,
-            albumId = albumId,
-            albumTitle = "Album Title",
-        )
-
-    fun workDetail(
-        work: BridgeWorkSummary = workSummary(),
-        releases: List<BridgeWorkReleaseSummary> = listOf(workReleaseSummary()),
-        tracks: List<BridgeWorkTrackSummary> = listOf(workTrackSummary()),
-    ): BridgeWorkDetail =
-        BridgeWorkDetail(
-            work = work,
-            childWorks = emptyList(),
-            releases = releases,
-            tracks = tracks,
         )
 
     fun searchResults(

--- a/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
@@ -68,12 +68,35 @@ class UiEventReducerTest {
         val (library, config) = stores()
         val detail = BridgeFixtures.albumDetail(BridgeFixtures.album(id = "alb-1"))
         val generationBefore = library.generation.value
+        val composerGenerationBefore = library.composerGeneration.value
 
         UiEventReducer.reduce(BridgeUiEvent.AlbumAdded(detail), library, config, noopPlayer, noopErrors)
 
         assertNotNull("album should be interned", library.albumDetail("alb-1"))
         assertEquals(detail, library.albumDetail("alb-1"))
         assertEquals(generationBefore + 1, library.generation.value)
+        assertEquals(composerGenerationBefore + 1, library.composerGeneration.value)
+    }
+
+    @Test
+    fun releaseChangesRefreshComposerPagesWithoutRebuildingAlbumPages() {
+        val (library, config) = stores()
+        val album = BridgeFixtures.album(id = "alb-1", releaseIds = listOf("rel-1", "rel-2"))
+        val detail = BridgeFixtures.albumDetail(album, releases = listOf(BridgeFixtures.release(id = "rel-1", albumId = "alb-1")))
+        UiEventReducer.reduce(BridgeUiEvent.AlbumAdded(detail), library, config, noopPlayer, noopErrors)
+        val albumGeneration = library.generation.value
+        val composerGeneration = library.composerGeneration.value
+
+        UiEventReducer.reduce(
+            BridgeUiEvent.ReleaseAdded(album = album, release = BridgeFixtures.release(id = "rel-2", albumId = "alb-1")),
+            library,
+            config,
+            noopPlayer,
+            noopErrors,
+        )
+
+        assertEquals(albumGeneration, library.generation.value)
+        assertEquals(composerGeneration + 1, library.composerGeneration.value)
     }
 
     @Test

--- a/bae-android/app/src/test/java/fm/bae/app/ui/SearchResultsScreenTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/ui/SearchResultsScreenTest.kt
@@ -34,19 +34,4 @@ class SearchResultsScreenTest {
                 ).hasNoResults(),
         )
     }
-
-    @Test
-    fun workDetailFixtureCarriesReleaseRows() {
-        val release =
-            BridgeFixtures.workReleaseSummary(
-                releaseId = "rel-2",
-                albumId = "alb-2",
-            )
-        val detail = BridgeFixtures.workDetail(releases = listOf(release))
-
-        assertFalse(detail.releases.isEmpty())
-        assertTrue(detail.releases.any { it.releaseId == "rel-2" })
-        assertTrue(detail.releases.any { it.albumId == "alb-2" })
-        assertTrue(detail.releases.any { it.albumTitle == "Album Title" })
-    }
 }

--- a/bae-android/app/src/test/java/fm/bae/app/ui/SearchResultsScreenTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/ui/SearchResultsScreenTest.kt
@@ -1,0 +1,52 @@
+package fm.bae.app.ui
+
+import fm.bae.app.BridgeFixtures
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchResultsScreenTest {
+    @Test
+    fun emptyStateConsidersEverySearchSection() {
+        assertTrue(BridgeFixtures.searchResults().hasNoResults())
+        assertFalse(
+            BridgeFixtures
+                .searchResults(
+                    albums = listOf(BridgeFixtures.albumSearchResult()),
+                ).hasNoResults(),
+        )
+        assertFalse(
+            BridgeFixtures
+                .searchResults(
+                    tracks = listOf(BridgeFixtures.trackSearchResult()),
+                ).hasNoResults(),
+        )
+        assertFalse(
+            BridgeFixtures
+                .searchResults(
+                    composers = listOf(BridgeFixtures.composerSummary()),
+                ).hasNoResults(),
+        )
+        assertFalse(
+            BridgeFixtures
+                .searchResults(
+                    works = listOf(BridgeFixtures.workSummary()),
+                ).hasNoResults(),
+        )
+    }
+
+    @Test
+    fun workDetailFixtureCarriesReleaseRows() {
+        val release =
+            BridgeFixtures.workReleaseSummary(
+                releaseId = "rel-2",
+                albumId = "alb-2",
+            )
+        val detail = BridgeFixtures.workDetail(releases = listOf(release))
+
+        assertFalse(detail.releases.isEmpty())
+        assertTrue(detail.releases.any { it.releaseId == "rel-2" })
+        assertTrue(detail.releases.any { it.albumId == "alb-2" })
+        assertTrue(detail.releases.any { it.albumTitle == "Album Title" })
+    }
+}

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -28,8 +28,8 @@ use crate::types::{
     BridgeRelease, BridgeReleaseRoleSummary, BridgeReleaseSummary, BridgeRepeatMode,
     BridgeSaveSyncConfig, BridgeSearchResults, BridgeSortCriterion, BridgeStorageFilter,
     BridgeStoragePage, BridgeStorageRow, BridgeStorageSort, BridgeTrack, BridgeTrackGroup,
-    BridgeTrackRoleSummary, BridgeTrackSearchResult, BridgeWorkDetail, BridgeWorkSummary,
-    BridgeWorkTrackSummary,
+    BridgeTrackRoleSummary, BridgeTrackSearchResult, BridgeWorkDetail, BridgeWorkReleaseSummary,
+    BridgeWorkSummary, BridgeWorkTrackSummary,
 };
 #[cfg(feature = "desktop")]
 use crate::types::{bridge_storage_mode_to_core, BridgeMcpServerStatus, BridgeStorageMode};
@@ -2143,6 +2143,19 @@ fn convert_work_track_summary(
     }
 }
 
+fn convert_work_release_summary(
+    s: bae_core::album_detail::WorkReleaseSummary,
+) -> BridgeWorkReleaseSummary {
+    BridgeWorkReleaseSummary {
+        release_id: s.release_id,
+        album_id: s.album_id,
+        album_title: s.album_title,
+        display_name: s.display_name,
+        format: s.format,
+        cover: s.cover.map(crate::types::BridgeImageRef::from_core),
+    }
+}
+
 fn convert_composer_detail(d: bae_core::album_detail::ComposerDetail) -> BridgeComposerDetail {
     BridgeComposerDetail {
         composer: convert_composer_summary(d.composer),
@@ -2180,7 +2193,7 @@ fn convert_work_detail(d: bae_core::album_detail::WorkDetail) -> BridgeWorkDetai
         releases: d
             .releases
             .into_iter()
-            .map(convert_release_summary)
+            .map(convert_work_release_summary)
             .collect(),
         tracks: d
             .tracks
@@ -2303,7 +2316,10 @@ pub fn raw_release_edit_from_user_edit(
 
 #[cfg(test)]
 mod tests {
-    use bae_core::album_detail::{ComposerDetail, ComposerSummary, ComposerWorkGroup, WorkSummary};
+    use bae_core::album_detail::{
+        ComposerDetail, ComposerSummary, ComposerWorkGroup, WorkDetail, WorkReleaseSummary,
+        WorkSummary,
+    };
     use bae_core::db::{DbArtist, DbComposerSummary, DbWork, DbWorkSummary};
     use std::sync::{Arc, Mutex};
 
@@ -2433,5 +2449,49 @@ mod tests {
             group.works[0].representative_release_id.as_deref(),
             Some("release-a")
         );
+    }
+
+    #[test]
+    fn work_detail_conversion_preserves_work_release_rows() {
+        let created_at = "2026-01-01T00:00:00Z".parse().unwrap();
+        let work = WorkSummary {
+            raw: DbWorkSummary {
+                work: DbWork {
+                    id: "work-a".to_string(),
+                    title: "Work Title A".to_string(),
+                    disambiguation: None,
+                    work_type: Some("work".to_string()),
+                    created_at,
+                },
+                parent_work_id: None,
+                composer_names: Some("Composer Name A".to_string()),
+                linked_release_count: 1,
+                representative_release_id: Some("release-a".to_string()),
+            },
+            representative_cover: None,
+        };
+        let detail = WorkDetail {
+            work,
+            child_works: Vec::new(),
+            releases: vec![WorkReleaseSummary {
+                release_id: "release-a".to_string(),
+                album_id: "album-a".to_string(),
+                album_title: "Album Title A".to_string(),
+                display_name: "2026 CD".to_string(),
+                format: Some("CD".to_string()),
+                cover: None,
+            }],
+            tracks: Vec::new(),
+        };
+
+        let bridge = super::convert_work_detail(detail);
+
+        assert_eq!(bridge.releases.len(), 1);
+        let release = &bridge.releases[0];
+        assert_eq!(release.release_id, "release-a");
+        assert_eq!(release.album_id, "album-a");
+        assert_eq!(release.album_title, "Album Title A");
+        assert_eq!(release.display_name, "2026 CD");
+        assert_eq!(release.format.as_deref(), Some("CD"));
     }
 }

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -2145,6 +2145,16 @@ pub struct BridgeWorkTrackSummary {
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeWorkReleaseSummary {
+    pub release_id: String,
+    pub album_id: String,
+    pub album_title: String,
+    pub display_name: String,
+    pub format: Option<String>,
+    pub cover: Option<BridgeImageRef>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeComposerDetail {
     pub composer: BridgeComposerSummary,
     pub work_groups: Vec<BridgeComposerWorkGroup>,
@@ -2164,7 +2174,7 @@ pub struct BridgeComposerWorkGroup {
 pub struct BridgeWorkDetail {
     pub work: BridgeWorkSummary,
     pub child_works: Vec<BridgeWorkSummary>,
-    pub releases: Vec<BridgeReleaseSummary>,
+    pub releases: Vec<BridgeWorkReleaseSummary>,
     pub tracks: Vec<BridgeWorkTrackSummary>,
 }
 

--- a/bae-cli/src/main.rs
+++ b/bae-cli/src/main.rs
@@ -578,7 +578,7 @@ fn bootstrap_registered_library(id: String) -> Result<RunningApp, CliError> {
     let config = Config::load_registered_library(&id, &coven::UuidProvider)
         .map_err(|e| CliError::Config(e.to_string()))?;
     require_unlocked_for_headless(&config)?;
-    bootstrap(id, 1000).map_err(bootstrap_error)
+    bootstrap(id, 1000, None).map_err(bootstrap_error)
 }
 
 fn require_unlocked_for_headless(config: &Config) -> Result<(), CliError> {

--- a/bae-core/src/album_detail/composer.rs
+++ b/bae-core/src/album_detail/composer.rs
@@ -2,7 +2,8 @@
 
 use super::*;
 use crate::db::{
-    DbComposerSummary, DbReleaseRoleSummary, DbTrackRoleSummary, DbWorkSummary, DbWorkTrackSummary,
+    DbComposerSummary, DbReleaseRoleSummary, DbTrackRoleSummary, DbWorkReleaseSummary,
+    DbWorkSummary, DbWorkTrackSummary,
 };
 
 #[derive(Debug, Clone)]
@@ -52,8 +53,48 @@ pub struct ComposerWorkGroup {
 pub struct WorkDetail {
     pub work: WorkSummary,
     pub child_works: Vec<WorkSummary>,
-    pub releases: Vec<ReleaseSummary>,
+    pub releases: Vec<WorkReleaseSummary>,
     pub tracks: Vec<WorkTrackSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkReleaseSummary {
+    pub release_id: String,
+    pub album_id: String,
+    pub album_title: String,
+    pub display_name: String,
+    pub format: Option<String>,
+    pub cover: Option<ImageRef>,
+}
+
+impl WorkReleaseSummary {
+    pub(crate) fn from_raw(raw: DbWorkReleaseSummary, cover: Option<ImageRef>) -> Self {
+        let display_name = match raw.release_name.as_deref() {
+            Some(name) => name.to_string(),
+            None => {
+                let mut parts = Vec::new();
+                if let Some(year) = raw.year {
+                    parts.push(year.to_string());
+                }
+                if let Some(format) = raw.format.as_deref() {
+                    parts.push(format.to_string());
+                }
+                if parts.is_empty() {
+                    format!("Release {}", raw.release_index)
+                } else {
+                    parts.join(" ")
+                }
+            }
+        };
+        Self {
+            release_id: raw.release_id,
+            album_id: raw.album_id,
+            album_title: raw.album_title,
+            display_name,
+            format: raw.format,
+            cover,
+        }
+    }
 }
 
 pub type ReleaseRoleSummary = DbReleaseRoleSummary;

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -240,25 +240,52 @@ fn row_to_track_role_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbTrackRo
     })
 }
 
-fn work_release_rows(conn: &Connection, work_id: &str) -> Result<Vec<DbReleaseSummary>, DbError> {
+fn work_release_rows(
+    conn: &Connection,
+    work_id: &str,
+) -> Result<Vec<DbWorkReleaseSummary>, DbError> {
     let mut stmt = conn.prepare(
         "SELECT DISTINCT
             r.id AS release_id,
             r.album_id,
+            a.title AS album_title,
+            r.release_name,
+            r.year AS release_year,
             r.format AS release_format,
-            r.remote,
-            (SELECT rf.id FROM release_files rf WHERE rf.release_id = r.id LIMIT 1) AS any_file_id,
-            COALESCE((SELECT COUNT(*) FROM release_files rf WHERE rf.release_id = r.id), 0) AS file_count,
-            COALESCE((SELECT SUM(rf.file_size) FROM release_files rf WHERE rf.release_id = r.id), 0) AS total_size
+            (
+                SELECT COUNT(*)
+                FROM releases indexed_release
+                WHERE indexed_release.album_id = r.album_id
+                  AND (
+                      indexed_release.created_at < r.created_at
+                      OR (
+                          indexed_release.created_at = r.created_at
+                          AND indexed_release.id <= r.id
+                      )
+                  )
+            ) AS release_index
          FROM track_works tw
          JOIN tracks t ON t.id = tw.track_id
          JOIN releases r ON r.id = t.release_id
+         JOIN albums a ON a.id = r.album_id
          WHERE tw.work_id = ?
-         ORDER BY r.created_at",
+         ORDER BY a.title, r.created_at, r.id",
     )?;
-    let rows = stmt.query_map(params![work_id], row_to_release_summary)?;
+    let rows = stmt.query_map(params![work_id], row_to_work_release_summary)?;
     rows.collect::<coven::rusqlite::Result<Vec<_>>>()
         .map_err(DbError::from)
+}
+
+fn row_to_work_release_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbWorkReleaseSummary> {
+    Ok(DbWorkReleaseSummary {
+        release_id: row.get("release_id")?,
+        album_id: row.get("album_id")?,
+        album_title: row.get("album_title")?,
+        release_name: row.get("release_name")?,
+        year: row.get("release_year")?,
+        format: row.get("release_format")?,
+        release_index: row.get("release_index")?,
+    })
 }
 
 fn row_to_release_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbReleaseSummary> {

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -8,6 +8,31 @@ impl Database {
         self.call(move |conn| insert_release_row(conn, &release, &reg))
             .await
     }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn insert_composition_fixture_rows(
+        &self,
+        works: &[DbWork],
+        track_works: &[DbTrackWork],
+        images: &[DbLibraryImage],
+    ) -> Result<(), DbError> {
+        let (works, track_works, images) = (works.to_vec(), track_works.to_vec(), images.to_vec());
+        let reg = self.register_stamp().await?;
+        self.call(move |conn| {
+            for work in &works {
+                insert_work_row(conn, work, &reg)?;
+            }
+            for track_work in &track_works {
+                insert_track_work_row(conn, track_work, &reg)?;
+            }
+            for image in &images {
+                upsert_library_image_row(conn, image, &reg)?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
     /// Insert album, release, and tracks in a single transaction
     /// Note: Artists and artist relationships should be inserted separately before calling this
     pub async fn insert_album_with_release_and_tracks(

--- a/bae-core/src/db/client/tests.rs
+++ b/bae-core/src/db/client/tests.rs
@@ -850,6 +850,27 @@ mod composer_mode_tests {
             Some("release-a")
         );
     }
+
+    #[tokio::test]
+    async fn work_detail_release_rows_carry_album_release_display_fields() {
+        let (db, _tmp) = seeded_db().await;
+
+        let detail = db
+            .find_work_detail("work-child-a")
+            .await
+            .unwrap()
+            .expect("work detail");
+
+        assert_eq!(detail.releases.len(), 1);
+        let release = &detail.releases[0];
+        assert_eq!(release.release_id, "release-a");
+        assert_eq!(release.album_id, "album-a");
+        assert_eq!(release.album_title, "Album Title A");
+        assert_eq!(release.release_name, None);
+        assert_eq!(release.year, Some(2026));
+        assert_eq!(release.format.as_deref(), Some("CD"));
+        assert_eq!(release.release_index, 1);
+    }
 }
 
 #[cfg(test)]

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -1239,8 +1239,19 @@ pub struct DbComposerWorkGroup {
 pub struct DbWorkDetail {
     pub work: DbWorkSummary,
     pub child_works: Vec<DbWorkSummary>,
-    pub releases: Vec<DbReleaseSummary>,
+    pub releases: Vec<DbWorkReleaseSummary>,
     pub tracks: Vec<DbWorkTrackSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbWorkReleaseSummary {
+    pub release_id: String,
+    pub album_id: String,
+    pub album_title: String,
+    pub release_name: Option<String>,
+    pub year: Option<i32>,
+    pub format: Option<String>,
+    pub release_index: i64,
 }
 
 #[derive(Debug, Clone)]

--- a/bae-core/src/library/manager/composer.rs
+++ b/bae-core/src/library/manager/composer.rs
@@ -85,8 +85,7 @@ impl LibraryManager {
         let Some(raw) = self.database.find_work_detail(work_id).await? else {
             return Ok(None);
         };
-        let has_cloud_home = self.has_cloud_home();
-        let release_ids: Vec<String> = raw.releases.iter().map(|r| r.id.clone()).collect();
+        let release_ids: Vec<String> = raw.releases.iter().map(|r| r.release_id.clone()).collect();
         let covers = self.cover_refs(&release_ids).await?;
         let work_cover = raw
             .work
@@ -99,17 +98,6 @@ impl LibraryManager {
             .filter_map(|work| work.representative_release_id.clone())
             .collect();
         let child_covers = self.cover_refs(&child_release_ids).await?;
-        let mut releases = Vec::with_capacity(raw.releases.len());
-        for release in raw.releases {
-            let pinned = self.release_pinned(release.any_file_id.as_deref()).await?;
-            let cover = covers.get(&release.id).cloned();
-            let ctx = ReleaseResolveCtx {
-                has_cloud_home,
-                pinned,
-                cover,
-            };
-            releases.push(ReleaseSummary::from_raw(release, &ctx));
-        }
         Ok(Some(WorkDetail {
             work: WorkSummary::from_raw(raw.work, work_cover),
             child_works: raw
@@ -117,7 +105,14 @@ impl LibraryManager {
                 .into_iter()
                 .map(|work| work_summary_with_cover(work, &child_covers))
                 .collect(),
-            releases,
+            releases: raw
+                .releases
+                .into_iter()
+                .map(|release| {
+                    let cover = covers.get(&release.release_id).cloned();
+                    WorkReleaseSummary::from_raw(release, cover)
+                })
+                .collect(),
             tracks: raw.tracks,
         }))
     }

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -31,9 +31,9 @@ use tracing::{debug, error, info, warn};
 use crate::album_detail::{
     join_artist_names, AlbumDetail, AlbumSummary, ComposerDetail, ComposerSummary,
     ComposerWorkGroup, GallerySource, ImageRef, ReleaseDetail, ReleaseResolveCtx,
-    ReleaseStorageAction, ReleaseStorageSummary, ReleaseSummary, SearchResults, StorageFilter,
-    StoragePage, StorageRow, StorageSort, StorageSortDirection, StorageSortField, WorkDetail,
-    WorkSummary,
+    ReleaseStorageAction, ReleaseStorageSummary, SearchResults, StorageFilter, StoragePage,
+    StorageRow, StorageSort, StorageSortDirection, StorageSortField, WorkDetail,
+    WorkReleaseSummary, WorkSummary,
 };
 #[cfg(feature = "oauth-providers")]
 use crate::config::CloudProvider;

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -1,8 +1,10 @@
 use super::*;
 use crate::config::Config;
-use crate::db::{DbAlbum, DbRelease};
+use crate::db::{DbAlbum, DbLibraryImage, DbRelease, DbTrackWork, DbWork, LibraryImageType};
+use crate::import::MetadataSource;
 #[cfg(feature = "test-utils")]
 use crate::sync::CloudCipher;
+use crate::util::content_type::ContentType;
 use chrono::Utc;
 #[cfg(feature = "test-utils")]
 use coven::InMemoryCloudHome;
@@ -133,6 +135,64 @@ fn create_test_release(album_id: &str) -> DbRelease {
         album_peak_linear: None,
         created_at: Utc::now(),
     }
+}
+
+#[tokio::test]
+async fn work_detail_release_rows_are_display_ready() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let mut release = create_test_release(&album.id);
+    release.pressing.format = Some("CD".to_string());
+    let track = crate::db::DbTrack::new_test(&release.id, "track-a", "Track Title", Some(1));
+    let now = Utc::now();
+    let work = DbWork::new("work-a", "Work Title", None, Some("work".to_string()), now);
+    let track_work = DbTrackWork::new(
+        &track.id,
+        &work.id,
+        0,
+        MetadataSource::MusicBrainz,
+        "track-work-a".to_string(),
+        now,
+    );
+    let cover = DbLibraryImage {
+        id: release.id.clone(),
+        image_type: LibraryImageType::Cover,
+        content_type: ContentType::Jpeg,
+        file_size: 100,
+        width: None,
+        height: None,
+        source: "local".to_string(),
+        source_url: None,
+        cloud_path: None,
+        created_at: now,
+    };
+
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+    manager.database.insert_track(&track).await.unwrap();
+    manager
+        .database
+        .insert_composition_fixture_rows(std::slice::from_ref(&work), &[track_work], &[cover])
+        .await
+        .unwrap();
+
+    let detail = manager
+        .get_work_detail(&work.id)
+        .await
+        .unwrap()
+        .expect("work detail");
+
+    assert_eq!(detail.releases.len(), 1);
+    let row = &detail.releases[0];
+    assert_eq!(row.release_id, release.id);
+    assert_eq!(row.album_id, album.id);
+    assert_eq!(row.album_title, album.title);
+    assert_eq!(row.display_name, "2024 CD");
+    assert_eq!(row.format.as_deref(), Some("CD"));
+    let cover = row.cover.as_ref().expect("work release cover");
+    assert_eq!(cover.id, release.id);
+    assert!(!cover.version.is_empty());
+    assert_eq!(cover.image_type, crate::db::LibraryImageType::Cover);
 }
 
 #[tokio::test]

--- a/bae-core/src/playback/data_source.rs
+++ b/bae-core/src/playback/data_source.rs
@@ -1008,8 +1008,7 @@ mod tests {
     /// demand. Dropping the buffer's last strong ref frees it, and the buffer's
     /// `Drop` wakes the parked fill so the task exits — releasing its clone of
     /// the wake handle. Sabotage either half — `start_reading` keeping a strong
-    /// ref, or removing the `Drop` wake — and an assertion fails. Yields, not a
-    /// timer, advance the single-threaded test runtime.
+    /// ref, or removing the `Drop` wake — and an assertion fails.
     #[tokio::test]
     async fn start_reading_fill_follows_the_buffer_and_exits_when_it_is_dropped() {
         let source_size = 4 * WINDOW;
@@ -1045,14 +1044,13 @@ mod tests {
         // parked fill, which upgrades to None and exits, dropping its wake clone.
         drop(buffer);
         assert!(weak.upgrade().is_none(), "the buffer must be freed");
-        for _ in 0..20 {
-            tokio::task::yield_now().await;
-        }
-        assert_eq!(
-            Arc::strong_count(&wake),
-            1,
-            "the parked fill task must exit when the buffer is dropped, not leak"
-        );
+        timeout(Duration::from_secs(5), async {
+            while Arc::strong_count(&wake) != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the parked fill task must exit when the buffer is dropped, not leak");
     }
 
     /// A reader blocked at the seek target unblocks as soon as that target's

--- a/bae-ios/bae/bae/AppService.swift
+++ b/bae-ios/bae/bae/AppService.swift
@@ -51,6 +51,18 @@ final class AppService: Observable {
                     limit: $2
                 )
             },
+            getComposerCount: { try appHandle.getComposerCount() },
+            getComposerPage: {
+                try appHandle.getComposerPage(
+                    sortCriterion: $0,
+                    offset: $1,
+                    limit: $2
+                )
+            },
+            getComposerDetail: {
+                try appHandle.getComposerDetail(artistId: $0)
+            },
+            getWorkDetail: { try appHandle.getWorkDetail(workId: $0) },
             searchLibrary: { try await appHandle.searchLibrary(query: $0) },
             findReleaseDetail: { try appHandle.findReleaseDetail(releaseId: $0) },
             resolveToTrackIds: { try appHandle.resolveToTrackIds(ids: $0) }

--- a/bae-ios/bae/bae/Localizable.xcstrings
+++ b/bae-ios/bae/bae/Localizable.xcstrings
@@ -6276,6 +6276,197 @@
         }
       }
     },
+    "iCloud email": {
+      "comment": "Approve-device sheet: placeholder for the joining member's iCloud account email",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud email"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        }
+      }
+    },
     "Key fingerprint: %@": {
       "localizations": {
         "en": {
@@ -13122,7 +13313,7 @@
       }
     },
     "Shuffle Library": {
-      "comment": "Library view: shuffle the whole library into a fresh session",
+      "comment": "Library view: shuffle the whole library into a new session",
       "localizations": {
         "en": {
           "stringUnit": {

--- a/bae-ios/bae/bae/Localizable.xcstrings
+++ b/bae-ios/bae/bae/Localizable.xcstrings
@@ -1,388 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "Close": {
-      "comment": "Alert dismiss button",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cerrar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fermer"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schließen"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fechar"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "閉じる"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关闭"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إغلاق"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגור"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Закрити"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Затваряне"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zamknij"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zavřít"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zatvori"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "닫기"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "關閉"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chiudi"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kapat"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đóng"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sluiten"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बंद करें"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "বন্ধ"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "மூடு"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "మూసివేయి"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बंद करा"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بند کریں"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "બંધ કરો"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ಮುಚ್ಚು"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "അടയ്ക്കുക"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ਬੰਦ ਕਰੋ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปิด"
-          }
-        }
-      }
-    },
-    "Error": {
-      "comment": "Global error alert title",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erreur"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fehler"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エラー"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "错误"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خطأ"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שגיאה"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Помилка"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Грешка"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Błąd"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chyba"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pogreška"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오류"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "錯誤"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Errore"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hata"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lỗi"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fout"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "त्रुटि"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ত্রুটি"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "பிழை"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "లోపం"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "त्रुटी"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خرابی"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ભૂલ"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ದೋಷ"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "പിശക്"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ਗਲਤੀ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อผิดพลาด"
-          }
-        }
-      }
-    },
     "%@ by %@": {
       "comment": "Album card VoiceOver label: title by artist",
       "localizations": {
@@ -2474,6 +2092,197 @@
         }
       }
     },
+    "Close": {
+      "comment": "Alert dismiss button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fechar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إغلاق"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגור"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрити"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затваряне"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zamknij"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zavřít"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zatvori"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닫기"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiudi"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapat"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đóng"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sluiten"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद करें"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "বন্ধ"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "மூடு"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "మూసివేయి"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद करा"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند کریں"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "બંધ કરો"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಮುಚ್ಚು"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "അടയ്ക്കുക"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਬੰਦ ਕਰੋ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        }
+      }
+    },
     "Cloud sign-in isn't configured on this build (no oauth-creds.json).": {
       "localizations": {
         "en": {
@@ -3040,6 +2849,387 @@
           "stringUnit": {
             "state": "translated",
             "value": "ยุบ"
+          }
+        }
+      }
+    },
+    "Composer detail not found": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer detail not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composer detail not found"
+          }
+        }
+      }
+    },
+    "Composers": {
+      "comment": "Library/search composer section and mode label",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Composers"
           }
         }
       }
@@ -4374,6 +4564,197 @@
         }
       }
     },
+    "Credits": {
+      "comment": "Composer sort field and unlinked credits section header",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credits"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Credits"
+          }
+        }
+      }
+    },
     "Descending": {
       "localizations": {
         "en": {
@@ -5320,6 +5701,197 @@
           "stringUnit": {
             "state": "translated",
             "value": "การเข้ารหัส key (64 hex characters)"
+          }
+        }
+      }
+    },
+    "Error": {
+      "comment": "Global error alert title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطأ"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שגיאה"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Грешка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Błąd"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chyba"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pogreška"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오류"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "錯誤"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hata"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lỗi"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fout"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "त्रुटि"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ত্রুটি"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பிழை"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "లోపం"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "त्रुटी"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خرابی"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ભૂલ"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ದೋಷ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "പിശക്"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਗਲਤੀ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ข้อผิดพลาด"
           }
         }
       }
@@ -7224,6 +7796,197 @@
         }
       }
     },
+    "No composers": {
+      "comment": "Empty composer library message title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No composers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No composers"
+          }
+        }
+      }
+    },
     "No results for “%@”": {
       "localizations": {
         "en": {
@@ -8364,6 +9127,196 @@
         }
       }
     },
+    "Pause between sides": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause between sides"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pause between sides"
+          }
+        }
+      }
+    },
     "Play": {
       "localizations": {
         "en": {
@@ -8740,6 +9693,196 @@
           "stringUnit": {
             "state": "translated",
             "value": "Play Next"
+          }
+        }
+      }
+    },
+    "Playback": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Playback"
           }
         }
       }
@@ -9695,6 +10838,197 @@
         }
       }
     },
+    "Recordings": {
+      "comment": "Composer work detail recording section header",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recordings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Recordings"
+          }
+        }
+      }
+    },
     "Release": {
       "localizations": {
         "en": {
@@ -9881,6 +11215,197 @@
           "stringUnit": {
             "state": "translated",
             "value": "Release"
+          }
+        }
+      }
+    },
+    "Releases": {
+      "comment": "Composer work detail release section header",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Releases"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Releases"
           }
         }
       }
@@ -11025,195 +12550,196 @@
         }
       }
     },
-    "Search albums and tracks": {
+    "Search albums, tracks, composers, and works": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Search albums and tracks"
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "es": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Buscar álbumes y pistas"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Rechercher des albums et des pistes"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "de": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Alben und Titel durchsuchen"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Buscar álbuns e faixas"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
-            "value": "アルバムとトラックを検索"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "translated",
-            "value": "搜索专辑和曲目"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "ar": {
           "stringUnit": {
-            "state": "translated",
-            "value": "ابحث في الألبومات والمقطوعات"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "he": {
           "stringUnit": {
-            "state": "translated",
-            "value": "חפשו אלבומים ורצועות"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "uk": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Пошук альбомів і треків"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "bg": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Търсене на албуми и песни"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "pl": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Szukaj albumów i utworów"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "cs": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Hledat alba a skladby"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "hr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Pretraži albume i skladbe"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "translated",
-            "value": "앨범과 트랙 검색"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "zh-Hant": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "it": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Cerca album e tracce"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "tr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Albüm ve parça ara"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "vi": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Tìm album và track"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "nl": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Zoek albums en tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "hi": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "bn": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "ta": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "te": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "mr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "ur": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "gu": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "kn": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "ml": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "pa": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         },
         "th": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Search albums and tracks"
+            "state": "new",
+            "value": "Search albums, tracks, composers, and works"
           }
         }
-      }
+      },
+      "comment": "iOS library search prompt"
     },
     "Settings": {
       "localizations": {
@@ -11591,6 +13117,197 @@
           "stringUnit": {
             "state": "translated",
             "value": "สุ่ม"
+          }
+        }
+      }
+    },
+    "Shuffle Library": {
+      "comment": "Library view: shuffle the whole library into a fresh session",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuffle Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir biblioteca al azar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture aléatoire de la bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mediathek zufällig wiedergeben"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Embaralhar biblioteca"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリをシャッフル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随机播放音乐库"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل المكتبة عشوائيًا"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערבוב הספרייה"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемішати фонотеку"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разбъркване на библиотеката"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzaj bibliotekę losowo"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Náhodně přehrát knihovnu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nasumično reproduciraj biblioteku"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이브러리 셔플"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隨機播放資料庫"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduci libreria in ordine casuale"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kitaplığı karıştır"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phát ngẫu nhiên thư viện"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibliotheek shufflen"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइब्रेरी शफ़ल करें"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "লাইব্রেরি শাফল করুন"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "நூலகத்தை கலைத்து இயக்கு"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "లైబ్రరీని షఫుల్ చేయి"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लायब्ररी शफल करा"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائبریری کو شفل کریں"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "લાઇબ્રેરી શફલ કરો"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ലൈബ്രറി ഷഫിൾ ചെയ്യുക"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สุ่มเล่นคลังเพลง"
           }
         }
       }
@@ -14066,6 +15783,578 @@
         }
       }
     },
+    "Work detail not found": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Work detail not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Work detail not found"
+          }
+        }
+      }
+    },
+    "Works": {
+      "comment": "Library/search works section and composer work count label",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Works"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Works"
+          }
+        }
+      }
+    },
+    "Your Library": {
+      "comment": "Queue panel: context section header when playing the whole library",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu biblioteca"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votre bibliothèque"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deine Mediathek"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sua biblioteca"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的音乐库"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مكتبتك"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הספרייה שלך"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваша фонотека"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вашата библиотека"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twoja biblioteka"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaše knihovna"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaša biblioteka"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보관함"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的資料庫"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tua libreria"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kitaplığınız"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thư viện của bạn"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je bibliotheek"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी लाइब्रेरी"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "আপনার লাইব্রেরি"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "உங்கள் நூலகம்"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "మీ లైబ్రరీ"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "तुमची लायब्ररी"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کی لائبریری"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "તમારી લાઇબ્રેરી"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ನಿಮ್ಮ ಲೈಬ್ರರಿ"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "നിങ്ങളുടെ ലൈബ്രറി"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลังของคุณ"
+          }
+        }
+      }
+    },
     "Your library in the cloud is untouched.": {
       "localizations": {
         "en": {
@@ -15392,768 +17681,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "ซิงค์ing…"
-          }
-        }
-      }
-    },
-    "Pause between sides": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pause between sides"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pause between sides"
-          }
-        }
-      }
-    },
-    "Playback": {
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Playback"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Playback"
-          }
-        }
-      }
-    },
-    "Shuffle Library": {
-      "comment": "Library view: shuffle the whole library into a fresh session",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuffle Library"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reproducir biblioteca al azar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lecture aléatoire de la bibliothèque"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mediathek zufällig wiedergeben"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Embaralhar biblioteca"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライブラリをシャッフル"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "随机播放音乐库"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تشغيل المكتبة عشوائيًا"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ערבוב הספרייה"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемішати фонотеку"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Разбъркване на библиотеката"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Odtwarzaj bibliotekę losowo"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Náhodně přehrát knihovnu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nasumično reproduciraj biblioteku"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "라이브러리 셔플"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "隨機播放資料庫"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Riproduci libreria in ordine casuale"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kitaplığı karıştır"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phát ngẫu nhiên thư viện"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bibliotheek shufflen"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "लाइब्रेरी शफ़ल करें"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "লাইব্রেরি শাফল করুন"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "நூலகத்தை கலைத்து இயக்கு"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "లైబ్రరీని షఫుల్ చేయి"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "लायब्ररी शफल करा"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لائبریری کو شفل کریں"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "લાઇબ્રેરી શફલ કરો"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ലൈബ്രറി ഷഫിൾ ചെയ്യുക"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สุ่มเล่นคลังเพลง"
-          }
-        }
-      }
-    },
-    "Your Library": {
-      "comment": "Queue panel: context section header when playing the whole library",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Library"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tu biblioteca"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Votre bibliothèque"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deine Mediathek"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sua biblioteca"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライブラリ"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的音乐库"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مكتبتك"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הספרייה שלך"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ваша фонотека"
-          }
-        },
-        "bg": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вашата библиотека"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Twoja biblioteka"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaše knihovna"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaša biblioteka"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "보관함"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你的資料庫"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La tua libreria"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kitaplığınız"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thư viện của bạn"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Je bibliotheek"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आपकी लाइब्रेरी"
-          }
-        },
-        "bn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "আপনার লাইব্রেরি"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "உங்கள் நூலகம்"
-          }
-        },
-        "te": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "మీ లైబ్రరీ"
-          }
-        },
-        "mr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "तुमची लायब्ररी"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آپ کی لائبریری"
-          }
-        },
-        "gu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "તમારી લાઇબ્રેરી"
-          }
-        },
-        "kn": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ನಿಮ್ಮ ಲೈಬ್ರರಿ"
-          }
-        },
-        "ml": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "നിങ്ങളുടെ ലൈബ്രറി"
-          }
-        },
-        "pa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คลังของคุณ"
           }
         }
       }

--- a/bae-ios/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-ios/bae/bae/Views/AlbumDetailView.swift
@@ -37,10 +37,25 @@ struct AlbumDetailView: View {
 
     var body: some View {
         Group {
-            if let summary = libraryStore.albumSummaries[albumId] {
+            if let context {
+                if let releaseId = selectedReleaseId,
+                    let detail = libraryStore.releaseDetails[releaseId]
+                {
+                    content(
+                        display: AlbumDetailDisplay(context: context),
+                        releasePickerSummary: nil,
+                        releaseId: releaseId,
+                        detail: detail
+                    )
+                }
+                else {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            else if let summary = libraryStore.albumSummaries[albumId] {
                 let releaseId = activeReleaseId(summary: summary)
-                let detail = releaseId.flatMap { libraryStore.releaseDetails[$0] }
-                if let releaseId, let detail {
+                if let detail = libraryStore.releaseDetails[releaseId] {
                     content(
                         display: AlbumDetailDisplay(summary: summary),
                         releasePickerSummary: summary,
@@ -52,17 +67,6 @@ struct AlbumDetailView: View {
                     ProgressView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-            }
-            else if let releaseId = selectedReleaseId,
-                let detail = libraryStore.releaseDetails[releaseId],
-                let context
-            {
-                content(
-                    display: AlbumDetailDisplay(context: context),
-                    releasePickerSummary: nil,
-                    releaseId: releaseId,
-                    detail: detail
-                )
             }
             else {
                 ProgressView()
@@ -76,6 +80,15 @@ struct AlbumDetailView: View {
             NowPlayingBar()
         }
         .task(id: albumId) {
+            if context != nil {
+                if let releaseId = selectedReleaseId {
+                    await libraryStore.loadReleaseDetail(
+                        releaseId: releaseId,
+                        library: library
+                    )
+                }
+                return
+            }
             // Eagerly load detail for every release so the picker has labels
             // and switching releases doesn't flash a spinner. N is typically
             // 1-3. Bail on cancellation (the user navigated away).
@@ -150,9 +163,6 @@ struct AlbumDetailView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
                 ForEach(summary.releaseIds, id: \.self) { id in
-                    let label =
-                        libraryStore.releaseDetails[id]?.displayName
-                        ?? String(localized: "Release")
                     Button {
                         selectedReleaseId = id
                         Task {
@@ -162,19 +172,27 @@ struct AlbumDetailView: View {
                             )
                         }
                     } label: {
-                        Text(label)
-                            .font(.callout)
-                            .lineLimit(1)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 16)
-                                    .fill(
-                                        id == activeReleaseId(summary: summary)
-                                            ? Theme.accentSoft
-                                            : Theme.surfaceElevated
-                                    )
-                            )
+                        Group {
+                            if let label = libraryStore.releaseDetails[id]?.displayName {
+                                Text(label)
+                                    .font(.callout)
+                                    .lineLimit(1)
+                            }
+                            else {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16)
+                                .fill(
+                                    id == activeReleaseId(summary: summary)
+                                        ? Theme.accentSoft
+                                        : Theme.surfaceElevated
+                                )
+                        )
                     }
                     .buttonStyle(.plain)
                 }
@@ -182,15 +200,16 @@ struct AlbumDetailView: View {
         }
     }
 
-    /// The active release: explicit selection → primary → first.
-    private func activeReleaseId(summary: AlbumSummary) -> String? {
+    /// The active release: explicit selection, otherwise the album's primary release.
+    private func activeReleaseId(summary: AlbumSummary) -> String {
         if let id = selectedReleaseId, summary.releaseIds.contains(id) {
             return id
         }
-        if summary.releaseIds.contains(summary.primaryReleaseId) {
-            return summary.primaryReleaseId
-        }
-        return summary.releaseIds.first
+        precondition(
+            summary.releaseIds.contains(summary.primaryReleaseId),
+            "primaryReleaseId missing from releaseIds for album \(summary.id)"
+        )
+        return summary.primaryReleaseId
     }
 }
 

--- a/bae-ios/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-ios/bae/bae/Views/AlbumDetailView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// on demand. The store stays live, so sync updates re-render in place.
 struct AlbumDetailView: View {
     let albumId: String
+    private let context: AlbumDetailContext?
 
     @Environment(LibraryStore.self)
     private var libraryStore
@@ -24,18 +25,44 @@ struct AlbumDetailView: View {
     @State
     private var showGallery = false
 
+    init(
+        albumId: String,
+        initialReleaseId: String? = nil,
+        context: AlbumDetailContext? = nil
+    ) {
+        self.albumId = albumId
+        self.context = context
+        _selectedReleaseId = State(initialValue: initialReleaseId)
+    }
+
     var body: some View {
         Group {
             if let summary = libraryStore.albumSummaries[albumId] {
                 let releaseId = activeReleaseId(summary: summary)
                 let detail = releaseId.flatMap { libraryStore.releaseDetails[$0] }
                 if let releaseId, let detail {
-                    content(summary: summary, releaseId: releaseId, detail: detail)
+                    content(
+                        display: AlbumDetailDisplay(summary: summary),
+                        releasePickerSummary: summary,
+                        releaseId: releaseId,
+                        detail: detail
+                    )
                 }
                 else {
                     ProgressView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
+            }
+            else if let releaseId = selectedReleaseId,
+                let detail = libraryStore.releaseDetails[releaseId],
+                let context
+            {
+                content(
+                    display: AlbumDetailDisplay(context: context),
+                    releasePickerSummary: nil,
+                    releaseId: releaseId,
+                    detail: detail
+                )
             }
             else {
                 ProgressView()
@@ -53,6 +80,12 @@ struct AlbumDetailView: View {
             // and switching releases doesn't flash a spinner. N is typically
             // 1-3. Bail on cancellation (the user navigated away).
             guard let summary = libraryStore.albumSummaries[albumId] else {
+                if let releaseId = selectedReleaseId {
+                    await libraryStore.loadReleaseDetail(
+                        releaseId: releaseId,
+                        library: library
+                    )
+                }
                 return
             }
             for releaseId in summary.releaseIds {
@@ -68,19 +101,27 @@ struct AlbumDetailView: View {
     }
 
     private func content(
-        summary: AlbumSummary,
+        display: AlbumDetailDisplay,
+        releasePickerSummary: AlbumSummary?,
         releaseId: String,
         detail: ReleaseDetail
     ) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                header(summary: summary, releaseId: releaseId, detail: detail)
-                if summary.releaseIds.count > 1 {
+                AlbumDetailHeader(
+                    display: display,
+                    releaseId: releaseId,
+                    detail: detail,
+                    showGallery: $showGallery
+                )
+                if let summary = releasePickerSummary,
+                    summary.releaseIds.count > 1
+                {
                     releasePicker(summary: summary)
                 }
                 TrackList(
                     detail: detail,
-                    isCompilation: summary.isCompilation,
+                    artistDisplay: display.trackArtistDisplay,
                     onPlayTrackAt: { index in
                         playback.playRelease(releaseId, UInt32(index), false)
                     },
@@ -103,81 +144,6 @@ struct AlbumDetailView: View {
                 }
             )
         }
-    }
-
-    private func header(
-        summary: AlbumSummary,
-        releaseId: String,
-        detail: ReleaseDetail
-    ) -> some View {
-        HStack(alignment: .top, spacing: 16) {
-            ImageView(imageRef: detail.summary.cover, pointSize: 140)
-                .frame(width: 140, height: 140)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    if !detail.galleryItems.isEmpty { showGallery = true }
-                }
-            VStack(alignment: .leading, spacing: 4) {
-                Text(summary.title)
-                    .font(.title2.bold())
-                Text(summary.artistNames)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                if let year = summary.year {
-                    Text(String(year))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                if !detail.compactMetadata.isEmpty {
-                    Text(detail.compactMetadata)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 4)
-                }
-                playButtons(releaseId: releaseId)
-                    .padding(.top, 8)
-                queueButtons(releaseId: releaseId)
-                    .padding(.top, 4)
-            }
-            Spacer(minLength: 0)
-        }
-    }
-
-    private func playButtons(releaseId: String) -> some View {
-        HStack(spacing: 8) {
-            Button {
-                playback.playRelease(releaseId, nil, false)
-            } label: {
-                Label("Play", systemImage: "play.fill")
-            }
-            .buttonStyle(.borderedProminent)
-            Button {
-                playback.playRelease(releaseId, nil, true)
-            } label: {
-                Label("Shuffle", systemImage: "shuffle")
-            }
-            .buttonStyle(.bordered)
-        }
-    }
-
-    private func queueButtons(releaseId: String) -> some View {
-        HStack(spacing: 8) {
-            Button {
-                queue.addReleaseNext(releaseId)
-            } label: {
-                Label("Play Next", systemImage: "text.insert")
-                    .font(.caption)
-            }
-            Button {
-                queue.addReleaseToQueue(releaseId)
-            } label: {
-                Label("Add to Queue", systemImage: "text.append")
-                    .font(.caption)
-            }
-        }
-        .buttonStyle(.bordered)
-        .tint(Theme.accent)
     }
 
     private func releasePicker(summary: AlbumSummary) -> some View {
@@ -228,11 +194,169 @@ struct AlbumDetailView: View {
     }
 }
 
+private enum AlbumDetailDisplay {
+    case album(AlbumSummary)
+    case workRelease(AlbumDetailContext)
+
+    init(summary: AlbumSummary) {
+        self = .album(summary)
+    }
+
+    init(context: AlbumDetailContext) {
+        self = .workRelease(context)
+    }
+
+    var title: String {
+        switch self {
+        case .album(let summary):
+            summary.title
+        case .workRelease(let context):
+            context.title
+        }
+    }
+
+    var albumMetadata: AlbumDetailAlbumMetadata? {
+        switch self {
+        case .album(let summary):
+            AlbumDetailAlbumMetadata(
+                artistNames: summary.artistNames,
+                year: summary.year
+            )
+        case .workRelease:
+            nil
+        }
+    }
+
+    var trackArtistDisplay: TrackArtistDisplay {
+        switch self {
+        case .album(let summary):
+            .album(isCompilation: summary.isCompilation)
+        case .workRelease:
+            .workRelease
+        }
+    }
+}
+
+struct AlbumDetailContext: Hashable {
+    let title: String
+
+    init(workRelease: BridgeWorkReleaseSummary) {
+        title = workRelease.albumTitle
+    }
+}
+
+private struct AlbumDetailAlbumMetadata {
+    let artistNames: String
+    let year: Int32?
+}
+
+private enum TrackArtistDisplay {
+    case album(isCompilation: Bool)
+    case workRelease
+
+    var showsArtist: Bool {
+        switch self {
+        case .album(let isCompilation):
+            isCompilation
+        case .workRelease:
+            true
+        }
+    }
+}
+
+private struct AlbumDetailHeader: View {
+    let display: AlbumDetailDisplay
+    let releaseId: String
+    let detail: ReleaseDetail
+    @Binding
+    var showGallery: Bool
+
+    @Environment(Playback.self)
+    private var playback
+    @Environment(Queue.self)
+    private var queue
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            ImageView(imageRef: detail.summary.cover, pointSize: 140)
+                .frame(width: 140, height: 140)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if !detail.galleryItems.isEmpty { showGallery = true }
+                }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(display.title)
+                    .font(.title2.bold())
+                if let metadata = display.albumMetadata,
+                    !metadata.artistNames.isEmpty
+                {
+                    Text(metadata.artistNames)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if let year = display.albumMetadata?.year {
+                    Text(String(year))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if !detail.compactMetadata.isEmpty {
+                    Text(detail.compactMetadata)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+                }
+                playButtons
+                    .padding(.top, 8)
+                queueButtons
+                    .padding(.top, 4)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var playButtons: some View {
+        HStack(spacing: 8) {
+            Button {
+                playback.playRelease(releaseId, nil, false)
+            } label: {
+                Label("Play", systemImage: "play.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            Button {
+                playback.playRelease(releaseId, nil, true)
+            } label: {
+                Label("Shuffle", systemImage: "shuffle")
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private var queueButtons: some View {
+        HStack(spacing: 8) {
+            Button {
+                queue.addReleaseNext(releaseId)
+            } label: {
+                Label("Play Next", systemImage: "text.insert")
+                    .font(.caption)
+            }
+            Button {
+                queue.addReleaseToQueue(releaseId)
+            } label: {
+                Label("Add to Queue", systemImage: "text.append")
+                    .font(.caption)
+            }
+        }
+        .buttonStyle(.bordered)
+        .tint(Theme.accent)
+    }
+}
+
 /// Side-grouped track list. Flattens groups to a release-wide index so a tap
 /// maps to the ordered list the player builds from the same flattening.
 private struct TrackList: View {
     let detail: ReleaseDetail
-    let isCompilation: Bool
+    let artistDisplay: TrackArtistDisplay
     let onPlayTrackAt: (Int) -> Void
     let onPlayNext: (String) -> Void
     let onAddToQueue: (String) -> Void
@@ -263,7 +387,7 @@ private struct TrackList: View {
                     track in
                     TrackRow(
                         track: track,
-                        showArtist: isCompilation,
+                        showArtist: artistDisplay.showsArtist,
                         onPlay: { onPlayTrackAt(groupOffset + localIndex) },
                         onPlayNext: { onPlayNext(track.id) },
                         onAddToQueue: { onAddToQueue(track.id) }

--- a/bae-ios/bae/bae/Views/ApproveDeviceView.swift
+++ b/bae-ios/bae/bae/Views/ApproveDeviceView.swift
@@ -8,11 +8,14 @@ private let logger = Logger.bae("ApproveDevice")
 /// code (camera scan or pasted text), preview its public key, approve it, then
 /// show the invite code to carry back to that device.
 ///
-/// `invite` is `Sync.inviteMember`: it takes the joining device's public key and
-/// returns the invite code. The sheet drives a small step machine so each stage
-/// renders only what that stage needs. Presented as a sheet from `MembersView`.
+/// `invite` is `Sync.inviteMember`: it takes the joining device's public key
+/// plus any provider account email and returns the invite code. The sheet
+/// drives a small step machine so each stage renders only what that stage
+/// needs. Presented as a sheet from `MembersView`.
 struct ApproveDeviceView: View {
-    let invite: @Sendable (_ publicKeyHex: String) async throws -> String
+    let invite:
+        @Sendable (_ publicKeyHex: String, _ providerAccountEmail: String?)
+            async throws -> String
     let onDismiss: () -> Void
     /// Called once a device has been approved, so the caller can refresh its
     /// member list.
@@ -32,6 +35,8 @@ struct ApproveDeviceView: View {
     private var step: Step = .capture
     @State
     private var pasteInput = ""
+    @State
+    private var providerAccountEmail = ""
     @State
     private var error: String?
     @State
@@ -151,6 +156,10 @@ struct ApproveDeviceView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+            TextField("iCloud email", text: $providerAccountEmail)
+                .textFieldStyle(.roundedBorder)
+                .textContentType(.emailAddress)
+                .frame(maxWidth: 260)
             Text(
                 "It will be added to your library and able to sync. You'll get a code to enter on it."
             )
@@ -231,6 +240,7 @@ struct ApproveDeviceView: View {
         }
         do {
             let info = try decodeJoinRequest(code: trimmed)
+            providerAccountEmail = info.email ?? ""
             error = nil
             step = .confirm(info)
         }
@@ -244,12 +254,15 @@ struct ApproveDeviceView: View {
 
     private func approve(_ info: BridgeJoinRequestInfo) {
         let pubkey = info.pubkey
+        let email = providerAccountEmail.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
         error = nil
         step = .inviting(info)
         inviteTask?.cancel()
         inviteTask = Task { @MainActor in
             do {
-                let code = try await invite(pubkey)
+                let code = try await invite(pubkey, email.isEmpty ? nil : email)
                 step = .invited(code: code)
                 onApproved()
             }

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -3,6 +3,21 @@ import SwiftUI
 
 private let pageSize = 60
 
+private enum LibraryBrowserMode {
+    case albums
+    case composers
+}
+
+private enum LibraryRoute: Hashable {
+    case album(
+        albumId: String,
+        initialReleaseId: String?,
+        context: AlbumDetailContext?
+    )
+    case composer(String)
+    case work(String)
+}
+
 /// Library browse root: a top bar with sync status, an album grid paged from
 /// the database, navigation into album detail, and a persistent now-playing
 /// bar. The grid re-queries whenever the library shape changes (sync streams
@@ -23,9 +38,13 @@ struct LibraryView: View {
     @State
     private var showSettings = false
     @State
-    private var list: AlbumList?
+    private var mode: LibraryBrowserMode = .albums
     @State
-    private var selectedAlbumId: String?
+    private var albumList: AlbumList?
+    @State
+    private var composerList: ComposerList?
+    @State
+    private var routePath: [LibraryRoute] = []
     @State
     private var searchQuery = ""
     @State
@@ -38,26 +57,72 @@ struct LibraryView: View {
     private var sortField = BridgeSortField.dateAdded
     @State
     private var sortDirection = BridgeSortDirection.descending
+    @State
+    private var composerSortCriterion =
+        BridgeComposerSortCriterion(field: .name, direction: .ascending)
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $routePath) {
             VStack(spacing: 0) {
-                banner
+                LibraryBanner()
+                LibraryModePicker(mode: $mode)
                 content
             }
             .background(Theme.background)
-            .navigationDestination(item: $selectedAlbumId) { albumId in
-                AlbumDetailView(albumId: albumId)
+            .navigationDestination(for: LibraryRoute.self) { route in
+                switch route {
+                case .album(let albumId, let releaseId, let context):
+                    AlbumDetailView(
+                        albumId: albumId,
+                        initialReleaseId: releaseId,
+                        context: context
+                    )
+                case .composer(let artistId):
+                    ComposerDetailScreen(
+                        artistId: artistId,
+                        openWork: { routePath.append(.work($0)) },
+                        openAlbum: {
+                            routePath.appendAlbum(
+                                albumId: $0,
+                                initialReleaseId: nil,
+                                context: nil
+                            )
+                        }
+                    )
+                case .work(let workId):
+                    WorkDetailScreen(
+                        workId: workId,
+                        openWork: { routePath.append(.work($0)) },
+                        openAlbum: { release in
+                            routePath.appendAlbum(
+                                albumId: release.albumId,
+                                initialReleaseId: release.releaseId,
+                                context: AlbumDetailContext(workRelease: release)
+                            )
+                        }
+                    )
+                }
             }
             .navigationTitle("bae")
             .navigationBarTitleDisplayMode(.inline)
-            .searchable(text: $searchQuery, prompt: "Search albums and tracks")
+            .searchable(
+                text: $searchQuery,
+                prompt: "Search albums, tracks, composers, and works"
+            )
             .task(id: searchQuery) {
                 await runSearch()
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    sortMenu
+                    switch mode {
+                    case .albums:
+                        AlbumSortMenu(
+                            sortField: $sortField,
+                            sortDirection: $sortDirection
+                        )
+                    case .composers:
+                        ComposerSortMenu(criterion: $composerSortCriterion)
+                    }
                 }
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
@@ -92,66 +157,32 @@ struct LibraryView: View {
                 NowPlayingBar()
             }
         }
-        .task {
-            if list == nil {
-                await rebuildList()
+        .task(id: mode) {
+            switch mode {
+            case .albums:
+                if albumList == nil {
+                    await rebuildList()
+                }
+            case .composers:
+                if composerList == nil {
+                    await rebuildComposerList()
+                }
             }
         }
         .onChange(of: sortField) { Task { await rebuildList() } }
         .onChange(of: sortDirection) { Task { await rebuildList() } }
+        .onChange(of: composerSortCriterion) {
+            Task { await rebuildComposerList() }
+        }
         .onReceive(libraryStore.libraryShapeSubject) { change in
-            // Grid rows are albums, so only album-level shape changes move rows.
             switch change {
             case .albumAdded, .albumUpdated, .albumRemoved:
-                list?.invalidate()
+                albumList?.invalidate()
+                composerList?.invalidate()
             case .releaseAdded, .releaseUpdated, .releaseRemoved:
-                break
+                composerList?.invalidate()
             }
         }
-    }
-
-    @ViewBuilder
-    private var banner: some View {
-        // An app error is a one-shot notification with nothing to retry, so the
-        // user dismisses it. A sync error is live state — it clears itself when
-        // sync recovers — so it offers Retry instead of a (misleading) dismiss.
-        // Both arrive as a typed `DisplayError`; the banner shows its localized
-        // line (the opaque diagnostic detail isn't surfaced in the mobile UI).
-        if let error = configStore.lastError {
-            errorBanner(message: error.line) {
-                Button {
-                    configStore.clearError()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.caption.bold())
-                        .foregroundStyle(Color.white)
-                }
-                .accessibilityLabel("Dismiss")
-            }
-        }
-        else if let error = configStore.syncError {
-            errorBanner(message: error.line) {
-                Button("Retry") { sync.triggerSync() }
-                    .font(.caption.bold())
-                    .foregroundStyle(Color.white)
-            }
-        }
-    }
-
-    private func errorBanner<Trailing: View>(
-        message: String,
-        @ViewBuilder trailing: () -> Trailing
-    ) -> some View {
-        HStack {
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(Color.white)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            trailing()
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(Color.red.opacity(0.7))
     }
 
     private var isSearching: Bool {
@@ -177,11 +208,145 @@ struct LibraryView: View {
                 configStore.showError(error)
             },
         )
-        list = albumList
+        self.albumList = albumList
         await albumList.loadInitial()
     }
 
-    private var sortMenu: some View {
+    private func rebuildComposerList() async {
+        let list = ComposerList(
+            pageSource: LibraryComposerPageSource(
+                library: library,
+                sort: composerSortCriterion
+            ),
+            ingest: { rows in
+                for row in rows {
+                    _ = libraryStore.internComposerSummary(row)
+                }
+            },
+            onError: { error in
+                configStore.showError(error)
+            },
+        )
+        composerList = list
+        await list.loadInitial()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        LibraryContentView(
+            isSearching: isSearching,
+            mode: mode,
+            albumList: albumList,
+            composerList: composerList,
+            searchResults: searchResults,
+            searchError: searchError,
+            sync: sync,
+            onSelectAlbum: {
+                routePath.appendAlbum(
+                    albumId: $0,
+                    initialReleaseId: nil,
+                    context: nil
+                )
+            },
+            onSelectComposer: { routePath.append(.composer($0)) },
+            onSelectWork: { routePath.append(.work($0)) }
+        )
+    }
+
+    /// Debounced library search. `.task(id: searchQuery)` cancels the prior run
+    /// on each keystroke: a pending 300ms debounce unwinds, and the post-await
+    /// `Task.checkCancellation()` drops a superseded query's results before they
+    /// are assigned — so only the latest query's results land. Prior results
+    /// stay on screen while the next search runs.
+    private func runSearch() async {
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        searchError = nil
+        guard !query.isEmpty else {
+            searchResults = nil
+            return
+        }
+        do {
+            try await Task.sleep(for: .milliseconds(300))
+            let bridge = try await library.searchLibrary(query)
+            try Task.checkCancellation()
+            searchResults = SearchResults(bridge: bridge, query: query)
+        }
+        catch is CancellationError {
+            // Superseded by a newer query (or cleared); leave prior results.
+        }
+        catch {
+            searchError = error.localizedDescription
+        }
+    }
+}
+
+private struct LibraryBanner: View {
+    @Environment(ConfigStore.self)
+    private var configStore
+    @Environment(Sync.self)
+    private var sync
+
+    var body: some View {
+        if let error = configStore.lastError {
+            banner(message: error.line) {
+                Button {
+                    configStore.clearError()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.caption.bold())
+                        .foregroundStyle(Color.white)
+                }
+                .accessibilityLabel("Dismiss")
+            }
+        }
+        else if let error = configStore.syncError {
+            banner(message: error.line) {
+                Button("Retry") { sync.triggerSync() }
+                    .font(.caption.bold())
+                    .foregroundStyle(Color.white)
+            }
+        }
+    }
+
+    private func banner<Trailing: View>(
+        message: String,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        HStack {
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            trailing()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(Color.red.opacity(0.7))
+    }
+}
+
+private struct LibraryModePicker: View {
+    @Binding
+    var mode: LibraryBrowserMode
+
+    var body: some View {
+        Picker("Library", selection: $mode) {
+            Text("Albums").tag(LibraryBrowserMode.albums)
+            Text("Composers").tag(LibraryBrowserMode.composers)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}
+
+private struct AlbumSortMenu: View {
+    @Binding
+    var sortField: BridgeSortField
+    @Binding
+    var sortDirection: BridgeSortDirection
+
+    var body: some View {
         Menu {
             ForEach(BridgeSortField.allCases, id: \.self) { field in
                 Button {
@@ -212,28 +377,92 @@ struct LibraryView: View {
             Image(systemName: "arrow.up.arrow.down")
         }
     }
+}
 
-    @ViewBuilder
-    private var content: some View {
+private struct ComposerSortMenu: View {
+    @Binding
+    var criterion: BridgeComposerSortCriterion
+
+    var body: some View {
+        Menu {
+            ForEach(BridgeComposerSortField.allCases, id: \.self) { field in
+                Button {
+                    criterion = BridgeComposerSortCriterion(
+                        field: field,
+                        direction: criterion.direction
+                    )
+                } label: {
+                    if field == criterion.field {
+                        Label(field.displayName, systemImage: "checkmark")
+                    }
+                    else {
+                        Text(field.displayName)
+                    }
+                }
+            }
+            Divider()
+            Button {
+                let direction: BridgeSortDirection =
+                    criterion.direction == .ascending ? .descending : .ascending
+                criterion = BridgeComposerSortCriterion(
+                    field: criterion.field,
+                    direction: direction
+                )
+            } label: {
+                Label(
+                    criterion.direction == .ascending
+                        ? String(localized: "Ascending")
+                        : String(localized: "Descending"),
+                    systemImage: criterion.direction == .ascending
+                        ? "arrow.up" : "arrow.down"
+                )
+            }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+        }
+    }
+}
+
+private struct LibraryContentView: View {
+    let isSearching: Bool
+    let mode: LibraryBrowserMode
+    let albumList: AlbumList?
+    let composerList: ComposerList?
+    let searchResults: SearchResults?
+    let searchError: String?
+    let sync: Sync
+    let onSelectAlbum: (String) -> Void
+    let onSelectComposer: (String) -> Void
+    let onSelectWork: (String) -> Void
+
+    var body: some View {
         if isSearching {
             SearchResultsView(
                 results: searchResults,
                 error: searchError,
-                onSelect: { selectedAlbumId = $0 }
+                onSelectAlbum: onSelectAlbum,
+                onSelectComposer: onSelectComposer,
+                onSelectWork: onSelectWork
             )
         }
-        else if let list {
-            AlbumGrid(
-                list: list,
-                onSelect: { selectedAlbumId = $0 }
-            )
-            .refreshable {
-                // Re-kick sync; results stream back via library events. Hold the
-                // spinner briefly to acknowledge the pull (sync has no
-                // in-progress signal to await).
-                sync.triggerSync()
-                try? await Task.sleep(for: .seconds(0.9))
+        else {
+            switch mode {
+            case .albums:
+                albumContent
+            case .composers:
+                composerContent
             }
+        }
+    }
+
+    @ViewBuilder
+    private var albumContent: some View {
+        if let albumList {
+            AlbumGrid(list: albumList, onSelect: onSelectAlbum)
+                .refreshable {
+                    sync.triggerSync()
+                    try? await Task.sleep(for: .seconds(0.9))
+                }
         }
         else {
             ProgressView()
@@ -241,30 +470,35 @@ struct LibraryView: View {
         }
     }
 
-    /// Debounced library search. `.task(id: searchQuery)` cancels the prior run
-    /// on each keystroke: a pending 300ms debounce unwinds, and the post-await
-    /// `Task.checkCancellation()` drops a superseded query's results before they
-    /// are assigned — so only the latest query's results land. Prior results
-    /// stay on screen while the next search runs.
-    private func runSearch() async {
-        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        searchError = nil
-        guard !query.isEmpty else {
-            searchResults = nil
-            return
+    @ViewBuilder
+    private var composerContent: some View {
+        if let composerList {
+            ComposerListView(list: composerList, onSelect: onSelectComposer)
+                .refreshable {
+                    sync.triggerSync()
+                    try? await Task.sleep(for: .seconds(0.9))
+                }
         }
-        do {
-            try await Task.sleep(for: .milliseconds(300))
-            let bridge = try await library.searchLibrary(query)
-            try Task.checkCancellation()
-            searchResults = SearchResults(bridge: bridge, query: query)
+        else {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        catch is CancellationError {
-            // Superseded by a newer query (or cleared); leave prior results.
-        }
-        catch {
-            searchError = error.localizedDescription
-        }
+    }
+}
+
+private extension Array where Element == LibraryRoute {
+    mutating func appendAlbum(
+        albumId: String,
+        initialReleaseId: String?,
+        context: AlbumDetailContext?
+    ) {
+        append(
+            .album(
+                albumId: albumId,
+                initialReleaseId: initialReleaseId,
+                context: context
+            )
+        )
     }
 }
 
@@ -371,5 +605,369 @@ private struct AlbumCard: View {
                     comment: "Album card VoiceOver label: title by artist"
                 )
         )
+    }
+}
+
+private struct ComposerListView: View {
+    let list: ComposerList
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        if list.totalCount == 0 {
+            Text("No composers")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(32)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        else {
+            List {
+                ForEach(0..<list.totalCount, id: \.self) { position in
+                    ComposerRowSlot(
+                        list: list,
+                        position: position,
+                        onSelect: onSelect
+                    )
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+private struct ComposerRowSlot: View {
+    let list: ComposerList
+    let position: Int
+    let onSelect: (String) -> Void
+
+    @Environment(LibraryStore.self)
+    private var libraryStore
+
+    var body: some View {
+        Group {
+            if let id = list.idAt(position),
+                let summary = libraryStore.composerSummaries[id]
+            {
+                Button {
+                    onSelect(id)
+                } label: {
+                    ComposerSummaryRow(summary: summary)
+                }
+                .buttonStyle(.plain)
+            }
+            else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .task(id: list.loadEpoch) {
+            let offset = (position / pageSize) * pageSize
+            await list.loadRange(offset: offset, limit: pageSize)
+        }
+    }
+}
+
+private struct ComposerSummaryRow: View {
+    let summary: BridgeComposerSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: summary.image, pointSize: 48)
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(summary.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Text("\(summary.workCount) \(String(localized: "Works"))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct ComposerDetailScreen: View {
+    let artistId: String
+    let openWork: (String) -> Void
+    let openAlbum: (String) -> Void
+
+    @Environment(Library.self)
+    private var library
+
+    @State
+    private var detail: BridgeComposerDetail?
+    @State
+    private var error: String?
+
+    var body: some View {
+        Group {
+            if let error {
+                Text(error)
+                    .foregroundStyle(.red)
+                    .padding(32)
+            }
+            else if let detail {
+                ComposerDetailContent(
+                    detail: detail,
+                    openWork: openWork,
+                    openAlbum: openAlbum
+                )
+            }
+            else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(detail?.composer.name ?? String(localized: "Composers"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: artistId) {
+            await load()
+        }
+    }
+
+    private func load() async {
+        error = nil
+        do {
+            let getComposerDetail = library.getComposerDetail
+            let loaded =
+                try await Task.detached {
+                    try getComposerDetail(artistId)
+                }
+                .value
+            try Task.checkCancellation()
+            guard let loaded else {
+                error = String(localized: "Composer detail not found")
+                return
+            }
+            detail = loaded
+        }
+        catch is CancellationError {}
+        catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct ComposerDetailContent: View {
+    let detail: BridgeComposerDetail
+    let openWork: (String) -> Void
+    let openAlbum: (String) -> Void
+
+    var body: some View {
+        List {
+            Section {
+                ComposerSummaryRow(summary: detail.composer)
+            }
+            if !detail.workGroups.isEmpty {
+                Section("Works") {
+                    ForEach(detail.workGroups, id: \.id) { group in
+                        if let parent = group.parent {
+                            WorkSummaryButton(summary: parent, openWork: openWork)
+                        }
+                        ForEach(group.works, id: \.workId) { work in
+                            WorkSummaryButton(summary: work, openWork: openWork)
+                        }
+                    }
+                }
+            }
+            if !detail.unlinkedReleaseRoles.isEmpty {
+                Section("Credits") {
+                    ForEach(detail.unlinkedReleaseRoles, id: \.releaseId) {
+                        role in
+                        Button {
+                            openAlbum(role.albumId)
+                        } label: {
+                            TwoLineRow(
+                                title: role.albumTitle,
+                                subtitle: role.sourceCredit
+                            )
+                        }
+                    }
+                }
+            }
+            if !detail.unlinkedTrackRoles.isEmpty {
+                Section("Recordings") {
+                    ForEach(detail.unlinkedTrackRoles, id: \.trackId) { role in
+                        TwoLineRow(
+                            title: role.trackTitle,
+                            subtitle: role.albumTitle
+                        )
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+}
+
+private struct WorkDetailScreen: View {
+    let workId: String
+    let openWork: (String) -> Void
+    let openAlbum: (BridgeWorkReleaseSummary) -> Void
+
+    @Environment(Library.self)
+    private var library
+
+    @State
+    private var detail: BridgeWorkDetail?
+    @State
+    private var error: String?
+
+    var body: some View {
+        Group {
+            if let error {
+                Text(error)
+                    .foregroundStyle(.red)
+                    .padding(32)
+            }
+            else if let detail {
+                WorkDetailContent(
+                    detail: detail,
+                    openWork: openWork,
+                    openAlbum: openAlbum
+                )
+            }
+            else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(detail?.work.title ?? String(localized: "Works"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: workId) {
+            await load()
+        }
+    }
+
+    private func load() async {
+        error = nil
+        do {
+            let getWorkDetail = library.getWorkDetail
+            let loaded =
+                try await Task.detached {
+                    try getWorkDetail(workId)
+                }
+                .value
+            try Task.checkCancellation()
+            guard let loaded else {
+                error = String(localized: "Work detail not found")
+                return
+            }
+            detail = loaded
+        }
+        catch is CancellationError {}
+        catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct WorkDetailContent: View {
+    let detail: BridgeWorkDetail
+    let openWork: (String) -> Void
+    let openAlbum: (BridgeWorkReleaseSummary) -> Void
+
+    var body: some View {
+        List {
+            Section {
+                WorkSummaryRow(summary: detail.work)
+            }
+            if !detail.childWorks.isEmpty {
+                Section("Works") {
+                    ForEach(detail.childWorks, id: \.workId) { work in
+                        WorkSummaryButton(summary: work, openWork: openWork)
+                    }
+                }
+            }
+            if !detail.releases.isEmpty {
+                Section("Releases") {
+                    ForEach(detail.releases, id: \.releaseId) { release in
+                        Button {
+                            openAlbum(release)
+                        } label: {
+                            HStack(spacing: 12) {
+                                ImageView(imageRef: release.cover, pointSize: 42)
+                                    .frame(width: 42, height: 42)
+                                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                                TwoLineRow(
+                                    title: release.albumTitle,
+                                    subtitle: workReleaseMetadata(release)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            if !detail.tracks.isEmpty {
+                Section("Recordings") {
+                    ForEach(detail.tracks, id: \.trackId) { track in
+                        TwoLineRow(
+                            title: track.trackTitle,
+                            subtitle: track.albumTitle
+                        )
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private func workReleaseMetadata(
+        _ release: BridgeWorkReleaseSummary
+    ) -> String {
+        [release.displayName, release.format]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " \u{00B7} ")
+    }
+}
+
+private struct WorkSummaryButton: View {
+    let summary: BridgeWorkSummary
+    let openWork: (String) -> Void
+
+    var body: some View {
+        Button {
+            openWork(summary.workId)
+        } label: {
+            WorkSummaryRow(summary: summary)
+        }
+    }
+}
+
+private struct WorkSummaryRow: View {
+    let summary: BridgeWorkSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: summary.representativeCover, pointSize: 42)
+                .frame(width: 42, height: 42)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            TwoLineRow(title: summary.title, subtitle: summary.composerNames)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct TwoLineRow: View {
+    let title: String
+    let subtitle: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.body)
+                .lineLimit(1)
+            if let subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
     }
 }

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -81,10 +81,10 @@ struct LibraryView: View {
                     ComposerDetailScreen(
                         artistId: artistId,
                         openWork: { routePath.append(.work($0)) },
-                        openAlbum: {
+                        openAlbum: { albumId, releaseId in
                             routePath.appendAlbum(
-                                albumId: $0,
-                                initialReleaseId: nil,
+                                albumId: albumId,
+                                initialReleaseId: releaseId,
                                 context: nil
                             )
                         }
@@ -461,7 +461,7 @@ private struct LibraryContentView: View {
             AlbumGrid(list: albumList, onSelect: onSelectAlbum)
                 .refreshable {
                     sync.triggerSync()
-                    try? await Task.sleep(for: .seconds(0.9))
+                    await settleAfterRefresh()
                 }
         }
         else {
@@ -476,12 +476,22 @@ private struct LibraryContentView: View {
             ComposerListView(list: composerList, onSelect: onSelectComposer)
                 .refreshable {
                     sync.triggerSync()
-                    try? await Task.sleep(for: .seconds(0.9))
+                    await settleAfterRefresh()
                 }
         }
         else {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func settleAfterRefresh() async {
+        do {
+            try await Task.sleep(for: .seconds(0.9))
+        }
+        catch is CancellationError {}
+        catch {
+            preconditionFailure("Unexpected refresh sleep error: \(error)")
         }
     }
 }
@@ -693,7 +703,7 @@ private struct ComposerSummaryRow: View {
 private struct ComposerDetailScreen: View {
     let artistId: String
     let openWork: (String) -> Void
-    let openAlbum: (String) -> Void
+    let openAlbum: (String, String) -> Void
 
     @Environment(Library.self)
     private var library
@@ -722,11 +732,21 @@ private struct ComposerDetailScreen: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .navigationTitle(detail?.composer.name ?? String(localized: "Composers"))
+        .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .task(id: artistId) {
             await load()
         }
+    }
+
+    private var navigationTitle: String {
+        if let detail {
+            return detail.composer.name
+        }
+        if error != nil {
+            return String(localized: "Composers")
+        }
+        return ""
     }
 
     private func load() async {
@@ -755,7 +775,7 @@ private struct ComposerDetailScreen: View {
 private struct ComposerDetailContent: View {
     let detail: BridgeComposerDetail
     let openWork: (String) -> Void
-    let openAlbum: (String) -> Void
+    let openAlbum: (String, String) -> Void
 
     var body: some View {
         List {
@@ -779,7 +799,7 @@ private struct ComposerDetailContent: View {
                     ForEach(detail.unlinkedReleaseRoles, id: \.releaseId) {
                         role in
                         Button {
-                            openAlbum(role.albumId)
+                            openAlbum(role.albumId, role.releaseId)
                         } label: {
                             TwoLineRow(
                                 title: role.albumTitle,
@@ -836,11 +856,21 @@ private struct WorkDetailScreen: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .navigationTitle(detail?.work.title ?? String(localized: "Works"))
+        .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .task(id: workId) {
             await load()
         }
+    }
+
+    private var navigationTitle: String {
+        if let detail {
+            return detail.work.title
+        }
+        if error != nil {
+            return String(localized: "Works")
+        }
+        return ""
     }
 
     private func load() async {
@@ -919,10 +949,14 @@ private struct WorkDetailContent: View {
     private func workReleaseMetadata(
         _ release: BridgeWorkReleaseSummary
     ) -> String {
-        [release.displayName, release.format]
-            .compactMap { $0 }
-            .filter { !$0.isEmpty }
-            .joined(separator: " \u{00B7} ")
+        precondition(
+            !release.displayName.isEmpty,
+            "work release display name is empty for \(release.releaseId)"
+        )
+        if let format = release.format, !format.isEmpty {
+            return "\(release.displayName) \u{00B7} \(format)"
+        }
+        return release.displayName
     }
 }
 

--- a/bae-ios/bae/bae/Views/SearchResultsView.swift
+++ b/bae-ios/bae/bae/Views/SearchResultsView.swift
@@ -1,20 +1,24 @@
 import SwiftUI
 
-/// Library search results: two sections — Albums then Tracks. Both row types
-/// open the album's detail; a track navigates to its album rather than playing.
+/// Library search results. Album and track rows open album detail; composer and
+/// work rows navigate to their bridge ids.
 /// Iterates and renders only — the search call and the bridge→model mapping
 /// live in the data layer (`Library.searchLibrary` / `SearchResults`).
 struct SearchResultsView: View {
     let results: SearchResults?
     let error: String?
-    let onSelect: (String) -> Void
+    let onSelectAlbum: (String) -> Void
+    let onSelectComposer: (String) -> Void
+    let onSelectWork: (String) -> Void
 
     var body: some View {
         if let error {
             centered(Text(error).foregroundStyle(.red))
         }
         else if let results {
-            if results.albums.isEmpty, results.tracks.isEmpty {
+            if results.albums.isEmpty, results.tracks.isEmpty,
+                results.composers.isEmpty, results.works.isEmpty
+            {
                 centered(
                     Text("No results for \u{201C}\(results.query)\u{201D}")
                         .foregroundStyle(.secondary)
@@ -26,7 +30,7 @@ struct SearchResultsView: View {
                         Section("Albums") {
                             ForEach(results.albums) { album in
                                 Button {
-                                    onSelect(album.id)
+                                    onSelectAlbum(album.id)
                                 } label: {
                                     AlbumResultRow(album: album)
                                 }
@@ -38,9 +42,34 @@ struct SearchResultsView: View {
                         Section("Tracks") {
                             ForEach(results.tracks) { track in
                                 Button {
-                                    onSelect(track.albumId)
+                                    onSelectAlbum(track.albumId)
                                 } label: {
                                     TrackResultRow(track: track)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    if !results.composers.isEmpty {
+                        Section("Composers") {
+                            ForEach(results.composers, id: \.artistId) {
+                                composer in
+                                Button {
+                                    onSelectComposer(composer.artistId)
+                                } label: {
+                                    ComposerResultRow(composer: composer)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    if !results.works.isEmpty {
+                        Section("Works") {
+                            ForEach(results.works, id: \.workId) { work in
+                                Button {
+                                    onSelectWork(work.workId)
+                                } label: {
+                                    WorkResultRow(work: work)
                                 }
                                 .buttonStyle(.plain)
                             }
@@ -105,6 +134,52 @@ private struct TrackResultRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+}
+
+private struct ComposerResultRow: View {
+    let composer: BridgeComposerSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: composer.image, pointSize: 48)
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(composer.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Text("\(composer.workCount) \(String(localized: "Works"))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+    }
+}
+
+private struct WorkResultRow: View {
+    let work: BridgeWorkSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: work.representativeCover, pointSize: 48)
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(work.title)
+                    .font(.body)
+                    .lineLimit(1)
+                if let composers = work.composerNames {
+                    Text(composers)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
         }
     }
 }

--- a/bae-ios/bae/project.yml
+++ b/bae-ios/bae/project.yml
@@ -40,6 +40,7 @@ targets:
       # `#if canImport`, so it compiles AppKit-free on iOS.
       - path: ../../bae-macos/bae/bae/ImageLoader.swift
       - path: ../../bae-macos/bae/bae/BridgeSortField+CaseIterable.swift
+      - path: ../../bae-macos/bae/bae/BridgeComposerSortField+CaseIterable.swift
       - path: ../../bae-macos/bae/bae/DurationClock.swift
       - path: ../../bae-macos/bae/bae/Services/PlaybackStore.swift
       - path: ../../bae-macos/bae/bae/Services/PlaybackPositionEvent.swift

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -847,9 +847,13 @@ private struct WorkDetailView: View {
     private func workReleaseMetadata(
         _ release: BridgeWorkReleaseSummary
     ) -> String {
-        [release.displayName, release.format]
-            .compactMap { $0 }
-            .filter { !$0.isEmpty }
-            .joined(separator: " \u{00B7} ")
+        precondition(
+            !release.displayName.isEmpty,
+            "work release display name is empty for \(release.releaseId)"
+        )
+        if let format = release.format, !format.isEmpty {
+            return "\(release.displayName) \u{00B7} \(format)"
+        }
+        return release.displayName
     }
 }

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -355,7 +355,11 @@ extension LibraryView {
                                     )
                                 }
                             },
-                            openAlbum: { albumId in
+                            openAlbum: { albumId, releaseId in
+                                uiStore.selectRelease(
+                                    releaseId,
+                                    inAlbum: albumId
+                                )
                                 uiStore.selectAlbum(albumId)
                                 mode = .albums
                             }
@@ -369,7 +373,8 @@ extension LibraryView {
                             detailSelection = .work(workId: workId)
                             composerPaneDetail = .empty
                         },
-                        openAlbum: { albumId in
+                        openAlbum: { albumId, releaseId in
+                            uiStore.selectRelease(releaseId, inAlbum: albumId)
                             uiStore.selectAlbum(albumId)
                             mode = .albums
                         }
@@ -778,7 +783,7 @@ private struct CreditRow: View {
 private struct WorkDetailView: View {
     let detail: BridgeWorkDetail
     let openWork: (String) -> Void
-    let openAlbum: (String) -> Void
+    let openAlbum: (String, String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -796,20 +801,24 @@ private struct WorkDetailView: View {
             }
             if !detail.releases.isEmpty {
                 SectionHeader(title: String(localized: "Releases"))
-                ForEach(detail.releases, id: \.id) { release in
-                    Button(action: { openAlbum(release.albumId) }) {
+                ForEach(detail.releases, id: \.releaseId) { release in
+                    Button(action: {
+                        openAlbum(release.albumId, release.releaseId)
+                    }) {
                         HStack(spacing: 12) {
                             ImageView(imageRef: release.cover, pointSize: 42)
                                 .frame(width: 42, height: 42)
                                 .clipShape(RoundedRectangle(cornerRadius: 6))
                             VStack(alignment: .leading, spacing: 3) {
-                                Text(release.id)
+                                Text(release.albumTitle)
                                     .font(.body)
                                     .lineLimit(1)
-                                OptionalLineText(
-                                    text: release.format,
+                                StableOptionalText(
+                                    text: workReleaseMetadata(release),
                                     font: .caption,
-                                    foreground: .secondary
+                                    foreground: .secondary,
+                                    lineHeight: 12,
+                                    lineLimit: 1
                                 )
                             }
                             Spacer()
@@ -833,5 +842,14 @@ private struct WorkDetailView: View {
                 }
             }
         }
+    }
+
+    private func workReleaseMetadata(
+        _ release: BridgeWorkReleaseSummary
+    ) -> String {
+        [release.displayName, release.format]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " \u{00B7} ")
     }
 }

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -14,7 +14,9 @@ use std::{
 };
 
 use bae_core::album_detail::ReleaseStorageState;
-use bae_core::db::{AlbumSortCriterion, AlbumSortField, SortDirection};
+use bae_core::db::{
+    AlbumSortCriterion, AlbumSortField, ComposerSortCriterion, ComposerSortField, SortDirection,
+};
 use bae_core::diagnostics::{
     AppDiagnosticMetadata, DatadogDiagnosticsConfig, DiagnosticLevel, Diagnostics,
     DiagnosticsConfig,
@@ -1472,6 +1474,76 @@ struct FfiAlbum {
     cover: Option<FfiImageRef>,
 }
 
+#[derive(Serialize)]
+struct FfiTrackSearchResult {
+    id: String,
+    title: String,
+    duration_ms: Option<i64>,
+    album_id: String,
+    album_title: String,
+    artist_name: String,
+}
+
+#[derive(Serialize)]
+struct FfiComposerSummary {
+    artist_id: String,
+    name: String,
+    sort_name: Option<String>,
+    work_count: i64,
+    linked_release_count: i64,
+    unlinked_credit_count: i64,
+    image: Option<FfiImageRef>,
+}
+
+#[derive(Serialize)]
+struct FfiWorkSummary {
+    work_id: String,
+    title: String,
+    disambiguation: Option<String>,
+    work_type: Option<String>,
+    parent_work_id: Option<String>,
+    composer_names: Option<String>,
+    linked_release_count: i64,
+    representative_release_id: Option<String>,
+    representative_cover: Option<FfiImageRef>,
+}
+
+#[derive(Serialize)]
+struct FfiSearchResults {
+    albums: Vec<FfiAlbum>,
+    tracks: Vec<FfiTrackSearchResult>,
+    composers: Vec<FfiComposerSummary>,
+    works: Vec<FfiWorkSummary>,
+}
+
+fn composer_summary_to_ffi(
+    composer: bae_core::album_detail::ComposerSummary,
+) -> FfiComposerSummary {
+    FfiComposerSummary {
+        artist_id: composer.raw.artist.id,
+        name: composer.raw.artist.name,
+        sort_name: composer.raw.artist.sort_name,
+        work_count: composer.raw.work_count,
+        linked_release_count: composer.raw.linked_release_count,
+        unlinked_credit_count: composer.raw.unlinked_credit_count,
+        image: composer.image.map(FfiImageRef::from_core),
+    }
+}
+
+fn work_summary_to_ffi(work: bae_core::album_detail::WorkSummary) -> FfiWorkSummary {
+    FfiWorkSummary {
+        work_id: work.raw.work.id,
+        title: work.raw.work.title,
+        disambiguation: work.raw.work.disambiguation,
+        work_type: work.raw.work.work_type,
+        parent_work_id: work.raw.parent_work_id,
+        composer_names: work.raw.composer_names,
+        linked_release_count: work.raw.linked_release_count,
+        representative_release_id: work.raw.representative_release_id,
+        representative_cover: work.representative_cover.map(FfiImageRef::from_core),
+    }
+}
+
 /// Serialize `value` to a JSON C string the caller frees with [`bae_string_free`],
 /// or null on failure (logged).
 fn json_cstring<T: Serialize>(value: &T) -> *mut c_char {
@@ -1561,8 +1633,93 @@ pub unsafe extern "C" fn bae_album_page(
     json_cstring(&page)
 }
 
-/// Album results for `query` as the same JSON shape as [`bae_album_page`]
-/// (`{id, title, artist, cover}`), so the grid renders them directly.
+#[no_mangle]
+/// Returns the number of composer rows available to the library browser.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by this library and must remain
+/// valid for the duration of the call.
+pub unsafe extern "C" fn bae_composer_count(handle: *const BaeHandle) -> i64 {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_composer_count: null handle");
+        return -1;
+    };
+    let app = &handle.0;
+    match app
+        .runtime
+        .block_on(app.services.library_manager().get_composer_count())
+    {
+        Ok(count) => count as i64,
+        Err(e) => {
+            tracing::error!("bae_composer_count failed: {e}");
+            -1
+        }
+    }
+}
+
+fn composer_sort_field_from_str(field: &str) -> Option<ComposerSortField> {
+    match field {
+        "name" => Some(ComposerSortField::Name),
+        "work_count" => Some(ComposerSortField::WorkCount),
+        "linked_release_count" => Some(ComposerSortField::LinkedReleaseCount),
+        _ => None,
+    }
+}
+
+#[no_mangle]
+/// Returns a JSON array of composer summaries for the requested page.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by this library and must remain
+/// valid for the duration of the call. `sort_field` must be a valid
+/// NUL-terminated UTF-8 string: `name`, `work_count`, or
+/// `linked_release_count`.
+pub unsafe extern "C" fn bae_composer_page(
+    handle: *const BaeHandle,
+    offset: u64,
+    limit: u64,
+    sort_field: *const c_char,
+    ascending: bool,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_composer_page: null handle");
+        return std::ptr::null_mut();
+    };
+    let Some(sort_field) = cstr(sort_field) else {
+        tracing::error!("bae_composer_page: null or non-UTF-8 sort_field");
+        return std::ptr::null_mut();
+    };
+    let Some(field) = composer_sort_field_from_str(&sort_field) else {
+        tracing::error!("bae_composer_page: unknown sort field {sort_field}");
+        return std::ptr::null_mut();
+    };
+    let direction = if ascending {
+        SortDirection::Ascending
+    } else {
+        SortDirection::Descending
+    };
+    let app = &handle.0;
+    let sort = ComposerSortCriterion { field, direction };
+    let page = match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .get_composer_page(sort, offset, limit),
+    ) {
+        Ok(composers) => composers
+            .into_iter()
+            .map(composer_summary_to_ffi)
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            tracing::error!("bae_composer_page failed: {e}");
+            return std::ptr::null_mut();
+        }
+    };
+    json_cstring(&page)
+}
+
+/// Sectioned library results for `query`: albums, tracks, composers, and works.
 /// Returns null on error. Free the result with [`bae_string_free`].
 ///
 /// # Safety
@@ -1587,17 +1744,37 @@ pub unsafe extern "C" fn bae_search(handle: *const BaeHandle, query: *const c_ch
             return std::ptr::null_mut();
         }
     };
-    let albums: Vec<FfiAlbum> = results
-        .albums
-        .into_iter()
-        .map(|album| FfiAlbum {
-            id: album.id,
-            title: album.title,
-            artist: album.artist_name,
-            cover: album.cover.map(FfiImageRef::from_core),
-        })
-        .collect();
-    json_cstring(&albums)
+    let out = FfiSearchResults {
+        albums: results
+            .albums
+            .into_iter()
+            .map(|album| FfiAlbum {
+                id: album.id,
+                title: album.title,
+                artist: album.artist_name,
+                cover: album.cover.map(FfiImageRef::from_core),
+            })
+            .collect(),
+        tracks: results
+            .tracks
+            .into_iter()
+            .map(|track| FfiTrackSearchResult {
+                id: track.id,
+                title: track.title,
+                duration_ms: track.duration_ms,
+                album_id: track.album_id,
+                album_title: track.album_title,
+                artist_name: track.artist_name,
+            })
+            .collect(),
+        composers: results
+            .composers
+            .into_iter()
+            .map(composer_summary_to_ffi)
+            .collect(),
+        works: results.works.into_iter().map(work_summary_to_ffi).collect(),
+    };
+    json_cstring(&out)
 }
 
 /// Which byte source a gallery slot is read from, as a `kind`-tagged JSON object:
@@ -2261,6 +2438,69 @@ struct FfiAlbumDetail {
     releases: Vec<FfiRelease>,
 }
 
+#[derive(Serialize)]
+struct FfiReleaseRoleSummary {
+    release_id: String,
+    album_id: String,
+    album_title: String,
+    source_credit: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FfiTrackRoleSummary {
+    track_id: String,
+    track_title: String,
+    release_id: String,
+    album_id: String,
+    album_title: String,
+    artist_id: String,
+    artist_name: String,
+    source_credit: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FfiComposerWorkGroup {
+    id: String,
+    parent: Option<FfiWorkSummary>,
+    works: Vec<FfiWorkSummary>,
+}
+
+#[derive(Serialize)]
+struct FfiComposerDetail {
+    composer: FfiComposerSummary,
+    work_groups: Vec<FfiComposerWorkGroup>,
+    unlinked_release_roles: Vec<FfiReleaseRoleSummary>,
+    unlinked_track_roles: Vec<FfiTrackRoleSummary>,
+    default_work_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FfiWorkReleaseSummary {
+    release_id: String,
+    album_id: String,
+    album_title: String,
+    display_name: String,
+    format: Option<String>,
+    cover: Option<FfiImageRef>,
+}
+
+#[derive(Serialize)]
+struct FfiWorkTrackSummary {
+    track_id: String,
+    track_title: String,
+    release_id: String,
+    album_id: String,
+    album_title: String,
+}
+
+#[derive(Serialize)]
+struct FfiWorkDetail {
+    work: FfiWorkSummary,
+    child_works: Vec<FfiWorkSummary>,
+    releases: Vec<FfiWorkReleaseSummary>,
+    tracks: Vec<FfiWorkTrackSummary>,
+}
+
 /// Full detail for one album as JSON, or null on error / not found. Free the
 /// result with [`bae_string_free`].
 ///
@@ -2334,6 +2574,145 @@ pub unsafe extern "C" fn bae_album_detail(
         primary_release_id: detail.primary_release_id,
         cover: detail.cover.map(FfiImageRef::from_core),
         releases,
+    };
+    json_cstring(&out)
+}
+
+#[no_mangle]
+/// Returns composer detail JSON for `artist_id`, or null when it is absent.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by this library and must remain
+/// valid for the duration of the call. `artist_id` must be a valid
+/// NUL-terminated UTF-8 string.
+pub unsafe extern "C" fn bae_composer_detail(
+    handle: *const BaeHandle,
+    artist_id: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_composer_detail: null handle");
+        return std::ptr::null_mut();
+    };
+    let Some(artist_id) = cstr(artist_id) else {
+        tracing::error!("bae_composer_detail: null or non-UTF-8 artist_id");
+        return std::ptr::null_mut();
+    };
+    let app = &handle.0;
+    let detail = match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .get_composer_detail(&artist_id),
+    ) {
+        Ok(Some(detail)) => detail,
+        Ok(None) => return std::ptr::null_mut(),
+        Err(e) => {
+            tracing::error!("bae_composer_detail failed: {e}");
+            return std::ptr::null_mut();
+        }
+    };
+    let out = FfiComposerDetail {
+        composer: composer_summary_to_ffi(detail.composer),
+        work_groups: detail
+            .work_groups
+            .into_iter()
+            .map(|group| FfiComposerWorkGroup {
+                id: group.id,
+                parent: group.parent.map(work_summary_to_ffi),
+                works: group.works.into_iter().map(work_summary_to_ffi).collect(),
+            })
+            .collect(),
+        unlinked_release_roles: detail
+            .unlinked_release_roles
+            .into_iter()
+            .map(|role| FfiReleaseRoleSummary {
+                release_id: role.role.release_id,
+                album_id: role.album.id,
+                album_title: role.album.title,
+                source_credit: role.role.source_credit,
+            })
+            .collect(),
+        unlinked_track_roles: detail
+            .unlinked_track_roles
+            .into_iter()
+            .map(|role| FfiTrackRoleSummary {
+                track_id: role.track.id,
+                track_title: role.track.title,
+                release_id: role.track.release_id,
+                album_id: role.album.id,
+                album_title: role.album.title,
+                artist_id: role.artist.id,
+                artist_name: role.artist.name,
+                source_credit: role.role.source_credit,
+            })
+            .collect(),
+        default_work_id: detail.default_work_id,
+    };
+    json_cstring(&out)
+}
+
+#[no_mangle]
+/// Returns work detail JSON for `work_id`, or null when it is absent.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by this library and must remain
+/// valid for the duration of the call. `work_id` must be a valid
+/// NUL-terminated UTF-8 string.
+pub unsafe extern "C" fn bae_work_detail(
+    handle: *const BaeHandle,
+    work_id: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_work_detail: null handle");
+        return std::ptr::null_mut();
+    };
+    let Some(work_id) = cstr(work_id) else {
+        tracing::error!("bae_work_detail: null or non-UTF-8 work_id");
+        return std::ptr::null_mut();
+    };
+    let app = &handle.0;
+    let detail = match app
+        .runtime
+        .block_on(app.services.library_manager().get_work_detail(&work_id))
+    {
+        Ok(Some(detail)) => detail,
+        Ok(None) => return std::ptr::null_mut(),
+        Err(e) => {
+            tracing::error!("bae_work_detail failed: {e}");
+            return std::ptr::null_mut();
+        }
+    };
+    let out = FfiWorkDetail {
+        work: work_summary_to_ffi(detail.work),
+        child_works: detail
+            .child_works
+            .into_iter()
+            .map(work_summary_to_ffi)
+            .collect(),
+        releases: detail
+            .releases
+            .into_iter()
+            .map(|release| FfiWorkReleaseSummary {
+                release_id: release.release_id,
+                album_id: release.album_id,
+                album_title: release.album_title,
+                display_name: release.display_name,
+                format: release.format,
+                cover: release.cover.map(FfiImageRef::from_core),
+            })
+            .collect(),
+        tracks: detail
+            .tracks
+            .into_iter()
+            .map(|track| FfiWorkTrackSummary {
+                track_id: track.track.id,
+                track_title: track.track.title,
+                release_id: track.track.release_id,
+                album_id: track.album.id,
+                album_title: track.album.title,
+            })
+            .collect(),
     };
     json_cstring(&out)
 }
@@ -5027,5 +5406,86 @@ mod tests {
         assert_eq!(config.client_token, "token");
         assert_eq!(config.source, "windows");
         assert_eq!(config.app.environment, "dev");
+    }
+
+    #[test]
+    fn windows_library_search_json_preserves_section_and_work_release_fields() {
+        let search = FfiSearchResults {
+            albums: vec![FfiAlbum {
+                id: "album-a".to_string(),
+                title: "Album Title A".to_string(),
+                artist: "Artist Name A".to_string(),
+                cover: None,
+            }],
+            tracks: vec![FfiTrackSearchResult {
+                id: "track-a".to_string(),
+                title: "Track Title A".to_string(),
+                duration_ms: Some(1000),
+                album_id: "album-a".to_string(),
+                album_title: "Album Title A".to_string(),
+                artist_name: "Artist Name A".to_string(),
+            }],
+            composers: vec![FfiComposerSummary {
+                artist_id: "artist-a".to_string(),
+                name: "Composer Name A".to_string(),
+                sort_name: None,
+                work_count: 1,
+                linked_release_count: 1,
+                unlinked_credit_count: 0,
+                image: None,
+            }],
+            works: vec![FfiWorkSummary {
+                work_id: "work-a".to_string(),
+                title: "Work Title A".to_string(),
+                disambiguation: None,
+                work_type: Some("work".to_string()),
+                parent_work_id: None,
+                composer_names: Some("Composer Name A".to_string()),
+                linked_release_count: 1,
+                representative_release_id: Some("release-a".to_string()),
+                representative_cover: None,
+            }],
+        };
+        let work_release = FfiWorkReleaseSummary {
+            release_id: "release-a".to_string(),
+            album_id: "album-a".to_string(),
+            album_title: "Album Title A".to_string(),
+            display_name: "2026 CD".to_string(),
+            format: Some("CD".to_string()),
+            cover: None,
+        };
+
+        let search_json = serde_json::to_value(search).expect("search json");
+        assert!(search_json.get("albums").is_some());
+        assert!(search_json.get("tracks").is_some());
+        assert!(search_json.get("composers").is_some());
+        assert!(search_json.get("works").is_some());
+        assert_eq!(search_json["tracks"][0]["album_id"], "album-a");
+        assert_eq!(search_json["composers"][0]["artist_id"], "artist-a");
+        assert_eq!(search_json["works"][0]["work_id"], "work-a");
+
+        let release_json = serde_json::to_value(work_release).expect("work release json");
+        assert_eq!(release_json["release_id"], "release-a");
+        assert_eq!(release_json["album_id"], "album-a");
+        assert_eq!(release_json["album_title"], "Album Title A");
+        assert_eq!(release_json["display_name"], "2026 CD");
+    }
+
+    #[test]
+    fn windows_composer_sort_tags_use_public_wire_names() {
+        assert!(matches!(
+            super::composer_sort_field_from_str("name"),
+            Some(ComposerSortField::Name)
+        ));
+        assert!(matches!(
+            super::composer_sort_field_from_str("work_count"),
+            Some(ComposerSortField::WorkCount)
+        ));
+        assert!(matches!(
+            super::composer_sort_field_from_str("linked_release_count"),
+            Some(ComposerSortField::LinkedReleaseCount)
+        ));
+        assert!(super::composer_sort_field_from_str("works").is_none());
+        assert!(super::composer_sort_field_from_str("releases").is_none());
     }
 }

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn bae_init(
         tracing::error!("bae_init: null or non-UTF-8 library_id");
         return std::ptr::null_mut();
     };
-    match bae_desktop::bootstrap(library_id, position_update_interval_ms) {
+    match bae_desktop::bootstrap(library_id, position_update_interval_ms, None) {
         Ok(app) => Box::into_raw(Box::new(BaeHandle(app))),
         Err(e) => {
             tracing::error!("bae_init failed: {e}");
@@ -4476,7 +4476,7 @@ pub unsafe extern "C" fn bae_invite_member(
     match app.runtime.block_on(
         app.services
             .library_manager()
-            .invite_member(&public_key_hex),
+            .invite_member(&public_key_hex, None),
     ) {
         Ok(code) => error_cstring(&code),
         Err(e) => {

--- a/bae-windows/Composer.cs
+++ b/bae-windows/Composer.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.UI.Xaml.Media;
 
@@ -26,6 +27,13 @@ public sealed class TrackSearchResult
 
 public sealed class ComposerSummary
 {
+    [SetsRequiredMembers]
+    public ComposerSummary()
+    {
+        ArtistId = string.Empty;
+        Name = string.Empty;
+    }
+
     public required string ArtistId { get; set; }
     public required string Name { get; set; }
     public string? SortName { get; set; }

--- a/bae-windows/Composer.cs
+++ b/bae-windows/Composer.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Microsoft.UI.Xaml.Media;
+
+namespace Bae.Windows;
+
+public sealed class LibrarySearchResults
+{
+    public required List<Album> Albums { get; set; }
+    public required List<TrackSearchResult> Tracks { get; set; }
+    public required List<ComposerSummary> Composers { get; set; }
+    public required List<WorkSummary> Works { get; set; }
+}
+
+public sealed class TrackSearchResult
+{
+    public required string Id { get; set; }
+    public required string Title { get; set; }
+    public long? DurationMs { get; set; }
+    public required string AlbumId { get; set; }
+    public required string AlbumTitle { get; set; }
+    public required string ArtistName { get; set; }
+    public string DurationLabel => Loc.Duration(DurationMs);
+}
+
+public sealed class ComposerSummary
+{
+    public required string ArtistId { get; set; }
+    public required string Name { get; set; }
+    public string? SortName { get; set; }
+    public long WorkCount { get; set; }
+    public long LinkedReleaseCount { get; set; }
+    public long UnlinkedCreditCount { get; set; }
+    public ImageRef? Image { get; set; }
+
+    [JsonIgnore]
+    public IntPtr Handle { get; set; }
+
+    public ImageSource? Cover => CoverImage.LoadByImageRef(Handle, Image);
+    public string WorkCountText => Loc.Chrome("work.count", "count", Loc.Number(WorkCount));
+}
+
+public sealed class WorkSummary
+{
+    public required string WorkId { get; set; }
+    public required string Title { get; set; }
+    public string? Disambiguation { get; set; }
+    public string? WorkType { get; set; }
+    public string? ParentWorkId { get; set; }
+    public string? ComposerNames { get; set; }
+    public long LinkedReleaseCount { get; set; }
+    public string? RepresentativeReleaseId { get; set; }
+    public ImageRef? RepresentativeCover { get; set; }
+
+    [JsonIgnore]
+    public IntPtr Handle { get; set; }
+
+    public ImageSource? Cover => CoverImage.LoadByImageRef(Handle, RepresentativeCover);
+}
+
+public sealed class ComposerWorkGroup
+{
+    public required string Id { get; set; }
+    public WorkSummary? Parent { get; set; }
+    public required List<WorkSummary> Works { get; set; }
+}
+
+public sealed class ComposerDetail
+{
+    public required ComposerSummary Composer { get; set; }
+    public required List<ComposerWorkGroup> WorkGroups { get; set; }
+    public required List<ReleaseRoleSummary> UnlinkedReleaseRoles { get; set; }
+    public required List<TrackRoleSummary> UnlinkedTrackRoles { get; set; }
+    public string? DefaultWorkId { get; set; }
+}
+
+public sealed class ReleaseRoleSummary
+{
+    public required string ReleaseId { get; set; }
+    public required string AlbumId { get; set; }
+    public required string AlbumTitle { get; set; }
+    public string? SourceCredit { get; set; }
+}
+
+public sealed class TrackRoleSummary
+{
+    public required string TrackId { get; set; }
+    public required string TrackTitle { get; set; }
+    public required string ReleaseId { get; set; }
+    public required string AlbumId { get; set; }
+    public required string AlbumTitle { get; set; }
+    public required string ArtistId { get; set; }
+    public required string ArtistName { get; set; }
+    public string? SourceCredit { get; set; }
+}
+
+public sealed class WorkReleaseSummary
+{
+    public required string ReleaseId { get; set; }
+    public required string AlbumId { get; set; }
+    public required string AlbumTitle { get; set; }
+    public required string DisplayName { get; set; }
+    public string? Format { get; set; }
+    public ImageRef? Cover { get; set; }
+
+    [JsonIgnore]
+    public IntPtr Handle { get; set; }
+
+    public ImageSource? CoverImage => Bae.Windows.CoverImage.LoadByImageRef(Handle, Cover);
+    public string DisplaySubtitle =>
+        string.IsNullOrWhiteSpace(Format)
+            ? DisplayName
+            : $"{DisplayName} · {Format}";
+}
+
+public sealed class WorkTrackSummary
+{
+    public required string TrackId { get; set; }
+    public required string TrackTitle { get; set; }
+    public required string ReleaseId { get; set; }
+    public required string AlbumId { get; set; }
+    public required string AlbumTitle { get; set; }
+}
+
+public sealed class WorkDetail
+{
+    public required WorkSummary Work { get; set; }
+    public required List<WorkSummary> ChildWorks { get; set; }
+    public required List<WorkReleaseSummary> Releases { get; set; }
+    public required List<WorkTrackSummary> Tracks { get; set; }
+}

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -33,6 +33,7 @@
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
                 <TextBlock x:Name="SyncIndicator" VerticalAlignment="Center"
                            Foreground="Gray" TextWrapping="NoWrap" />
+                <ComboBox x:Name="BrowserModeBox" SelectionChanged="OnBrowserModeChanged" VerticalAlignment="Center" />
                 <ComboBox x:Name="SortBox" SelectionChanged="OnSortChanged" VerticalAlignment="Center" />
                 <Button x:Uid="ShuffleLibraryButton" Content="shuffle library" Click="OnShuffleLibraryClick" />
                 <Button x:Uid="LibrariesButton" Content="libraries" Click="OnLibrariesClick" />
@@ -58,6 +59,7 @@
             </StackPanel>
         </Grid>
         <GridView
+            x:Name="AlbumGrid"
             Grid.Row="1"
             ItemsSource="{x:Bind Albums}"
             Padding="24"
@@ -88,6 +90,52 @@
                 </DataTemplate>
             </GridView.ItemTemplate>
         </GridView>
+        <Grid
+            x:Name="ComposerBrowser"
+            Grid.Row="1"
+            Margin="24"
+            ColumnSpacing="16"
+            Visibility="Collapsed">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <ListView
+                x:Name="ComposerList"
+                Grid.Column="0"
+                ItemsSource="{x:Bind Composers}"
+                IsItemClickEnabled="True"
+                SelectionMode="Single"
+                ItemClick="OnComposerClick">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local:ComposerSummary">
+                        <StackPanel Orientation="Horizontal" Spacing="10" Padding="4">
+                            <Border
+                                Width="42"
+                                Height="42"
+                                CornerRadius="6"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                                <Image Source="{x:Bind Cover}" Stretch="UniformToFill" />
+                            </Border>
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="{x:Bind Name}" MaxLines="1" TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{x:Bind WorkCountText}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <ScrollViewer Grid.Column="1">
+                <StackPanel x:Name="ComposerDetailPane" Spacing="10" />
+            </ScrollViewer>
+        </Grid>
+        <ScrollViewer
+            x:Name="SearchResultsScroll"
+            Grid.Row="1"
+            Padding="24"
+            Visibility="Collapsed">
+            <StackPanel x:Name="SearchResultsPanel" Spacing="10" />
+        </ScrollViewer>
         <StackPanel
             x:Name="EmptyState"
             Grid.Row="1"

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -36,16 +36,30 @@ public sealed partial class MainWindow : Window
     // time; Field is the locale-free sort identifier the FFI expects (never
     // localized).
     private sealed record SortOption(string LabelKey, string Field, bool Ascending);
+    private enum BrowserMode
+    {
+        Albums,
+        Composers,
+    }
 
-    private static readonly SortOption[] SortOptions =
+    private static readonly SortOption[] AlbumSortOptions =
     {
         new("sort.newest", "date_added", false),
         new("sort.title", "title", true),
         new("sort.artist", "artist", true),
         new("sort.year", "year", true),
     };
+    private static readonly SortOption[] ComposerSortOptions =
+    {
+        new("sort.name", "name", true),
+        new("search.section.works", "work_count", false),
+        new("search.section.releases", "linked_release_count", false),
+    };
 
-    private SortOption _sort = SortOptions[0];
+    private SortOption _albumSort = AlbumSortOptions[0];
+    private SortOption _composerSort = ComposerSortOptions[0];
+    private BrowserMode _browserMode = BrowserMode.Albums;
+    private bool _populatingSortBox;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -135,6 +149,7 @@ public sealed partial class MainWindow : Window
     private string? _nowPlayingTrackId;
 
     public ObservableCollection<Album> Albums { get; } = new();
+    public ObservableCollection<ComposerSummary> Composers { get; } = new();
 
     public MainWindow()
     {
@@ -149,11 +164,10 @@ public sealed partial class MainWindow : Window
             ? FlowDirection.RightToLeft
             : FlowDirection.LeftToRight;
 
-        foreach (var option in SortOptions)
-        {
-            SortBox.Items.Add(Loc.Chrome(option.LabelKey));
-        }
-        SortBox.SelectedIndex = 0;
+        BrowserModeBox.Items.Add(Loc.Chrome("library.mode.albums"));
+        BrowserModeBox.Items.Add(Loc.Chrome("library.mode.composers"));
+        PopulateSortBox();
+        BrowserModeBox.SelectedIndex = 0;
 
         // Seek on release, not on every drag tick. The Slider handles pointer
         // events internally, so register with handledEventsToo.
@@ -174,18 +188,103 @@ public sealed partial class MainWindow : Window
 
     private void OnSortChanged(object sender, SelectionChangedEventArgs e)
     {
+        if (_populatingSortBox)
+        {
+            return;
+        }
         if (SortBox.SelectedIndex < 0)
         {
             return;
         }
 
-        _sort = SortOptions[SortBox.SelectedIndex];
+        SetActiveSort(ActiveSortOptions[SortBox.SelectedIndex]);
 
         // Sort drives the full-library view; search results keep their relevance
         // order. Reload only when no search is active and the library is open.
         if (_handle != IntPtr.Zero && string.IsNullOrEmpty(SearchBox.Text))
         {
-            SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
+            LoadCurrentBrowserMode();
+        }
+    }
+
+    private void OnBrowserModeChanged(object sender, SelectionChangedEventArgs e)
+    {
+        _browserMode = BrowserModeBox.SelectedIndex == 1 ? BrowserMode.Composers : BrowserMode.Albums;
+        PopulateSortBox();
+        if (_handle != IntPtr.Zero && string.IsNullOrEmpty(SearchBox.Text))
+        {
+            LoadCurrentBrowserMode();
+        }
+    }
+
+    private SortOption[] ActiveSortOptions =>
+        _browserMode == BrowserMode.Composers ? ComposerSortOptions : AlbumSortOptions;
+
+    private SortOption ActiveSort =>
+        _browserMode == BrowserMode.Composers ? _composerSort : _albumSort;
+
+    private void SetActiveSort(SortOption sort)
+    {
+        if (_browserMode == BrowserMode.Composers)
+        {
+            _composerSort = sort;
+        }
+        else
+        {
+            _albumSort = sort;
+        }
+    }
+
+    private void PopulateSortBox()
+    {
+        _populatingSortBox = true;
+        SortBox.Items.Clear();
+        foreach (var option in ActiveSortOptions)
+        {
+            SortBox.Items.Add(Loc.Chrome(option.LabelKey));
+        }
+        SortBox.SelectedIndex = Math.Max(0, Array.IndexOf(ActiveSortOptions, ActiveSort));
+        _populatingSortBox = false;
+    }
+
+    private void ShowAlbumBrowser()
+    {
+        AlbumGrid.Visibility = Visibility.Visible;
+        ComposerBrowser.Visibility = Visibility.Collapsed;
+        SearchResultsScroll.Visibility = Visibility.Collapsed;
+    }
+
+    private void ShowComposerBrowser()
+    {
+        AlbumGrid.Visibility = Visibility.Collapsed;
+        ComposerBrowser.Visibility = Visibility.Visible;
+        SearchResultsScroll.Visibility = Visibility.Collapsed;
+    }
+
+    private void ShowSearchBrowser()
+    {
+        AlbumGrid.Visibility = Visibility.Collapsed;
+        ComposerBrowser.Visibility = Visibility.Collapsed;
+        SearchResultsScroll.Visibility = Visibility.Visible;
+    }
+
+    private void LoadCurrentBrowserMode()
+    {
+        switch (_browserMode)
+        {
+            case BrowserMode.Albums:
+                SetAlbums(
+                    NativeBae.AlbumPageJson(
+                        _handle,
+                        0,
+                        FirstPageSize,
+                        _albumSort.Field,
+                        _albumSort.Ascending),
+                    Loc.Chrome("library.empty"));
+                break;
+            case BrowserMode.Composers:
+                LoadComposers();
+                break;
         }
     }
 
@@ -252,7 +351,7 @@ public sealed partial class MainWindow : Window
         // above leaves the welcome in place rather than stranding the user.
         DismissWelcome();
 
-        SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
+        LoadCurrentBrowserMode();
 
         _suppressVolume = true;
         NpVolume.Value = NativeBae.GetVolume(_handle);
@@ -1507,7 +1606,7 @@ public sealed partial class MainWindow : Window
             case "LibraryChanged":
                 if (string.IsNullOrEmpty(SearchBox.Text))
                 {
-                    SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
+                    LoadCurrentBrowserMode();
                 }
                 _refreshStorageRows?.Invoke();
                 break;
@@ -2947,17 +3046,119 @@ public sealed partial class MainWindow : Window
         var query = args.QueryText?.Trim() ?? string.Empty;
         if (query.Length == 0)
         {
-            SetAlbums(NativeBae.AlbumPageJson(_handle, 0, FirstPageSize, _sort.Field, _sort.Ascending), Loc.Chrome("library.empty"));
+            LoadCurrentBrowserMode();
         }
         else
         {
-            SetAlbums(NativeBae.SearchJson(_handle, query), Loc.Chrome("search.no_matches"));
+            SetSearchResults(NativeBae.SearchJson(_handle, query), query);
         }
+    }
+
+    private void SetSearchResults(string? json, string query)
+    {
+        ShowSearchBrowser();
+        SearchResultsPanel.Children.Clear();
+        if (json is null)
+        {
+            StatusText.Text = Loc.Chrome("search.failed");
+            return;
+        }
+
+        LibrarySearchResults? results;
+        try
+        {
+            results = JsonSerializer.Deserialize<LibrarySearchResults>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            StatusText.Text = Loc.Chrome("search.failed");
+            return;
+        }
+        if (results is null)
+        {
+            StatusText.Text = Loc.Chrome("search.failed");
+            return;
+        }
+        foreach (var album in results.Albums)
+        {
+            album.Handle = _handle;
+        }
+        foreach (var composer in results.Composers)
+        {
+            composer.Handle = _handle;
+        }
+        foreach (var work in results.Works)
+        {
+            work.Handle = _handle;
+        }
+
+        if (results.Albums.Count == 0 && results.Tracks.Count == 0
+            && results.Composers.Count == 0 && results.Works.Count == 0)
+        {
+            StatusText.Text = Loc.Chrome("search.no_matches");
+            return;
+        }
+
+        StatusText.Text = string.Empty;
+        AddSearchSection(Loc.Chrome("search.section.albums"), results.Albums, album =>
+            SearchButton(album.Title, album.Artist, async () => await ShowAlbumDetail(album.Id)));
+        AddSearchSection(Loc.Chrome("search.section.tracks"), results.Tracks, track =>
+            SearchButton(track.Title, $"{track.ArtistName} — {track.AlbumTitle}", async () => await ShowAlbumDetail(track.AlbumId)));
+        AddSearchSection(Loc.Chrome("search.section.composers"), results.Composers, composer =>
+            SearchButton(composer.Name, composer.WorkCountText, async () => await ShowComposerDetail(composer.ArtistId)));
+        AddSearchSection(Loc.Chrome("search.section.works"), results.Works, work =>
+            SearchButton(work.Title, work.ComposerNames ?? string.Empty, async () => await ShowWorkDetail(work.WorkId)));
+    }
+
+    private void AddSearchSection<T>(
+        string title,
+        IReadOnlyList<T> rows,
+        Func<T, Button> button)
+    {
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        SearchResultsPanel.Children.Add(new TextBlock
+        {
+            Text = title,
+            Style = (Style)Resources["SubtitleTextBlockStyle"],
+        });
+        foreach (var row in rows)
+        {
+            SearchResultsPanel.Children.Add(button(row));
+        }
+    }
+
+    private static Button SearchButton(string title, string subtitle, Func<System.Threading.Tasks.Task> action)
+    {
+        var panel = new StackPanel { Spacing = 2 };
+        panel.Children.Add(new TextBlock { Text = title, MaxLines = 1, TextTrimming = TextTrimming.CharacterEllipsis });
+        if (!string.IsNullOrWhiteSpace(subtitle))
+        {
+            panel.Children.Add(new TextBlock
+            {
+                Text = subtitle,
+                MaxLines = 1,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            });
+        }
+        var button = new Button
+        {
+            Content = panel,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+        };
+        button.Click += async (_, _) => await action();
+        return button;
     }
 
     /// <summary>Replace the grid's albums from an FFI JSON array (or show a status).</summary>
     private void SetAlbums(string? json, string emptyMessage)
     {
+        ShowAlbumBrowser();
         Albums.Clear();
         if (json is null)
         {
@@ -2978,6 +3179,227 @@ public sealed partial class MainWindow : Window
         StatusText.Text = albums.Count == 0 ? emptyMessage : string.Empty;
     }
 
+    private void LoadComposers()
+    {
+        ShowComposerBrowser();
+        Composers.Clear();
+        ComposerDetailPane.Children.Clear();
+        var json = NativeBae.ComposerPageJson(
+            _handle,
+            0,
+            FirstPageSize,
+            _composerSort.Field,
+            _composerSort.Ascending);
+        if (json is null)
+        {
+            StatusText.Text = Loc.Chrome("library.load_failed");
+            return;
+        }
+
+        List<ComposerSummary>? composers;
+        try
+        {
+            composers = JsonSerializer.Deserialize<List<ComposerSummary>>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            StatusText.Text = Loc.Chrome("library.load_failed");
+            return;
+        }
+        if (composers is null)
+        {
+            StatusText.Text = Loc.Chrome("library.load_failed");
+            return;
+        }
+        foreach (var composer in composers)
+        {
+            composer.Handle = _handle;
+            Composers.Add(composer);
+        }
+        StatusText.Text = composers.Count == 0 ? Loc.Chrome("library.no_composers") : string.Empty;
+    }
+
+    private async void OnComposerClick(object sender, ItemClickEventArgs e)
+    {
+        if (_handle == IntPtr.Zero || e.ClickedItem is not ComposerSummary composer)
+        {
+            return;
+        }
+
+        await ShowComposerDetail(composer.ArtistId);
+    }
+
+    private async System.Threading.Tasks.Task ShowComposerDetail(string artistId)
+    {
+        var json = NativeBae.ComposerDetailJson(_handle, artistId);
+        if (json is null)
+        {
+            StatusText.Text = Loc.Chrome("composer.open_failed");
+            return;
+        }
+
+        var detail = JsonSerializer.Deserialize<ComposerDetail>(json, JsonOptions);
+        if (detail is null)
+        {
+            StatusText.Text = Loc.Chrome("composer.open_failed");
+            return;
+        }
+        detail.Composer.Handle = _handle;
+        foreach (var group in detail.WorkGroups)
+        {
+            if (group.Parent is not null)
+            {
+                group.Parent.Handle = _handle;
+            }
+            foreach (var work in group.Works)
+            {
+                work.Handle = _handle;
+            }
+        }
+
+        ShowComposerBrowser();
+        ComposerDetailPane.Children.Clear();
+        ComposerDetailPane.Children.Add(new TextBlock
+        {
+            Text = detail.Composer.Name,
+            Style = (Style)Resources["TitleTextBlockStyle"],
+        });
+        if (detail.WorkGroups.Count > 0)
+        {
+            AddPaneHeader(Loc.Chrome("search.section.works"));
+            foreach (var group in detail.WorkGroups)
+            {
+                if (group.Parent is not null)
+                {
+                    ComposerDetailPane.Children.Add(WorkButton(group.Parent));
+                }
+                foreach (var work in group.Works)
+                {
+                    ComposerDetailPane.Children.Add(WorkButton(work));
+                }
+            }
+        }
+        if (detail.UnlinkedReleaseRoles.Count > 0)
+        {
+            AddPaneHeader(Loc.Chrome("search.section.credits"));
+            foreach (var role in detail.UnlinkedReleaseRoles)
+            {
+                ComposerDetailPane.Children.Add(PaneButton(role.AlbumTitle, role.SourceCredit ?? string.Empty, async () =>
+                    await ShowAlbumDetail(role.AlbumId)));
+            }
+        }
+        if (detail.UnlinkedTrackRoles.Count > 0)
+        {
+            AddPaneHeader(Loc.Chrome("search.section.recordings"));
+            foreach (var role in detail.UnlinkedTrackRoles)
+            {
+                ComposerDetailPane.Children.Add(PaneButton(role.TrackTitle, role.AlbumTitle, async () => await ShowAlbumDetail(role.AlbumId)));
+            }
+        }
+        if (detail.DefaultWorkId is not null)
+        {
+            await ShowWorkDetail(detail.DefaultWorkId, replacePane: false);
+        }
+    }
+
+    private Button WorkButton(WorkSummary work) =>
+        PaneButton(work.Title, work.ComposerNames ?? string.Empty, async () => await ShowWorkDetail(work.WorkId));
+
+    private void AddPaneHeader(string title)
+    {
+        ComposerDetailPane.Children.Add(new TextBlock
+        {
+            Text = title,
+            Style = (Style)Resources["SubtitleTextBlockStyle"],
+        });
+    }
+
+    private static Button PaneButton(string title, string subtitle, Func<System.Threading.Tasks.Task> action)
+    {
+        var panel = new StackPanel { Spacing = 2 };
+        panel.Children.Add(new TextBlock { Text = title, MaxLines = 1, TextTrimming = TextTrimming.CharacterEllipsis });
+        if (!string.IsNullOrWhiteSpace(subtitle))
+        {
+            panel.Children.Add(new TextBlock
+            {
+                Text = subtitle,
+                MaxLines = 1,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            });
+        }
+        var button = new Button
+        {
+            Content = panel,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+        };
+        button.Click += async (_, _) => await action();
+        return button;
+    }
+
+    private async System.Threading.Tasks.Task ShowWorkDetail(string workId, bool replacePane = true)
+    {
+        var json = NativeBae.WorkDetailJson(_handle, workId);
+        if (json is null)
+        {
+            StatusText.Text = Loc.Chrome("work.open_failed");
+            return;
+        }
+
+        var detail = JsonSerializer.Deserialize<WorkDetail>(json, JsonOptions);
+        if (detail is null)
+        {
+            StatusText.Text = Loc.Chrome("work.open_failed");
+            return;
+        }
+        detail.Work.Handle = _handle;
+        foreach (var work in detail.ChildWorks)
+        {
+            work.Handle = _handle;
+        }
+        foreach (var release in detail.Releases)
+        {
+            release.Handle = _handle;
+        }
+
+        ShowComposerBrowser();
+        if (replacePane)
+        {
+            ComposerDetailPane.Children.Clear();
+        }
+        ComposerDetailPane.Children.Add(new TextBlock
+        {
+            Text = detail.Work.Title,
+            Style = (Style)Resources["TitleTextBlockStyle"],
+        });
+        if (detail.ChildWorks.Count > 0)
+        {
+            AddPaneHeader(Loc.Chrome("search.section.works"));
+            foreach (var work in detail.ChildWorks)
+            {
+                ComposerDetailPane.Children.Add(WorkButton(work));
+            }
+        }
+        if (detail.Releases.Count > 0)
+        {
+            AddPaneHeader(Loc.Chrome("search.section.releases"));
+            foreach (var release in detail.Releases)
+            {
+                ComposerDetailPane.Children.Add(PaneButton(release.AlbumTitle, release.DisplaySubtitle, async () =>
+                    await ShowAlbumDetail(release.AlbumId, initialReleaseId: release.ReleaseId)));
+            }
+        }
+        if (detail.Tracks.Count > 0)
+        {
+            AddPaneHeader(Loc.Chrome("search.section.recordings"));
+            foreach (var track in detail.Tracks)
+            {
+                ComposerDetailPane.Children.Add(PaneButton(track.TrackTitle, track.AlbumTitle, async () => await ShowAlbumDetail(track.AlbumId)));
+            }
+        }
+    }
+
     private async void OnAlbumClick(object sender, ItemClickEventArgs e)
     {
         if (_handle == IntPtr.Zero || e.ClickedItem is not Album album)
@@ -2995,7 +3417,10 @@ public sealed partial class MainWindow : Window
     /// change cover / delete). Reused by the album grid (<see cref="OnAlbumClick"/>)
     /// and the import confirmation's "view in library" banner.
     /// </summary>
-    private async System.Threading.Tasks.Task ShowAlbumDetail(string albumId, string? scrollToTrackId = null)
+    private async System.Threading.Tasks.Task ShowAlbumDetail(
+        string albumId,
+        string? scrollToTrackId = null,
+        string? initialReleaseId = null)
     {
         var json = NativeBae.AlbumDetailJson(_handle, albumId);
         if (json is null)
@@ -3027,6 +3452,7 @@ public sealed partial class MainWindow : Window
             ? null
             : detail.Releases.FirstOrDefault(r => r.Tracks.Any(t => t.TrackId == scrollToTrackId));
         Release selectedRelease = trackRelease
+            ?? detail.Releases.FirstOrDefault(r => r.ReleaseId == initialReleaseId)
             ?? detail.Releases.FirstOrDefault(r => r.ReleaseId == detail.PrimaryReleaseId)
             ?? detail.Releases[0];
 

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3123,7 +3123,7 @@ public sealed partial class MainWindow : Window
         SearchResultsPanel.Children.Add(new TextBlock
         {
             Text = title,
-            Style = (Style)Resources["SubtitleTextBlockStyle"],
+            Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"],
         });
         foreach (var row in rows)
         {
@@ -3262,7 +3262,7 @@ public sealed partial class MainWindow : Window
         ComposerDetailPane.Children.Add(new TextBlock
         {
             Text = detail.Composer.Name,
-            Style = (Style)Resources["TitleTextBlockStyle"],
+            Style = (Style)Application.Current.Resources["TitleTextBlockStyle"],
         });
         if (detail.WorkGroups.Count > 0)
         {
@@ -3310,7 +3310,7 @@ public sealed partial class MainWindow : Window
         ComposerDetailPane.Children.Add(new TextBlock
         {
             Text = title,
-            Style = (Style)Resources["SubtitleTextBlockStyle"],
+            Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"],
         });
     }
 
@@ -3371,7 +3371,7 @@ public sealed partial class MainWindow : Window
         ComposerDetailPane.Children.Add(new TextBlock
         {
             Text = detail.Work.Title,
-            Style = (Style)Resources["TitleTextBlockStyle"],
+            Style = (Style)Application.Current.Resources["TitleTextBlockStyle"],
         });
         if (detail.ChildWorks.Count > 0)
         {

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -418,6 +418,20 @@ internal static class NativeBae
     internal static string? AlbumPageJson(IntPtr handle, ulong offset, ulong limit, string sortField, bool ascending) =>
         CopyAndFree(AlbumPage(handle, offset, limit, sortField, ascending));
 
+    [DllImport(Dll, EntryPoint = "bae_composer_count", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern long ComposerCount(IntPtr handle);
+
+    [DllImport(Dll, EntryPoint = "bae_composer_page", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ComposerPagePtr(
+        IntPtr handle,
+        ulong offset,
+        ulong limit,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string sortField,
+        [MarshalAs(UnmanagedType.I1)] bool ascending);
+
+    internal static string? ComposerPageJson(IntPtr handle, ulong offset, ulong limit, string sortField, bool ascending) =>
+        CopyAndFree(ComposerPagePtr(handle, offset, limit, sortField, ascending));
+
     /// <summary>
     /// A release's gallery images as JSON, or <see cref="IntPtr.Zero"/> on error.
     /// Prefer <see cref="GalleryJson"/>.
@@ -566,6 +580,22 @@ internal static class NativeBae
     /// </summary>
     internal static string? AlbumDetailJson(IntPtr handle, string albumId) =>
         CopyAndFree(AlbumDetailPtr(handle, albumId));
+
+    [DllImport(Dll, EntryPoint = "bae_composer_detail", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ComposerDetailPtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string artistId);
+
+    internal static string? ComposerDetailJson(IntPtr handle, string artistId) =>
+        CopyAndFree(ComposerDetailPtr(handle, artistId));
+
+    [DllImport(Dll, EntryPoint = "bae_work_detail", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr WorkDetailPtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string workId);
+
+    internal static string? WorkDetailJson(IntPtr handle, string workId) =>
+        CopyAndFree(WorkDetailPtr(handle, workId));
 
     /// <summary>Current settings as JSON, or null on error. Copies and frees.</summary>
     [DllImport(Dll, EntryPoint = "bae_settings", CallingConvention = CallingConvention.Cdecl)]

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>رمز MCP غير متوفر</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>تم نسخ الرمز</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>تم تدوير الرمز ونسخه</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP токенът не е наличен</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>токенът е копиран</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>токенът е сменен и копиран</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP টোকেন পাওয়া যায়নি</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>টোকেন কপি হয়েছে</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>টোকেন ঘোরানো হয়েছে এবং কপি হয়েছে</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Token MCP není k dispozici</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token zkopírován</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token obměněn a zkopírován</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP-Token nicht verfügbar</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>Token kopiert</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>Token erneuert und kopiert</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -180,7 +180,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -216,6 +216,7 @@
   <data name="signal.kind.catalog" xml:space="preserve"><value>Catalog</value></data>
   <data name="signal.kind.disc_id" xml:space="preserve"><value>Disc ID</value></data>
   <data name="sort.artist" xml:space="preserve"><value>artist</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
   <data name="sort.newest" xml:space="preserve"><value>newest</value></data>
   <data name="sort.title" xml:space="preserve"><value>title</value></data>
   <data name="sort.year" xml:space="preserve"><value>year</value></data>
@@ -270,4 +271,17 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP token unavailable</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token copied</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token rotated and copied</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Token de MCP no disponible</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token copiado</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token rotado y copiado</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Jeton MCP indisponible</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>jeton copié</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>jeton renouvelé et copié</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP ટોકન ઉપલબ્ધ નથી</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>ટોકન કૉપિ થયું</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ટોકન ફેરવાયું અને કૉપિ થયું</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>אסימון MCP אינו זמין</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>האסימון הועתק</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>האסימון הוחלף והועתק</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP टोकन उपलब्ध नहीं है</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>टोकन कॉपी किया गया</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>टोकन बदला गया और कॉपी किया गया</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP token nije dostupan</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token kopiran</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token rotiran i kopiran</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Token MCP non disponibile</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token copiato</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token ruotato e copiato</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCPトークンを利用できません</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>トークンをコピーしました</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>トークンを更新してコピーしました</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP ಟೋಕನ್ ಲಭ್ಯವಿಲ್ಲ</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>ಟೋಕನ್ ನಕಲಿಸಲಾಗಿದೆ</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ಟೋಕನ್ ಬದಲಿಸಿ ನಕಲಿಸಲಾಗಿದೆ</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP 토큰을 사용할 수 없음</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>토큰이 복사됨</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>토큰이 교체되어 복사됨</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP ടോക്കൺ ലഭ്യമല്ല</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>ടോക്കൺ പകർത്തി</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ടോക്കൺ മാറ്റി പകർത്തി</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP टोकन उपलब्ध नाही</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>टोकन कॉपी केले</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>टोकन बदलून कॉपी केले</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP-token niet beschikbaar</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token gekopieerd</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token vervangen en gekopieerd</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP ਟੋਕਨ ਉਪਲਬਧ ਨਹੀਂ ਹੈ</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>ਟੋਕਨ ਕਾਪੀ ਹੋ ਗਿਆ</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ਟੋਕਨ ਬਦਲਿਆ ਤੇ ਕਾਪੀ ਹੋਇਆ</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Token MCP niedostępny</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token skopiowany</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token zmieniony i skopiowany</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Token MCP indisponível</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>token copiado</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token trocado e copiado</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP டோக்கன் கிடைக்கவில்லை</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>டோக்கன் நகலெடுக்கப்பட்டது</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>டோக்கன் மாற்றப்பட்டு நகலெடுக்கப்பட்டது</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP టోకెన్ అందుబాటులో లేదు</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>టోకెన్ కాపీ చేయబడింది</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>టోకెన్ మార్చి కాపీ చేయబడింది</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>โทเค็น MCP ไม่พร้อมใช้งาน</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>คัดลอกโทเค็นแล้ว</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>หมุนเวียนและคัดลอกโทเค็นแล้ว</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP belirteci kullanılamıyor</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>belirteç kopyalandı</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>belirteç değiştirildi ve kopyalandı</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Токен MCP недоступний</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>токен скопійовано</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>токен змінено й скопійовано</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP ٹوکن دستیاب نہیں</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>ٹوکن کاپی ہو گیا</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ٹوکن تبدیل کر کے کاپی ہو گیا</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>Không có mã thông báo MCP</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>đã sao chép mã thông báo</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>đã đổi và sao chép mã thông báo</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP 令牌不可用</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>令牌已复制</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>令牌已轮换并复制</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
   <resheader name="version"><value>2.0</value></resheader>
@@ -142,7 +142,7 @@
   <data name="s3.field.key_prefix" xml:space="preserve"><value>key prefix (optional)</value></data>
   <data name="s3.field.region" xml:space="preserve"><value>region</value></data>
   <data name="s3.field.secret_key" xml:space="preserve"><value>secret key</value></data>
-  <data name="search.failed" xml:space="preserve"><value>search failed</value></data>
+  <data name="search.failed" xml:space="preserve"><value>Search failed</value></data>
   <data name="search.field.album" xml:space="preserve"><value>album</value></data>
   <data name="search.field.artist" xml:space="preserve"><value>artist</value></data>
   <data name="search.field.source" xml:space="preserve"><value>source</value></data>
@@ -229,4 +229,18 @@
   <data name="settings.automation.token_unavailable" xml:space="preserve"><value>MCP 權杖無法使用</value></data>
   <data name="settings.automation.token_copied" xml:space="preserve"><value>權杖已複製</value></data>
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>權杖已輪替並複製</value></data>
+  <data name="sort.name" xml:space="preserve"><value>name</value></data>
+  <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
+  <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
+  <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="search.section.works" xml:space="preserve"><value>Works</value></data>
+  <data name="search.section.releases" xml:space="preserve"><value>Releases</value></data>
+  <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
+  <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
+  <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
+  <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
 </root>


### PR DESCRIPTION
This brings composer/work browsing into the mobile and Windows surfaces using the core composer/work model as the source of truth. iOS and Android now expose composer list, composer detail, work detail, and sectioned search navigation, while Windows gets matching C ABI endpoints, DTOs, sectioned search, and split composer browsing. Work detail release rows now carry the album/release fields needed to open the selected pressing directly.

Test plan:
- cargo test -p bae-bridge
- cargo test -p bae-windows-ffi
- cargo test -p bae-core --features bae-core/test-utils db::client::tests::composer_mode_tests
- cargo clippy -p bae-windows-ffi --all-targets -- -D warnings
- python3 scripts/loc-chrome-orphans.py
- ktlint "bae-android/app/src/**/*.kt"
- detekt --input bae-android/app/src/main/java --config bae-android/detekt.yml --build-upon-default-config
- xcrun swift-format lint -s bae-ios/bae/bae/Views/LibraryView.swift bae-ios/bae/bae/Views/AlbumDetailView.swift
- swiftlint lint bae-ios/bae/bae --quiet
- scripts/check.sh: code checks pass through macOS/iOS SwiftLint, Android ktlint/detekt; remaining local failures are missing Java for Gradle, missing iOS simulator destination, and FFmpeg dylib lookup in the script's internal Rust test runners. Direct Rust tests above pass with the explicit library path.