### PR TITLE
Normalize stored covers to ≤600 JPEG thumbnails

### DIFF
--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -40,6 +40,11 @@ libc = "0.2"
 chardetng = "0.1"
 encoding_rs = "0.8"
 rtrb = "0.3.2"
+# Cover-art resizing at store time (src/util/cover.rs) runs on every platform —
+# imports and change-cover normalize to a ≤600 JPEG thumbnail everywhere, so the
+# stored cover blob is uniform regardless of which device imported it. jpeg+png
+# only, no default features (no rayon), so it builds on mobile and wasm.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 futures = "0.3.31"
 tokio-util = { version = "0.7", features = ["io", "rt"] }
 rand = "0.9"
@@ -81,7 +86,6 @@ rayon = "1.10"
 dotenvy = "0.15"
 discid = "0.5"
 lofty = "0.24"
-image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 # Loudness + true-peak measurement at import (src/loudness.rs). Pure Rust, no
 # system libs. Desktop-only: import decodes audio only on these targets, and the
 # playback gain is derived from the stored measurements with plain arithmetic

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -1064,6 +1064,19 @@ impl ImportService {
         let cover_winner = remote_cover_image
             .or(local_cover_image)
             .or(embedded_cover_image);
+        // Resize the winning cover to a ≤600px JPEG thumbnail — one funnel for
+        // all three sources — and patch the record to describe the stored bytes:
+        // the resize always emits JPEG, so the row and the `cloud_path` extension
+        // `finalize_import_atomic` derives from it must say JPEG too.
+        let cover_winner = match cover_winner {
+            Some((mut image, bytes)) => {
+                let bytes = crate::util::cover::resize_cover(&bytes)?;
+                image.content_type = crate::util::content_type::ContentType::Jpeg;
+                image.file_size = bytes.len() as i64;
+                Some((image, bytes))
+            }
+            None => None,
+        };
         let library_image = cover_winner
             .as_ref()
             .map(|(image, bytes)| (image, bytes.as_slice()));

--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -258,9 +258,6 @@ impl ExportService {
     }
 }
 
-/// Maximum dimension for embedded cover art.
-const COVER_MAX_SIZE: u32 = 600;
-
 /// Write metadata tags to an encoded audio file. Each tag is written only when
 /// the user's `metadata` selection includes it; cover art is governed by
 /// `cover_data` being `Some` (the plan omits the bytes when it's deselected),
