### PR TITLE
Fold the Members settings tab into the Library tab

### DIFF
--- a/bae-macos/bae/bae/Views/Settings/LibrarySettingsTab.swift
+++ b/bae-macos/bae/bae/Views/Settings/LibrarySettingsTab.swift
@@ -72,6 +72,7 @@ struct LibrarySettingsTab: View {
             }
 
             if isConnected {
+                MembersSection()
                 RecoveryCodeSection(generate: sync.generateRestoreCode)
             }
         }

--- a/bae-macos/bae/bae/Views/Settings/MembersSection.swift
+++ b/bae-macos/bae/bae/Views/Settings/MembersSection.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 import os.log
 
-private let logger = Logger.bae("MembersSettings")
+private let logger = Logger.bae("MembersSection")
 
-/// The Members settings tab: lists the devices in this library's membership
-/// chain, lets an owner approve a new device (which hands back an invite code),
-/// and lets an owner remove a device (which rotates the library key). The list
-/// loads when the tab appears and after each approve/remove so the chain stays
-/// current. Reading the chain and the mutations all run off the main thread.
-struct MembersSettingsTab: View {
+/// Device-management rows for the current library's membership chain: lists the
+/// devices (with this device flagged), lets an owner approve a new device
+/// (handing back an invite code) and remove a device (which rotates the library
+/// key). Rendered inside the Library settings Form, below the Sync section and
+/// only while sync is connected — the underlying membership calls require an
+/// active sync manager. The list loads when the section appears and after each
+/// approve/remove.
+struct MembersSection: View {
     @Environment(Sync.self)
     var sync
 
@@ -28,45 +30,27 @@ struct MembersSettingsTab: View {
     private var showApprove = false
 
     var body: some View {
-        Form {
-            Section("Devices") {
-                switch membership {
-                case nil:
-                    if let loadError {
-                        Text(loadError)
-                            .foregroundStyle(.red)
-                            .font(.callout)
-                    }
-                    else {
-                        ProgressView()
-                            .frame(maxWidth: .infinity)
-                    }
-                case .some(let membership):
-                    ForEach(membership.members, id: \.pubkey) { member in
-                        MemberRow(
-                            member: member,
-                            onRemove: { removeConfirm = member },
-                        )
-                    }
+        Section("Devices") {
+            switch membership {
+            case nil:
+                if let loadError {
+                    Text(loadError)
+                        .foregroundStyle(.red)
+                        .font(.callout)
                 }
-            }
-
-            if let actionError {
-                Text(actionError)
-                    .foregroundStyle(.red)
-                    .font(.callout)
-            }
-
-            if membership?.selfIsOwner == true {
-                Section {
-                    Button("Add a device...") {
-                        actionError = nil
-                        showApprove = true
-                    }
+                else {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                }
+            case .some(let membership):
+                ForEach(membership.members, id: \.pubkey) { member in
+                    MemberRow(
+                        member: member,
+                        onRemove: { removeConfirm = member },
+                    )
                 }
             }
         }
-        .formStyle(.grouped)
         .task { load() }
         .onDisappear {
             loadTask?.cancel()
@@ -97,6 +81,21 @@ struct MembersSettingsTab: View {
             Text(
                 "It will lose access and the library key will be rotated. Devices still in the library re-key automatically."
             )
+        }
+
+        if let actionError {
+            Text(actionError)
+                .foregroundStyle(.red)
+                .font(.callout)
+        }
+
+        if membership?.selfIsOwner == true {
+            Section {
+                Button("Add a device...") {
+                    actionError = nil
+                    showApprove = true
+                }
+            }
         }
     }
 

--- a/bae-macos/bae/bae/Views/Settings/SettingsView.swift
+++ b/bae-macos/bae/bae/Views/Settings/SettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum SettingsTab: Hashable {
-    case library, members, playback, export, automation, discogs, about
+    case library, playback, export, automation, discogs, about
 }
 
 struct SettingsView: View {
@@ -15,9 +15,6 @@ struct SettingsView: View {
             LibrarySettingsTab()
                 .tag(SettingsTab.library)
                 .tabItem { Label("Library", systemImage: "books.vertical") }
-            MembersSettingsTab()
-                .tag(SettingsTab.members)
-                .tabItem { Label("Members", systemImage: "person.2") }
             PlaybackSettingsTab()
                 .tag(SettingsTab.playback)
                 .tabItem { Label("Playback", systemImage: "play.circle") }


### PR DESCRIPTION
The Members settings tab lists a library's devices and lets an owner approve or remove them. Every one of those operations requires an active sync manager — with no cloud provider connected, `get_members`, `invite_member`, and `remove_member` all fail with "sync is not configured". Because the tab was always visible, a library that hadn't set up sync showed nothing but that error whenever the user opened it.

This moves the device-management content out of its own tab and into the Library tab, positioned between the existing Sync and Recovery sections and placed under the Library tab's existing connected-only guard — the same guard the Recovery section already uses. Device management now appears only in the state where it actually works, and the standalone tab goes away.

The content moves verbatim into a `MembersSection` view that emits its sections into the Library form; behavior (load-on-appear, approve/remove flows, cancellation, error surfacing) is unchanged.

## Test plan
- [ ] With sync connected, open Library settings: sections read Path → Sync → Devices → Recovery; the device list loads; approve and remove flows work.
- [ ] With sync disconnected, open Library settings: only Path and the sync-setup entry show; no Devices/Recovery, no error.
- [ ] Settings window no longer has a Members tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)