### PR TITLE
Pin bae to split coven

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=8ffd761#8ffd761b37273a4642b8028aae8ecfcfce2b1b74"
+source = "git+https://github.com/bae-fm/coven?rev=c21904d#c21904dd8666bdc52f9ec6a7a370ea0af92ae339"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -1339,19 +1339,13 @@ dependencies = [
  "aws-smithy-http-client",
  "axum 0.7.9",
  "base64",
- "blake2",
  "bytes",
- "chacha20poly1305",
  "chrono",
- "crypto_box",
+ "coven-core",
  "dirs",
  "ed25519-dalek",
- "fallible-streaming-iterator",
  "futures-util",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
  "hex",
- "hkdf",
  "keyring-core",
  "libsqlite3-sys",
  "open",
@@ -1363,6 +1357,37 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "coven-core"
+version = "0.0.0-dev"
+source = "git+https://github.com/bae-fm/coven?rev=c21904d#c21904dd8666bdc52f9ec6a7a370ea0af92ae339"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chacha20poly1305",
+ "chrono",
+ "crypto_box",
+ "ed25519-dalek",
+ "fallible-streaming-iterator",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "libsqlite3-sys",
+ "rand 0.9.2",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1819,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3032,7 +3057,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3424,7 +3449,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3790,7 +3815,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3848,7 +3873,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4250,7 +4275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4380,7 +4405,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5203,7 +5228,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "8ffd761" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "c21904d" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-core/src/keys.rs
+++ b/bae-core/src/keys.rs
@@ -22,13 +22,20 @@ fn account(ks: &KeyService, base: &str) -> String {
     format!("{}:{}", base, ks.library_id())
 }
 
+fn map_keyring_error(e: keyring_core::Error) -> KeyError {
+    KeyError::Persistence(e.to_string())
+}
+
 fn set_keyring_credential(
     ks: &KeyService,
     account_base: &str,
     value: &str,
     saved_message: &'static str,
 ) -> Result<(), KeyError> {
-    keyring_core::Entry::new(keyring_service(), &account(ks, account_base))?.set_password(value)?;
+    keyring_core::Entry::new(keyring_service(), &account(ks, account_base))
+        .map_err(map_keyring_error)?
+        .set_password(value)
+        .map_err(map_keyring_error)?;
     info!("{saved_message}");
     Ok(())
 }
@@ -70,7 +77,8 @@ impl BaeKeyServiceExt for KeyService {
     }
 
     fn delete_discogs_key(&self) -> Result<(), KeyError> {
-        match keyring_core::Entry::new(keyring_service(), &account(self, "discogs_api_key"))?
+        match keyring_core::Entry::new(keyring_service(), &account(self, "discogs_api_key"))
+            .map_err(map_keyring_error)?
             .delete_credential()
         {
             Ok(()) => {
@@ -81,7 +89,7 @@ impl BaeKeyServiceExt for KeyService {
                 warn!("Tried to delete Discogs key but none was stored");
                 Ok(())
             }
-            Err(e) => Err(KeyError::Keyring(e)),
+            Err(e) => Err(map_keyring_error(e)),
         }
     }
 
@@ -99,7 +107,8 @@ impl BaeKeyServiceExt for KeyService {
     }
 
     fn forget_encryption_key(&self) -> Result<(), KeyError> {
-        match keyring_core::Entry::new(keyring_service(), &account(self, "encryption_master_key"))?
+        match keyring_core::Entry::new(keyring_service(), &account(self, "encryption_master_key"))
+            .map_err(map_keyring_error)?
             .delete_credential()
         {
             Ok(()) => {
@@ -107,7 +116,7 @@ impl BaeKeyServiceExt for KeyService {
                 Ok(())
             }
             Err(keyring_core::Error::NoEntry) => Ok(()),
-            Err(e) => Err(KeyError::Keyring(e)),
+            Err(e) => Err(map_keyring_error(e)),
         }
     }
 }

--- a/bae-core/src/library/sync_controller.rs
+++ b/bae-core/src/library/sync_controller.rs
@@ -238,7 +238,7 @@ impl SyncController {
         tokio::sync::watch::Receiver<bool>,
         tokio::task::JoinHandle<()>,
     ) {
-        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(cancel.is_cancelled());
         let token = cancel.clone();
         let handle = tokio::spawn(async move {
             token.cancelled().await;


### PR DESCRIPTION
Pins bae to coven c21904d, where coven is split into native, core, and wasm crates. The bae changes adapt key persistence errors to coven's current API and initialize the blob-copy cancel bridge from the token's current state so pre-cancelled operations still stop before work begins.

Local checks:
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo clippy -p bae-core --features oauth-providers -- -D warnings
- cargo clippy -p bae-bridge --features oauth-providers,cloudkit -- -D warnings
- SKIP_AUDIO_TESTS=1 DYLD_LIBRARY_PATH=/Users/dima/dev/bae/bae-ffmpeg/dist/lib cargo test -p bae-core --features bae-core/test-utils -- --test-threads=1
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo machete
- cargo deny check