### PR TITLE
Configurable single-track export on Windows (filename template + metadata)

### DIFF
--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -716,6 +716,40 @@ pub unsafe extern "C" fn bae_export_track(
     }
 }
 
+/// The default filename stem (no extension) a single-track export suggests for
+/// `track_id`, rendered from the configured template. Returns the stem as a C
+/// string (free with [`bae_string_free`]), or null on error (logged).
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed;
+/// `track_id` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_export_track_suggested_name(
+    handle: *const BaeHandle,
+    track_id: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        tracing::error!("bae_export_track_suggested_name: null handle");
+        return std::ptr::null_mut();
+    };
+    let Some(track_id) = cstr(track_id) else {
+        tracing::error!("bae_export_track_suggested_name: null or non-UTF-8 track_id");
+        return std::ptr::null_mut();
+    };
+    let app = &handle.0;
+    match app.runtime.block_on(
+        app.services
+            .library_manager()
+            .export_track_suggested_name(&track_id),
+    ) {
+        Ok(stem) => error_cstring(&stem),
+        Err(e) => {
+            tracing::error!("bae_export_track_suggested_name failed: {e}");
+            std::ptr::null_mut()
+        }
+    }
+}
+
 /// One of a release's image files, offered as a cover-art choice. The UI loads
 /// the thumbnail with [`bae_gallery_bytes`] of the release id and a `ReleaseFile`
 /// source carrying this `id`.
