### PR TITLE
Wire CloudKit share invitations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "coven"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=57ab063#57ab06351fabde973d3a5b154fecbaa54d7f82e4"
+source = "git+https://github.com/bae-fm/coven?rev=8c8266fea99c09a02f676702d08d1e9cfaa2fb01#8c8266fea99c09a02f676702d08d1e9cfaa2fb01"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "coven-core"
 version = "0.0.0-dev"
-source = "git+https://github.com/bae-fm/coven?rev=57ab063#57ab06351fabde973d3a5b154fecbaa54d7f82e4"
+source = "git+https://github.com/bae-fm/coven?rev=8c8266fea99c09a02f676702d08d1e9cfaa2fb01#8c8266fea99c09a02f676702d08d1e9cfaa2fb01"
 dependencies = [
  "async-trait",
  "base64",
@@ -1844,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3057,7 +3057,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3449,7 +3449,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3815,7 +3815,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3873,7 +3873,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4275,7 +4275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4405,7 +4405,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5228,7 +5228,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # coven: bae's data layer (local-first store + cloud sync). Pinned by rev here so
 # every crate that touches it (bae-core, and bae-bridge's CloudKit adapter, which
 # implements coven's CloudKitOps) resolves the same instance.
-coven = { git = "https://github.com/bae-fm/coven", rev = "57ab063" }
+coven = { git = "https://github.com/bae-fm/coven", rev = "8c8266fea99c09a02f676702d08d1e9cfaa2fb01" }
 # HTTP
 reqwest = { version = "0.13", default-features = false }
 # Logging

--- a/bae-bridge/src/cloudkit.rs
+++ b/bae-bridge/src/cloudkit.rs
@@ -9,11 +9,51 @@ use crate::types::CloudKitError;
 /// Synchronous CloudKit operations, implemented in Swift via UniFFI callback.
 #[uniffi::export(callback_interface)]
 pub trait CloudKitDriver: Send + Sync {
-    fn write_record(&self, key: String, data: Vec<u8>) -> Result<(), CloudKitError>;
-    fn read_record(&self, key: String) -> Result<Vec<u8>, CloudKitError>;
-    fn list_records(&self, prefix: String) -> Result<Vec<String>, CloudKitError>;
-    fn delete_record(&self, key: String) -> Result<(), CloudKitError>;
-    fn record_exists(&self, key: String) -> Result<bool, CloudKitError>;
+    fn write_record(
+        &self,
+        owner_name: Option<String>,
+        zone_name: Option<String>,
+        key: String,
+        data: Vec<u8>,
+    ) -> Result<(), CloudKitError>;
+    fn read_record(
+        &self,
+        owner_name: Option<String>,
+        zone_name: Option<String>,
+        key: String,
+    ) -> Result<Vec<u8>, CloudKitError>;
+    fn list_records(
+        &self,
+        owner_name: Option<String>,
+        zone_name: Option<String>,
+        prefix: String,
+    ) -> Result<Vec<String>, CloudKitError>;
+    fn delete_record(
+        &self,
+        owner_name: Option<String>,
+        zone_name: Option<String>,
+        key: String,
+    ) -> Result<(), CloudKitError>;
+    fn record_exists(
+        &self,
+        owner_name: Option<String>,
+        zone_name: Option<String>,
+        key: String,
+    ) -> Result<bool, CloudKitError>;
+    fn grant_share(
+        &self,
+        member_pubkey: String,
+        email: String,
+    ) -> Result<BridgeCloudKitShare, CloudKitError>;
+    fn revoke_share(&self, member_pubkey: String, email: String) -> Result<(), CloudKitError>;
+    fn accept_share(&self, share_url: String) -> Result<BridgeCloudKitShare, CloudKitError>;
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeCloudKitShare {
+    pub share_url: String,
+    pub owner_name: String,
+    pub zone_name: String,
 }
 
 /// Adapts a UniFFI `CloudKitDriver` callback to `CloudKitOps` (bae-core).
@@ -22,34 +62,102 @@ struct CloudKitDriverAdapter {
 }
 
 impl coven::CloudKitOps for CloudKitDriverAdapter {
-    fn write_record(&self, key: &str, data: Vec<u8>) -> Result<(), coven::CloudHomeError> {
+    fn write_record(
+        &self,
+        scope: &coven::CloudKitScope,
+        key: &str,
+        data: Vec<u8>,
+    ) -> Result<(), coven::CloudHomeError> {
+        let (owner_name, zone_name) = scope_fields(scope);
         self.driver
-            .write_record(key.to_string(), data)
+            .write_record(owner_name, zone_name, key.to_string(), data)
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn read_record(&self, key: &str) -> Result<Vec<u8>, coven::CloudHomeError> {
+    fn read_record(
+        &self,
+        scope: &coven::CloudKitScope,
+        key: &str,
+    ) -> Result<Vec<u8>, coven::CloudHomeError> {
+        let (owner_name, zone_name) = scope_fields(scope);
         self.driver
-            .read_record(key.to_string())
+            .read_record(owner_name, zone_name, key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn list_records(&self, prefix: &str) -> Result<Vec<String>, coven::CloudHomeError> {
+    fn list_records(
+        &self,
+        scope: &coven::CloudKitScope,
+        prefix: &str,
+    ) -> Result<Vec<String>, coven::CloudHomeError> {
+        let (owner_name, zone_name) = scope_fields(scope);
         self.driver
-            .list_records(prefix.to_string())
+            .list_records(owner_name, zone_name, prefix.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn delete_record(&self, key: &str) -> Result<(), coven::CloudHomeError> {
+    fn delete_record(
+        &self,
+        scope: &coven::CloudKitScope,
+        key: &str,
+    ) -> Result<(), coven::CloudHomeError> {
+        let (owner_name, zone_name) = scope_fields(scope);
         self.driver
-            .delete_record(key.to_string())
+            .delete_record(owner_name, zone_name, key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
-    fn record_exists(&self, key: &str) -> Result<bool, coven::CloudHomeError> {
+    fn record_exists(
+        &self,
+        scope: &coven::CloudKitScope,
+        key: &str,
+    ) -> Result<bool, coven::CloudHomeError> {
+        let (owner_name, zone_name) = scope_fields(scope);
         self.driver
-            .record_exists(key.to_string())
+            .record_exists(owner_name, zone_name, key.to_string())
             .map_err(cloudkit_err_to_cloud_home_err)
+    }
+
+    fn grant_share(
+        &self,
+        member_pubkey: &str,
+        email: &str,
+    ) -> Result<coven::CloudKitShare, coven::CloudHomeError> {
+        self.driver
+            .grant_share(member_pubkey.to_string(), email.to_string())
+            .map(bridge_share_to_coven)
+            .map_err(cloudkit_err_to_cloud_home_err)
+    }
+
+    fn revoke_share(&self, member_pubkey: &str, email: &str) -> Result<(), coven::CloudHomeError> {
+        self.driver
+            .revoke_share(member_pubkey.to_string(), email.to_string())
+            .map_err(cloudkit_err_to_cloud_home_err)
+    }
+
+    fn accept_share(&self, share_url: &str) -> Result<coven::CloudKitShare, coven::CloudHomeError> {
+        self.driver
+            .accept_share(share_url.to_string())
+            .map(bridge_share_to_coven)
+            .map_err(cloudkit_err_to_cloud_home_err)
+    }
+}
+
+fn scope_fields(scope: &coven::CloudKitScope) -> (Option<String>, Option<String>) {
+    match scope {
+        coven::CloudKitScope::Private => (None, None),
+        coven::CloudKitScope::Shared {
+            owner_name,
+            zone_name,
+        } => (Some(owner_name.clone()), Some(zone_name.clone())),
+    }
+}
+
+fn bridge_share_to_coven(share: BridgeCloudKitShare) -> coven::CloudKitShare {
+    coven::CloudKitShare {
+        share_url: share.share_url,
+        owner_name: share.owner_name,
+        zone_name: share.zone_name,
     }
 }
 

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -677,10 +677,14 @@ impl AppHandle {
 
     /// Approve a joining device by its public key (from its join-request code),
     /// returning the invite code to hand back to that device.
-    pub async fn invite_member(&self, public_key_hex: String) -> Result<String, BridgeError> {
+    pub async fn invite_member(
+        &self,
+        public_key_hex: String,
+        provider_account_email: Option<String>,
+    ) -> Result<String, BridgeError> {
         self.services
             .library_manager()
-            .invite_member(&public_key_hex)
+            .invite_member(&public_key_hex, provider_account_email.as_deref())
             .await
             .map_err(BridgeError::internal)
     }

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -11,6 +11,14 @@ use bae_core::diagnostics::{
 use crate::handle::AppHandle;
 use crate::types::BridgeError;
 
+#[cfg(feature = "cloudkit")]
+use crate::cloudkit::get_cloudkit_ops;
+
+#[cfg(not(feature = "cloudkit"))]
+fn get_cloudkit_ops() -> Option<Arc<dyn coven::CloudKitOps>> {
+    None
+}
+
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum BridgeDiagnosticsConfig {
     Disabled,
@@ -65,9 +73,10 @@ pub fn init_app(
 
     #[cfg(feature = "desktop")]
     {
-        let app = bae_desktop::bootstrap(library_id, position_update_interval_ms)
-            .map_err(bootstrap_error_to_bridge)?;
-        return Ok(Arc::new(AppHandle { app }));
+        let app =
+            bae_desktop::bootstrap(library_id, position_update_interval_ms, get_cloudkit_ops())
+                .map_err(bootstrap_error_to_bridge)?;
+        Ok(Arc::new(AppHandle { app }))
     }
 
     #[cfg(not(feature = "desktop"))]
@@ -75,7 +84,8 @@ pub fn init_app(
         runtime,
         services,
         ui_event_bus,
-    } = bootstrap(library_id, position_update_interval_ms).map_err(bootstrap_error_to_bridge)?;
+    } = bootstrap(library_id, position_update_interval_ms, get_cloudkit_ops())
+        .map_err(bootstrap_error_to_bridge)?;
 
     #[cfg(not(feature = "desktop"))]
     Ok(Arc::new(AppHandle {

--- a/bae-core/src/app.rs
+++ b/bae-core/src/app.rs
@@ -52,10 +52,12 @@ pub enum BootstrapError {
 pub fn bootstrap(
     library_id: String,
     position_update_interval_ms: u32,
+    cloudkit_ops: Option<crate::CloudKitOpsRef>,
 ) -> Result<RunningApp, BootstrapError> {
     bootstrap_on_thread(
         BootstrapTarget::RegisteredId(library_id),
         position_update_interval_ms,
+        cloudkit_ops,
     )
 }
 
@@ -66,12 +68,14 @@ pub fn bootstrap_library_path(
     bootstrap_on_thread(
         BootstrapTarget::LibraryPath(library_path),
         position_update_interval_ms,
+        None,
     )
 }
 
 fn bootstrap_on_thread(
     target: BootstrapTarget,
     position_update_interval_ms: u32,
+    cloudkit_ops: Option<crate::CloudKitOpsRef>,
 ) -> Result<RunningApp, BootstrapError> {
     // Building the sync manager (loading keys, opening the synced DB) and
     // `block_on`-ing the async setup uses a deep stack — especially in debug
@@ -83,7 +87,7 @@ fn bootstrap_on_thread(
     std::thread::Builder::new()
         .name("bae-bootstrap".to_string())
         .stack_size(32 * 1024 * 1024)
-        .spawn(move || bootstrap_inner(target, position_update_interval_ms))
+        .spawn(move || bootstrap_inner(target, position_update_interval_ms, cloudkit_ops))
         .expect("spawn bae-bootstrap thread")
         .join()
         .expect("bae-bootstrap thread panicked")
@@ -97,6 +101,7 @@ enum BootstrapTarget {
 fn bootstrap_inner(
     target: BootstrapTarget,
     position_update_interval_ms: u32,
+    cloudkit_ops: Option<crate::CloudKitOpsRef>,
 ) -> Result<RunningApp, BootstrapError> {
     // Composition root for the injected wall clock + id source. Production wires
     // the real implementations; both are passed down to the data layer. Built
@@ -185,6 +190,7 @@ fn bootstrap_inner(
         Arc::clone(&clock),
         ids,
         runtime.handle().clone(),
+        cloudkit_ops,
     )
     .map_err(|e| BootstrapError::Database(format!("Failed to open database: {e}")))?;
 

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -1366,17 +1366,33 @@ mod tests {
         let library_path = tmp.path().join("libraries").join("restored-lib-abc-123");
         let library_id = "restored-lib-abc-123";
 
-        let coven_config = coven::Config::with_defaults(
+        let mut coven_config = coven::Config::with_defaults(
             library_id.to_string(),
             "restored-device".to_string(),
             LibraryDir::new(library_path.clone()),
             "Test Library".to_string(),
         );
+        coven_config.cloud_home.provider = Some(CloudProvider::CloudKit);
+        coven_config.cloud_home.cloudkit_share_url = Some("https://icloud.com/share".to_string());
+        coven_config.cloud_home.cloudkit_owner_name = Some("_owner".to_string());
+        coven_config.cloud_home.cloudkit_zone_name = Some("bae-library".to_string());
         let config = Config::from_coven(coven_config);
 
         assert_eq!(config.library_id, library_id);
         assert_eq!(config.library_name, "Test Library");
         assert_eq!(config.mcp, McpConfig::disabled_default());
+        assert_eq!(
+            config.cloud_home.cloudkit_share_url.as_deref(),
+            Some("https://icloud.com/share")
+        );
+        assert_eq!(
+            config.cloud_home.cloudkit_owner_name.as_deref(),
+            Some("_owner")
+        );
+        assert_eq!(
+            config.cloud_home.cloudkit_zone_name.as_deref(),
+            Some("bae-library")
+        );
 
         config.save_to_config_yaml().unwrap();
 
@@ -1386,5 +1402,17 @@ mod tests {
         .unwrap();
         assert_eq!(yaml.library_id, library_id);
         assert_eq!(yaml.mcp, McpConfig::disabled_default());
+        assert_eq!(
+            yaml.cloud_home.cloudkit_share_url.as_deref(),
+            Some("https://icloud.com/share")
+        );
+        assert_eq!(
+            yaml.cloud_home.cloudkit_owner_name.as_deref(),
+            Some("_owner")
+        );
+        assert_eq!(
+            yaml.cloud_home.cloudkit_zone_name.as_deref(),
+            Some("bae-library")
+        );
     }
 }

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -36,3 +36,5 @@ pub mod sync;
 pub mod text_encoding;
 pub mod ui;
 pub mod util;
+
+pub type CloudKitOpsRef = std::sync::Arc<dyn coven::CloudKitOps>;

--- a/bae-core/src/library/manager/locality.rs
+++ b/bae-core/src/library/manager/locality.rs
@@ -55,8 +55,14 @@ impl LibraryManager {
     /// key to it and signing a membership entry. Returns the invite code to hand
     /// back to the joining device. bae adds every device as a `Member`; the
     /// founding device is the `Owner`.
-    pub async fn invite_member(&self, public_key_hex: &str) -> Result<String, String> {
-        self.sync.invite_member(public_key_hex).await
+    pub async fn invite_member(
+        &self,
+        public_key_hex: &str,
+        provider_account_email: Option<&str>,
+    ) -> Result<String, String> {
+        self.sync
+            .invite_member(public_key_hex, provider_account_email)
+            .await
     }
 
     /// Remove a device from the library and rotate the library key so the removed

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -615,6 +615,7 @@ impl LibraryManager {
         clock: ClockRef,
         ids: IdRef,
         runtime_handle: tokio::runtime::Handle,
+        cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     ) -> Result<Self, coven::DbError> {
         let (event_tx, _) = broadcast::channel(16);
         let outbox_in_flight = Arc::new(Mutex::new(HashMap::new()));
@@ -633,6 +634,7 @@ impl LibraryManager {
             .synced_tables(crate::sync::synced_tables())
             .clock(clock.clone())
             .key_service(key_service.clone())
+            .apply_cloudkit_ops(cloudkit_ops.clone())
             .observer(observer.clone() as Arc<dyn coven::BlobTransitionObserver>)
             .migrations(crate::migrations::all())
             .open()
@@ -654,6 +656,7 @@ impl LibraryManager {
             outbox_in_flight,
             upload_throughput,
             sync_paused,
+            cloudkit_ops,
         );
 
         let discogs = DiscogsCredentials::new(config_handle.clone(), key_service.clone());
@@ -704,6 +707,7 @@ impl LibraryManager {
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(crate::library::UploadThroughput::new()),
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            None,
         );
 
         let discogs = DiscogsCredentials::new(config_handle.clone(), key_service.clone());

--- a/bae-core/src/library/sync_controller.rs
+++ b/bae-core/src/library/sync_controller.rs
@@ -49,6 +49,7 @@ pub(crate) struct SyncController {
     upload_throughput: Arc<UploadThroughput>,
     /// User-driven pause flag for the cloud-upload pipeline.
     sync_paused: Arc<AtomicBool>,
+    cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
 }
 
 impl SyncController {
@@ -62,6 +63,7 @@ impl SyncController {
         outbox_in_flight: Arc<Mutex<HashMap<String, u64>>>,
         upload_throughput: Arc<UploadThroughput>,
         sync_paused: Arc<AtomicBool>,
+        cloudkit_ops: Option<Arc<dyn coven::CloudKitOps>>,
     ) -> Self {
         Self {
             handle,
@@ -72,6 +74,7 @@ impl SyncController {
             outbox_in_flight,
             upload_throughput,
             sync_paused,
+            cloudkit_ops,
         }
     }
 
@@ -345,10 +348,15 @@ impl SyncController {
     /// key to it and signing a membership entry. Returns the invite code to hand
     /// back to the joining device. bae adds every device as a `Member`; the
     /// founding device is the `Owner`.
-    pub(crate) async fn invite_member(&self, public_key_hex: &str) -> Result<String, String> {
+    pub(crate) async fn invite_member(
+        &self,
+        public_key_hex: &str,
+        provider_account_email: Option<&str>,
+    ) -> Result<String, String> {
         self.handle
             .invite_member(
                 public_key_hex,
+                provider_account_email,
                 crate::sync::sync_manager::MemberRole::Member,
             )
             .await
@@ -493,6 +501,9 @@ impl SyncController {
             .update(move |c| {
                 c.cloud_home.provider = Some(CloudProvider::CloudKit);
                 c.cloud_home.storage = storage;
+                c.cloud_home.cloudkit_share_url = None;
+                c.cloud_home.cloudkit_owner_name = None;
+                c.cloud_home.cloudkit_zone_name = None;
             })
             .map_err(|e| format!("Failed to save CloudKit config: {e}"))?;
         self.ensure_sync_manager_and_start().await?;
@@ -529,7 +540,21 @@ impl SyncController {
         &self,
         encryption_service: Option<EncryptionService>,
     ) -> Result<(), String> {
-        self.handle.connect_sync(encryption_service).await?;
+        let provider = self.config_handle.config().cloud_home.provider.clone();
+        match provider {
+            Some(CloudProvider::CloudKit) => {
+                let ops = self
+                    .cloudkit_ops
+                    .clone()
+                    .ok_or_else(|| "CloudKit driver not provided".to_string())?;
+                self.handle
+                    .connect_sync_with_cloudkit(encryption_service, ops)
+                    .await?;
+            }
+            _ => {
+                self.handle.connect_sync(encryption_service).await?;
+            }
+        }
         Ok(())
     }
 
@@ -585,7 +610,21 @@ impl SyncController {
         // — and the encryption-key fingerprint below is reached only on success, so
         // a failed setup stays a clean retry (no fingerprint telling the next
         // launch's unlock flow "encryption is set up" while sync is still broken).
-        self.handle.connect_sync(enc_service).await?;
+        let provider = self.config_handle.config().cloud_home.provider.clone();
+        match provider {
+            Some(CloudProvider::CloudKit) => {
+                let ops = self
+                    .cloudkit_ops
+                    .clone()
+                    .ok_or_else(|| "CloudKit driver not provided".to_string())?;
+                self.handle
+                    .connect_sync_with_cloudkit(enc_service, ops)
+                    .await?;
+            }
+            _ => {
+                self.handle.connect_sync(enc_service).await?;
+            }
+        }
 
         // Sync started. For an opaque home, persist the encryption-key hint flag so
         // the next launch's unlock flow knows this library has encryption set up. A

--- a/bae-core/tests/support/mod.rs
+++ b/bae-core/tests/support/mod.rs
@@ -461,12 +461,15 @@ impl coven::CloudHome for MockCloudHome {
 
     async fn grant_access(
         &self,
-        _member_id: &str,
+        _grant: coven::CloudAccessGrant,
     ) -> Result<coven::CloudHomeJoinInfo, coven::CloudHomeError> {
         unimplemented!("grant_access not used by storage transition tests")
     }
 
-    async fn revoke_access(&self, _member_id: &str) -> Result<(), coven::CloudHomeError> {
+    async fn revoke_access(
+        &self,
+        _revoke: coven::CloudAccessRevoke,
+    ) -> Result<(), coven::CloudHomeError> {
         unimplemented!("revoke_access not used by storage transition tests")
     }
 }

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -1459,6 +1459,7 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
         std::sync::Arc::new(coven::SystemClock),
         std::sync::Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
+        None,
     )
     .expect("open library manager");
     if storage_mode == StorageMode::Remote {

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -60,6 +60,7 @@ async fn setup(tmp: &TempDir) -> (Database, LibraryManager) {
         Arc::new(coven::SystemClock),
         Arc::new(coven::UuidProvider),
         tokio::runtime::Handle::current(),
+        None,
     )
     .unwrap();
     (mgr.database_for_test(), mgr)

--- a/bae-desktop/src/lib.rs
+++ b/bae-desktop/src/lib.rs
@@ -35,8 +35,10 @@ impl std::error::Error for DesktopMcpConfigError {}
 pub fn bootstrap(
     library_id: String,
     position_update_interval_ms: u32,
+    cloudkit_ops: Option<bae_core::CloudKitOpsRef>,
 ) -> Result<DesktopApp, BootstrapError> {
-    bootstrap_core(library_id, position_update_interval_ms).map(DesktopApp::from_running_app)
+    bootstrap_core(library_id, position_update_interval_ms, cloudkit_ops)
+        .map(DesktopApp::from_running_app)
 }
 
 impl DesktopApp {

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -79540,6 +79540,197 @@
         }
       }
     },
+    "iCloud email": {
+      "comment": "Approve-device sheet: placeholder for the joining member's iCloud account email",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud email"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud email"
+          }
+        }
+      }
+    },
     "matched %lld releases": {
       "comment": "Import search conflict: barcode section subtitle; %lld is the match count",
       "localizations": {

--- a/bae-macos/bae/bae/Services/CloudKitService.swift
+++ b/bae-macos/bae/bae/Services/CloudKitService.swift
@@ -18,11 +18,17 @@
         )
         private let recordType = "BaeFile"
 
-        private var database: CKDatabase {
+        private var privateDatabase: CKDatabase {
             container.privateCloudDatabase
         }
 
-        private let zoneID = CKRecordZone.ID(zoneName: CloudKitService.zoneName)
+        private var sharedDatabase: CKDatabase {
+            container.sharedCloudDatabase
+        }
+
+        private let privateZoneID = CKRecordZone.ID(
+            zoneName: CloudKitService.zoneName
+        )
 
         /// The service pointed at bae's CloudKit container and library zone.
         static func bae() -> CloudKitService {
@@ -80,8 +86,8 @@
             }
             let sem = DispatchSemaphore(value: 0)
             nonisolated(unsafe) var resultError: Error?
-            let zone = CKRecordZone(zoneID: zoneID)
-            database.save(zone) { _, error in
+            let zone = CKRecordZone(zoneID: privateZoneID)
+            privateDatabase.save(zone) { _, error in
                 resultError = error
                 sem.signal()
             }
@@ -96,8 +102,55 @@
 
         // MARK: - Record ID from key
 
-        private func recordID(for key: String) -> CKRecord.ID {
-            CKRecord.ID(recordName: key, zoneID: zoneID)
+        private struct RecordScope {
+            let database: CKDatabase
+            let zoneID: CKRecordZone.ID
+            let ownsZone: Bool
+        }
+
+        private func recordScope(ownerName: String?, zoneName: String?) throws
+            -> RecordScope
+        {
+            switch (ownerName, zoneName) {
+            case (nil, nil):
+                return RecordScope(
+                    database: privateDatabase,
+                    zoneID: privateZoneID,
+                    ownsZone: true
+                )
+            case (.some(let ownerName), .some(let zoneName)):
+                guard !ownerName.isEmpty, !zoneName.isEmpty else {
+                    throw CloudKitError.Storage(
+                        msg:
+                            "CloudKit shared scope requires non-empty owner and zone names"
+                    )
+                }
+                return RecordScope(
+                    database: sharedDatabase,
+                    zoneID: CKRecordZone.ID(
+                        zoneName: zoneName,
+                        ownerName: ownerName
+                    ),
+                    ownsZone: false
+                )
+            case (nil, .some(_)), (.some(_), nil):
+                throw CloudKitError.Storage(
+                    msg:
+                        "CloudKit shared scope requires both owner and zone names"
+                )
+            }
+        }
+
+        private func recordID(for key: String, in scope: RecordScope)
+            -> CKRecord.ID
+        {
+            CKRecord.ID(recordName: key, zoneID: scope.zoneID)
+        }
+
+        private func ensureWritableZone(for scope: RecordScope) throws {
+            if scope.ownsZone {
+                try ensureZone()
+            }
         }
 
         // MARK: - Error classification
@@ -135,8 +188,17 @@
     // MARK: - CloudKitDriver Protocol
 
     extension CloudKitService {
-        func writeRecord(key: String, data: Data) throws {
-            try ensureZone()
+        func writeRecord(
+            ownerName: String?,
+            zoneName: String?,
+            key: String,
+            data: Data
+        ) throws {
+            let scope = try recordScope(
+                ownerName: ownerName,
+                zoneName: zoneName
+            )
+            try ensureWritableZone(for: scope)
             let sem = DispatchSemaphore(value: 0)
             nonisolated(unsafe) var resultError: Error?
 
@@ -156,7 +218,7 @@
 
             let record = CKRecord(
                 recordType: recordType,
-                recordID: recordID(for: key)
+                recordID: recordID(for: key, in: scope)
             )
             record["key"] = key as CKRecordValue
             record["data"] = CKAsset(fileURL: tempURL)
@@ -172,7 +234,7 @@
                 }
                 sem.signal()
             }
-            database.add(op)
+            scope.database.add(op)
             sem.wait()
 
             if let error = resultError {
@@ -182,12 +244,22 @@
             }
         }
 
-        func readRecord(key: String) throws -> Data {
+        func readRecord(
+            ownerName: String?,
+            zoneName: String?,
+            key: String
+        ) throws -> Data {
+            let scope = try recordScope(
+                ownerName: ownerName,
+                zoneName: zoneName
+            )
             let sem = DispatchSemaphore(value: 0)
             nonisolated(unsafe) var resultData: Data?
             nonisolated(unsafe) var resultError: Error?
 
-            database.fetch(withRecordID: recordID(for: key)) { record, error in
+            scope.database.fetch(withRecordID: recordID(for: key, in: scope)) {
+                record,
+                error in
                 if let error {
                     resultError = error
                 }
@@ -220,23 +292,31 @@
             return data
         }
 
-        func listRecords(prefix: String) throws -> [String] {
-            try ensureZone()
+        func listRecords(
+            ownerName: String?,
+            zoneName: String?,
+            prefix: String
+        ) throws -> [String] {
+            let scope = try recordScope(
+                ownerName: ownerName,
+                zoneName: zoneName
+            )
+            try ensureWritableZone(for: scope)
             var keys: [String] = []
 
             let predicate = NSPredicate(format: "key BEGINSWITH %@", prefix)
             let query = CKQuery(recordType: recordType, predicate: predicate)
 
             var cursor = try fetchKeysPage(into: &keys) { handler in
-                database.fetch(
+                scope.database.fetch(
                     withQuery: query,
-                    inZoneWith: zoneID,
+                    inZoneWith: scope.zoneID,
                     completionHandler: handler
                 )
             }
             while let activeCursor = cursor {
                 cursor = try fetchKeysPage(into: &keys) { handler in
-                    database.fetch(
+                    scope.database.fetch(
                         withCursor: activeCursor,
                         completionHandler: handler
                     )
@@ -299,13 +379,21 @@
             return nextCursor
         }
 
-        func deleteRecord(key: String) throws {
+        func deleteRecord(
+            ownerName: String?,
+            zoneName: String?,
+            key: String
+        ) throws {
+            let scope = try recordScope(
+                ownerName: ownerName,
+                zoneName: zoneName
+            )
             let sem = DispatchSemaphore(value: 0)
             nonisolated(unsafe) var resultError: Error?
 
             let op = CKModifyRecordsOperation(
                 recordsToSave: nil,
-                recordIDsToDelete: [recordID(for: key)],
+                recordIDsToDelete: [recordID(for: key, in: scope)],
             )
             op.modifyRecordsResultBlock = { result in
                 if case .failure(let error) = result {
@@ -320,7 +408,7 @@
                 }
                 sem.signal()
             }
-            database.add(op)
+            scope.database.add(op)
             sem.wait()
 
             if let error = resultError {
@@ -330,12 +418,22 @@
             }
         }
 
-        func recordExists(key: String) throws -> Bool {
+        func recordExists(
+            ownerName: String?,
+            zoneName: String?,
+            key: String
+        ) throws -> Bool {
+            let scope = try recordScope(
+                ownerName: ownerName,
+                zoneName: zoneName
+            )
             let sem = DispatchSemaphore(value: 0)
             nonisolated(unsafe) var exists = false
             nonisolated(unsafe) var resultError: Error?
 
-            database.fetch(withRecordID: recordID(for: key)) { record, error in
+            scope.database.fetch(withRecordID: recordID(for: key, in: scope)) {
+                record,
+                error in
                 if let error {
                     if let ckError = error as? CKError,
                         ckError.code == .unknownItem
@@ -359,6 +457,336 @@
                 )
             }
             return exists
+        }
+
+        func grantShare(memberPubkey: String, email: String) throws
+            -> BridgeCloudKitShare
+        {
+            try ensureZoneSupportsSharing()
+            let participant = try fetchParticipant(email: email)
+            let share =
+                try fetchZoneWideShare()
+                ?? CKShare(
+                    recordZoneID: privateZoneID
+                )
+
+            participant.permission = .readWrite
+            share.addParticipant(participant)
+            share[memberEmailFieldKey(for: memberPubkey)] =
+                email as CKRecordValue
+
+            let savedShare = try saveShare(share, op: "Grant share")
+            guard let shareURL = savedShare.url?.absoluteString else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit did not return a URL for the saved share"
+                )
+            }
+            return BridgeCloudKitShare(
+                shareUrl: shareURL,
+                ownerName: savedShare.recordID.zoneID.ownerName,
+                zoneName: savedShare.recordID.zoneID.zoneName
+            )
+        }
+
+        func revokeShare(memberPubkey: String, email: String) throws {
+            guard let share = try fetchZoneWideShare() else {
+                return
+            }
+
+            let emailFieldKey = memberEmailFieldKey(for: memberPubkey)
+            let mappedEmail = share[emailFieldKey] as? String
+            let emailToRemove: String
+            if let mappedEmail {
+                guard mappedEmail == email else {
+                    throw CloudKitError.Storage(
+                        msg:
+                            "CloudKit share member email does not match signed membership email"
+                    )
+                }
+                emailToRemove = mappedEmail
+            }
+            else {
+                emailToRemove = email
+            }
+
+            if let participant = share.participants.first(where: {
+                participantMatches($0, email: emailToRemove)
+            }) {
+                share.removeParticipant(participant)
+            }
+            else {
+                return
+            }
+            share[emailFieldKey] = nil
+            _ = try saveShare(share, op: "Revoke share")
+        }
+
+        func acceptShare(shareUrl: String) throws -> BridgeCloudKitShare {
+            guard let url = URL(string: shareUrl) else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit share URL is invalid"
+                )
+            }
+            let metadata = try fetchShareMetadata(url: url)
+            let acceptedShare = try acceptShare(metadata: metadata)
+            return BridgeCloudKitShare(
+                shareUrl: shareUrl,
+                ownerName: acceptedShare.recordID.zoneID.ownerName,
+                zoneName: acceptedShare.recordID.zoneID.zoneName
+            )
+        }
+
+        private func ensureZoneSupportsSharing() throws {
+            try ensureZone()
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var fetchedZone: CKRecordZone?
+            nonisolated(unsafe) var resultError: Error?
+
+            privateDatabase.fetch(withRecordZoneID: privateZoneID) {
+                zone,
+                error in
+                if let error {
+                    resultError = error
+                }
+                else {
+                    fetchedZone = zone
+                }
+                sem.signal()
+            }
+            sem.wait()
+
+            if let error = resultError {
+                throw CloudKitError.Storage(
+                    msg: cloudKitErrorMessage(error, op: "Share zone lookup")
+                )
+            }
+            guard let fetchedZone else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit sharing zone was not returned"
+                )
+            }
+            guard fetchedZone.capabilities.contains(.zoneWideSharing) else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit zone-wide sharing is not available"
+                )
+            }
+        }
+
+        private func fetchParticipant(email: String) throws
+            -> CKShare.Participant
+        {
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var participant: CKShare.Participant?
+            nonisolated(unsafe) var resultError: Error?
+
+            container.fetchShareParticipant(withEmailAddress: email) {
+                fetchedParticipant,
+                error in
+                if let error {
+                    resultError = error
+                }
+                else {
+                    participant = fetchedParticipant
+                }
+                sem.signal()
+            }
+            sem.wait()
+
+            if let error = resultError {
+                throw CloudKitError.Storage(
+                    msg: cloudKitErrorMessage(
+                        error,
+                        op: "Share participant lookup"
+                    )
+                )
+            }
+            guard let participant else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit did not return a share participant"
+                )
+            }
+            return participant
+        }
+
+        private func fetchZoneWideShare() throws -> CKShare? {
+            let shareID = CKRecord.ID(
+                recordName: CKRecordNameZoneWideShare,
+                zoneID: privateZoneID
+            )
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var share: CKShare?
+            nonisolated(unsafe) var resultError: Error?
+
+            privateDatabase.fetch(withRecordID: shareID) { record, error in
+                if let error {
+                    if let ckError = error as? CKError,
+                        ckError.code == .unknownItem
+                    {
+                        share = nil
+                    }
+                    else {
+                        resultError = error
+                    }
+                }
+                else if let fetchedShare = record as? CKShare {
+                    share = fetchedShare
+                }
+                else if record != nil {
+                    resultError = CloudKitError.Storage(
+                        msg:
+                            "CloudKit zone-wide share record has an unexpected type"
+                    )
+                }
+                sem.signal()
+            }
+            sem.wait()
+
+            if let error = resultError {
+                throw CloudKitError.Storage(
+                    msg: cloudKitErrorMessage(error, op: "Share lookup")
+                )
+            }
+            return share
+        }
+
+        private func saveShare(_ share: CKShare, op: String) throws -> CKShare {
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var savedShare: CKShare?
+            nonisolated(unsafe) var resultError: Error?
+
+            let operation = CKModifyRecordsOperation(
+                recordsToSave: [share],
+                recordIDsToDelete: nil
+            )
+            operation.savePolicy = .allKeys
+            operation.perRecordSaveBlock = { _, result in
+                switch result {
+                case .success(let record):
+                    if let share = record as? CKShare {
+                        savedShare = share
+                    }
+                    else {
+                        resultError = CloudKitError.Storage(
+                            msg: "\(op) returned a non-share record"
+                        )
+                    }
+                case .failure(let error):
+                    resultError = error
+                }
+            }
+            operation.modifyRecordsResultBlock = { result in
+                if case .failure(let error) = result {
+                    resultError = error
+                }
+                sem.signal()
+            }
+            privateDatabase.add(operation)
+            sem.wait()
+
+            if let error = resultError {
+                throw CloudKitError.Storage(
+                    msg: cloudKitErrorMessage(error, op: op)
+                )
+            }
+            guard let savedShare else {
+                throw CloudKitError.Storage(
+                    msg: "\(op) failed: CloudKit did not return a share"
+                )
+            }
+            return savedShare
+        }
+
+        private func fetchShareMetadata(url: URL) throws -> CKShare.Metadata {
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var metadata: CKShare.Metadata?
+            nonisolated(unsafe) var resultError: Error?
+
+            let operation = CKFetchShareMetadataOperation(shareURLs: [url])
+            operation.perShareMetadataResultBlock = { _, result in
+                switch result {
+                case .success(let fetchedMetadata):
+                    metadata = fetchedMetadata
+                case .failure(let error):
+                    resultError = error
+                }
+            }
+            operation.fetchShareMetadataResultBlock = { result in
+                if case .failure(let error) = result {
+                    resultError = error
+                }
+                sem.signal()
+            }
+            operation.container = container
+            operation.qualityOfService = .userInitiated
+            operation.start()
+            sem.wait()
+
+            if let error = resultError {
+                throw CloudKitError.Storage(
+                    msg: cloudKitErrorMessage(
+                        error,
+                        op: "Share metadata lookup"
+                    )
+                )
+            }
+            guard let metadata else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit did not return share metadata"
+                )
+            }
+            return metadata
+        }
+
+        private func acceptShare(metadata: CKShare.Metadata) throws -> CKShare {
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var acceptedShare: CKShare?
+            nonisolated(unsafe) var resultError: Error?
+
+            let operation = CKAcceptSharesOperation(shareMetadatas: [metadata])
+            operation.perShareResultBlock = { _, result in
+                switch result {
+                case .success(let share):
+                    acceptedShare = share
+                case .failure(let error):
+                    resultError = error
+                }
+            }
+            operation.acceptSharesResultBlock = { result in
+                if case .failure(let error) = result {
+                    resultError = error
+                }
+                sem.signal()
+            }
+            operation.qualityOfService = .userInitiated
+            container.add(operation)
+            sem.wait()
+
+            if let error = resultError {
+                throw CloudKitError.Storage(
+                    msg: cloudKitErrorMessage(error, op: "Accept share")
+                )
+            }
+            guard let acceptedShare else {
+                throw CloudKitError.Storage(
+                    msg: "CloudKit did not return accepted share"
+                )
+            }
+            return acceptedShare
+        }
+
+        private func memberEmailFieldKey(for memberPubkey: String) -> String {
+            let prefix = memberPubkey.prefix(48)
+                .map { character in
+                    character.isLetter || character.isNumber ? character : "_"
+                }
+            return "coven_member_\(String(prefix))"
+        }
+
+        private func participantMatches(
+            _ participant: CKShare.Participant,
+            email: String
+        ) -> Bool {
+            participant.userIdentity.lookupInfo?.emailAddress == email
         }
     }
 

--- a/bae-macos/bae/bae/Services/Sync.swift
+++ b/bae-macos/bae/bae/Services/Sync.swift
@@ -25,7 +25,9 @@ final class Sync: Sendable, Observable {
     let getMembers: @Sendable () async throws -> BridgeMembership
     /// Approve a joining device by its public key (from its join-request code),
     /// returning the invite code to hand back to that device.
-    let inviteMember: @Sendable (_ publicKeyHex: String) async throws -> String
+    let inviteMember:
+        @Sendable (_ publicKeyHex: String, _ providerAccountEmail: String?)
+            async throws -> String
     /// Remove a device from the library and rotate the library key.
     let removeMember: @Sendable (_ publicKeyHex: String) async throws -> Void
     /// Warning text for the disconnect-sync confirmation: `nil` when no
@@ -77,10 +79,12 @@ final class Sync: Sendable, Observable {
         getMembers: @escaping @Sendable () async throws -> BridgeMembership = {
             throw StubError.notImplemented
         },
-        inviteMember: @escaping @Sendable (String) async throws -> String = {
-            _ in
-            throw StubError.notImplemented
-        },
+        inviteMember:
+            @escaping @Sendable (String, String?) async throws -> String = {
+                _,
+                _ in
+                throw StubError.notImplemented
+            },
         removeMember: @escaping @Sendable (String) async throws -> Void = {
             _ in
             throw StubError.notImplemented
@@ -152,7 +156,12 @@ final class Sync: Sendable, Observable {
             saveSyncConfig: { try await handle.saveSyncConfig(configData: $0) },
             generateRestoreCode: { try handle.generateRestoreCode() },
             getMembers: { try await handle.getMembers() },
-            inviteMember: { try await handle.inviteMember(publicKeyHex: $0) },
+            inviteMember: {
+                try await handle.inviteMember(
+                    publicKeyHex: $0,
+                    providerAccountEmail: $1
+                )
+            },
             removeMember: { try await handle.removeMember(publicKeyHex: $0) },
             disconnectWarningMessage: { try handle.disconnectWarningMessage() },
             retryOutbox: { try handle.retryOutbox() },

--- a/bae-macos/bae/bae/Views/Settings/ApproveDeviceSheet.swift
+++ b/bae-macos/bae/bae/Views/Settings/ApproveDeviceSheet.swift
@@ -7,11 +7,13 @@ private let logger = Logger.bae("ApproveDevice")
 /// code (camera scan or pasted text), preview its public key, approve it, then
 /// show the invite code to carry back to that device.
 ///
-/// `invite` is `Sync.inviteMember`: it takes the joining device's public key and
-/// returns the invite code. The sheet drives a small step machine so each stage
-/// renders only what that stage needs.
+/// `invite` is `Sync.inviteMember`: it takes the joining device's public key
+/// plus any provider account email and returns the invite code. The sheet drives
+/// a small step machine so each stage renders only what that stage needs.
 struct ApproveDeviceSheet: View {
-    let invite: @Sendable (_ publicKeyHex: String) async throws -> String
+    let invite:
+        @Sendable (_ publicKeyHex: String, _ providerAccountEmail: String?)
+            async throws -> String
     let onDismiss: () -> Void
     /// Called once a device has been approved, so the caller can refresh its
     /// member list.
@@ -31,6 +33,8 @@ struct ApproveDeviceSheet: View {
     private var step: Step = .capture
     @State
     private var pasteInput = ""
+    @State
+    private var providerAccountEmail = ""
     @State
     private var error: String?
     @State
@@ -130,6 +134,10 @@ struct ApproveDeviceSheet: View {
                         .foregroundStyle(.secondary)
                 }
             }
+            TextField("iCloud email", text: $providerAccountEmail)
+                .textFieldStyle(.roundedBorder)
+                .textContentType(.emailAddress)
+                .frame(maxWidth: 260)
             Text(
                 "It will be added to your library and able to sync. You'll get a code to enter on it."
             )
@@ -199,6 +207,7 @@ struct ApproveDeviceSheet: View {
         guard !trimmed.isEmpty else { return }
         do {
             let info = try decodeJoinRequest(code: trimmed)
+            providerAccountEmail = info.email ?? ""
             error = nil
             step = .confirm(info)
         }
@@ -212,12 +221,15 @@ struct ApproveDeviceSheet: View {
 
     private func approve(_ info: BridgeJoinRequestInfo) {
         let pubkey = info.pubkey
+        let email = providerAccountEmail.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
         error = nil
         step = .inviting(info)
         inviteTask?.cancel()
         inviteTask = Task { @MainActor in
             do {
-                let code = try await invite(pubkey)
+                let code = try await invite(pubkey, email.isEmpty ? nil : email)
                 step = .invited(code: code)
                 onApproved()
             }


### PR DESCRIPTION
This wires bae to coven's CloudKit share support from bae-fm/coven#189. The bridge now exposes scoped CloudKit record operations plus grant/revoke/accept share calls, bae passes CloudKit operations through app startup and sync manager creation, and the macOS approval flow collects the joining member's iCloud email for CKShare participants.\n\nTests:\n- cargo fmt --all --check\n- cargo check -p bae-bridge --features cloudkit,desktop\n- cargo test -p bae-core config::tests::from_coven_preserves_library_id_and_persists_bae_yaml --quiet\n- cargo clippy -p bae-bridge --features cloudkit,desktop --quiet -- -D warnings\n- cargo clippy -p bae-core --quiet -- -D warnings\n- cargo clippy -p bae-core --tests --quiet -- -D warnings\n- xcodebuild -project bae-macos/bae/bae.xcodeproj -scheme bae -configuration Debug -destination 'platform=macOS,arch=arm64' build\n- pre-commit hook passed with BAE_MACOS_DERIVED_DATA_PATH=/Users/dima/Library/Developer/Xcode/DerivedData/bae-dnggptbdeioctwbzryzjrphqgggx