### PR TITLE
Move the library mode switcher into the header row as a dropdown

### DIFF
--- a/bae-macos/bae/bae/Services/UiStore.swift
+++ b/bae-macos/bae/bae/Services/UiStore.swift
@@ -8,6 +8,18 @@ enum MainSection {
     case importing
 }
 
+enum LibraryBrowserMode: CaseIterable {
+    case albums
+    case composers
+
+    var displayName: String {
+        switch self {
+        case .albums: String(localized: "Albums")
+        case .composers: String(localized: "Composers")
+        }
+    }
+}
+
 /// One-shot imperative command fired when the UI should navigate to and
 /// reveal an album (and optionally flash a track inside it).
 struct NavigationCommand {
@@ -29,6 +41,7 @@ class UiStore: @unchecked Sendable {
     // ── Navigation ─────────────────────────────────────────────────────
 
     var activeSection: MainSection = .library
+    var libraryBrowserMode: LibraryBrowserMode = .albums
     var selectedAlbumId: String?
     var showQueue: Bool = false
 
@@ -75,6 +88,10 @@ class UiStore: @unchecked Sendable {
         activeSection = .library
     }
 
+    func setLibraryBrowserMode(_ mode: LibraryBrowserMode) {
+        libraryBrowserMode = mode
+    }
+
     func navigateToAlbum(
         _ albumId: String,
         trackId: String? = nil,
@@ -96,11 +113,13 @@ class UiStore: @unchecked Sendable {
 
     func navigateToComposer(_ artistId: String) {
         activeSection = .library
+        libraryBrowserMode = .composers
         libraryNavigationSubject.send(.composer(artistId))
     }
 
     func navigateToWork(_ workId: String) {
         activeSection = .library
+        libraryBrowserMode = .composers
         libraryNavigationSubject.send(.work(workId))
     }
 

--- a/bae-macos/bae/bae/Views/AlbumGridView.swift
+++ b/bae-macos/bae/bae/Views/AlbumGridView.swift
@@ -224,6 +224,7 @@ extension AlbumGridView {
             Text(headerTitle)
                 .font(.system(size: 36, weight: .bold))
             Spacer()
+            LibraryModeMenu()
             Button(action: onShuffleLibrary) {
                 Label("Shuffle Library", systemImage: "shuffle")
             }

--- a/bae-macos/bae/bae/Views/LibraryModeMenu.swift
+++ b/bae-macos/bae/bae/Views/LibraryModeMenu.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Borderless dropdown that selects the library browser mode (Albums /
+/// Composers). Styled to match `SortCriterionChip`'s label so it sits inline
+/// with the sort chips in the library header. Reads and writes mode through the
+/// environment `UiStore`.
+struct LibraryModeMenu: View {
+    @Environment(UiStore.self)
+    private var uiStore
+
+    var body: some View {
+        Menu {
+            LibraryModeButtons(uiStore: uiStore) { mode in
+                uiStore.setLibraryBrowserMode(mode)
+            }
+        } label: {
+            HStack(spacing: 2) {
+                Text(uiStore.libraryBrowserMode.displayName)
+                Image(systemName: "chevron.down")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+}
+
+/// One menu button per browser mode, each checkmarked when it is the active
+/// mode. The header dropdown and the View-menu commands share this list; they
+/// differ only in what selecting a mode does, so the action is injected.
+struct LibraryModeButtons: View {
+    let uiStore: UiStore
+    let select: (LibraryBrowserMode) -> Void
+
+    var body: some View {
+        ForEach(LibraryBrowserMode.allCases, id: \.self) { mode in
+            Button {
+                select(mode)
+            } label: {
+                if uiStore.libraryBrowserMode == mode {
+                    Label(mode.displayName, systemImage: "checkmark")
+                }
+                else {
+                    Text(mode.displayName)
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+    #Preview {
+        LibraryModeMenu()
+            .padding()
+            .environment(UiStore())
+    }
+#endif

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -2,11 +2,6 @@ import SwiftUI
 
 private let composerLoadBatchSize = 50
 
-private enum LibraryBrowserMode {
-    case albums
-    case composers
-}
-
 private enum ComposerPaneSelection: Equatable {
     case none
     case composer(artistId: String, workId: String?)
@@ -50,8 +45,6 @@ struct LibraryView: View {
     var uiStore
 
     @State
-    private var mode: LibraryBrowserMode = .albums
-    @State
     private var albumList: AlbumList?
     @State
     private var composerList: ComposerList?
@@ -66,19 +59,12 @@ struct LibraryView: View {
     private var detailSelection: ComposerPaneSelection = .none
 
     var body: some View {
-        @Bindable
-        var uiStore = uiStore
-        VStack(spacing: 0) {
-            modePicker
-                .padding(.top, 14)
-                .padding(.horizontal, 16)
-            Group {
-                switch mode {
-                case .albums:
-                    albumContent
-                case .composers:
-                    composerContent
-                }
+        Group {
+            switch uiStore.libraryBrowserMode {
+            case .albums:
+                albumContent
+            case .composers:
+                composerContent
             }
         }
         .background(Theme.background)
@@ -86,8 +72,8 @@ struct LibraryView: View {
             Self.saveSortCriteria(sortCriteria)
             await reloadAlbumList(sort: sortCriteria)
         }
-        .task(id: mode) {
-            if mode == .composers {
+        .task(id: uiStore.libraryBrowserMode) {
+            if uiStore.libraryBrowserMode == .composers {
                 await ensureComposerListLoaded()
             }
         }
@@ -98,7 +84,7 @@ struct LibraryView: View {
             await loadWorkDetail()
         }
         .task(id: composerSortCriterion) {
-            if mode == .composers {
+            if uiStore.libraryBrowserMode == .composers {
                 await reloadComposerList(sort: composerSortCriterion)
             }
         }
@@ -112,7 +98,6 @@ struct LibraryView: View {
             }
         }
         .onReceive(uiStore.libraryNavigationSubject) { target in
-            mode = .composers
             switch target {
             case .composer(let artistId):
                 detailSelection = .composer(artistId: artistId, workId: nil)
@@ -126,15 +111,6 @@ struct LibraryView: View {
 }
 
 extension LibraryView {
-    private var modePicker: some View {
-        Picker("Library", selection: $mode) {
-            Text("Albums").tag(LibraryBrowserMode.albums)
-            Text("Composers").tag(LibraryBrowserMode.composers)
-        }
-        .pickerStyle(.segmented)
-        .frame(maxWidth: 260)
-    }
-
     private var albumContent: some View {
         Group {
             if let albumList {
@@ -236,6 +212,7 @@ extension LibraryView {
             Text("Composers")
                 .font(.title.bold())
             Spacer()
+            LibraryModeMenu()
             composerSortControls
         }
     }
@@ -361,7 +338,7 @@ extension LibraryView {
                                     inAlbum: albumId
                                 )
                                 uiStore.selectAlbum(albumId)
-                                mode = .albums
+                                uiStore.setLibraryBrowserMode(.albums)
                             }
                         )
                     }
@@ -376,7 +353,7 @@ extension LibraryView {
                         openAlbum: { albumId, releaseId in
                             uiStore.selectRelease(releaseId, inAlbum: albumId)
                             uiStore.selectAlbum(albumId)
-                            mode = .albums
+                            uiStore.setLibraryBrowserMode(.albums)
                         }
                     )
                 }

--- a/bae-macos/bae/bae/Views/MainAppMenuCommands.swift
+++ b/bae-macos/bae/bae/Views/MainAppMenuCommands.swift
@@ -131,6 +131,23 @@ struct OpenStorageManagerButton: View {
     }
 }
 
+/// One checkmarked button per library browser mode. Opens the main window and
+/// navigates to the library section before setting the mode, so the item works
+/// from any window (matching `OpenLibraryButton`).
+struct LibraryModeCommandButtons: View {
+    let uiStore: UiStore
+    @Environment(\.openWindow)
+    private var openWindow
+
+    var body: some View {
+        LibraryModeButtons(uiStore: uiStore) { mode in
+            openWindow(id: "main")
+            uiStore.navigateToLibraryRoot()
+            uiStore.setLibraryBrowserMode(mode)
+        }
+    }
+}
+
 struct MainAppMenuCommands: Commands {
     let playback: Playback
     let importer: Importer
@@ -190,6 +207,10 @@ struct MainAppMenuCommands: Commands {
             OpenLibraryButton(uiStore: uiStore)
             OpenImportButton(uiStore: uiStore)
             OpenStorageManagerButton()
+
+            Divider()
+
+            LibraryModeCommandButtons(uiStore: uiStore)
 
             Divider()
 

--- a/bae-macos/bae/baeTests/UiStoreTests.swift
+++ b/bae-macos/bae/baeTests/UiStoreTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import bae
+
+@Suite("UiStore.libraryBrowserMode")
+struct UiStoreLibraryBrowserModeTests {
+
+    @Test("setLibraryBrowserMode sets the given value (absolute, idempotent)")
+    func setModeIsAbsoluteAndIdempotent() {
+        let store = UiStore()
+        #expect(store.libraryBrowserMode == .albums)
+
+        store.setLibraryBrowserMode(.composers)
+        #expect(store.libraryBrowserMode == .composers)
+
+        store.setLibraryBrowserMode(.composers)
+        #expect(store.libraryBrowserMode == .composers)
+
+        store.setLibraryBrowserMode(.albums)
+        #expect(store.libraryBrowserMode == .albums)
+    }
+
+    @Test("navigateToComposer switches to composers mode and library section")
+    func navigateToComposerSwitchesMode() {
+        let store = UiStore()
+        store.navigateToComposer("artist-1")
+        #expect(store.libraryBrowserMode == .composers)
+        #expect(store.activeSection == .library)
+    }
+
+    @Test("navigateToWork switches to composers mode")
+    func navigateToWorkSwitchesMode() {
+        let store = UiStore()
+        store.navigateToWork("work-1")
+        #expect(store.libraryBrowserMode == .composers)
+    }
+
+    @Test("navigateToLibraryRoot does not change libraryBrowserMode")
+    func navigateToLibraryRootPreservesMode() {
+        let store = UiStore()
+        store.setLibraryBrowserMode(.composers)
+        store.navigateToLibraryRoot()
+        #expect(store.libraryBrowserMode == .composers)
+        #expect(store.activeSection == .library)
+    }
+}


### PR DESCRIPTION
The Albums/Composers switcher was a segmented picker sitting in its own row above
the library content. This moves it into the album and composer header rows as a
borderless dropdown that sits alongside the Shuffle button and the sort controls,
styled to match the sort chips, and mirrors the same choice in the app's View
menu so the mode can be switched from the menu bar (and from any window).

The load-bearing change is where the mode lives. It was `LibraryView`'s private
`@State`, unreachable from the two views that now need it: the album header is a
separate view (`AlbumGridView`), and the View menu is built far from
`LibraryView` in `MainAppMenuCommands`. So the mode moves to `UiStore`, which
already holds this kind of UI-session navigation state and is injected into all
three sites. Composer navigation (`navigateToComposer`/`navigateToWork`) now sets
the mode on `UiStore` directly instead of routing it through the nav-subject
handler in `LibraryView`.

## Test plan

- [ ] Album grid header shows an Albums/Composers dropdown next to Shuffle + sort; switching to Composers swaps the content.
- [ ] Composer header shows the same dropdown; switching back to Albums works.
- [ ] View menu lists Albums / Composers with a checkmark on the current mode; picking one opens/raises the main window in that mode.
- [ ] Opening an album from a composer's work detail returns to Albums mode.
- [ ] `baeTests` UiStore suite passes.
