### PR TITLE
Project Apple seek drops

### DIFF
--- a/bae-ios/bae/bae/AppService.swift
+++ b/bae-ios/bae/bae/AppService.swift
@@ -98,6 +98,9 @@ final class AppService: Observable {
                 appHandle: appHandle
             )
         )
-        mediaControlService.setupRemoteCommands(playback: playback)
+        mediaControlService.setupRemoteCommands(
+            playback: playback,
+            playbackStore: playbackStore
+        )
     }
 }

--- a/bae-ios/bae/bae/MediaControlService.swift
+++ b/bae-ios/bae/bae/MediaControlService.swift
@@ -51,7 +51,10 @@ final class MediaControlService: @unchecked Sendable {
 
     // MARK: - Remote commands + session
 
-    func setupRemoteCommands(playback: Playback) {
+    func setupRemoteCommands(
+        playback: Playback,
+        playbackStore: PlaybackStore
+    ) {
         self.playback = playback
         registerSessionObservers()
 
@@ -99,6 +102,12 @@ final class MediaControlService: @unchecked Sendable {
                 return .commandFailed
             }
             let ratio = positionEvent.positionTime / (Double(durationMs) / 1000.0)
+            if let snapshot = playbackStore.projectSeek(ratio: ratio) {
+                updatePosition(
+                    positionMs: snapshot.positionMs,
+                    durationMs: snapshot.durationMs
+                )
+            }
             playback.seekByRatio(ratio)
             return .success
         }

--- a/bae-ios/bae/bae/UiEventReducer.swift
+++ b/bae-ios/bae/bae/UiEventReducer.swift
@@ -211,7 +211,7 @@ enum UiEventReducer {
         albumTitle: String,
         into context: ReducerContext
     ) {
-        context.playbackStore.nowPlaying = .playing(track)
+        context.playbackStore.play(track: track)
         context.mediaControlService.beginPlaybackSession()
         updateMediaControls(
             track: track,
@@ -248,7 +248,7 @@ enum UiEventReducer {
 
         case .playbackStopped:
             playbackStore.nowPlaying = .stopped
-            playbackStore.playbackPositionSubject.send(.reset)
+            playbackStore.resetPlaybackPosition()
             mediaControlService.clearNowPlaying()
             mediaControlService.endPlaybackSession()
 
@@ -264,19 +264,14 @@ enum UiEventReducer {
             let durationMs,
             let progress
         ):
-            playbackStore.playbackPositionSubject.send(
-                .position(
-                    progress: progress,
-                    elapsed: DurationClock.text(Int64(positionMs)),
-                    remaining: DurationClock.remaining(
-                        positionMs: positionMs,
-                        durationMs: durationMs
-                    )
-                )
+            let snapshot = playbackStore.updatePlaybackPosition(
+                positionMs: positionMs,
+                durationMs: durationMs,
+                progress: progress
             )
             mediaControlService.updatePosition(
-                positionMs: positionMs,
-                durationMs: durationMs
+                positionMs: snapshot.positionMs,
+                durationMs: snapshot.durationMs
             )
 
         default:
@@ -359,7 +354,6 @@ private func applyPlaybackLoading(
     }
     else {
         playbackStore.beginLoading(trackId: trackId)
-        playbackStore.playbackPositionSubject.send(.reset)
     }
 }
 

--- a/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
+++ b/bae-ios/bae/bae/Views/ExpandedNowPlayingView.swift
@@ -79,7 +79,10 @@ struct ExpandedNowPlayingView: View {
 
             ProgressBar(
                 positionSubject: playbackStore.playbackPositionSubject,
-                onSeek: { playback.seekByRatio($0) }
+                onSeek: { ratio in
+                    playbackStore.projectSeek(ratio: ratio)
+                    playback.seekByRatio(ratio)
+                }
             )
 
             transport

--- a/bae-ios/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-ios/bae/bae/Views/NowPlayingBar.swift
@@ -22,7 +22,10 @@ struct NowPlayingBar: View {
                 transport(track: track)
                 ProgressBar(
                     positionSubject: playbackStore.playbackPositionSubject,
-                    onSeek: { playback.seekByRatio($0) }
+                    onSeek: { ratio in
+                        playbackStore.projectSeek(ratio: ratio)
+                        playback.seekByRatio(ratio)
+                    }
                 )
             }
             .padding(.horizontal, 12)

--- a/bae-ios/bae/bae/Views/ProgressBar.swift
+++ b/bae-ios/bae/bae/Views/ProgressBar.swift
@@ -31,8 +31,8 @@ struct ProgressBar: View {
                 in: 0...1,
                 onEditingChanged: { editing in
                     if !editing, let ratio = dragRatio {
-                        onSeek(ratio)
                         dragRatio = nil
+                        onSeek(ratio)
                     }
                 }
             )

--- a/bae-macos/bae/bae/Services/AppService.swift
+++ b/bae-macos/bae/bae/Services/AppService.swift
@@ -153,7 +153,8 @@ final class AppService: @unchecked Sendable, Observable {
         appHandle.registerArtworkAnalyzer(analyzer: VisionArtworkAnalyzer())
         mediaControlService.setupRemoteCommands(
             playback: playback,
-            previewAudio: previewAudio
+            previewAudio: previewAudio,
+            playbackStore: playbackStore
         )
         revalidateDiscogsToken()
     }

--- a/bae-macos/bae/bae/Services/MediaControlService.swift
+++ b/bae-macos/bae/bae/Services/MediaControlService.swift
@@ -26,7 +26,11 @@ final class MediaControlService: @unchecked Sendable {
     private var isShowingPreview = false
     private var currentDurationMs: UInt64?
 
-    func setupRemoteCommands(playback: Playback, previewAudio: PreviewAudio) {
+    func setupRemoteCommands(
+        playback: Playback,
+        previewAudio: PreviewAudio,
+        playbackStore: PlaybackStore
+    ) {
         guard !commandsRegistered else {
             return
         }
@@ -46,7 +50,8 @@ final class MediaControlService: @unchecked Sendable {
         registerScrubCommand(
             center: center,
             playback: playback,
-            previewAudio: previewAudio
+            previewAudio: previewAudio,
+            playbackStore: playbackStore
         )
     }
 
@@ -116,7 +121,8 @@ final class MediaControlService: @unchecked Sendable {
     private func registerScrubCommand(
         center: MPRemoteCommandCenter,
         playback: Playback,
-        previewAudio: PreviewAudio
+        previewAudio: PreviewAudio,
+        playbackStore: PlaybackStore
     ) {
         center.changePlaybackPositionCommand.addTarget { [weak self] event in
             guard let self,
@@ -137,6 +143,12 @@ final class MediaControlService: @unchecked Sendable {
                 previewAudio.previewSeekByRatio(ratio)
             }
             else {
+                if let snapshot = playbackStore.projectSeek(ratio: ratio) {
+                    updatePosition(
+                        positionMs: snapshot.positionMs,
+                        durationMs: snapshot.durationMs
+                    )
+                }
                 playback.seekByRatio(ratio)
             }
             return .success

--- a/bae-macos/bae/bae/Services/PlaybackPositionEvent.swift
+++ b/bae-macos/bae/bae/Services/PlaybackPositionEvent.swift
@@ -12,3 +12,20 @@ enum PlaybackPositionEvent {
     case position(progress: Double, elapsed: String, remaining: String)
     case reset
 }
+
+struct PlaybackPositionSnapshot {
+    let positionMs: UInt64
+    let durationMs: UInt64
+    let progress: Double
+
+    var event: PlaybackPositionEvent {
+        .position(
+            progress: progress,
+            elapsed: DurationClock.text(Int64(positionMs)),
+            remaining: DurationClock.remaining(
+                positionMs: positionMs,
+                durationMs: durationMs
+            )
+        )
+    }
+}

--- a/bae-macos/bae/bae/Services/PlaybackStore.swift
+++ b/bae-macos/bae/bae/Services/PlaybackStore.swift
@@ -29,6 +29,7 @@ class PlaybackStore {
     let playbackPositionSubject = CurrentValueSubject<
         PlaybackPositionEvent, Never
     >(.reset)
+    private var playbackPosition: PlaybackPositionState?
 
     /// Fires when tracks have been appended/inserted into the playback queue.
     /// Payload is the count from a single add operation (release add, drag,
@@ -51,6 +52,7 @@ class PlaybackStore {
             target: nil,
             previous: nowPlaying.track
         )
+        resetPlaybackPosition()
     }
 
     /// A loading state carrying the target track's metadata arrived (core's
@@ -93,7 +95,116 @@ class PlaybackStore {
     }
 
     func pause(track: NowPlayingTrack, reason: BridgePlaybackPauseReason) {
+        preparePlaybackPosition(for: track)
         nowPlaying = .paused(track, reason: reason)
+    }
+
+    func play(track: NowPlayingTrack) {
+        preparePlaybackPosition(for: track)
+        nowPlaying = .playing(track)
+    }
+
+    func updatePlaybackPosition(
+        positionMs: UInt64,
+        durationMs: UInt64,
+        progress: Double
+    ) -> PlaybackPositionSnapshot {
+        if case .projected(let projected, let pendingSeek) = playbackPosition {
+            if !pendingSeek.accepts(positionMs) {
+                return projected
+            }
+        }
+        let snapshot = PlaybackPositionSnapshot(
+            positionMs: positionMs,
+            durationMs: durationMs,
+            progress: progress
+        )
+        return publish(snapshot, state: .current(snapshot))
+    }
+
+    @discardableResult
+    func projectSeek(ratio: Double) -> PlaybackPositionSnapshot? {
+        guard let currentPosition = playbackPosition?.snapshot,
+            currentPosition.durationMs > 0
+        else {
+            logger.warning(
+                "Seek projection ignored for ratio \(ratio): no known playback duration"
+            )
+            return nil
+        }
+        let clampedRatio = min(1.0, max(0.0, ratio))
+        let targetPositionMs = UInt64(
+            (clampedRatio * Double(currentPosition.durationMs)).rounded()
+        )
+        let snapshot = PlaybackPositionSnapshot(
+            positionMs: targetPositionMs,
+            durationMs: currentPosition.durationMs,
+            progress: clampedRatio
+        )
+        let pendingSeek = PendingSeek(
+            originPositionMs: currentPosition.positionMs,
+            targetPositionMs: targetPositionMs
+        )
+        return publish(snapshot, state: .projected(snapshot, pendingSeek))
+    }
+
+    func resetPlaybackPosition() {
+        playbackPosition = nil
+        playbackPositionSubject.send(.reset)
+    }
+
+    private func preparePlaybackPosition(for track: NowPlayingTrack) {
+        if track.trackId != nowPlaying.track?.trackId {
+            playbackPosition = playbackPosition?.withoutProjection
+        }
+    }
+
+    private func publish(
+        _ snapshot: PlaybackPositionSnapshot,
+        state: PlaybackPositionState
+    ) -> PlaybackPositionSnapshot {
+        playbackPosition = state
+        playbackPositionSubject.send(snapshot.event)
+        return snapshot
+    }
+}
+
+private enum PlaybackPositionState {
+    case current(PlaybackPositionSnapshot)
+    case projected(PlaybackPositionSnapshot, PendingSeek)
+
+    var snapshot: PlaybackPositionSnapshot {
+        switch self {
+        case .current(let snapshot), .projected(let snapshot, _):
+            snapshot
+        }
+    }
+
+    var withoutProjection: PlaybackPositionState {
+        .current(snapshot)
+    }
+}
+
+private struct PendingSeek {
+    let originPositionMs: UInt64
+    let targetPositionMs: UInt64
+    private static let targetAcceptanceWindowMs: UInt64 = 1_000
+
+    func accepts(_ positionMs: UInt64) -> Bool {
+        let distanceFromTarget =
+            positionMs > targetPositionMs
+            ? positionMs - targetPositionMs
+            : targetPositionMs - positionMs
+        if targetPositionMs >= originPositionMs {
+            return positionMs >= targetPositionMs
+        }
+        else {
+            guard positionMs <= originPositionMs else {
+                return false
+            }
+            return positionMs <= targetPositionMs
+                || distanceFromTarget <= Self.targetAcceptanceWindowMs
+        }
     }
 }
 

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -205,7 +205,7 @@ enum UiEventReducer {
         case .playbackStopped:
             let playbackStore = context.playbackStore
             playbackStore.nowPlaying = .stopped
-            playbackStore.playbackPositionSubject.send(.reset)
+            playbackStore.resetPlaybackPosition()
             context.appService.mediaControlService.updateNowPlaying(
                 state: .stopped,
                 appHandle: context.appService.appHandle
@@ -241,7 +241,6 @@ enum UiEventReducer {
         }
         else {
             playbackStore.beginLoading(trackId: trackId)
-            playbackStore.playbackPositionSubject.send(.reset)
         }
         context.appService.mediaControlService.updateNowPlaying(
             state: .loading(trackId: trackId, track: track),
@@ -259,7 +258,7 @@ enum UiEventReducer {
         _ fields: NowPlayingFields,
         into context: ReducerContext
     ) {
-        context.playbackStore.nowPlaying = .playing(fields.nowPlayingTrack())
+        context.playbackStore.play(track: fields.nowPlayingTrack())
         updateMediaControls(fields, isPlaying: true, into: context)
     }
 
@@ -307,19 +306,14 @@ enum UiEventReducer {
             let durationMs,
             let progress
         ):
-            playbackStore.playbackPositionSubject.send(
-                .position(
-                    progress: progress,
-                    elapsed: DurationClock.text(Int64(positionMs)),
-                    remaining: DurationClock.remaining(
-                        positionMs: positionMs,
-                        durationMs: durationMs
-                    )
-                )
+            let snapshot = playbackStore.updatePlaybackPosition(
+                positionMs: positionMs,
+                durationMs: durationMs,
+                progress: progress
             )
             context.appService.mediaControlService.updatePosition(
-                positionMs: positionMs,
-                durationMs: durationMs
+                positionMs: snapshot.positionMs,
+                durationMs: snapshot.durationMs
             )
 
         case .volumeChanged(let volume):

--- a/bae-macos/bae/bae/Views/NowPlayingBar.swift
+++ b/bae-macos/bae/bae/Views/NowPlayingBar.swift
@@ -46,7 +46,10 @@ struct NowPlayingBarContainer: View {
             onPlayPause: { playback.togglePlayPause() },
             onNext: { playback.nextTrack() },
             onPrevious: { playback.previousTrack() },
-            onSeek: { playback.seekByRatio($0) },
+            onSeek: { ratio in
+                playbackStore.projectSeek(ratio: ratio)
+                playback.seekByRatio(ratio)
+            },
             onVolumeChange: { playback.setVolume($0) },
             onToggleMute: { playback.toggleMute() },
             onCycleRepeat: { playback.cycleRepeatMode() },

--- a/bae-macos/bae/baeTests/PlaybackStoreTests.swift
+++ b/bae-macos/bae/baeTests/PlaybackStoreTests.swift
@@ -160,3 +160,227 @@ struct NowPlayingStateTests {
         #expect(!stopped.isPlaying)
     }
 }
+
+@Suite("PlaybackStore seek projection")
+struct PlaybackStoreSeekProjectionTests {
+    @MainActor
+    @Test("forward seek publishes the dropped target and ignores old progress")
+    func forwardSeekPublishesTarget() {
+        let store = PlaybackStore()
+        _ = store.updatePlaybackPosition(
+            positionMs: 10_000,
+            durationMs: 100_000,
+            progress: 0.1
+        )
+
+        let projected = store.projectSeek(ratio: 0.75)
+
+        #expect(projected?.positionMs == 75_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.75,
+            elapsed: "1:15",
+            remaining: "-0:25"
+        )
+        let stale = store.updatePlaybackPosition(
+            positionMs: 20_000,
+            durationMs: 100_000,
+            progress: 0.2
+        )
+        #expect(stale.positionMs == 75_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.75,
+            elapsed: "1:15",
+            remaining: "-0:25"
+        )
+
+        let accepted = store.updatePlaybackPosition(
+            positionMs: 76_000,
+            durationMs: 100_000,
+            progress: 0.76
+        )
+
+        #expect(accepted.positionMs == 76_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.76,
+            elapsed: "1:16",
+            remaining: "-0:24"
+        )
+    }
+
+    @MainActor
+    @Test("forward seek rejects stale progress before the target")
+    func forwardSeekRejectsOriginSideProgressNearTarget() {
+        let store = PlaybackStore()
+        _ = store.updatePlaybackPosition(
+            positionMs: 24_500,
+            durationMs: 100_000,
+            progress: 0.245
+        )
+
+        _ = store.projectSeek(ratio: 0.25)
+
+        let stale = store.updatePlaybackPosition(
+            positionMs: 24_600,
+            durationMs: 100_000,
+            progress: 0.246
+        )
+        #expect(stale.positionMs == 25_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.25,
+            elapsed: "0:25",
+            remaining: "-1:15"
+        )
+
+        let accepted = store.updatePlaybackPosition(
+            positionMs: 25_000,
+            durationMs: 100_000,
+            progress: 0.25
+        )
+
+        #expect(accepted.positionMs == 25_000)
+    }
+
+    @MainActor
+    @Test("backward seek holds the target until progress reaches it")
+    func backwardSeekPublishesTarget() {
+        let store = PlaybackStore()
+        _ = store.updatePlaybackPosition(
+            positionMs: 80_000,
+            durationMs: 100_000,
+            progress: 0.8
+        )
+
+        let projected = store.projectSeek(ratio: 0.25)
+
+        #expect(projected?.positionMs == 25_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.25,
+            elapsed: "0:25",
+            remaining: "-1:15"
+        )
+        let stale = store.updatePlaybackPosition(
+            positionMs: 70_000,
+            durationMs: 100_000,
+            progress: 0.7
+        )
+        #expect(stale.positionMs == 25_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.25,
+            elapsed: "0:25",
+            remaining: "-1:15"
+        )
+
+        let accepted = store.updatePlaybackPosition(
+            positionMs: 25_100,
+            durationMs: 100_000,
+            progress: 0.251
+        )
+
+        #expect(accepted.positionMs == 25_100)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.251,
+            elapsed: "0:25",
+            remaining: "-1:15"
+        )
+    }
+
+    @MainActor
+    @Test("backward seek rejects stale progress near the origin")
+    func backwardSeekRejectsOriginSideProgressNearTarget() {
+        let store = PlaybackStore()
+        _ = store.updatePlaybackPosition(
+            positionMs: 25_900,
+            durationMs: 100_000,
+            progress: 0.259
+        )
+
+        _ = store.projectSeek(ratio: 0.25)
+
+        let stale = store.updatePlaybackPosition(
+            positionMs: 25_950,
+            durationMs: 100_000,
+            progress: 0.2595
+        )
+        #expect(stale.positionMs == 25_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.25,
+            elapsed: "0:25",
+            remaining: "-1:15"
+        )
+
+        let accepted = store.updatePlaybackPosition(
+            positionMs: 25_100,
+            durationMs: 100_000,
+            progress: 0.251
+        )
+
+        #expect(accepted.positionMs == 25_100)
+    }
+
+    @MainActor
+    @Test("unknown duration seek leaves the position unchanged")
+    func unknownDurationSeekDoesNotProject() {
+        let store = PlaybackStore()
+        _ = store.updatePlaybackPosition(
+            positionMs: 10_000,
+            durationMs: 0,
+            progress: 0.1
+        )
+
+        #expect(store.projectSeek(ratio: 0.75) == nil)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.1,
+            elapsed: "0:10",
+            remaining: "-0:00"
+        )
+    }
+
+    @MainActor
+    @Test("reset clears projected position")
+    func resetClearsProjection() {
+        let store = PlaybackStore()
+        _ = store.updatePlaybackPosition(
+            positionMs: 10_000,
+            durationMs: 100_000,
+            progress: 0.1
+        )
+        _ = store.projectSeek(ratio: 0.75)
+
+        store.resetPlaybackPosition()
+
+        guard case .reset = store.playbackPositionSubject.value else {
+            Issue.record("position did not reset")
+            return
+        }
+    }
+}
+
+private func expectPosition(
+    _ event: PlaybackPositionEvent,
+    progress: Double,
+    elapsed: String,
+    remaining: String
+) {
+    guard
+        case .position(
+            let actualProgress,
+            let actualElapsed,
+            let actualRemaining
+        ) = event
+    else {
+        Issue.record("position event was reset")
+        return
+    }
+    #expect(actualProgress == progress)
+    #expect(actualElapsed == elapsed)
+    #expect(actualRemaining == remaining)
+}


### PR DESCRIPTION
Playback progress events can arrive from the old position after a user releases the seek slider. This moves Apple playback position rendering through PlaybackStore, where a dropped seek target is represented until core progress reaches it, so the iOS and macOS scrubber stays at the selected position instead of jumping back.\n\nTest plan:\n- xcodebuild -project bae.xcodeproj -scheme bae -configuration Debug -derivedDataPath .build/derivedData -only-testing:baeTests/PlaybackStoreSeekProjectionTests test\n- xcrun swift-format lint -s bae/Services/PlaybackStore.swift bae/Services/PlaybackPositionEvent.swift bae/Features/Player/PlayerFeature.swift bae-ios/bae/Features/Player/ProgressBar.swift bae-ios/bae/Features/Player/NowPlayingView.swift bae-ios/bae/Features/Player/PlayerFeature.swift\n- swiftlint lint --strict --config .swiftlint.yml bae/Services/PlaybackStore.swift bae/Services/PlaybackPositionEvent.swift bae/Features/Player/PlayerFeature.swift bae-ios/bae/Features/Player/ProgressBar.swift bae-ios/bae/Features/Player/NowPlayingView.swift bae-ios/bae/Features/Player/PlayerFeature.swift\n- iOS simulator build attempted; blocked locally because no eligible iOS Simulator destination is installed