@@ -323,10 +320,10 @@ fn write_tags(
     }
 
     if let Some(data) = cover_data {
-        let resized = resize_cover(data)?;
-
+        // The stored cover is already a ≤600 JPEG (resized at store time), so
+        // embed its bytes directly — no second resize/JPEG pass here.
         tag.push_picture(
-            Picture::unchecked(resized)
+            Picture::unchecked(data.to_vec())
                 .pic_type(PictureType::CoverFront)
                 .build(),
         );
@@ -340,33 +337,6 @@ fn write_tags(
 
     debug!("Wrote metadata tags to {}", path.display());
     Ok(())
-}
-
-/// Resize cover art to fit within COVER_MAX_SIZE, encoded as JPEG.
-fn resize_cover(data: &[u8]) -> Result<Vec<u8>, String> {
-    let img = image::load_from_memory(data)
-        .map_err(|e| format!("Failed to decode cover image: {}", e))?;
-
-    let (w, h) = (img.width(), img.height());
-
-    let img = if w > COVER_MAX_SIZE || h > COVER_MAX_SIZE {
-        debug!(
-            "Resizing cover art from {}x{} to fit {}x{}",
-            w, h, COVER_MAX_SIZE, COVER_MAX_SIZE
-        );
-        img.resize(
-            COVER_MAX_SIZE,
-            COVER_MAX_SIZE,
-            image::imageops::FilterType::Lanczos3,
-        )
-    } else {
-        img
-    };
-
-    let mut buf = std::io::Cursor::new(Vec::new());
-    img.write_to(&mut buf, image::ImageFormat::Jpeg)
-        .map_err(|e| format!("Failed to encode cover as JPEG: {}", e))?;
-    Ok(buf.into_inner())
 }
 
 /// Decode a track's source audio (already read into the plan) to PCM.

--- a/bae-core/src/library/manager/image.rs
+++ b/bae-core/src/library/manager/image.rs
@@ -95,7 +95,9 @@ impl LibraryManager {
         release_id: &str,
         selection: CoverSelection,
     ) -> Result<(), LibraryError> {
-        let (bytes, content_type, source, source_url) = match selection {
+        // The source content type is discarded: every stored cover is resized to
+        // JPEG below, so only the bytes, provenance, and URL carry through.
+        let (bytes, source, source_url) = match selection {
             CoverSelection::ReleaseImage { file_id } => {
                 let file = self
                     .get_file_by_id(&file_id)
@@ -106,24 +108,26 @@ impl LibraryManager {
                 // read (the user's own file when Local, the cache/cloud when Remote).
                 let bytes = self.read_release_blob(&file).await?;
                 let source_url = format!("release://{}", file.original_filename);
-                (
-                    bytes,
-                    file.content_type.clone(),
-                    "local".to_string(),
-                    Some(source_url),
-                )
+                (bytes, "local".to_string(), Some(source_url))
             }
             CoverSelection::RemoteCover { url, source } => {
-                let (bytes, content_type) =
+                let (bytes, _content_type) =
                     crate::import::cover_art::download_cover_art_bytes(&url)
                         .await
                         .map_err(|e| {
                             LibraryError::Import(format!("Failed to download cover: {e}"))
                         })?;
 
-                (bytes, content_type, source.as_str().to_string(), Some(url))
+                (bytes, source.as_str().to_string(), Some(url))
             }
         };
+
+        // Resize to a ≤600px JPEG thumbnail before deriving the storage key and
+        // record — the stored bytes, their format, and size all describe the
+        // thumbnail, not the source. The resize always emits JPEG.
+        let bytes = crate::util::cover::resize_cover(&bytes)
+            .map_err(|e| LibraryError::Import(format!("Failed to resize cover: {e}")))?;
+        let content_type = crate::util::content_type::ContentType::Jpeg;
 
         // Record the cover blob and row in one coven write. The cover's `id` IS
         // the release id. Under a

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -852,6 +852,79 @@ async fn gallery_includes_cloud_only_image_files_with_no_local_path() {
     );
 }
 
+/// `change_cover` resizes whatever the user picks to a ≤600 JPEG thumbnail
+/// before storing it: a 900×300 PNG release image lands as a 600×200 JPEG blob
+/// (downscaled to fit 600, aspect kept), and the `covers` row records JPEG.
+#[tokio::test]
+async fn change_cover_stores_a_resized_jpeg_thumbnail() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let mut release = create_test_release(&album.id);
+    release.remote = false;
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+
+    // An oversized non-JPEG release image on disk, registered as the release's
+    // user-provided file so `change_cover` reads it back through coven.
+    let source_dir = TempDir::new().unwrap();
+    let cover_bytes = {
+        let img = ::image::RgbImage::from_pixel(900, 300, ::image::Rgb([20, 160, 90]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        ::image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, ::image::ImageFormat::Png)
+            .unwrap();
+        buf.into_inner()
+    };
+    std::fs::write(source_dir.path().join("art.png"), &cover_bytes).unwrap();
+    let file = DbFile::new(
+        &release.id,
+        "art.png",
+        cover_bytes.len() as i64,
+        ContentType::Png,
+        Uuid::new_v4().to_string(),
+        Utc::now(),
+    );
+    manager.add_file(&file).await.unwrap();
+    manager
+        .database
+        .register_release_external_refs_for_test(&release.id, &source_dir.path().to_string_lossy())
+        .await
+        .unwrap();
+
+    manager
+        .change_cover(
+            &album.id,
+            &release.id,
+            CoverSelection::ReleaseImage {
+                file_id: file.id.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // The stored blob decodes as a ≤600 JPEG, not the 900×300 PNG source.
+    let stored = manager
+        .read_cover_image_blob(&release.id)
+        .await
+        .unwrap()
+        .expect("cover blob stored");
+    assert_eq!(
+        ::image::guess_format(&stored).unwrap(),
+        ::image::ImageFormat::Jpeg
+    );
+    let decoded = ::image::load_from_memory(&stored).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), (600, 200));
+
+    // The row describes the stored thumbnail: JPEG, and its size matches.
+    let row = manager
+        .get_library_image(&release.id, &LibraryImageType::Cover)
+        .await
+        .unwrap()
+        .expect("cover row stored");
+    assert_eq!(row.content_type, ContentType::Jpeg);
+    assert_eq!(row.file_size, stored.len() as i64);
+}
+
 /// Queueing an album expands to its PRIMARY release's tracks, not the
 /// earliest-imported one. When the user picks a non-default primary (e.g. a
 /// later remaster over the original vinyl rip), enqueueing the album must

--- a/bae-core/src/util/cover.rs
+++ b/bae-core/src/util/cover.rs
@@ -1,0 +1,82 @@
+//! Cover art resizing for storage and export.
+
+use tracing::debug;
+
+/// Maximum dimension for a stored/embedded cover thumbnail.
+const COVER_MAX_SIZE: u32 = 600;
+
+/// Resize cover art to fit within COVER_MAX_SIZE, encoded as JPEG.
+pub fn resize_cover(data: &[u8]) -> Result<Vec<u8>, String> {
+    let img = image::load_from_memory(data)
+        .map_err(|e| format!("Failed to decode cover image: {}", e))?;
+
+    let (w, h) = (img.width(), img.height());
+
+    let img = if w > COVER_MAX_SIZE || h > COVER_MAX_SIZE {
+        debug!(
+            "Resizing cover art from {}x{} to fit {}x{}",
+            w, h, COVER_MAX_SIZE, COVER_MAX_SIZE
+        );
+        img.resize(
+            COVER_MAX_SIZE,
+            COVER_MAX_SIZE,
+            image::imageops::FilterType::Lanczos3,
+        )
+    } else {
+        img
+    };
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    img.write_to(&mut buf, image::ImageFormat::Jpeg)
+        .map_err(|e| format!("Failed to encode cover as JPEG: {}", e))?;
+    Ok(buf.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a solid-color image of the given dimensions to PNG bytes, so the
+    /// resizer's input is a real decodable image of a non-JPEG format.
+    fn png_source(width: u32, height: u32) -> Vec<u8> {
+        let img = image::RgbImage::from_pixel(width, height, image::Rgb([120, 40, 200]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+        buf.into_inner()
+    }
+
+    /// Decode resized bytes to their real pixel dimensions and confirm JPEG.
+    fn decoded_dims(bytes: &[u8]) -> (u32, u32) {
+        let format = image::guess_format(bytes).unwrap();
+        assert_eq!(format, image::ImageFormat::Jpeg, "output must be JPEG");
+        let img = image::load_from_memory(bytes).unwrap();
+        (img.width(), img.height())
+    }
+
+    #[test]
+    fn square_large_downscales_to_600() {
+        let out = resize_cover(&png_source(1200, 1200)).unwrap();
+        assert_eq!(decoded_dims(&out), (600, 600));
+    }
+
+    #[test]
+    fn wide_source_keeps_aspect_no_pad() {
+        let out = resize_cover(&png_source(1200, 600)).unwrap();
+        assert_eq!(decoded_dims(&out), (600, 300));
+    }
+
+    #[test]
+    fn small_source_is_not_upscaled() {
+        // The load-bearing assertion: a sub-600 source keeps its dimensions —
+        // resize downscales only, it never enlarges.
+        let out = resize_cover(&png_source(300, 300)).unwrap();
+        assert_eq!(decoded_dims(&out), (300, 300));
+    }
+
+    #[test]
+    fn garbage_bytes_error() {
+        assert!(resize_cover(&[0u8; 16]).is_err());
+    }
+}

--- a/bae-core/src/util/mod.rs
+++ b/bae-core/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod content_type;
 pub mod content_type_hint;
+pub mod cover;
 pub mod format;
 pub mod fs;
 pub mod http;

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -140,16 +140,25 @@ fn generate_tagged_album_files(
     }
 }
 
-/// A minimal valid JPEG (SOI/APP0/DQT/SOF0/EOI) used as embedded cover
-/// data — the import never decodes it, it only stores the bytes.
-const EMBEDDED_JPEG: &[u8] = &[
-    0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
-    0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
-];
+/// Embedded cover width/height for the fixture below.
+const EMBEDDED_COVER_DIMS: (u32, u32) = (64, 48);
 
-/// Like `generate_tagged_album_files`, but also embeds `EMBEDDED_JPEG` as
-/// a front cover in every file — a tagged rip whose only artwork is
-/// embedded in the audio.
+/// A real, decodable JPEG cover (solid color, [`EMBEDDED_COVER_DIMS`]) embedded
+/// in test audio. The store path decodes every cover and re-encodes it to a
+/// ≤600 JPEG, so fixtures must be genuine images, not hand-written JPEG headers.
+fn embedded_cover_jpeg() -> Vec<u8> {
+    let (w, h) = EMBEDDED_COVER_DIMS;
+    let img = image::RgbImage::from_pixel(w, h, image::Rgb([200, 60, 40]));
+    let mut buf = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(&mut buf, image::ImageFormat::Jpeg)
+        .unwrap();
+    buf.into_inner()
+}
+
+/// Like `generate_tagged_album_files`, but also embeds a real JPEG cover
+/// (`embedded_cover_jpeg`) as the front cover in every file — a tagged rip
+/// whose only artwork is embedded in the audio.
 fn generate_tagged_album_files_with_embedded_cover(
     dir: &Path,
     album_title: &str,
@@ -176,7 +185,7 @@ fn generate_tagged_album_files_with_embedded_cover(
         tag.insert_text(ItemKey::AlbumArtist, album_artist.to_string());
         tag.set_track(t.track_number);
         tag.push_picture(
-            Picture::unchecked(EMBEDDED_JPEG.to_vec())
+            Picture::unchecked(embedded_cover_jpeg())
                 .pic_type(PictureType::CoverFront)
                 .mime_type(MimeType::Jpeg)
                 .build(),
@@ -192,16 +201,23 @@ fn generate_album_with_cover(dir: &Path, filenames: &[&str]) {
     generate_album_files(dir, filenames);
     let scans = dir.join("scans");
     fs::create_dir_all(&scans).unwrap();
-    let jpeg: Vec<u8> = vec![
-        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00,
-        0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06,
-        0x05, 0x08, 0x07, 0x07, 0x07, 0x09, 0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B,
-        0x0C, 0x19, 0x12, 0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
-        0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29, 0x2C, 0x30, 0x31,
-        0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32, 0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF,
-        0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xD9,
-    ];
-    fs::write(scans.join("back.jpg"), &jpeg).unwrap();
+    fs::write(scans.join("back.jpg"), embedded_cover_jpeg()).unwrap();
+}
+
+/// Like `generate_album_with_cover`, but the folder image is an oversized
+/// (1000×1000) PNG — a source that must be downscaled and re-encoded to JPEG at
+/// store time. Returns the selection path for the cover.
+fn generate_album_with_oversized_cover(dir: &Path, filenames: &[&str]) -> String {
+    generate_album_files(dir, filenames);
+    let scans = dir.join("scans");
+    fs::create_dir_all(&scans).unwrap();
+    let img = image::RgbImage::from_pixel(1000, 1000, image::Rgb([20, 160, 90]));
+    let mut buf = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(&mut buf, image::ImageFormat::Png)
+        .unwrap();
+    fs::write(scans.join("cover.png"), buf.into_inner()).unwrap();
+    "scans/cover.png".to_string()
 }
 
 fn discogs_release(title: &str, tracks: &[&str]) -> DiscogsRelease {
@@ -931,6 +947,65 @@ async fn import_with_cover_art() {
         .await
         .expect("cover blob should be readable");
     assert!(!cover_bytes.is_empty(), "cover bytes should not be empty");
+}
+
+/// An oversized folder cover is resized to a ≤600 JPEG thumbnail at import: the
+/// stored blob decodes to 600×600 JPEG (from a 1000×1000 PNG source) and the
+/// `covers` row records JPEG, not the source PNG.
+#[tokio::test]
+#[serial]
+async fn import_resizes_oversized_cover_to_jpeg_thumbnail() {
+    support::tracing_init();
+
+    let release = discogs_release("Oversized Cover Album", &["Track"]);
+    let release_id_key = seed_discogs_test_release(release);
+    let f = ImportFixture::new().await;
+
+    let album_dir = f.temp_path().join("album");
+    fs::create_dir_all(&album_dir).unwrap();
+    let cover_path = generate_album_with_oversized_cover(&album_dir, &["01 Track.flac"]);
+
+    let import_id = uuid::Uuid::new_v4().to_string();
+    f.handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: Some(CoverSelection::Local(cover_path)),
+            storage_mode: StorageMode::Local,
+            pin: false,
+            identity_choice: IdentityChoice::Exact {
+                release_ref: MetadataRef::new(release_id_key, MetadataSource::Discogs),
+            },
+            user_edit: None,
+        })
+        .unwrap();
+
+    let mut progress_rx = f.handle.subscribe_import(import_id);
+    let (release_id, _) = support::wait_for_import_complete(&mut progress_rx).await;
+
+    // The row records the stored format (JPEG), not the source PNG.
+    let cover =
+        f.db.find_library_image(&release_id, &LibraryImageType::Cover)
+            .await
+            .unwrap()
+            .expect("cover image in DB");
+    assert_eq!(
+        cover.content_type,
+        bae_core::util::content_type::ContentType::Jpeg
+    );
+
+    // The stored blob is a ≤600 JPEG downscaled from the 1000×1000 PNG source.
+    let cover_bytes = support::read_cover_image_blob(&f.db, &f.library_manager, &release_id)
+        .await
+        .expect("cover blob should be readable");
+    assert_eq!(
+        image::guess_format(&cover_bytes).unwrap(),
+        image::ImageFormat::Jpeg
+    );
+    let decoded = image::load_from_memory(&cover_bytes).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), (600, 600));
+    assert_eq!(cover.file_size, cover_bytes.len() as i64);
 }
 
 /// On a browsable home the readable cloud_path is computed AT IMPORT — for every
@@ -1722,10 +1797,17 @@ async fn unknown_import_seeds_embedded_cover_when_no_folder_image() {
         "cover must be sourced from the embedded picture"
     );
 
+    // The embedded picture (≤600) keeps its dimensions but the store path
+    // re-encodes it to JPEG, so assert on the decoded image, not raw bytes.
     let bytes = support::read_cover_image_blob(&f.db, &f.library_manager, &release_id)
         .await
         .expect("cover blob readable");
-    assert_eq!(bytes, EMBEDDED_JPEG, "cover bytes are the embedded picture");
+    assert_eq!(
+        image::guess_format(&bytes).unwrap(),
+        image::ImageFormat::Jpeg
+    );
+    let decoded = image::load_from_memory(&bytes).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), EMBEDDED_COVER_DIMS);
 }
 
 /// A folder image outranks the embedded picture: when both exist, the
@@ -1752,7 +1834,7 @@ async fn unknown_import_folder_image_wins_over_embedded_cover() {
     // selection — the auto-pick must still prefer this folder image.
     let scans = album_dir.join("scans");
     fs::create_dir_all(&scans).unwrap();
-    fs::write(scans.join("cover.jpg"), EMBEDDED_JPEG).unwrap();
+    fs::write(scans.join("cover.jpg"), embedded_cover_jpeg()).unwrap();
 
     let import_id = uuid::Uuid::new_v4().to_string();
     f.handle


### PR DESCRIPTION
The cover blob bae stores for a release is a host-provided, bae-managed artifact — distinct from the immutable, user-provided release files. Until now it was persisted at whatever size and format its source handed over (a folder image, an embedded picture, or a remote download), so the library carried full-resolution, mixed-format cover blobs. The only resize that existed ran at export time, and only on the copy embedded into re-encoded audio.

This moves that resize to the point where the cover is stored. The existing `resize_cover` (fit within 600px, aspect preserved, JPEG) is lifted out of `export.rs` into `util/cover.rs` and applied at the two places that write a cover blob: the settled `cover_winner` in the import pipeline, and `change_cover`. Because the resize always emits JPEG, both sites record the JPEG content type so the `covers` row and the browsable-home `cloud_path` extension describe the bytes actually stored.

Export stops resizing entirely. It reads the cover it embeds straight from the stored blob, and that blob is now already a ≤600 JPEG, so a second resize would only spend another JPEG generation for no change. The store boundary owns the invariant; export trusts it. `export_release` is unaffected — it copies user-provided release files verbatim and never touches the cover blob.

The function keeps its current behavior unchanged (downscale-only — it never enlarges a sub-600 source).

## Test plan

- [x] `util::cover` unit tests: 1200×1200→600×600, 1200×600→600×300, 300×300 stays 300×300 (no upscale), garbage bytes → error.
- [x] `change_cover` integration test: an oversized non-JPEG release image stores as a ≤600 JPEG blob and the row records JPEG.
- [x] Import integration test: an oversized folder cover stores as a 600×600 JPEG blob and the row records JPEG.
- [x] Full `cargo test -p bae-core` green; clippy clean; pre-commit hook (fmt + clippy) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)