### PR TITLE
Bump coven to reconciled main; drop dead CloudKit adapter stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=c21904d#c21904dd8666bdc52f9ec6a7a370ea0af92ae339"
+source = "git+https://github.com/bae-fm/coven?rev=6e916cf#6e916cf46b1945abfae3c9ee4a9e7a8caa5a1ec0"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "coven-core"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=c21904d#c21904dd8666bdc52f9ec6a7a370ea0af92ae339"
+source = "git+https://github.com/bae-fm/coven?rev=6e916cf#6e916cf46b1945abfae3c9ee4a9e7a8caa5a1ec0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "c21904d" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "6e916cf" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-bridge/src/cloudkit.rs
+++ b/bae-bridge/src/cloudkit.rs
@@ -51,28 +51,6 @@ impl coven::CloudKitOps for CloudKitDriverAdapter {
             .record_exists(key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
-
-    // coven's `CloudKitOps` trait declares the CKShare grant/revoke/accept
-    // methods. bae uses a personal library on its own iCloud account, so all
-    // three are unavailable; the Swift driver implements only the
-    // private-database storage methods.
-    fn grant_access(&self, _email: &str) -> Result<String, coven::CloudHomeError> {
-        Err(sharing_unsupported())
-    }
-
-    fn revoke_access(&self, _user_record_id: &str) -> Result<(), coven::CloudHomeError> {
-        Err(sharing_unsupported())
-    }
-
-    fn accept_share(&self, _share_url: &str) -> Result<(), coven::CloudHomeError> {
-        Err(sharing_unsupported())
-    }
-}
-
-/// The error coven's `CloudKitOps` sharing methods return on a personal library:
-/// bae has no library sharing, so grant/revoke/accept are unavailable.
-fn sharing_unsupported() -> coven::CloudHomeError {
-    coven::CloudHomeError::Storage("CloudKit library sharing is not supported".to_string())
 }
 
 fn cloudkit_err_to_cloud_home_err(e: CloudKitError) -> coven::CloudHomeError {


### PR DESCRIPTION
Pins coven to `main` (`57ab063`) — now a single line carrying the seal-style cleanups, the CloudKit single-account deletion, and the make_remote user-sources change. coven's `CloudKitOps` trait no longer declares grant/revoke/accept, so bae's adapter drops its three `sharing_unsupported` stubs and the helper; the CloudKit driver implements only the private-database storage methods.

## Test plan
- [x] `cargo build -p bae-core -p bae-bridge` clean against `57ab063`
- [x] pre-commit hook green (fmt + clippy + test + macOS app build)
- [ ] CI green