### PR TITLE
Keep Android seek bar at dropped position

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -133,6 +133,9 @@ interface PlaybackEventSink {
 private const val TAG = "bae.BaeCorePlayer"
 private val logger = BaeLogger(TAG)
 
+/** Bridge durations are 0 when unknown; map that to Media3's [C.TIME_UNSET]. */
+private fun durationOrUnset(durationMs: Long): Long = if (durationMs > 0L) durationMs else C.TIME_UNSET
+
 internal class PlaybackSystemHooks(
     private val context: Context,
     private val appHandle: AppHandle,
@@ -524,6 +527,7 @@ class BaeCorePlayer(
     /** Position anchor from the latest `PlaybackProgress`. */
     private var anchorPositionMs: Long = 0L
     private var durationMs: Long = C.TIME_UNSET
+    private var pendingSeek: PendingSeek? = null
 
     // Compose-facing projection of the same state, for the in-app NowPlayingBar
     // (read directly off this player — no second MediaController transport).
@@ -568,8 +572,20 @@ class BaeCorePlayer(
 
     /** Latest progress fields from `PlaybackProgress`, for the Compose bar. */
     private var progress: Double = 0.0
-    private var elapsedLabel: String = ""
-    private var remainingLabel: String = ""
+    private val effectivePositionMs: Long
+        get() = pendingSeek?.targetPositionMs ?: anchorPositionMs
+
+    private data class PendingSeek(
+        val originPositionMs: Long,
+        val targetPositionMs: Long,
+    ) {
+        fun accepts(positionMs: Long): Boolean =
+            if (targetPositionMs >= originPositionMs) {
+                positionMs >= targetPositionMs
+            } else {
+                positionMs <= targetPositionMs
+            }
+    }
 
     init {
         systemHooks.attach()
@@ -643,6 +659,7 @@ class BaeCorePlayer(
         playWhenReady = true
         sidePausePrompt = null
         if (current != null) {
+            pendingSeek = null
             playingTrackId = current.meta.trackId
             currentMeta = current.meta
             durationMs = current.durationMs
@@ -689,10 +706,10 @@ class BaeCorePlayer(
         }
     }
 
-    /** Bridge durations are 0 when unknown; map that to Media3's [C.TIME_UNSET]. */
-    private fun durationOrUnset(durationMs: Long): Long = if (durationMs > 0L) durationMs else C.TIME_UNSET
-
     override fun onPaused(event: BridgeUiEvent.PlaybackPaused) {
+        if (event.trackId != playingTrackId) {
+            pendingSeek = null
+        }
         transport = Transport.READY
         playWhenReady = false
         playingTrackId = event.trackId
@@ -714,11 +731,10 @@ class BaeCorePlayer(
         currentMeta = null
         refreshArtwork(null)
         sidePausePrompt = null
+        pendingSeek = null
         anchorPositionMs = 0L
         durationMs = C.TIME_UNSET
         progress = 0.0
-        elapsedLabel = ""
-        remainingLabel = ""
         systemHooks.onPlaybackStopped()
         publish()
     }
@@ -746,11 +762,16 @@ class BaeCorePlayer(
         durationMs: Long,
         progress: Double,
     ) {
+        val pendingSeek = pendingSeek
+        if (pendingSeek != null) {
+            if (!pendingSeek.accepts(positionMs)) {
+                return
+            }
+            this.pendingSeek = null
+        }
         anchorPositionMs = positionMs
         this.durationMs = durationOrUnset(durationMs)
         this.progress = progress
-        this.elapsedLabel = formatDurationMs(positionMs)
-        this.remainingLabel = formatRemainingMs(positionMs, durationMs)
         publish()
     }
 
@@ -820,12 +841,7 @@ class BaeCorePlayer(
             }
         _isPlaying.value = transport == Transport.READY && playWhenReady
         _isLoading.value = transport == Transport.BUFFERING
-        _position.value =
-            PlaybackPosition(
-                progress = progress,
-                elapsedLabel = elapsedLabel,
-                remainingLabel = remainingLabel,
-            )
+        _position.value = playbackPosition()
         _queue.value =
             QueueProjection(
                 manual = manualEntries.mapNotNull { it.toQueueItem() },
@@ -840,6 +856,24 @@ class BaeCorePlayer(
                         null
                     },
             )
+    }
+
+    private fun playbackPosition(): PlaybackPosition {
+        if (currentMeta == null) {
+            return PlaybackPosition(0.0, "", "")
+        }
+        val positionMs = effectivePositionMs
+        val progress =
+            if (durationMs > 0L) {
+                (positionMs.toDouble() / durationMs.toDouble()).coerceIn(0.0, 1.0)
+            } else {
+                progress.coerceIn(0.0, 1.0)
+            }
+        return PlaybackPosition(
+            progress = progress,
+            elapsedLabel = formatDurationMs(positionMs),
+            remainingLabel = if (durationMs > 0L) formatRemainingMs(positionMs, durationMs) else "",
+        )
     }
 
     private fun Meta.toQueueItem(): QueueItem? {
@@ -924,7 +958,7 @@ class BaeCorePlayer(
             .setCurrentMediaItemIndex(currentIndex)
             .setContentPositionMs(
                 PositionSupplier.getExtrapolating(
-                    anchorPositionMs,
+                    effectivePositionMs,
                     if (playbackState == Player.STATE_READY && playWhenReady) 1.0f else 0.0f,
                 ),
             ).build()
@@ -999,6 +1033,7 @@ class BaeCorePlayer(
                 // it is a no-op.
                 val entryId = orderedMetas(entries, currentMeta).getOrNull(mediaItemIndex)?.entryId
                 if (entryId != null) {
+                    pendingSeek = null
                     appHandle.skipToEntry(entryId)
                 } else {
                     logger.warning("handleSeek to media item $mediaItemIndex has no queue entry id")
@@ -1010,7 +1045,14 @@ class BaeCorePlayer(
                 // ratio; derive it from the requested position and known duration.
                 val total = durationMs
                 if (total > 0L) {
-                    appHandle.seekByRatio((positionMs.toDouble() / total.toDouble()).coerceIn(0.0, 1.0))
+                    val targetPositionMs = positionMs.coerceIn(0L, total)
+                    appHandle.seekByRatio(targetPositionMs.toDouble() / total.toDouble())
+                    pendingSeek =
+                        PendingSeek(
+                            originPositionMs = effectivePositionMs,
+                            targetPositionMs = targetPositionMs,
+                        )
+                    publish()
                 } else {
                     logger.warning("handleSeek ignored: no duration for in-track seek")
                 }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.media3.common.C
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
 import kotlinx.coroutines.launch
@@ -187,22 +186,9 @@ private fun ExpandedTrackInfo(
 @Composable
 private fun ExpandedSeekSection(player: fm.bae.app.playback.BaeCorePlayer) {
     val position by player.position.collectAsState()
-    // While dragging, follow the finger; the progress events would otherwise snap
-    // the thumb back mid-drag. Null means "not dragging". Same pattern as the bar.
-    var dragRatio by remember { mutableStateOf<Float?>(null) }
-    val shownRatio = dragRatio ?: position.progress.toFloat().coerceIn(0f, 1f)
-    Slider(
-        value = shownRatio,
-        onValueChange = { dragRatio = it },
-        onValueChangeFinished = {
-            dragRatio?.let { ratio ->
-                val duration = player.duration
-                if (duration != C.TIME_UNSET && duration > 0L) {
-                    player.seekTo((ratio * duration).toLong())
-                }
-            }
-            dragRatio = null
-        },
+    NowPlayingSeekSlider(
+        position = position,
+        player = player,
         modifier = Modifier.fillMaxWidth(),
     )
     Row(modifier = Modifier.fillMaxWidth()) {

--- a/bae-android/app/src/main/java/fm/bae/app/ui/NowPlayingBar.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/NowPlayingBar.kt
@@ -224,26 +224,15 @@ private fun NowPlayingSeekRow(
     position: fm.bae.app.playback.PlaybackPosition,
     player: fm.bae.app.playback.BaeCorePlayer,
 ) {
-    // While dragging, follow the finger; the progress events would otherwise snap
-    // the thumb back mid-drag. Null means "not dragging".
-    var dragRatio by remember { mutableStateOf<Float?>(null) }
-    val shownRatio = dragRatio ?: position.progress.toFloat().coerceIn(0f, 1f)
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = position.elapsedLabel,
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Slider(
-            value = shownRatio,
-            onValueChange = { dragRatio = it },
-            onValueChangeFinished = {
-                dragRatio?.let { ratio ->
-                    val duration = player.duration
-                    if (duration != C.TIME_UNSET && duration > 0L) player.seekTo((ratio * duration).toLong())
-                }
-                dragRatio = null
-            },
+        NowPlayingSeekSlider(
+            position = position,
+            player = player,
             modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
         )
         Text(
@@ -252,4 +241,29 @@ private fun NowPlayingSeekRow(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@Composable
+fun NowPlayingSeekSlider(
+    position: fm.bae.app.playback.PlaybackPosition,
+    player: fm.bae.app.playback.BaeCorePlayer,
+    modifier: Modifier = Modifier,
+) {
+    // While dragging, follow the finger; the progress events would otherwise snap
+    // the thumb back mid-drag. Null means "not dragging".
+    var dragRatio by remember { mutableStateOf<Float?>(null) }
+    val shownRatio = dragRatio ?: position.progress.toFloat().coerceIn(0f, 1f)
+    Slider(
+        value = shownRatio,
+        onValueChange = { dragRatio = it },
+        onValueChangeFinished = {
+            dragRatio?.let { ratio ->
+                val duration = player.duration
+                if (duration != C.TIME_UNSET && duration > 0L) player.seekTo((ratio * duration).toLong())
+            }
+            dragRatio = null
+        },
+        modifier = modifier,
+    )
 }

--- a/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackSeekProjectionTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackSeekProjectionTest.kt
@@ -1,0 +1,186 @@
+package fm.bae.app.playback
+
+import android.os.Looper
+import fm.bae.app.formatDurationMs
+import fm.bae.app.formatRemainingMs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import uniffi.bae_bridge.AppHandle
+import uniffi.bae_bridge.BridgeUiEvent
+import uniffi.bae_bridge.NoHandle
+import uniffi.bae_bridge.UiEventCallback
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class PlaybackSeekProjectionTest {
+    @Test
+    fun inTrackSeekPublishesDropPositionUntilCoreProgressCatchesUp() {
+        val (player, handle) = player()
+
+        player.startPlaying(durationMs = 100_000uL)
+        player.onProgress(positionMs = 10_000, durationMs = 100_000, progress = 0.10)
+
+        player.seekTo(75_000)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(0.75, handle.seekRatios.single(), 0.0)
+        assertPosition(
+            player.position.value,
+            progress = 0.75,
+            elapsed = formatDurationMs(75_000),
+            remaining = formatRemainingMs(75_000, 100_000),
+        )
+
+        player.onProgress(positionMs = 20_000, durationMs = 100_000, progress = 0.20)
+        assertPosition(
+            player.position.value,
+            progress = 0.75,
+            elapsed = formatDurationMs(75_000),
+            remaining = formatRemainingMs(75_000, 100_000),
+        )
+
+        player.onProgress(positionMs = 75_000, durationMs = 100_000, progress = 0.75)
+        assertPosition(
+            player.position.value,
+            progress = 0.75,
+            elapsed = formatDurationMs(75_000),
+            remaining = formatRemainingMs(75_000, 100_000),
+        )
+
+        player.onProgress(positionMs = 80_000, durationMs = 100_000, progress = 0.80)
+        assertPosition(
+            player.position.value,
+            progress = 0.80,
+            elapsed = formatDurationMs(80_000),
+            remaining = formatRemainingMs(80_000, 100_000),
+        )
+    }
+
+    @Test
+    fun backwardInTrackSeekRejectsStaleForwardProgress() {
+        val (player, handle) = player()
+
+        player.startPlaying(durationMs = 100_000uL)
+        player.onProgress(positionMs = 80_000, durationMs = 100_000, progress = 0.80)
+
+        player.seekTo(25_000)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(0.25, handle.seekRatios.single(), 0.0)
+        assertPosition(
+            player.position.value,
+            progress = 0.25,
+            elapsed = formatDurationMs(25_000),
+            remaining = formatRemainingMs(25_000, 100_000),
+        )
+
+        player.onProgress(positionMs = 82_000, durationMs = 100_000, progress = 0.82)
+        assertPosition(
+            player.position.value,
+            progress = 0.25,
+            elapsed = formatDurationMs(25_000),
+            remaining = formatRemainingMs(25_000, 100_000),
+        )
+
+        player.onProgress(positionMs = 25_000, durationMs = 100_000, progress = 0.25)
+        assertPosition(
+            player.position.value,
+            progress = 0.25,
+            elapsed = formatDurationMs(25_000),
+            remaining = formatRemainingMs(25_000, 100_000),
+        )
+    }
+
+    @Test
+    fun inTrackSeekWithoutDurationDoesNotChangeProjectedPosition() {
+        val (player, handle) = player()
+
+        player.startPlaying(durationMs = 0uL)
+        player.onProgress(positionMs = 10_000, durationMs = 0, progress = 0.0)
+        val positionBeforeSeek = player.position.value
+
+        player.seekTo(75_000)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(emptyList<Double>(), handle.seekRatios)
+        assertEquals(positionBeforeSeek, player.position.value)
+    }
+
+    @Test
+    fun stoppedPlaybackResetsProjectedPositionLabels() {
+        val (player, _) = player()
+
+        player.startPlaying(durationMs = 100_000uL)
+        player.onProgress(positionMs = 25_000, durationMs = 100_000, progress = 0.25)
+
+        player.onStopped()
+
+        assertPosition(
+            player.position.value,
+            progress = 0.0,
+            elapsed = "",
+            remaining = "",
+        )
+    }
+
+    private fun player(): Pair<BaeCorePlayer, SeekRecordingHandle> {
+        val context = RuntimeEnvironment.getApplication()
+        val handle = SeekRecordingHandle()
+        val player =
+            BaeCorePlayer(
+                applicationLooper = Looper.getMainLooper(),
+                appHandle = handle,
+                context = context,
+                scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+                isAppForeground = { false },
+            )
+        return player to handle
+    }
+
+    private fun BaeCorePlayer.startPlaying(durationMs: ULong) {
+        onPlaying(
+            BridgeUiEvent.PlaybackPlaying(
+                trackId = "track-1",
+                trackTitle = "Track Title",
+                artistNames = "Artist Name",
+                artistId = "artist-1",
+                albumId = "album-1",
+                albumTitle = "Album Title",
+                coverImageId = null,
+                durationMs = durationMs,
+            ),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun assertPosition(
+        position: PlaybackPosition,
+        progress: Double,
+        elapsed: String,
+        remaining: String,
+    ) {
+        assertEquals(progress, position.progress, 0.0)
+        assertEquals(elapsed, position.elapsedLabel)
+        assertEquals(remaining, position.remainingLabel)
+    }
+
+    private class SeekRecordingHandle : AppHandle(NoHandle) {
+        val seekRatios = mutableListOf<Double>()
+
+        override fun seekByRatio(ratio: Double) {
+            seekRatios += ratio
+        }
+
+        override fun savePlaybackState() {}
+
+        override fun subscribeUiEvents(callback: UiEventCallback) {}
+    }
+}


### PR DESCRIPTION
When the Android seek slider released, the UI cleared its drag value before bae-core emitted the next playback progress event. That let the player projection briefly repaint the previous position. This moves the pending seek into BaeCorePlayer so the compact bar, expanded player, and Media3 session all publish the requested drop position until core reaches it, including backward seeks.

Test plan:
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dima/Library/Android/sdk" ./gradlew :app:testFullDebugUnitTest --tests fm.bae.app.playback.PlaybackSeekProjectionTest --no-daemon
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dima/Library/Android/sdk" ./gradlew :app:testFullDebugUnitTest --no-daemon