### PR TITLE
Decouple the album reveal into a durable, cancellable request

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -87,6 +87,26 @@ impl AppHandle {
         })
     }
 
+    /// 0-based position of `album_id` under the given sort, matching
+    /// `get_album_page`'s ordering, or `None` if the album isn't present.
+    /// Lets the grid load the page containing an album and scroll to it
+    /// without depending on that page already being fetched.
+    pub fn get_album_index(
+        &self,
+        sort_criteria: Vec<BridgeSortCriterion>,
+        album_id: String,
+    ) -> Result<Option<u64>, BridgeError> {
+        self.runtime.block_on(async {
+            let sort: Vec<bae_core::db::AlbumSortCriterion> =
+                sort_criteria.iter().map(bridge_sort_to_core).collect();
+            self.services
+                .library_manager()
+                .get_album_index(&sort, &album_id)
+                .await
+                .map_err(|e| BridgeError::database(format!("{e}")))
+        })
+    }
+
     pub fn get_album_count(&self) -> Result<u64, BridgeError> {
         self.runtime.block_on(async {
             self.services

--- a/bae-core/src/db/client/album.rs
+++ b/bae-core/src/db/client/album.rs
@@ -200,6 +200,42 @@ impl Database {
         .await
     }
 
+    /// Resolve an album's 0-based position under a sort.
+    ///
+    /// Wraps the *identical* `build_order_by` + `album_summary_artist_join`
+    /// that `get_album_page` uses in a `ROW_NUMBER() OVER (ORDER BY …)`
+    /// window, then selects the row for `album_id`. Because the ORDER BY is
+    /// the same, the returned index is exactly the offset at which
+    /// `get_album_page` would return this album — the caller can load that
+    /// page and scroll to the row deterministically. `None` when the album
+    /// isn't in the library.
+    pub async fn get_album_index(
+        &self,
+        sort: &[AlbumSortCriterion],
+        album_id: &str,
+    ) -> Result<Option<u64>, DbError> {
+        let (order_by, needs_artist_sort_join) = build_order_by(sort, "a.created_at DESC");
+        let artist_sort_join = album_summary_artist_join(needs_artist_sort_join);
+        let album_id = album_id.to_string();
+
+        let query = format!(
+            "SELECT idx FROM ( \
+                SELECT a.id AS id, \
+                    ROW_NUMBER() OVER (ORDER BY {order_by}) - 1 AS idx \
+                FROM albums a \
+                {artist_sort_join} \
+            ) WHERE id = ?"
+        );
+
+        self.call(move |conn| {
+            conn.query_row(&query, params![album_id], |row| row.get::<_, i64>("idx"))
+                .optional()
+                .map(|idx| idx.map(|i| i as u64))
+                .map_err(DbError::from)
+        })
+        .await
+    }
+
     /// Count total albums.
     pub async fn get_album_count(&self) -> Result<u64, DbError> {
         self.call(move |conn| {

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -375,8 +375,16 @@ fn row_to_library_image(
 /// Build an ORDER BY clause from sort criteria.
 /// Returns `(order_by_clause, needs_artist_join)`.
 fn build_order_by(sort: &[AlbumSortCriterion], default: &str) -> (String, bool) {
+    // Every clause ends with `a.id` — a total-order tiebreaker over the album
+    // primary key. Without it, rows sharing a sort value (same title, same
+    // year, same created_at from a bulk import) order arbitrarily, and the
+    // ambiguity is worse than cosmetic: `get_album_page` (LIMIT/OFFSET) and
+    // `get_album_index` (a ROW_NUMBER window) are different query shapes, so
+    // SQLite could tie-break them differently and a reveal would scroll to the
+    // wrong album. The id tiebreaker makes both deterministic and mutually
+    // consistent.
     if sort.is_empty() {
-        return (default.to_string(), false);
+        return (format!("{default}, a.id"), false);
     }
     let needs_artist_join = sort.iter().any(|c| c.field == AlbumSortField::Artist);
     let clause = sort
@@ -412,7 +420,7 @@ fn build_order_by(sort: &[AlbumSortCriterion], default: &str) -> (String, bool) 
         })
         .collect::<Vec<_>>()
         .join(", ");
-    (clause, needs_artist_join)
+    (format!("{clause}, a.id"), needs_artist_join)
 }
 
 /// Build an ORDER BY clause for `get_storage_page`. Returns

--- a/bae-core/src/library/manager/album.rs
+++ b/bae-core/src/library/manager/album.rs
@@ -32,6 +32,16 @@ impl LibraryManager {
             .collect())
     }
 
+    /// Resolve an album's 0-based position under a sort, matching the paging
+    /// order of `get_album_page`. `None` if the album isn't in the library.
+    pub async fn get_album_index(
+        &self,
+        sort: &[crate::db::AlbumSortCriterion],
+        album_id: &str,
+    ) -> Result<Option<u64>, LibraryError> {
+        Ok(self.database.get_album_index(sort, album_id).await?)
+    }
+
     /// Count total albums.
     pub async fn get_album_count(&self) -> Result<u64, LibraryError> {
         Ok(self.database.get_album_count().await?)

--- a/bae-core/tests/test_album_sort.rs
+++ b/bae-core/tests/test_album_sort.rs
@@ -313,6 +313,85 @@ async fn test_multi_criteria_artist_then_year() {
 }
 
 #[tokio::test]
+async fn test_album_index_matches_page_position() {
+    let (db, _dir) = setup_db().await;
+    let aid = insert_default_artist(&db).await;
+
+    // A handful of albums with distinct titles so a title sort is total.
+    let titles = ["Delta", "alpha", "Charlie", "Bravo", "echo"];
+    for (i, title) in titles.iter().enumerate() {
+        db.insert_album(&make_album(title, &aid, Some(2000), i as i64))
+            .await
+            .unwrap();
+    }
+
+    let sort = [AlbumSortCriterion {
+        field: AlbumSortField::Title,
+        direction: SortDirection::Ascending,
+    }];
+
+    // The paged list is the ground truth; the index query must agree with it.
+    let page = db.get_album_page(&sort, 0, 100).await.unwrap();
+    assert_eq!(page.len(), titles.len());
+
+    for (position, summary) in page.iter().enumerate() {
+        let index = db.get_album_index(&sort, &summary.id).await.unwrap();
+        assert_eq!(index, Some(position as u64), "album {}", summary.title);
+    }
+
+    // An id that isn't in the library has no position.
+    let missing = db.get_album_index(&sort, "no-such-album").await.unwrap();
+    assert_eq!(missing, None);
+}
+
+#[tokio::test]
+async fn test_album_index_matches_page_position_default_sort() {
+    let (db, _dir) = setup_db().await;
+    let aid = insert_default_artist(&db).await;
+
+    for i in 0..4 {
+        db.insert_album(&make_album(&format!("Album {i}"), &aid, Some(2000), i))
+            .await
+            .unwrap();
+    }
+
+    // Empty sort exercises the default `created_at DESC` order, which needs no
+    // artist join — same path `get_album_page` takes for the default sort.
+    let page = db.get_album_page(&[], 0, 100).await.unwrap();
+    for (position, summary) in page.iter().enumerate() {
+        let index = db.get_album_index(&[], &summary.id).await.unwrap();
+        assert_eq!(index, Some(position as u64));
+    }
+}
+
+#[tokio::test]
+async fn test_album_index_matches_page_position_on_ties() {
+    let (db, _dir) = setup_db().await;
+    let aid = insert_default_artist(&db).await;
+
+    // Many albums sharing one title and one created_at offset: the sort value
+    // ties on every row, so only the `a.id` tiebreaker gives a total order.
+    // The window-function index query and the LIMIT/OFFSET page query must
+    // still agree row-for-row.
+    for _ in 0..8 {
+        db.insert_album(&make_album("Same Title", &aid, Some(2000), 0))
+            .await
+            .unwrap();
+    }
+
+    let sort = [AlbumSortCriterion {
+        field: AlbumSortField::Title,
+        direction: SortDirection::Ascending,
+    }];
+    let page = db.get_album_page(&sort, 0, 100).await.unwrap();
+    assert_eq!(page.len(), 8);
+    for (position, summary) in page.iter().enumerate() {
+        let index = db.get_album_index(&sort, &summary.id).await.unwrap();
+        assert_eq!(index, Some(position as u64), "album {}", summary.id);
+    }
+}
+
+#[tokio::test]
 async fn test_multi_criteria_year_asc_then_title_asc() {
     let (db, _dir) = setup_db().await;
     let aid = insert_default_artist(&db).await;

--- a/bae-macos/bae/bae/Services/Library.swift
+++ b/bae-macos/bae/bae/Services/Library.swift
@@ -11,6 +11,9 @@ final class Library: Sendable, Observable {
             _ sortCriteria: [BridgeSortCriterion], _ offset: UInt64,
             _ limit: UInt64
         ) throws -> [BridgeAlbum]
+    let getAlbumIndex:
+        @Sendable (_ sortCriteria: [BridgeSortCriterion], _ albumId: String)
+            throws -> UInt64?
     let getComposerCount: @Sendable () throws -> UInt64
     let getComposerPage:
         @Sendable (
@@ -42,6 +45,9 @@ final class Library: Sendable, Observable {
         getAlbumPage:
             @escaping @Sendable ([BridgeSortCriterion], UInt64, UInt64) throws
             -> [BridgeAlbum] = { _, _, _ in [] },
+        getAlbumIndex:
+            @escaping @Sendable ([BridgeSortCriterion], String) throws
+            -> UInt64? = { _, _ in throw StubError.notImplemented },
         getComposerCount: @escaping @Sendable () throws -> UInt64 = {
             throw StubError.notImplemented
         },
@@ -88,6 +94,7 @@ final class Library: Sendable, Observable {
     ) {
         self.getAlbumCount = getAlbumCount
         self.getAlbumPage = getAlbumPage
+        self.getAlbumIndex = getAlbumIndex
         self.getComposerCount = getComposerCount
         self.getComposerPage = getComposerPage
         self.getComposerDetail = getComposerDetail
@@ -115,6 +122,9 @@ final class Library: Sendable, Observable {
                         offset: $1,
                         limit: $2
                     )
+                },
+                getAlbumIndex: {
+                    try handle.getAlbumIndex(sortCriteria: $0, albumId: $1)
                 },
                 getComposerCount: { try handle.getComposerCount() },
                 getComposerPage: {

--- a/bae-macos/bae/bae/Services/UiStore.swift
+++ b/bae-macos/bae/bae/Services/UiStore.swift
@@ -20,11 +20,20 @@ enum LibraryBrowserMode: CaseIterable {
     }
 }
 
-/// One-shot imperative command fired when the UI should navigate to and
-/// reveal an album (and optionally flash a track inside it).
-struct NavigationCommand {
+/// A request to reveal an album (scroll the grid to it) and optionally flash
+/// a track inside it. Durable state, not a `PassthroughSubject`: the consumer
+/// (`AlbumGridView`, `AlbumDetailView`) does not exist when the producer emits.
+/// Navigating from composers mode switches to albums mode, which *mounts* the
+/// grid — so a subject would publish before any subscriber is alive and the
+/// request would be lost. As state, the request persists across that remount
+/// and the freshly-mounted grid reads it. `seq` is the version: it lets a
+/// consumer detect a new request even when `albumId` repeats (navigate to the
+/// same album twice), and drives `.task(id:)` so SwiftUI cancels a stale reveal
+/// when a newer one arrives.
+struct AlbumReveal {
     let albumId: String
     let trackId: String?
+    let seq: Int
 }
 
 enum LibraryNavigationTarget {
@@ -45,10 +54,11 @@ class UiStore: @unchecked Sendable {
     var selectedAlbumId: String?
     var showQueue: Bool = false
 
-    /// One-shot navigation commands (scroll/flash). State fields describe
-    /// what the UI *is*; this subject carries what should *happen once*.
-    @ObservationIgnored
-    let navigationSubject = PassthroughSubject<NavigationCommand, Never>()
+    /// The current album-reveal request (scroll + optional track flash), or
+    /// `nil` before any navigation. Durable — see `AlbumReveal` for why this is
+    /// state rather than a one-shot subject.
+    private(set) var albumReveal: AlbumReveal?
+    private var revealSeq = 0
 
     @ObservationIgnored
     let libraryNavigationSubject = PassthroughSubject<
@@ -103,8 +113,11 @@ class UiStore: @unchecked Sendable {
         if let releaseId {
             selectRelease(releaseId, inAlbum: albumId)
         }
-        navigationSubject.send(
-            NavigationCommand(albumId: albumId, trackId: trackId)
+        revealSeq += 1
+        albumReveal = AlbumReveal(
+            albumId: albumId,
+            trackId: trackId,
+            seq: revealSeq
         )
     }
 

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -1031,8 +1031,12 @@ private struct TrackRowView: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(Color.accentColor.opacity(highlightOpacity)),
         )
-        .onReceive(uiStore.navigationSubject) { command in
-            guard command.trackId == track.id else {
+        // Keyed on the reveal's `seq` (not a subject) for the same reason the
+        // grid scroll is: navigating here can remount this row, and durable
+        // state survives that where a one-shot emit would be lost. Re-fires when
+        // seq changes (repeat navigation) and cancels cleanly on a newer reveal.
+        .task(id: uiStore.albumReveal?.seq) {
+            guard uiStore.albumReveal?.trackId == track.id else {
                 return
             }
             highlightOpacity = 0.3

--- a/bae-macos/bae/bae/Views/AlbumGridView.swift
+++ b/bae-macos/bae/bae/Views/AlbumGridView.swift
@@ -11,6 +11,8 @@ struct AlbumGridView<ExpansionContent: View>: View {
     private var uiStore
     @Environment(LibraryStore.self)
     private var libraryStore
+    @Environment(Library.self)
+    private var library
     let list: AlbumList
     @Binding
     var sortCriteria: [BridgeSortCriterion]
@@ -153,18 +155,8 @@ struct AlbumGridView<ExpansionContent: View>: View {
                                         index: rowIndex
                                     )
                                 ) {
-                                    let firstAlbum = max(
-                                        0,
-                                        rowIndex * columnCount - loadBatchSize
-                                            / 2
-                                    )
-                                    let batchEnd = min(
-                                        firstAlbum + loadBatchSize,
-                                        list.totalCount
-                                    )
-                                    await list.loadRange(
-                                        offset: firstAlbum,
-                                        limit: batchEnd - firstAlbum
+                                    await loadBatch(
+                                        around: rowIndex * columnCount
                                     )
                                 }
                                 AlbumExpansionSlot(
@@ -182,23 +174,15 @@ struct AlbumGridView<ExpansionContent: View>: View {
                     .frame(maxWidth: Self.maxContentWidth)
                     .frame(maxWidth: .infinity)
                 }
-                .onReceive(uiStore.navigationSubject) { command in
-                    guard let albumIndex = list.position(of: command.albumId),
-                        columnCount > 0
-                    else {
-                        albumGridLogger.warning(
-                            "Dropping album navigation command for unloaded album \(command.albumId)"
-                        )
+                .task(id: uiStore.albumReveal?.seq) {
+                    guard let reveal = uiStore.albumReveal else {
                         return
                     }
-
-                    let rowIndex = albumIndex / columnCount
-                    Task { @MainActor in
-                        try? await Task.sleep(for: .milliseconds(50))
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            scrollProxy.scrollTo(rowIndex, anchor: .top)
-                        }
-                    }
+                    await revealAlbum(
+                        reveal.albumId,
+                        columnCount: columnCount,
+                        scrollProxy: scrollProxy
+                    )
                 }
             }
         }
@@ -207,6 +191,62 @@ struct AlbumGridView<ExpansionContent: View>: View {
 }
 
 extension AlbumGridView {
+    /// Scroll the grid to `albumId`, resolving its row deterministically.
+    ///
+    /// The album's page may never have been fetched, so `list.position(of:)`
+    /// can't be trusted. Ask the core for the album's index under the current
+    /// sort (off the main actor), load the page that contains it, then scroll.
+    /// Each async stage checks `Task.isCancelled`, and the scroll — the only
+    /// durable effect — commits last, so a cancel (a newer reveal, or the grid
+    /// disappearing) before that point changes nothing. SwiftUI drives the
+    /// cancellation by keying the calling `.task` on `albumReveal.seq`.
+    private func revealAlbum(
+        _ albumId: String,
+        columnCount: Int,
+        scrollProxy: ScrollViewProxy
+    ) async {
+        let getAlbumIndex = library.getAlbumIndex
+        let sort = sortCriteria
+        do {
+            let resolved = try await DetachedWork.run {
+                try getAlbumIndex(sort, albumId)
+            }
+            if Task.isCancelled {
+                return
+            }
+            guard let index = resolved.map(Int.init) else {
+                albumGridLogger.warning(
+                    "No index for album \(albumId) under the current sort; skipping reveal"
+                )
+                return
+            }
+
+            // Load the page that holds the target so its row exists to scroll to.
+            await loadBatch(around: index)
+            if Task.isCancelled {
+                return
+            }
+
+            let rowIndex = index / columnCount
+            withAnimation(.easeInOut(duration: 0.3)) {
+                scrollProxy.scrollTo(rowIndex, anchor: .top)
+            }
+        }
+        catch {
+            uiStore.showError(error.localizedDescription)
+        }
+    }
+
+    /// Load the batch of albums centered on `albumIndex` so its row is
+    /// materialized. Shared by lazy row loading and by `revealAlbum`, which
+    /// scrolls to a possibly-unfetched album — one definition of the batch
+    /// bounds keeps the two from drifting.
+    private func loadBatch(around albumIndex: Int) async {
+        let first = max(0, albumIndex - loadBatchSize / 2)
+        let end = min(first + loadBatchSize, list.totalCount)
+        await list.loadRange(offset: first, limit: end - first)
+    }
+
     private func selectedAlbumId(rowIndex: Int, columnCount: Int) -> String? {
         guard let selectedId = uiStore.selectedAlbumId else {
             return nil

--- a/bae-macos/bae/baeTests/UiStoreTests.swift
+++ b/bae-macos/bae/baeTests/UiStoreTests.swift
@@ -60,4 +60,34 @@ struct UiStoreLibraryBrowserModeTests {
         store.navigateToAlbum("album-1", releaseId: "release-9")
         #expect(store.selectedReleaseIdByAlbum["album-1"] == "release-9")
     }
+
+    @Test("navigateToAlbum sets the reveal request with albumId and trackId")
+    func navigateToAlbumSetsRevealRequest() {
+        let store = UiStore()
+        store.navigateToAlbum("album-1", trackId: "track-7")
+        #expect(store.albumReveal?.albumId == "album-1")
+        #expect(store.albumReveal?.trackId == "track-7")
+    }
+
+    @Test("navigateToAlbum bumps the reveal seq (strictly increasing)")
+    func navigateToAlbumBumpsSeq() {
+        let store = UiStore()
+        store.navigateToAlbum("album-1")
+        let first = store.albumReveal?.seq
+        store.navigateToAlbum("album-2")
+        let second = store.albumReveal?.seq
+        #expect(first != nil)
+        #expect(second != nil)
+        #expect(second! > first!)
+    }
+
+    @Test("repeat navigation to the same album produces two distinct seq values")
+    func navigateToSameAlbumTwiceRefires() {
+        let store = UiStore()
+        store.navigateToAlbum("album-1")
+        let first = store.albumReveal?.seq
+        store.navigateToAlbum("album-1")
+        let second = store.albumReveal?.seq
+        #expect(first != second)
+    }
 }


### PR DESCRIPTION
Scrolling the grid to an album was a fire-and-forget `Task` with a fixed 50ms
sleep, sent over a one-shot `PassthroughSubject`. It had two defects: it was
dropped whenever the album's page wasn't already loaded, and it was lost entirely
when the navigation itself mounted the grid — navigating from composers mode
switches to albums mode, which mounts `AlbumGridView`, so the subject published
before any subscriber existed. Nothing cancelled a pending scroll when the user
navigated away, either.

This replaces the subject with durable `AlbumReveal` state carrying a monotonic
`seq`, consumed via `.task(id:)` so SwiftUI owns cancellation (a newer reveal or
the grid disappearing cancels the in-flight one). The comment on `AlbumReveal`
explains why this is durable state rather than pub/sub: the consumer isn't alive
when the producer emits, so a subject can't deliver across the remount.

The target row is resolved deterministically by a new core `get_album_index`
query — a `ROW_NUMBER()` window over the *same* ORDER BY `get_album_page` pages
with, so the index it returns is exactly the offset that page query would place
the album at. `build_order_by` gains an `a.id` tiebreaker (matching its sibling
`storage_order_by`) so the two query shapes agree even when rows tie on the sort
value. The grid loads the page containing that index and scrolls — no dependence
on the page already being fetched, no magic sleep. The track-flash moves onto the
same reveal state.

## Test plan
- [ ] Navigate to an album far down the list from a composer's work → grid switches to albums mode and scrolls to it.
- [ ] Fast-navigate to album A then away (to composers, or another album) → the scroll to A cancels.
- [ ] Go to Now Playing while already in albums mode still scrolls + flashes the track.
- [ ] `cargo test -p bae-core --features test-utils --test test_album_sort` and the macOS UiStore suite pass.