@@ -4032,6 +4066,11 @@ struct FfiSettings {
     sync_ready: bool,
     /// Whether playback pauses between vinyl/cassette sides.
     pause_between_sides: bool,
+    /// Template rendering a single-track export's suggested filename.
+    export_filename_template: String,
+    /// Which metadata tags a single-track export embeds — the seven booleans
+    /// serialized straight from core's `ExportMetadata`.
+    export_metadata: bae_core::config::ExportMetadata,
     /// Whether the local MCP server is enabled in persisted config.
     mcp_enabled: bool,
     /// The configured local MCP server port.
@@ -4073,6 +4112,8 @@ pub unsafe extern "C" fn bae_settings(handle: *const BaeHandle) -> *mut c_char {
         sync_account: config.cloud_account_display(),
         sync_ready: manager.is_sync_ready(),
         pause_between_sides: config.pause_between_sides,
+        export_filename_template: config.export_filename_template.clone(),
+        export_metadata: config.export_metadata,
         mcp_enabled: config.mcp.enabled,
         mcp_port: config.mcp.port,
         mcp_status: handle.0.mcp_server_status(),
@@ -4099,6 +4140,68 @@ pub unsafe extern "C" fn bae_set_pause_between_sides(
         .services
         .library_manager()
         .set_pause_between_sides(enabled)
+    {
+        Ok(()) => std::ptr::null_mut(),
+        Err(error) => error_cstring(&error.to_string()),
+    }
+}
+
+/// Set the single-track export filename template. Returns null on success, or an
+/// error-message C string (free with [`bae_string_free`]).
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed;
+/// `template` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_set_export_filename_template(
+    handle: *const BaeHandle,
+    template: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        return error_cstring("no app handle");
+    };
+    let Some(template) = cstr(template) else {
+        return error_cstring("invalid export filename template");
+    };
+    match handle
+        .0
+        .services
+        .library_manager()
+        .set_export_filename_template(template)
+    {
+        Ok(()) => std::ptr::null_mut(),
+        Err(error) => error_cstring(&error.to_string()),
+    }
+}
+
+/// Set which metadata tags a single-track export embeds. `metadata_json` is a
+/// JSON object of the seven booleans (`title`, `artist`, `album`, `year`,
+/// `track_number`, `disc_number`, `cover_art`). Returns null on success, or an
+/// error-message C string (free with [`bae_string_free`]).
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed;
+/// `metadata_json` must be a valid NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn bae_set_export_metadata(
+    handle: *const BaeHandle,
+    metadata_json: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        return error_cstring("no app handle");
+    };
+    let Some(metadata_json) = cstr(metadata_json) else {
+        return error_cstring("invalid export metadata JSON");
+    };
+    let metadata: bae_core::config::ExportMetadata = match serde_json::from_str(&metadata_json) {
+        Ok(metadata) => metadata,
+        Err(e) => return error_cstring(&format!("invalid export metadata JSON: {e}")),
+    };
+    match handle
+        .0
+        .services
+        .library_manager()
+        .set_export_metadata(metadata)
     {
         Ok(()) => std::ptr::null_mut(),
         Err(error) => error_cstring(&error.to_string()),

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3592,9 +3592,30 @@ public sealed partial class MainWindow : Window
                 // round-trips back to the format string the FFI expects.
                 picker.FileTypeChoices.Add(Loc.Chrome("track.export.flac"), new List<string> { ".flac" });
                 picker.FileTypeChoices.Add(Loc.Chrome("track.export.mp3"), new List<string> { ".mp3" });
-                var invalid = System.IO.Path.GetInvalidFileNameChars();
-                var suggested = new string(track.Title.Select(c => invalid.Contains(c) ? '-' : c).ToArray());
-                picker.SuggestedFileName = string.IsNullOrWhiteSpace(suggested) ? "track" : suggested;
+                // Seed the suggested name from the configured filename template,
+                // which the core renders and sanitizes from this track's metadata
+                // (falling back to the title, then a fixed stem, on its own). A
+                // null return — or a throw — means that render failed (the core
+                // logged the cause); surface it and abort rather than exporting
+                // under a guessed name.
+                string? stem;
+                try
+                {
+                    stem = await System.Threading.Tasks.Task.Run(
+                        () => NativeBae.ExportTrackSuggestedName(_handle, track.TrackId));
+                }
+                catch (Exception ex)
+                {
+                    BaeDiagnostics.Logger.Error("export suggested-name lookup threw", ex);
+                    stem = null;
+                }
+                if (stem is null)
+                {
+                    exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
+                    exportStatus.Visibility = Visibility.Visible;
+                    return;
+                }
+                picker.SuggestedFileName = stem;
                 var file = await picker.PickSaveFileAsync();
                 if (file is null)
                 {
@@ -5164,6 +5185,128 @@ public sealed partial class MainWindow : Window
         pauseBetweenSides.Checked += async (_, _) => await SetPauseBetweenSides(true);
         pauseBetweenSides.Unchecked += async (_, _) => await SetPauseBetweenSides(false);
 
+        // Export: the single-track "Save As…" suggested-filename template and the
+        // metadata tags an export embeds. Windows has no release export, so this is
+        // the per-track section only. Writes round-trip through ConfigChanged into
+        // the settings re-read (RenderExport); the checkboxes send the whole seven-
+        // bool set (set-state), never one mutated field.
+        var exportLabel = new TextBlock
+        {
+            Text = Loc.Chrome("settings.export.label"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        };
+        var exportTemplate = new TextBox
+        {
+            Header = Loc.Chrome("settings.export.filename_format"),
+            Text = s.ExportFilenameTemplate,
+        };
+        var exportTokensHelp = new TextBlock
+        {
+            Text = Loc.Chrome("settings.export.tokens_help"),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        };
+        var exportTitle = new CheckBox { Content = Loc.Chrome("settings.export.metadata.title"), IsChecked = s.ExportMetadata.Title };
+        var exportArtist = new CheckBox { Content = Loc.Chrome("settings.export.metadata.artist"), IsChecked = s.ExportMetadata.Artist };
+        var exportAlbum = new CheckBox { Content = Loc.Chrome("settings.export.metadata.album"), IsChecked = s.ExportMetadata.Album };
+        var exportYear = new CheckBox { Content = Loc.Chrome("settings.export.metadata.year"), IsChecked = s.ExportMetadata.Year };
+        var exportTrackNumber = new CheckBox { Content = Loc.Chrome("settings.export.metadata.track_number"), IsChecked = s.ExportMetadata.TrackNumber };
+        var exportDiscNumber = new CheckBox { Content = Loc.Chrome("settings.export.metadata.disc_number"), IsChecked = s.ExportMetadata.DiscNumber };
+        var exportCoverArt = new CheckBox { Content = Loc.Chrome("settings.export.metadata.cover_art"), IsChecked = s.ExportMetadata.CoverArt };
+
+        void RenderExport(Settings settings)
+        {
+            if (refreshingSettings)
+            {
+                return;
+            }
+
+            refreshingSettings = true;
+            exportTemplate.Text = settings.ExportFilenameTemplate;
+            exportTitle.IsChecked = settings.ExportMetadata.Title;
+            exportArtist.IsChecked = settings.ExportMetadata.Artist;
+            exportAlbum.IsChecked = settings.ExportMetadata.Album;
+            exportYear.IsChecked = settings.ExportMetadata.Year;
+            exportTrackNumber.IsChecked = settings.ExportMetadata.TrackNumber;
+            exportDiscNumber.IsChecked = settings.ExportMetadata.DiscNumber;
+            exportCoverArt.IsChecked = settings.ExportMetadata.CoverArt;
+            refreshingSettings = false;
+        }
+
+        async System.Threading.Tasks.Task SaveExportTemplate()
+        {
+            if (refreshingSettings)
+            {
+                return;
+            }
+
+            ClearSettingsError();
+            var template = exportTemplate.Text ?? string.Empty;
+            var error = await System.Threading.Tasks.Task.Run(
+                () => NativeBae.SetExportFilenameTemplate(_handle, template));
+            if (error is not null)
+            {
+                ShowSettingsError(error);
+            }
+            // On success a ConfigChanged re-read settles the field via RenderExport.
+        }
+
+        async System.Threading.Tasks.Task SaveExportMetadata()
+        {
+            if (refreshingSettings)
+            {
+                return;
+            }
+
+            ClearSettingsError();
+            // Send the whole set (set-state), not the one field that toggled.
+            var metadata = new ExportMetadata
+            {
+                Title = exportTitle.IsChecked == true,
+                Artist = exportArtist.IsChecked == true,
+                Album = exportAlbum.IsChecked == true,
+                Year = exportYear.IsChecked == true,
+                TrackNumber = exportTrackNumber.IsChecked == true,
+                DiscNumber = exportDiscNumber.IsChecked == true,
+                CoverArt = exportCoverArt.IsChecked == true,
+            };
+            var json = JsonSerializer.Serialize(metadata, JsonOptions);
+            var error = await System.Threading.Tasks.Task.Run(
+                () => NativeBae.SetExportMetadata(_handle, json));
+            if (error is not null)
+            {
+                ShowSettingsError(error);
+                // Nothing persisted — restore every checkbox from the stored state
+                // so the UI matches config.
+                _refreshSettings?.Invoke();
+            }
+            // On success a ConfigChanged re-read settles the checkboxes via RenderExport.
+        }
+
+        exportTemplate.LostFocus += async (_, _) => await SaveExportTemplate();
+        exportTemplate.KeyDown += async (_, args) =>
+        {
+            if (args.Key == VirtualKey.Enter)
+            {
+                args.Handled = true;
+                await SaveExportTemplate();
+            }
+        };
+        exportTitle.Checked += async (_, _) => await SaveExportMetadata();
+        exportTitle.Unchecked += async (_, _) => await SaveExportMetadata();
+        exportArtist.Checked += async (_, _) => await SaveExportMetadata();
+        exportArtist.Unchecked += async (_, _) => await SaveExportMetadata();
+        exportAlbum.Checked += async (_, _) => await SaveExportMetadata();
+        exportAlbum.Unchecked += async (_, _) => await SaveExportMetadata();
+        exportYear.Checked += async (_, _) => await SaveExportMetadata();
+        exportYear.Unchecked += async (_, _) => await SaveExportMetadata();
+        exportTrackNumber.Checked += async (_, _) => await SaveExportMetadata();
+        exportTrackNumber.Unchecked += async (_, _) => await SaveExportMetadata();
+        exportDiscNumber.Checked += async (_, _) => await SaveExportMetadata();
+        exportDiscNumber.Unchecked += async (_, _) => await SaveExportMetadata();
+        exportCoverArt.Checked += async (_, _) => await SaveExportMetadata();
+        exportCoverArt.Unchecked += async (_, _) => await SaveExportMetadata();
+
         var automationLabel = new TextBlock
         {
             Text = Loc.Chrome("settings.automation.label"),
@@ -5289,6 +5432,16 @@ public sealed partial class MainWindow : Window
         var discogsLabel = new TextBlock { Text = Loc.Chrome("settings.discogs.label") };
         content.Children.Add(libraryLabel);
         content.Children.Add(pauseBetweenSides);
+        content.Children.Add(exportLabel);
+        content.Children.Add(exportTemplate);
+        content.Children.Add(exportTokensHelp);
+        content.Children.Add(exportTitle);
+        content.Children.Add(exportArtist);
+        content.Children.Add(exportAlbum);
+        content.Children.Add(exportYear);
+        content.Children.Add(exportTrackNumber);
+        content.Children.Add(exportDiscNumber);
+        content.Children.Add(exportCoverArt);
         content.Children.Add(automationLabel);
         content.Children.Add(mcpEnabled);
         content.Children.Add(mcpPort);
@@ -5443,6 +5596,7 @@ public sealed partial class MainWindow : Window
             refreshingSettings = true;
             pauseBetweenSides.IsChecked = fresh.PauseBetweenSides;
             refreshingSettings = false;
+            RenderExport(fresh);
             RenderMcp(fresh);
             RenderDiscogs(fresh);
         };

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -376,6 +376,19 @@ internal static class NativeBae
     internal static string? ExportTrack(IntPtr handle, string trackId, string outputPath, string format) =>
         ResultMessage(ExportTrackPtr(handle, trackId, outputPath, format));
 
+    [DllImport(Dll, EntryPoint = "bae_export_track_suggested_name", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ExportTrackSuggestedNamePtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string trackId);
+
+    /// <summary>
+    /// The default filename stem (no extension) a single-track export suggests for
+    /// <paramref name="trackId"/>, rendered from the configured template, or null on
+    /// error (the cause is logged in the core). Copies and frees.
+    /// </summary>
+    internal static string? ExportTrackSuggestedName(IntPtr handle, string trackId) =>
+        CopyAndFree(ExportTrackSuggestedNamePtr(handle, trackId));
+
     [DllImport(Dll, EntryPoint = "bae_get_release_images", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr GetReleaseImagesPtr(
         IntPtr handle,
@@ -630,6 +643,30 @@ internal static class NativeBae
     /// <summary>Set physical-side playback pauses; null on success, else the error.</summary>
     internal static string? SetPauseBetweenSides(IntPtr handle, bool enabled) =>
         ResultMessage(SetPauseBetweenSidesPtr(handle, enabled));
+
+    [DllImport(Dll, EntryPoint = "bae_set_export_filename_template", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr SetExportFilenameTemplatePtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string template);
+
+    /// <summary>Set the single-track export filename template; null on success, else the error.</summary>
+    internal static string? SetExportFilenameTemplate(IntPtr handle, string template) =>
+        ResultMessage(SetExportFilenameTemplatePtr(handle, template));
+
+    [DllImport(Dll, EntryPoint = "bae_set_export_metadata", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr SetExportMetadataPtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string metadataJson);
+
+    /// <summary>
+    /// Set which metadata tags a single-track export embeds. <paramref name="metadataJson"/>
+    /// is a JSON object of the seven booleans with snake_case keys (<c>title</c>,
+    /// <c>artist</c>, <c>album</c>, <c>year</c>, <c>track_number</c>,
+    /// <c>disc_number</c>, <c>cover_art</c>) — the whole set, not one field. Null on
+    /// success, else the error.
+    /// </summary>
+    internal static string? SetExportMetadata(IntPtr handle, string metadataJson) =>
+        ResultMessage(SetExportMetadataPtr(handle, metadataJson));
 
     [DllImport(Dll, EntryPoint = "bae_set_mcp_server_config", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr SetMcpServerConfigPtr(

--- a/bae-windows/Settings.cs
+++ b/bae-windows/Settings.cs
@@ -22,6 +22,13 @@ public sealed class Settings
     public string? SyncAccount { get; set; }
     public bool SyncReady { get; set; }
     public bool PauseBetweenSides { get; set; }
+
+    /// <summary>Template rendering a single-track export's suggested filename.</summary>
+    public string ExportFilenameTemplate { get; set; } = string.Empty;
+
+    /// <summary>Which metadata tags a single-track export embeds.</summary>
+    public ExportMetadata ExportMetadata { get; set; } = new();
+
     public bool McpEnabled { get; set; }
     public ushort McpPort { get; set; }
     public McpServerStatus McpStatus { get; set; } = new();
@@ -119,6 +126,25 @@ public sealed class Settings
         "error" when McpStatus.Error is not null => McpStatus.Error.DisplayText,
         _ => Loc.Chrome("settings.automation.status.disabled"),
     };
+}
+
+/// <summary>
+/// Which metadata tags a single-track export embeds — the seven booleans from
+/// core's <c>ExportMetadata</c>. The JSON keys are snake_case
+/// (<c>title</c>, <c>artist</c>, <c>album</c>, <c>year</c>, <c>track_number</c>,
+/// <c>disc_number</c>, <c>cover_art</c>) via the shared snake_case naming policy,
+/// so the PascalCase properties map without per-property attributes. All default
+/// on, matching core's default.
+/// </summary>
+public sealed class ExportMetadata
+{
+    public bool Title { get; set; } = true;
+    public bool Artist { get; set; } = true;
+    public bool Album { get; set; } = true;
+    public bool Year { get; set; } = true;
+    public bool TrackNumber { get; set; } = true;
+    public bool DiscNumber { get; set; } = true;
+    public bool CoverArt { get; set; } = true;
 }
 
 public sealed class McpServerStatus

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -237,6 +237,7 @@
   <data name="sync.syncing" xml:space="preserve"><value>syncing…</value></data>
   <data name="track.export.flac" xml:space="preserve"><value>FLAC (lossless)</value></data>
   <data name="track.export.mp3" xml:space="preserve"><value>MP3 (320 kbps)</value></data>
+  <data name="track.export.prepare_failed" xml:space="preserve"><value>Couldn't prepare the export.</value></data>
   <data name="welcome.choose_library" xml:space="preserve"><value>choose a library</value></data>
   <data name="welcome.join_library" xml:space="preserve"><value>join a library</value></data>
   <data name="welcome.create_library" xml:space="preserve"><value>create library</value></data>
@@ -284,4 +285,14 @@
   <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
+  <data name="settings.export.label" xml:space="preserve"><value>Export</value></data>
+  <data name="settings.export.filename_format" xml:space="preserve"><value>Filename format</value></data>
+  <data name="settings.export.tokens_help" xml:space="preserve"><value>Available tokens: {title} {artist} {album} {year} {track_number} {disc_number} {track_total}</value></data>
+  <data name="settings.export.metadata.title" xml:space="preserve"><value>Title</value></data>
+  <data name="settings.export.metadata.artist" xml:space="preserve"><value>Artist</value></data>
+  <data name="settings.export.metadata.album" xml:space="preserve"><value>Album</value></data>
+  <data name="settings.export.metadata.year" xml:space="preserve"><value>Year</value></data>
+  <data name="settings.export.metadata.track_number" xml:space="preserve"><value>Track number</value></data>
+  <data name="settings.export.metadata.disc_number" xml:space="preserve"><value>Disc number</value></data>
+  <data name="settings.export.metadata.cover_art" xml:space="preserve"><value>Cover art</value></data>
 </root>


### PR DESCRIPTION
The macOS app and bae-core already carry configurable single-track export — a filename template and a per-tag metadata selection, persisted in the shared library config. This brings the same controls to the Windows app.

Windows has single-track export but no release export, so the Windows Export section is per-track only: a filename-format field and one checkbox per metadata tag (title, artist, album, year, track number, disc number, cover art). The controls read and write the same bae-core config the macOS side uses, reached through three new functions on the hand-written C ABI (`bae-windows-ffi`): a suggested-name read that seeds the save picker, and setters for the template and the metadata selection. The metadata selection crosses as a JSON object of the seven booleans; the C# side serializes it with the app's existing snake_case naming policy so it round-trips against the Rust config type.

The single-track "Save As…" picker now pre-fills its suggested name from the configured template (rendered in core), falling back to the track title only if that read fails.

## Test plan
- [x] `cargo build -p bae-windows-ffi` passes
- [ ] `Windows / build` CI job compiles and verifies the C# (can't be built on the authoring machine)
- [ ] Manual on Windows: Export settings section shows the template field + metadata checkboxes; a per-track export pre-fills the templated name and embeds only the selected tags