### PR TITLE
OAuth pairing: joiner picks provider, authenticates, and sends its account email

### DIFF
--- a/bae-android/app/src/full/java/fm/bae/app/OAuthLinking.kt
+++ b/bae-android/app/src/full/java/fm/bae/app/OAuthLinking.kt
@@ -93,6 +93,18 @@ class OAuthLinking private constructor(
         }
     }
 
+    /**
+     * Fetch the account email for [provider] from an OAuth token. The bridge
+     * call is a blocking network request, so it runs off the main thread.
+     */
+    override suspend fun fetchAccountEmail(
+        provider: BridgeCloudProvider,
+        oauthTokenJson: String,
+    ): String =
+        withContext(Dispatchers.IO) {
+            uniffi.bae_bridge.fetchAccountEmail(provider, oauthTokenJson)
+        }
+
     companion object {
         /**
          * Set while an auth flow awaits its redirect; completed by

--- a/bae-android/app/src/main/java/fm/bae/app/OAuthLinker.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/OAuthLinker.kt
@@ -30,6 +30,16 @@ interface OAuthLinker {
         provider: BridgeCloudProvider,
     ): String
 
+    /**
+     * Turn an OAuth token into the account email so the joiner can bake it into
+     * its join-request. Routed through this interface because the underlying
+     * `fetchAccountEmail` bridge binding exists only in the full edition.
+     */
+    suspend fun fetchAccountEmail(
+        provider: BridgeCloudProvider,
+        oauthTokenJson: String,
+    ): String
+
     companion object {
         /**
          * Load the host's OAuth client creds, or null when this edition ships no

--- a/bae-android/app/src/main/java/fm/bae/app/ui/JoinLibraryScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/JoinLibraryScreen.kt
@@ -1,6 +1,7 @@
 package fm.bae.app.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -19,7 +20,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,30 +27,26 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import fm.bae.app.BaeLogger
 import fm.bae.app.OAuthLinker
 import fm.bae.app.R
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import uniffi.bae_bridge.generateJoinRequest
-
-private const val TAG = "bae.JoinLibraryScreen"
-private val logger = BaeLogger(TAG)
+import uniffi.bae_bridge.BridgeCloudProvider
+import uniffi.bae_bridge.availableCloudProviders
 
 /**
- * The joining device's side of adding itself to an existing library: it shows
- * this device's join-request code (a QR plus the copyable text and its
- * fingerprint) for an existing member to approve, and accepts the invite code
- * that member hands back (scan or paste). The join-request code is generated
- * once when the screen appears.
+ * The joining device's side of adding itself to an existing library. The flow
+ * starts with a provider picker: picking the target library's provider drives
+ * [JoinLauncher.selectProvider], which (for an OAuth provider) authenticates and
+ * fetches the account email up front, then generates this device's join-request
+ * with the email baked in. Once the code is ready this shows it (a QR plus the
+ * copyable text and its fingerprint) for an existing member to approve, and
+ * accepts the invite code that member hands back (scan or paste). The captured
+ * OAuth token is reused for the join — no second sign-in.
  */
 @Composable
 fun JoinLibraryScreen(
@@ -60,64 +56,28 @@ fun JoinLibraryScreen(
     onRequestScan: () -> Unit,
     onBack: () -> Unit,
 ) {
-    val context = LocalContext.current
-    var requestCode by remember { mutableStateOf<String?>(null) }
-    var fingerprint by remember { mutableStateOf<String?>(null) }
-    var generateError by remember { mutableStateOf<String?>(null) }
-    var showPasteDialog by remember { mutableStateOf(false) }
-    var pasteInput by remember { mutableStateOf("") }
-
-    LaunchedEffect(Unit) {
-        try {
-            val request = withContext(Dispatchers.IO) { generateJoinRequest() }
-            requestCode = request.code
-            fingerprint = request.fingerprint
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error("Failed to generate join request", e)
-            generateError = e.message ?: context.getString(R.string.onboarding_join_generate_failed)
-        }
-    }
-
     Column(
         modifier = Modifier.fillMaxSize().padding(32.dp).verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         JoinLibraryHeader()
         Spacer(modifier = Modifier.height(24.dp))
-        JoinRequestCode(requestCode = requestCode, fingerprint = fingerprint, generateError = generateError)
-        Spacer(modifier = Modifier.height(32.dp))
-        JoinInviteEntry(
-            error = joinLauncher.error,
-            onScanInvite = onRequestScan,
-            onPasteInvite = {
-                joinLauncher.error = null
-                pasteInput = ""
-                showPasteDialog = true
-            },
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        TextButton(onClick = onBack) { Text(stringResource(R.string.back)) }
-    }
 
-    if (showPasteDialog) {
-        PasteCodeDialog(
-            text =
-                PasteDialogText(
-                    title = stringResource(R.string.onboarding_join_paste_invite),
-                    instructions = stringResource(R.string.onboarding_join_paste_invite_instructions),
-                    placeholder = stringResource(R.string.onboarding_invite_code_placeholder),
-                    confirmLabel = stringResource(R.string.onboarding_join_action),
-                ),
-            pasteInput = pasteInput,
-            onInputChange = { pasteInput = it },
-            onConfirm = { code ->
-                showPasteDialog = false
-                joinLauncher.join(code, oauthLinking, oauthLinkingError)
-            },
-            onDismiss = { showPasteDialog = false },
-        )
+        if (joinLauncher.provider == null) {
+            JoinProviderPicker(
+                onSelect = { joinLauncher.selectProvider(it, oauthLinking, oauthLinkingError) },
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            TextButton(onClick = onBack) { Text(stringResource(R.string.back)) }
+        } else {
+            JoinCodeExchange(
+                joinLauncher = joinLauncher,
+                onRequestScan = onRequestScan,
+                // Back from the code step returns to the provider picker, dropping
+                // the generated code and any captured token.
+                onBack = { joinLauncher.resetProvider() },
+            )
+        }
     }
 }
 
@@ -137,16 +97,96 @@ private fun JoinLibraryHeader() {
     )
 }
 
+/** Step one: pick the cloud provider the target library uses. */
+@Composable
+private fun JoinProviderPicker(onSelect: (BridgeCloudProvider) -> Unit) {
+    Text(
+        text = stringResource(R.string.onboarding_join_pick_provider),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    val buttonWidth = Modifier.width(220.dp)
+    availableCloudProviders().forEach { provider ->
+        Button(onClick = { onSelect(provider) }, modifier = buttonWidth) {
+            Text(cloudProviderLabel(provider))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+/** Step two: show this device's code and take the invite code returned. */
+@Composable
+private fun JoinCodeExchange(
+    joinLauncher: JoinLauncher,
+    onRequestScan: () -> Unit,
+    onBack: () -> Unit,
+) {
+    JoinRequestCode(
+        requestCode = joinLauncher.requestCode,
+        fingerprint = joinLauncher.fingerprint,
+        generateError = joinLauncher.generateError,
+        isAuthorizing = joinLauncher.isAuthorizing,
+    )
+    Spacer(modifier = Modifier.height(32.dp))
+    var showPasteDialog by remember { mutableStateOf(false) }
+    var pasteInput by remember { mutableStateOf("") }
+    JoinInviteEntry(
+        error = joinLauncher.error,
+        onScanInvite = onRequestScan,
+        onPasteInvite = {
+            joinLauncher.error = null
+            pasteInput = ""
+            showPasteDialog = true
+        },
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    TextButton(onClick = onBack) { Text(stringResource(R.string.back)) }
+
+    if (showPasteDialog) {
+        PasteCodeDialog(
+            text =
+                PasteDialogText(
+                    title = stringResource(R.string.onboarding_join_paste_invite),
+                    instructions = stringResource(R.string.onboarding_join_paste_invite_instructions),
+                    placeholder = stringResource(R.string.onboarding_invite_code_placeholder),
+                    confirmLabel = stringResource(R.string.onboarding_join_action),
+                ),
+            pasteInput = pasteInput,
+            onInputChange = { pasteInput = it },
+            onConfirm = { code ->
+                showPasteDialog = false
+                joinLauncher.join(code)
+            },
+            onDismiss = { showPasteDialog = false },
+        )
+    }
+}
+
+/** The display name for a provider in the join picker. */
+@Composable
+private fun cloudProviderLabel(provider: BridgeCloudProvider): String =
+    when (provider) {
+        BridgeCloudProvider.GOOGLE_DRIVE -> stringResource(R.string.cloud_provider_google_drive)
+        BridgeCloudProvider.DROPBOX -> stringResource(R.string.cloud_provider_dropbox)
+        BridgeCloudProvider.ONE_DRIVE -> stringResource(R.string.cloud_provider_onedrive)
+        BridgeCloudProvider.S3 -> stringResource(R.string.cloud_provider_s3)
+        BridgeCloudProvider.CLOUD_KIT -> stringResource(R.string.cloud_provider_icloud)
+    }
+
 /**
  * The join-request code this device shows for approval: a QR plus its copyable
- * text and fingerprint once generated, the generate error if that failed, or a
- * spinner while it's still being generated.
+ * text and fingerprint once generated, the generate error if that failed, a
+ * "signing in" spinner while authenticating with an OAuth provider, or a plain
+ * spinner while the code is still being generated.
  */
 @Composable
 private fun JoinRequestCode(
     requestCode: String?,
     fingerprint: String?,
     generateError: String?,
+    isAuthorizing: Boolean,
 ) {
     val clipboard = LocalClipboardManager.current
     if (requestCode != null) {
@@ -171,6 +211,15 @@ private fun JoinRequestCode(
         }
     } else if (generateError != null) {
         Text(text = generateError, color = MaterialTheme.colorScheme.error)
+    } else if (isAuthorizing) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp))
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.onboarding_join_signing_in),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     } else {
         CircularProgressIndicator()
     }
@@ -203,3 +252,16 @@ private fun JoinInviteEntry(
         Text(text = it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
     }
 }
+
+/** The OAuth providers, for which the joiner authenticates before generating its code. */
+internal fun providerUsesOauth(provider: BridgeCloudProvider): Boolean =
+    when (provider) {
+        BridgeCloudProvider.GOOGLE_DRIVE,
+        BridgeCloudProvider.DROPBOX,
+        BridgeCloudProvider.ONE_DRIVE,
+        -> true
+
+        BridgeCloudProvider.S3,
+        BridgeCloudProvider.CLOUD_KIT,
+        -> false
+    }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/OnboardingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/OnboardingScreen.kt
@@ -99,13 +99,12 @@ private class LinkFlow(
 }
 
 /**
- * One in-progress join attempt: decode the invite code, run OAuth if the
- * library's provider needs it, then join from the code on a background thread.
- * Mirrors [LinkFlow] exactly — the only difference is which bridge code it
- * decodes (an invite code, not a restore code) and that it joins as a new
- * member rather than restoring this device's own library. The blocking
- * `join()` bridge call can't be interrupted by coroutine cancellation, so
- * [cancel] also cancels the operation's own token.
+ * One in-progress join attempt: join from the invite code on a background
+ * thread, using the OAuth token the joiner already obtained when it picked the
+ * provider. Mirrors [LinkFlow], except it joins as a new member rather than
+ * restoring this device's own library. The blocking `join()` bridge call can't
+ * be interrupted by coroutine cancellation, so [cancel] also cancels the
+ * operation's own token.
  */
 private class JoinFlow(
     val job: Job,

--- a/bae-android/app/src/main/java/fm/bae/app/ui/OnboardingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/OnboardingScreen.kt
@@ -59,8 +59,8 @@ import uniffi.bae_bridge.BridgeException
 import uniffi.bae_bridge.BridgeLibrary
 import uniffi.bae_bridge.JoinFromCodeOperation
 import uniffi.bae_bridge.RestoreFromCodeOperation
-import uniffi.bae_bridge.decodeInviteCode
 import uniffi.bae_bridge.decodeRestoreCode
+import uniffi.bae_bridge.generateJoinRequest
 import uniffi.bae_bridge.joinFromCodeOperation
 import uniffi.bae_bridge.restoreFromCodeOperation
 
@@ -114,18 +114,11 @@ private class JoinFlow(
 
     suspend fun execute(
         code: String,
-        oauthLinking: OAuthLinker?,
-        oauthLinkingError: String?,
-        context: Context,
+        oauthTokenJson: String?,
         onJoined: (BridgeLibrary) -> Unit,
     ) {
-        val info = decodeInviteCode(code)
-        val oauthTokenJson =
-            if (info.needsOauth) {
-                resolveOauthToken(oauthLinking, oauthLinkingError, context, info.cloudProvider)
-            } else {
-                null
-            }
+        // OAuth (and the account-email fetch) already ran when the provider was
+        // picked; the token captured then is reused here — no second sign-in.
         val operation = joinFromCodeOperation(code = code, oauthTokenJson = oauthTokenJson)
         joinOperation = operation
         val libraryInfo = withContext(Dispatchers.IO) { operation.join() }
@@ -203,9 +196,12 @@ private class LinkLauncher(
 }
 
 /**
- * The join twin of [LinkLauncher]: holds the in-progress join attempt and its
- * UI state. Identical attempt/supersede/cleanup discipline; it drives a
- * [JoinFlow] instead of a [LinkFlow].
+ * The join twin of [LinkLauncher], plus the up-front provider step joining needs.
+ * The joiner first picks the target library's provider ([selectProvider]); for an
+ * OAuth provider that authenticates and fetches the account email, then generates
+ * this device's join-request with the email baked in. The captured token is held
+ * and reused by [join] — no second sign-in. Same attempt/supersede/cleanup
+ * discipline as [LinkLauncher] for the join itself.
  */
 class JoinLauncher(
     private val scope: CoroutineScope,
@@ -216,18 +212,98 @@ class JoinLauncher(
     private var flow by mutableStateOf<JoinFlow?>(null)
     val isJoining: Boolean get() = flow != null
 
-    fun join(
-        code: String,
+    // Provider-prep state, read by JoinLibraryScreen.
+    var provider by mutableStateOf<BridgeCloudProvider?>(null)
+        private set
+    var requestCode by mutableStateOf<String?>(null)
+        private set
+    var fingerprint by mutableStateOf<String?>(null)
+        private set
+    var generateError by mutableStateOf<String?>(null)
+        private set
+    var isAuthorizing by mutableStateOf(false)
+        private set
+
+    // The token/email captured at provider selection: the token is reused for
+    // the join, the email is baked into the generated code.
+    private var oauthTokenJson: String? = null
+    private var prepJob: Job? = null
+
+    /**
+     * Pick the provider the target library uses and prepare this device's
+     * join-request. For an OAuth provider this authenticates and fetches the
+     * account email up front; for S3/iCloud it generates the code with no email.
+     */
+    fun selectProvider(
+        provider: BridgeCloudProvider,
         oauthLinking: OAuthLinker?,
         oauthLinkingError: String?,
     ) {
+        prepJob?.cancel()
+        error = null
+        generateError = null
+        oauthTokenJson = null
+        requestCode = null
+        fingerprint = null
+        this.provider = provider
+        prepJob =
+            scope.launch {
+                try {
+                    var email: String? = null
+                    if (providerUsesOauth(provider)) {
+                        isAuthorizing = true
+                        val oauthError =
+                            oauthLinkingError
+                                ?: if (oauthLinking == null) {
+                                    context.getString(R.string.onboarding_oauth_unconfigured)
+                                } else {
+                                    null
+                                }
+                        if (oauthError != null) {
+                            generateError = oauthError
+                            isAuthorizing = false
+                            return@launch
+                        }
+                        val token = oauthLinking!!.authorize(context, provider)
+                        email = oauthLinking.fetchAccountEmail(provider, token)
+                        oauthTokenJson = token
+                        isAuthorizing = false
+                    }
+                    val request = withContext(Dispatchers.IO) { generateJoinRequest(email) }
+                    requestCode = request.code
+                    fingerprint = request.fingerprint
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.error("Failed to prepare join request", e)
+                    isAuthorizing = false
+                    generateError = e.message ?: context.getString(R.string.onboarding_join_generate_failed)
+                }
+            }
+    }
+
+    /** Return to the provider picker, dropping the generated code and token. */
+    fun resetProvider() {
+        prepJob?.cancel()
+        provider = null
+        requestCode = null
+        fingerprint = null
+        generateError = null
+        isAuthorizing = false
+        oauthTokenJson = null
+        error = null
+    }
+
+    fun join(code: String) {
+        // Reuse the token captured at provider selection — no second OAuth.
+        val oauthTokenJson = this.oauthTokenJson
         error = null
         flow?.cancel()
         lateinit var started: JoinFlow
         val launched =
             scope.launch(start = CoroutineStart.LAZY) {
                 try {
-                    started.execute(code, oauthLinking, oauthLinkingError, context, onJoined)
+                    started.execute(code, oauthTokenJson, onJoined)
                 } catch (e: BridgeException.Cancelled) {
                     logger.debug("join flow cancelled by bridge", e)
                 } catch (e: CancellationException) {
@@ -357,7 +433,7 @@ fun OnboardingScreen(
                     scanTarget = null
                     when (target) {
                         ScanTarget.RESTORE_CODE -> launcher.link(code, oauthLinking, oauthLinkingError)
-                        ScanTarget.INVITE_CODE -> joinLauncher.join(code, oauthLinking, oauthLinkingError)
+                        ScanTarget.INVITE_CODE -> joinLauncher.join(code)
                     }
                 },
                 onDismiss = { scanTarget = null },
@@ -379,7 +455,7 @@ fun OnboardingScreen(
                 oauthLinkingError = oauthLinkingError,
                 onRequestScan = { onRequestScan(ScanTarget.INVITE_CODE) },
                 onBack = {
-                    joinLauncher.error = null
+                    joinLauncher.resetProvider()
                     showJoin = false
                 },
             )

--- a/bae-android/app/src/main/res/values/strings.xml
+++ b/bae-android/app/src/main/res/values/strings.xml
@@ -159,6 +159,14 @@
 
     <!-- Onboarding: join a library -->
     <string name="onboarding_join_title">Join a library</string>
+    <string name="onboarding_join_pick_provider">Choose the cloud provider the library you\'re joining uses.</string>
+    <string name="onboarding_join_signing_in">Signing in…</string>
+    <!-- Cloud provider names for the join provider picker -->
+    <string name="cloud_provider_google_drive">Google Drive</string>
+    <string name="cloud_provider_dropbox">Dropbox</string>
+    <string name="cloud_provider_onedrive">OneDrive</string>
+    <string name="cloud_provider_s3">S3-compatible</string>
+    <string name="cloud_provider_icloud">iCloud</string>
     <string name="onboarding_join_instructions">Show this code to one of your other devices and approve it there from Settings → Devices.</string>
     <string name="onboarding_join_code_description">This device\'s join code</string>
     <!-- %1$s = this device's fingerprint -->

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -412,13 +412,36 @@ impl RestoreFromCodeOperation {
 /// hand to an existing member for approval. Safe to call before any library
 /// exists on this device (the joining device has no library yet); it only needs
 /// the keyring initialized.
+///
+/// `email` is the OAuth account address the joiner authenticated as, baked into
+/// the code so the approver can share the OAuth folder to it; `None` for S3. The
+/// caller runs the OAuth flow and `fetch_account_email` first, then passes the
+/// result here.
 #[uniffi::export]
-pub fn generate_join_request() -> Result<BridgeJoinRequest, BridgeError> {
-    let request = bae_core::sync::sync_manager::generate_join_request(None)
+pub fn generate_join_request(email: Option<String>) -> Result<BridgeJoinRequest, BridgeError> {
+    let request = bae_core::sync::sync_manager::generate_join_request(email)
         .map_err(|e| BridgeError::config(format!("Failed to generate join request: {e}")))?;
     Ok(BridgeJoinRequest {
         code: request.code,
         fingerprint: request.fingerprint,
+    })
+}
+
+/// Fetch the email of the OAuth account `oauth_token_json` authenticated, so the
+/// joiner can bake it into its join-request. The caller runs `oauth_authorize`
+/// (or `oauth_begin`/`oauth_complete`) first and passes the resulting token JSON.
+#[cfg(feature = "oauth-providers")]
+#[uniffi::export]
+pub fn fetch_account_email(
+    provider: BridgeCloudProvider,
+    oauth_token_json: String,
+) -> Result<String, BridgeError> {
+    let tokens = parse_oauth_tokens(&oauth_token_json)?;
+    let core_provider = bridge_cloud_provider_to_core(provider);
+    on_worker(move || async move {
+        bae_core::sync::sync_manager::fetch_account_email(core_provider, &tokens)
+            .await
+            .map_err(|e| BridgeError::config(format!("Failed to fetch account email: {e}")))
     })
 }
 

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -414,7 +414,7 @@ impl RestoreFromCodeOperation {
 /// the keyring initialized.
 #[uniffi::export]
 pub fn generate_join_request() -> Result<BridgeJoinRequest, BridgeError> {
-    let request = bae_core::sync::sync_manager::generate_join_request()
+    let request = bae_core::sync::sync_manager::generate_join_request(None)
         .map_err(|e| BridgeError::config(format!("Failed to generate join request: {e}")))?;
     Ok(BridgeJoinRequest {
         code: request.code,

--- a/bae-core/src/sync/sync_manager.rs
+++ b/bae-core/src/sync/sync_manager.rs
@@ -71,13 +71,28 @@ pub struct JoinRequest {
 
 /// Generate this device's join-request code and the fingerprint of the public
 /// key it carries. Creates this device's keypair if one doesn't exist yet.
-pub fn generate_join_request() -> Result<JoinRequest, crate::keys::KeyError> {
-    let code = coven::generate_join_request(None)?;
+///
+/// `email` is the OAuth account address the joiner authenticated as, baked into
+/// the code so the approver can share the OAuth folder to it; `None` for S3,
+/// which shares no folder to an email.
+pub fn generate_join_request(email: Option<String>) -> Result<JoinRequest, crate::keys::KeyError> {
+    let code = coven::generate_join_request(email)?;
     let pubkey = coven::decode_join_request(&code)
         .expect("a code this device just encoded decodes")
         .public_key;
     let fingerprint = pubkey_fingerprint(&pubkey);
     Ok(JoinRequest { code, fingerprint })
+}
+
+/// Fetch the email of the OAuth account `oauth_tokens` authenticated, so the
+/// joiner can bake it into its join-request. A thin pass-through to coven, which
+/// dispatches per provider and rejects non-OAuth providers.
+#[cfg(feature = "oauth-providers")]
+pub async fn fetch_account_email(
+    provider: crate::config::CloudProvider,
+    oauth_tokens: &coven::OAuthTokens,
+) -> Result<String, coven::oauth::OAuthError> {
+    coven::fetch_account_email(provider, oauth_tokens).await
 }
 
 /// A decoded join-request code: the joining device's public key, its
@@ -133,4 +148,29 @@ pub struct S3ConfigData {
     pub secret_key: String,
     /// Opaque (encrypted, obfuscated) or browsable (plaintext, readable) home.
     pub storage: crate::config::HomeStorage,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The email the joiner authenticated as is baked into the join-request code
+    /// and comes back out when the approver decodes it — the wire that carries an
+    /// OAuth account address across device pairing.
+    #[test]
+    fn join_request_round_trips_the_email() {
+        crate::config::install_test_keyring();
+
+        let with_email = generate_join_request(Some("joiner@example.com".to_string())).unwrap();
+        let decoded = decode_join_request(&with_email.code).unwrap();
+        assert_eq!(decoded.email.as_deref(), Some("joiner@example.com"));
+        assert_eq!(decoded.fingerprint, with_email.fingerprint);
+
+        // S3 carries no email; the code decodes with `None`, not an empty string.
+        let without_email = generate_join_request(None).unwrap();
+        assert_eq!(
+            decode_join_request(&without_email.code).unwrap().email,
+            None
+        );
+    }
 }

--- a/bae-ios/bae/bae/Localizable.xcstrings
+++ b/bae-ios/bae/bae/Localizable.xcstrings
@@ -17875,6 +17875,39 @@
           }
         }
       }
+    },
+    "Choose the cloud provider the library you're joining uses.": {
+      "comment": "Join flow: provider picker prompt shown before generating this device's join code",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the cloud provider the library you're joining uses."
+          }
+        }
+      }
+    },
+    "Signing in...": {
+      "comment": "Join flow: authenticating with the chosen OAuth provider before generating the join code",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signing in..."
+          }
+        }
+      }
+    },
+    "This library needs a signed-in provider. Go back and choose the provider it uses.": {
+      "comment": "Join flow: the picked provider does not match the library's OAuth provider",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This library needs a signed-in provider. Go back and choose the provider it uses."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-ios/bae/bae/Views/OnboardingView.swift
+++ b/bae-ios/bae/bae/Views/OnboardingView.swift
@@ -65,9 +65,31 @@ struct OnboardingView: View {
     private var pasteInput = ""
 
     // Join-a-library flow
+    /// The cloud provider the joiner picked for the library it's adding this
+    /// device to. `nil` until picked — while `nil` the join flow shows the
+    /// provider picker and no code is generated yet. Picking an OAuth provider
+    /// authenticates up front so the account email lands in the join-request;
+    /// picking S3/iCloud generates the code with no email.
+    @State
+    private var joinProvider: BridgeCloudProvider?
+    /// The OAuth token captured up front for the picked provider, held so the
+    /// eventual join reuses it instead of authenticating a second time. `nil`
+    /// for S3/iCloud.
+    @State
+    private var joinTokenJson: String?
+    /// The account email fetched from the picked OAuth provider, baked into the
+    /// join-request so the approver shares the OAuth folder to it. `nil` for
+    /// S3/iCloud. Held so a code retry reuses it without re-authenticating.
+    @State
+    private var joinEmail: String?
+    /// True while authenticating with the picked OAuth provider before the code
+    /// is generated.
+    @State
+    private var isAuthorizing = false
     /// This device's join-request code and a short fingerprint of its public
-    /// key, generated on appear and shown for an existing member to scan or
-    /// paste. `nil` while generating; `.failure` if generation fails.
+    /// key, generated once a provider is picked (and, for OAuth, authenticated)
+    /// and shown for an existing member to scan or paste. `nil` while generating;
+    /// `.failure` if generation fails.
     @State
     private var joinRequest: Result<BridgeJoinRequest, Error>?
     @State
@@ -302,19 +324,12 @@ struct OnboardingView: View {
 extension OnboardingView {
     fileprivate var joinView: some View {
         NavigationStack {
-            List {
-                Section("This device's code") {
-                    joinRequestRow
+            Group {
+                if joinProvider == nil {
+                    joinProviderPicker
                 }
-                Section("Invite code") {
-                    inviteCodeRow
-                }
-                if let error {
-                    Section {
-                        Text(error)
-                            .foregroundStyle(.red)
-                            .font(.callout)
-                    }
+                else {
+                    joinCodeExchange
                 }
             }
             .navigationTitle("Join a library")
@@ -322,21 +337,97 @@ extension OnboardingView {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Back") {
-                        mode = .entry
+                        if joinProvider == nil {
+                            mode = .entry
+                        }
+                        else {
+                            // Return to the provider picker; drop the generated
+                            // code and any OAuth token so re-picking starts clean.
+                            joinProvider = nil
+                            joinRequest = nil
+                            joinTokenJson = nil
+                            joinEmail = nil
+                            inviteCodeInput = ""
+                            decodedInvite = nil
+                        }
                         error = nil
                     }
+                    .disabled(isAuthorizing)
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Join") { join() }
-                        .disabled(!joinReady)
+                if joinProvider != nil {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Join") { join() }
+                            .disabled(!joinReady)
+                    }
                 }
             }
         }
-        // Entering the join flow: clear any prior decode/error, then generate
-        // this device's code.
+        // Entering the join flow fresh: clear any prior provider/token/decode so
+        // nothing leaks across attempts. The code is generated only once the
+        // joiner picks a provider.
         .task {
+            joinProvider = nil
+            joinTokenJson = nil
+            joinEmail = nil
+            joinRequest = nil
             error = nil
-            await generateJoinCode()
+        }
+    }
+
+    /// Step one of the join flow: pick the cloud provider the target library
+    /// uses. For an OAuth provider this authenticates up front so the account
+    /// email is baked into the join-request; for S3/iCloud it goes straight to
+    /// generating a code with no email.
+    fileprivate var joinProviderPicker: some View {
+        List {
+            Section {
+                if isAuthorizing {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                        Text("Signing in...")
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                else {
+                    ForEach(availableCloudProviders(), id: \.self) { provider in
+                        Button(provider.displayName) {
+                            selectJoinProvider(provider)
+                        }
+                    }
+                }
+            } header: {
+                Text("Choose the cloud provider the library you're joining uses.")
+            }
+            if let error {
+                Section {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
+            }
+        }
+    }
+
+    /// Step two of the join flow: show this device's code and take the invite
+    /// code the approving device hands back. Reached only after a provider is
+    /// picked, so the code is already generated (with the account email for an
+    /// OAuth provider).
+    fileprivate var joinCodeExchange: some View {
+        List {
+            Section("This device's code") {
+                joinRequestRow
+            }
+            Section("Invite code") {
+                inviteCodeRow
+            }
+            if let error {
+                Section {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
+            }
         }
     }
 
@@ -422,7 +513,18 @@ extension OnboardingView {
                 "Owner",
                 value: info.ownerFingerprint
             )
-            #if !BAE_OAUTH_PROVIDERS
+            #if BAE_OAUTH_PROVIDERS
+            // OAuth is done up front at provider selection, so a token is
+            // already held. A missing token here means the joiner picked a
+            // provider that doesn't match this library — send them back.
+            if info.needsOauth && joinTokenJson == nil {
+                Text(
+                    "This library needs a signed-in provider. Go back and choose the provider it uses."
+                )
+                .foregroundStyle(.red)
+                .font(.callout)
+            }
+            #else
             if info.needsOauth {
                 Text(
                     "This library uses a provider this build can't connect to."
@@ -439,13 +541,17 @@ extension OnboardingView {
         }
     }
 
-    /// Whether the Join button should be enabled: a valid invite code that this
-    /// build can connect to. OAuth, when needed, runs as part of the join.
+    /// Whether the Join button should be enabled: a valid invite code, plus the
+    /// up-front OAuth token held when the picked provider needs it.
     fileprivate var joinReady: Bool {
         guard case .success(let info) = decodedInvite else {
             return false
         }
-        #if !BAE_OAUTH_PROVIDERS
+        #if BAE_OAUTH_PROVIDERS
+        if info.needsOauth {
+            return joinTokenJson != nil
+        }
+        #else
         if info.needsOauth {
             return false
         }
@@ -453,12 +559,77 @@ extension OnboardingView {
         return true
     }
 
+    /// Pick the provider the target library uses. For an OAuth provider this
+    /// authenticates and fetches the account email up front (baked into the
+    /// generated code and reused for the eventual join); for S3/iCloud it goes
+    /// straight to generating a code with no email.
+    private func selectJoinProvider(_ provider: BridgeCloudProvider) {
+        genTask?.cancel()
+        error = nil
+        joinTokenJson = nil
+        joinEmail = nil
+        genTask = Task { await prepareJoin(provider: provider) }
+    }
+
+    private func prepareJoin(provider: BridgeCloudProvider) async {
+        #if BAE_OAUTH_PROVIDERS
+        switch provider {
+        case .googleDrive, .dropbox, .oneDrive:
+            isAuthorizing = true
+            do {
+                guard let token = try await oauthToken(provider: provider)
+                else {
+                    // Cancelled, or unavailable with `error` already set.
+                    isAuthorizing = false
+                    return
+                }
+                let email = try await fetchAccountEmailDetached(
+                    provider: provider,
+                    tokenJson: token
+                )
+                joinTokenJson = token
+                joinEmail = email
+            }
+            catch {
+                isAuthorizing = false
+                if !isLinkCancellation(error) {
+                    self.error = error.localizedDescription
+                }
+                return
+            }
+            isAuthorizing = false
+        default:
+            break
+        }
+        #endif
+        joinProvider = provider
+        await generateJoinCode()
+    }
+
+    #if BAE_OAUTH_PROVIDERS
+    /// Turn the OAuth token into the account email off the main thread — the
+    /// bridge call is synchronous and hits the network.
+    private func fetchAccountEmailDetached(
+        provider: BridgeCloudProvider,
+        tokenJson: String
+    ) async throws -> String {
+        try await Task.detached {
+            try fetchAccountEmail(
+                provider: provider,
+                oauthTokenJson: tokenJson
+            )
+        }
+        .value
+    }
+    #endif
+
     private func generateJoinCode() async {
         joinRequest = nil
+        let email = joinEmail
         do {
             let generated = try await withTaskCancellationHandler {
                 let detached = Task.detached { () throws -> BridgeJoinRequest in
-                    try generateJoinRequest()
+                    try generateJoinRequest(email: email)
                 }
                 return try await detached.value
             } onCancel: {
@@ -486,13 +657,16 @@ extension OnboardingView {
     /// in-flight one through the operation's own token, so the bridge stops its
     /// blocking work rather than running to completion on a stale library.
     func join() {
-        guard case .success(let info) = decodedInvite else {
+        guard case .success = decodedInvite else {
             logger.warning("join tapped without a decoded invite code")
             return
         }
         let code = inviteCodeInput.trimmingCharacters(
             in: .whitespacesAndNewlines
         )
+        // Reuse the token captured when the provider was picked — no second
+        // OAuth at join time.
+        let tokenJson = joinTokenJson
         error = nil
         cancelLink()
         let flow = LinkFlow { flow in
@@ -502,7 +676,7 @@ extension OnboardingView {
                         linkFlow = nil
                     }
                 }
-                await performJoin(code: code, info: info, flow: flow)
+                await performJoin(code: code, tokenJson: tokenJson, flow: flow)
             }
         }
         linkFlow = flow
@@ -511,25 +685,10 @@ extension OnboardingView {
 
     private func performJoin(
         code: String,
-        info: BridgeInviteCodeInfo,
+        tokenJson: String?,
         flow: LinkFlow
     ) async {
         do {
-            let tokenJson: String?
-            if info.needsOauth {
-                guard
-                    let token = try await oauthToken(
-                        provider: info.cloudProvider
-                    )
-                else {
-                    logger.debug("join cancelled at cloud sign-in")
-                    return
-                }
-                tokenJson = token
-            }
-            else {
-                tokenJson = nil
-            }
             try await runJoin(code: code, tokenJson: tokenJson, flow: flow)
         }
         catch {

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -86659,6 +86659,39 @@
           }
         }
       }
+    },
+    "Choose the cloud provider the library you're joining uses.": {
+      "comment": "Join flow: provider picker prompt shown before generating this device's join code",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the cloud provider the library you're joining uses."
+          }
+        }
+      }
+    },
+    "Signing in...": {
+      "comment": "Join flow: authenticating with the chosen OAuth provider before generating the join code",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signing in..."
+          }
+        }
+      }
+    },
+    "This library needs a signed-in provider. Go back and choose the provider it uses.": {
+      "comment": "Join flow: the picked provider does not match the library's OAuth provider",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This library needs a signed-in provider. Go back and choose the provider it uses."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-macos/bae/bae/Views/WelcomeView.swift
+++ b/bae-macos/bae/bae/Views/WelcomeView.swift
@@ -59,13 +59,28 @@ struct WelcomeView: View {
     private var showManualForm = false
 
     // Join-a-library flow
+    /// The cloud provider the joiner picked for the library they're adding this
+    /// device to. `nil` until picked — while `nil` the join flow shows the
+    /// provider picker and no code is generated yet. Picking an OAuth provider
+    /// authenticates up front so the account email lands in the join-request;
+    /// picking S3/iCloud generates the code with no email.
+    @State
+    private var joinProvider: BridgeCloudProvider?
     /// This device's join-request code and a short fingerprint of its public
-    /// key, generated on appear and shown for an existing member to scan or
-    /// paste. `nil` while generating; `.failure` if generation fails.
+    /// key, generated once a provider is picked (and, for OAuth, authenticated)
+    /// and shown for an existing member to scan or paste. `nil` while generating;
+    /// `.failure` if generation fails.
     @State
     private var joinRequest: Result<BridgeJoinRequest, Error>?
-    /// The in-flight (re)generation of this device's join code, owned so a retry
-    /// supersedes the previous attempt and the view's disappear cancels it.
+    /// The account email fetched from the picked OAuth provider, baked into the
+    /// join-request so the approver shares the OAuth folder to it. `nil` for
+    /// S3/iCloud, which share no folder. Held so a code retry reuses it without
+    /// re-authenticating.
+    @State
+    private var joinEmail: String?
+    /// The in-flight provider-prepare / (re)generation of this device's join
+    /// code, owned so a retry supersedes the previous attempt and the view's
+    /// disappear cancels it.
     @State
     private var genTask: Task<Void, Never>?
     @State
@@ -889,6 +904,108 @@ extension WelcomeView {
             .foregroundStyle(.secondary)
             .padding(.bottom, 16)
 
+            if joinProvider == nil {
+                joinProviderPicker
+            }
+            else {
+                joinCodeExchange
+            }
+        }
+        .padding(.horizontal)
+        // Entering the join flow fresh: clear any provider/token connected in
+        // another mode (or a prior join attempt) so nothing leaks across flows.
+        // The code is generated only once the joiner picks a provider.
+        .task {
+            joinProvider = nil
+            oauthTokenJson = nil
+            joinRequest = nil
+            error = nil
+        }
+        .onDisappear {
+            genTask?.cancel()
+            joinTask?.cancel()
+        }
+        .sheet(isPresented: $showInviteScanner) {
+            InviteScannerSheet(
+                onScan: { code in
+                    inviteCodeInput = code
+                    showInviteScanner = false
+                },
+                onDismiss: { showInviteScanner = false },
+            )
+        }
+    }
+
+    /// Step one of the join flow: pick the cloud provider the target library
+    /// uses. For an OAuth provider this authenticates up front so the account
+    /// email is baked into the join-request; for S3/iCloud it generates the code
+    /// with no email. The picker offers the providers this build supports.
+    private var joinProviderPicker: some View {
+        VStack(spacing: 0) {
+            Text(
+                "Choose the cloud provider the library you're joining uses."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .padding(.bottom, 16)
+
+            if isAuthorizing {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Signing in...")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Button("Cancel") {
+                        #if BAE_OAUTH_PROVIDERS
+                            oauthCancel()
+                        #endif
+                        genTask?.cancel()
+                        isAuthorizing = false
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.callout)
+                }
+                .padding(.bottom, 12)
+            }
+            else {
+                VStack(spacing: 8) {
+                    ForEach(availableCloudProviders(), id: \.self) { provider in
+                        Button(provider.displayName) {
+                            selectJoinProvider(provider)
+                        }
+                        .buttonStyle(.bordered)
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding(.bottom, 8)
+            }
+
+            if let error {
+                Text(error)
+                    .foregroundStyle(.red)
+                    .font(.callout)
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+            }
+
+            Button("Back") {
+                mode = .choose
+                error = nil
+            }
+            .buttonStyle(.bordered)
+            .disabled(isAuthorizing)
+            .padding(.bottom, 24)
+        }
+    }
+
+    /// Step two of the join flow: show this device's code and take the invite
+    /// code the approving device hands back. Reached only after a provider is
+    /// picked, so the code is already generated (with the account email for an
+    /// OAuth provider).
+    private var joinCodeExchange: some View {
+        VStack(spacing: 0) {
             Form {
                 Section("This device's code") {
                     joinRequestRow
@@ -919,7 +1036,13 @@ extension WelcomeView {
             }
             HStack(spacing: 12) {
                 Button("Back") {
-                    mode = .choose
+                    // Return to the provider picker; drop the generated code and
+                    // any OAuth token so re-picking starts clean.
+                    joinProvider = nil
+                    joinRequest = nil
+                    oauthTokenJson = nil
+                    inviteCodeInput = ""
+                    decodedInvite = nil
                     error = nil
                 }
                 .buttonStyle(.bordered)
@@ -930,27 +1053,6 @@ extension WelcomeView {
                     .keyboardShortcut(.defaultAction)
             }
             .padding(.bottom, 24)
-        }
-        .padding(.horizontal)
-        // Entering the join flow fresh: clear any OAuth token connected in
-        // another mode so it can't leak across flows, then generate the code.
-        .task {
-            oauthTokenJson = nil
-            error = nil
-            await generateJoinCode()
-        }
-        .onDisappear {
-            genTask?.cancel()
-            joinTask?.cancel()
-        }
-        .sheet(isPresented: $showInviteScanner) {
-            InviteScannerSheet(
-                onScan: { code in
-                    inviteCodeInput = code
-                    showInviteScanner = false
-                },
-                onDismiss: { showInviteScanner = false },
-            )
         }
     }
 
@@ -1024,7 +1126,6 @@ extension WelcomeView {
             Button("Scan") { showInviteScanner = true }
         }
         .onChange(of: inviteCodeInput) { _, newInput in
-            oauthTokenJson = nil
             let trimmed = newInput.trimmingCharacters(in: .whitespaces)
             decodedInvite =
                 trimmed.isEmpty
@@ -1043,8 +1144,15 @@ extension WelcomeView {
                 value: info.ownerFingerprint
             )
             #if BAE_OAUTH_PROVIDERS
-                if info.needsOauth {
-                    inviteOauthRow(provider: info.cloudProvider)
+                // OAuth is done up front at provider selection, so a token is
+                // already held. A missing token here means the joiner picked a
+                // provider that doesn't match this library — send them back.
+                if info.needsOauth && oauthTokenJson == nil {
+                    Text(
+                        "This library needs a signed-in provider. Go back and choose the provider it uses."
+                    )
+                    .foregroundStyle(.red)
+                    .font(.callout)
                 }
             #else
                 if info.needsOauth {
@@ -1063,40 +1171,8 @@ extension WelcomeView {
         }
     }
 
-    #if BAE_OAUTH_PROVIDERS
-        private func inviteOauthRow(
-            provider: BridgeCloudProvider
-        ) -> some View {
-            HStack {
-                if oauthTokenJson != nil {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text("Connected")
-                        .foregroundStyle(.secondary)
-                }
-                else if isAuthorizing {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Authorizing...")
-                        .foregroundStyle(.secondary)
-                    Button("Cancel") {
-                        oauthCancel()
-                        isAuthorizing = false
-                    }
-                    .buttonStyle(.borderless)
-                    .font(.callout)
-                }
-                else {
-                    Button("Connect \(provider.displayName)") {
-                        doOAuthAuthorize(provider: provider)
-                    }
-                }
-            }
-        }
-    #endif
-
-    /// Whether the Join button should be enabled: a valid invite code, plus
-    /// OAuth done if the provider needs it.
+    /// Whether the Join button should be enabled: a valid invite code, plus the
+    /// up-front OAuth token held when the picked provider needs it.
     private var joinReady: Bool {
         guard case .success(let info) = decodedInvite else {
             return false
@@ -1107,11 +1183,60 @@ extension WelcomeView {
         return true
     }
 
+    /// Pick the provider the target library uses. For an OAuth provider this
+    /// authenticates and fetches the account email up front (baked into the
+    /// generated code and reused for the eventual join); for S3/iCloud it goes
+    /// straight to generating a code with no email.
+    private func selectJoinProvider(_ provider: BridgeCloudProvider) {
+        genTask?.cancel()
+        error = nil
+        oauthTokenJson = nil
+        joinEmail = nil
+        genTask = Task { await prepareJoin(provider: provider) }
+    }
+
+    private func prepareJoin(provider: BridgeCloudProvider) async {
+        #if BAE_OAUTH_PROVIDERS
+            switch provider {
+            case .googleDrive, .dropbox, .oneDrive:
+                isAuthorizing = true
+                do {
+                    let tokenJson = try await DetachedWork.run {
+                        try oauthAuthorize(provider: provider)
+                    }
+                    let email = try await DetachedWork.run {
+                        try fetchAccountEmail(
+                            provider: provider,
+                            oauthTokenJson: tokenJson
+                        )
+                    }
+                    isAuthorizing = false
+                    oauthTokenJson = tokenJson
+                    joinEmail = email
+                }
+                catch is CancellationError {
+                    isAuthorizing = false
+                    return
+                }
+                catch {
+                    isAuthorizing = false
+                    self.error = error.localizedDescription
+                    return
+                }
+            default:
+                break
+            }
+        #endif
+        joinProvider = provider
+        await generateJoinCode()
+    }
+
     private func generateJoinCode() async {
         joinRequest = nil
+        let email = joinEmail
         do {
             let generated = try await DetachedWork.run {
-                try generateJoinRequest(email: nil)
+                try generateJoinRequest(email: email)
             }
             joinRequest = .success(generated)
         }

--- a/bae-macos/bae/bae/Views/WelcomeView.swift
+++ b/bae-macos/bae/bae/Views/WelcomeView.swift
@@ -1111,7 +1111,7 @@ extension WelcomeView {
         joinRequest = nil
         do {
             let generated = try await DetachedWork.run {
-                try generateJoinRequest()
+                try generateJoinRequest(email: nil)
             }
             joinRequest = .success(generated)
         }

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -1055,6 +1055,73 @@ pub unsafe extern "C" fn bae_oauth_authorize(provider: *const c_char) -> *mut c_
     json_cstring(&out)
 }
 
+/// The account email fetched for an OAuth provider, or the reason it failed.
+#[cfg(feature = "oauth-providers")]
+#[derive(Serialize)]
+struct FfiAccountEmailResult {
+    email: Option<String>,
+    error: Option<String>,
+}
+
+/// The email of the OAuth account `oauth_token_json` authenticated, so the joiner
+/// can bake it into its join-request via `bae_generate_join_request`. The caller
+/// runs [`bae_oauth_authorize`] first and passes the resulting token JSON.
+/// Returns `{email, error}` as JSON. No handle — runs before [`bae_init`]. Free
+/// with [`bae_string_free`].
+///
+/// # Safety
+/// `provider` and `oauth_token_json` must be valid NUL-terminated UTF-8 C strings.
+#[cfg(feature = "oauth-providers")]
+#[no_mangle]
+pub unsafe extern "C" fn bae_fetch_account_email(
+    provider: *const c_char,
+    oauth_token_json: *const c_char,
+) -> *mut c_char {
+    let Some(provider) = cstr(provider).and_then(|p| oauth_provider_from_str(&p)) else {
+        return json_cstring(&FfiAccountEmailResult {
+            email: None,
+            error: Some("unknown or unsupported provider".to_string()),
+        });
+    };
+    let tokens = match cstr(oauth_token_json)
+        .ok_or_else(|| "oauth token json is null or not valid UTF-8".to_string())
+        .and_then(|json| {
+            serde_json::from_str::<coven::OAuthTokens>(&json)
+                .map_err(|e| format!("invalid oauth token json: {e}"))
+        }) {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            return json_cstring(&FfiAccountEmailResult {
+                email: None,
+                error: Some(e),
+            })
+        }
+    };
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("bae_fetch_account_email: runtime: {e}");
+            return json_cstring(&FfiAccountEmailResult {
+                email: None,
+                error: Some("couldn't start the sign-in runtime".to_string()),
+            });
+        }
+    };
+    let out = match runtime.block_on(bae_core::sync::sync_manager::fetch_account_email(
+        provider, &tokens,
+    )) {
+        Ok(email) => FfiAccountEmailResult {
+            email: Some(email),
+            error: None,
+        },
+        Err(e) => FfiAccountEmailResult {
+            email: None,
+            error: Some(e.to_string()),
+        },
+    };
+    json_cstring(&out)
+}
+
 /// Restore a library from a restore code. For OAuth providers (Google Drive,
 /// Dropbox, OneDrive) the caller first runs `bae_oauth_authorize` and passes
 /// the resulting token JSON as `oauth_token_json`; for credential providers it
@@ -1122,9 +1189,16 @@ pub unsafe extern "C" fn bae_restore_from_code(
 /// string, or null on error (logged). The joining device has no library yet, so
 /// this needs no handle; it only requires the keyring initialized
 /// ([`bae_startup`]). Free with [`bae_string_free`].
+///
+/// `email` is the OAuth account address the joiner authenticated as (from
+/// `bae_fetch_account_email`), baked into the code so the approver can share
+/// the OAuth folder to it; pass null/empty for S3, which shares no folder.
+///
+/// # Safety
+/// `email`, if non-null, must be a valid NUL-terminated UTF-8 C string.
 #[no_mangle]
-pub extern "C" fn bae_generate_join_request() -> *mut c_char {
-    match bae_core::sync::sync_manager::generate_join_request() {
+pub unsafe extern "C" fn bae_generate_join_request(email: *const c_char) -> *mut c_char {
+    match bae_core::sync::sync_manager::generate_join_request(opt_cstr(email)) {
         Ok(request) => json_cstring(&FfiJoinRequest {
             code: request.code,
             fingerprint: request.fingerprint,

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -130,6 +130,19 @@ internal static class NativeBae
     internal static string? CloudProviderLabelKey(string? provider) =>
         CopyAndFree(CloudProviderLabelKeyPtr(provider));
 
+    [DllImport(Dll, EntryPoint = "bae_fetch_account_email", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr FetchAccountEmailPtr(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string provider,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string oauthTokenJson);
+
+    /// <summary>
+    /// The joiner's account email for an OAuth provider, fetched from its
+    /// authenticated session, as JSON (<c>{email, error}</c>), or null on error.
+    /// <paramref name="provider"/> is the wire tag ("google_drive"/…). Copies and frees.
+    /// </summary>
+    internal static string? FetchAccountEmail(string provider, string oauthTokenJson) =>
+        CopyAndFree(FetchAccountEmailPtr(provider, oauthTokenJson));
+
     [DllImport(Dll, EntryPoint = "bae_audio_channels_key", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr AudioChannelsKeyPtr(long channels);
 

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -234,7 +234,8 @@ internal static class NativeBae
         CopyAndFree(RestoreFromCodePtr(code, oauthTokenJson));
 
     [DllImport(Dll, EntryPoint = "bae_generate_join_request", CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr GenerateJoinRequestPtr();
+    private static extern IntPtr GenerateJoinRequestPtr(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? email);
 
     /// <summary>
     /// This device's join-request code and the fingerprint it encodes, as JSON
@@ -242,7 +243,11 @@ internal static class NativeBae
     /// or null on error. The joining device has no library yet, so this needs no
     /// handle; it only requires <see cref="Startup"/>. Copies and frees.
     /// </summary>
-    internal static string? GenerateJoinRequest() => CopyAndFree(GenerateJoinRequestPtr());
+    /// <param name="email">The OAuth account address the joiner authenticated as,
+    /// baked into the code so the approver can share the OAuth folder to it; null
+    /// for S3, which shares no folder.</param>
+    internal static string? GenerateJoinRequest(string? email = null) =>
+        CopyAndFree(GenerateJoinRequestPtr(email));
 
     [DllImport(Dll, EntryPoint = "bae_decode_join_request", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr DecodeJoinRequestPtr([MarshalAs(UnmanagedType.LPUTF8Str)] string code);


### PR DESCRIPTION
Completes OAuth device pairing by building the joiner side. coven already fetches an account email and shares folders to it, and bae's approver side already threads `provider_account_email` and prefills it from the join code — but the joiner never populated it (`generate_join_request` passed `None`), so there was nothing to prefill.

Now the join flow starts with a provider picker. For a Google Drive / Dropbox / OneDrive library the joiner authenticates up front, we fetch the account email and bake it into the join-request, and reuse that OAuth token for the join itself (no second sign-in). S3 and iCloud pass no email, unchanged. The fetched email flows to the approver via the existing prefill → `invite_member` → `grant_access`.

Reuses the reviewed, CI-green joiner-side implementation from the earlier (superseded) OAuth PR, re-applied on the current base.

## Test plan
- [x] bae-core clippy + join-request email round-trip test
- [x] bae-bridge clippy + macOS app build via the hook; Windows FFI cargo doc/check clean; Android ktlint clean
- [ ] iOS Swift — relying on CI (no local sim)
- [ ] CI green