### PR TITLE
navigateToAlbum owns the browser mode

### DIFF
--- a/bae-macos/bae/bae/Services/UiStore.swift
+++ b/bae-macos/bae/bae/Services/UiStore.swift
@@ -98,9 +98,10 @@ class UiStore: @unchecked Sendable {
         releaseId: String? = nil
     ) {
         activeSection = .library
+        libraryBrowserMode = .albums
         selectedAlbumId = albumId
         if let releaseId {
-            selectedReleaseIdByAlbum[albumId] = releaseId
+            selectRelease(releaseId, inAlbum: albumId)
         }
         navigationSubject.send(
             NavigationCommand(albumId: albumId, trackId: trackId)

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -333,12 +333,10 @@ extension LibraryView {
                                 }
                             },
                             openAlbum: { albumId, releaseId in
-                                uiStore.selectRelease(
-                                    releaseId,
-                                    inAlbum: albumId
+                                uiStore.navigateToAlbum(
+                                    albumId,
+                                    releaseId: releaseId
                                 )
-                                uiStore.selectAlbum(albumId)
-                                uiStore.setLibraryBrowserMode(.albums)
                             }
                         )
                     }
@@ -351,9 +349,10 @@ extension LibraryView {
                             composerPaneDetail = .empty
                         },
                         openAlbum: { albumId, releaseId in
-                            uiStore.selectRelease(releaseId, inAlbum: albumId)
-                            uiStore.selectAlbum(albumId)
-                            uiStore.setLibraryBrowserMode(.albums)
+                            uiStore.navigateToAlbum(
+                                albumId,
+                                releaseId: releaseId
+                            )
                         }
                     )
                 }

--- a/bae-macos/bae/baeTests/UiStoreTests.swift
+++ b/bae-macos/bae/baeTests/UiStoreTests.swift
@@ -43,4 +43,21 @@ struct UiStoreLibraryBrowserModeTests {
         #expect(store.libraryBrowserMode == .composers)
         #expect(store.activeSection == .library)
     }
+
+    @Test("navigateToAlbum switches to albums mode and library section")
+    func navigateToAlbumSwitchesToAlbumsMode() {
+        let store = UiStore()
+        store.setLibraryBrowserMode(.composers)
+        store.navigateToAlbum("album-1")
+        #expect(store.libraryBrowserMode == .albums)
+        #expect(store.activeSection == .library)
+        #expect(store.selectedAlbumId == "album-1")
+    }
+
+    @Test("navigateToAlbum records the release override")
+    func navigateToAlbumRecordsReleaseOverride() {
+        let store = UiStore()
+        store.navigateToAlbum("album-1", releaseId: "release-9")
+        #expect(store.selectedReleaseIdByAlbum["album-1"] == "release-9")
+    }
 }


### PR DESCRIPTION
An album is only ever shown in albums mode, so "navigate to this album" inherently
implies being in albums mode — that's a fixed consequence of showing an album, not
a choice each caller should re-make. `navigateToAlbum` now sets the browser mode
itself.

Two `openAlbum` closures in the composer/work detail pane hand-rolled the sequence
`selectRelease` + `selectAlbum` + `setLibraryBrowserMode(.albums)` — a partial
re-implementation of `navigateToAlbum` that could drift from it. Both collapse to a
single `navigateToAlbum(albumId, releaseId:)` call, giving the operation one
definition. A side effect: these two paths now also reveal/flash the target the way
every other navigate-to-album path does.

## Test plan
- [ ] From a composer's work detail, open an album → lands in albums mode with that album selected.
- [ ] Now-playing bar / Go to Now Playing / post-import / re-identify still navigate correctly.
- [ ] `baeTests` UiStore suite passes.
