### PR TITLE
Clear scrub projections on seek completion

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt
@@ -139,7 +139,6 @@ interface PlaybackEventSink {
 }
 
 private const val TAG = "bae.BaeCorePlayer"
-private const val SEEK_TARGET_WINDOW_MS = 100L
 private val logger = BaeLogger(TAG)
 
 /** Bridge durations are 0 when unknown; map that to Media3's [C.TIME_UNSET]. */
@@ -628,10 +627,7 @@ class BaeCorePlayer(
         val trackId: String?,
         val targetPositionMs: Long,
     ) {
-        fun isNearTarget(positionMs: Long): Boolean {
-            val distanceFromTarget = kotlin.math.abs(positionMs - targetPositionMs)
-            return distanceFromTarget <= SEEK_TARGET_WINDOW_MS
-        }
+        fun matches(trackId: String): Boolean = this.trackId == null || this.trackId == trackId
     }
 
     init {
@@ -813,14 +809,8 @@ class BaeCorePlayer(
         progress: Double,
     ) {
         val pendingSeek = pendingSeek
-        if (pendingSeek != null) {
-            if (pendingSeek.trackId != null && pendingSeek.trackId != trackId) {
-                return
-            }
-            if (!pendingSeek.isNearTarget(positionMs)) {
-                return
-            }
-            this.pendingSeek = null
+        if (pendingSeek != null && pendingSeek.matches(trackId)) {
+            return
         }
         applyPlaybackPosition(trackId, positionMs, durationMs, progress)
     }

--- a/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackSeekProjectionTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackSeekProjectionTest.kt
@@ -48,7 +48,23 @@ class PlaybackSeekProjectionTest {
             remaining = formatRemainingMs(75_000, 100_000),
         )
 
-        player.onProgress(positionMs = 75_000, durationMs = 100_000, progress = 0.75)
+        player.onProgress(positionMs = 75_050, durationMs = 100_000, progress = 0.7505)
+        assertPosition(
+            player.position.value,
+            progress = 0.75,
+            elapsed = formatDurationMs(75_000),
+            remaining = formatRemainingMs(75_000, 100_000),
+        )
+
+        player.onProgress(positionMs = 80_000, durationMs = 100_000, progress = 0.80)
+        assertPosition(
+            player.position.value,
+            progress = 0.75,
+            elapsed = formatDurationMs(75_000),
+            remaining = formatRemainingMs(75_000, 100_000),
+        )
+
+        player.onSeeked(positionMs = 75_000, durationMs = 100_000, progress = 0.75)
         assertPosition(
             player.position.value,
             progress = 0.75,

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1458,9 +1458,7 @@ impl AppHandle {
 
         let core_format = match format {
             BridgeExportFormat::Flac => bae_core::library::ExportFormat::Flac,
-            BridgeExportFormat::Mp3 => bae_core::library::ExportFormat::Mp3 {
-                bitrate: bae_core::library::MP3_EXPORT_BITRATE,
-            },
+            BridgeExportFormat::Mp3 => bae_core::library::ExportFormat::Mp3,
         };
 
         self.services

--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -40,6 +40,11 @@ libc = "0.2"
 chardetng = "0.1"
 encoding_rs = "0.8"
 rtrb = "0.3.2"
+# Cover-art resizing at store time (src/util/cover.rs) runs on every platform —
+# imports and change-cover normalize to a ≤600 JPEG thumbnail everywhere, so the
+# stored cover blob is uniform regardless of which device imported it. jpeg+png
+# only, no default features (no rayon), so it builds on mobile and wasm.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 futures = "0.3.31"
 tokio-util = { version = "0.7", features = ["io", "rt"] }
 rand = "0.9"
@@ -81,7 +86,6 @@ rayon = "1.10"
 dotenvy = "0.15"
 discid = "0.5"
 lofty = "0.24"
-image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 # Loudness + true-peak measurement at import (src/loudness.rs). Pure Rust, no
 # system libs. Desktop-only: import decodes audio only on these targets, and the
 # playback gain is derived from the stored measurements with plain arithmetic

--- a/bae-core/src/audio_codec/mod.rs
+++ b/bae-core/src/audio_codec/mod.rs
@@ -28,6 +28,9 @@ pub use probe::{probe_audio_from_path, ProbeResult};
 /// FFmpeg uses for its own file IO.
 const AVIO_BUFFER_SIZE: usize = 32768;
 
+/// Standard bitrate for MP3 track export, in bits per second (320 kbit/s).
+pub const MP3_EXPORT_BITRATE: u32 = 320_000;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StreamingDecodeError {
     InputCancelled,
@@ -151,24 +154,15 @@ pub fn encode_to_mp3(
     samples: &[i32],
     sample_rate: u32,
     channels: u32,
-    bitrate: u32,
     cancel: &std::sync::atomic::AtomicBool,
 ) -> Result<Vec<u8>, String> {
-    unsafe {
-        encode_avio(
-            samples,
-            sample_rate,
-            channels,
-            EncodeFormat::Mp3 { bitrate },
-            cancel,
-        )
-    }
+    unsafe { encode_avio(samples, sample_rate, channels, EncodeFormat::Mp3, cancel) }
 }
 
 #[derive(Clone, Copy)]
 enum EncodeFormat {
     Flac { bits_per_sample: u32 },
-    Mp3 { bitrate: u32 },
+    Mp3,
 }
 
 struct EncodeCodecContext {
@@ -219,21 +213,21 @@ impl EncodeFormat {
     fn label(self) -> &'static str {
         match self {
             Self::Flac { .. } => "FLAC",
-            Self::Mp3 { .. } => "MP3",
+            Self::Mp3 => "MP3",
         }
     }
 
     fn format_name(self) -> *const std::ffi::c_char {
         match self {
             Self::Flac { .. } => c"flac".as_ptr(),
-            Self::Mp3 { .. } => c"mp3".as_ptr(),
+            Self::Mp3 => c"mp3".as_ptr(),
         }
     }
 
     fn codec_id(self) -> ffmpeg_sys_next::AVCodecID {
         match self {
             Self::Flac { .. } => ffmpeg_sys_next::AVCodecID::AV_CODEC_ID_FLAC,
-            Self::Mp3 { .. } => ffmpeg_sys_next::AVCodecID::AV_CODEC_ID_MP3,
+            Self::Mp3 => ffmpeg_sys_next::AVCodecID::AV_CODEC_ID_MP3,
         }
     }
 
@@ -245,28 +239,28 @@ impl EncodeFormat {
                 17..=32 => Ok(AVSampleFormat::AV_SAMPLE_FMT_S32),
                 _ => Err(format!("Unsupported FLAC bit depth: {bits_per_sample}")),
             },
-            Self::Mp3 { .. } => Ok(AVSampleFormat::AV_SAMPLE_FMT_S16P),
+            Self::Mp3 => Ok(AVSampleFormat::AV_SAMPLE_FMT_S16P),
         }
     }
 
     fn output_capacity(self, samples_len: usize) -> usize {
         match self {
             Self::Flac { .. } => samples_len * 2,
-            Self::Mp3 { .. } => samples_len,
+            Self::Mp3 => samples_len,
         }
     }
 
     fn default_frame_size(self) -> usize {
         match self {
             Self::Flac { .. } => 4096,
-            Self::Mp3 { .. } => 1152,
+            Self::Mp3 => 1152,
         }
     }
 
     fn encoder_missing_message(self) -> &'static str {
         match self {
             Self::Flac { .. } => "FLAC encoder not found",
-            Self::Mp3 { .. } => "MP3 encoder not found (libmp3lame)",
+            Self::Mp3 => "MP3 encoder not found (libmp3lame)",
         }
     }
 
@@ -289,8 +283,8 @@ impl EncodeFormat {
             Self::Flac { bits_per_sample } => {
                 (*codec_ctx).bits_per_raw_sample = bits_per_sample as c_int;
             }
-            Self::Mp3 { bitrate } => {
-                (*codec_ctx).bit_rate = bitrate as i64;
+            Self::Mp3 => {
+                (*codec_ctx).bit_rate = MP3_EXPORT_BITRATE as i64;
             }
         }
 
@@ -327,7 +321,7 @@ impl EncodeFormat {
                     _ => unreachable!("FLAC bit depth was validated before encoding"),
                 }
             }
-            Self::Mp3 { .. } => {
+            Self::Mp3 => {
                 for ch in 0..channels {
                     let dst = (*frame).data[ch] as *mut i16;
                     for i in 0..chunk_frames {

--- a/bae-core/src/audio_codec/tests.rs
+++ b/bae-core/src/audio_codec/tests.rs
@@ -310,7 +310,7 @@ fn test_encode_mp3() {
         .collect();
 
     let cancel = std::sync::atomic::AtomicBool::new(false);
-    let mp3_data = encode_to_mp3(&samples, sample_rate, 2, 320_000, &cancel).unwrap();
+    let mp3_data = encode_to_mp3(&samples, sample_rate, 2, &cancel).unwrap();
 
     // MP3 files start with either ID3 tag (0x49 0x44 0x33) or sync word (0xFF 0xFB)
     assert!(

--- a/bae-core/src/cue_flac.rs
+++ b/bae-core/src/cue_flac.rs
@@ -1,11 +1,4 @@
-use nom::{
-    branch::alt,
-    bytes::complete::{tag, take_until},
-    character::complete::{digit1, line_ending, space1},
-    combinator::{map_res, opt},
-    multi::many0,
-    IResult,
-};
+use nom::IResult;
 use std::path::Path;
 use thiserror::Error;
 use tracing::warn;
@@ -88,15 +81,6 @@ impl CueTrack {
     }
 }
 
-/// Classifies a `REM <keyword> <value>` line. `Other` covers REM keywords we
-/// don't capture (e.g. REM COMMENT, REM GENRE, REM DISCID, ripper-specific
-/// extensions).
-#[derive(Debug)]
-enum RemKind {
-    Date(String),
-    Other,
-}
-
 /// Represents a parsed CUE sheet
 #[derive(Debug, Clone)]
 pub struct CueSheet {
@@ -129,6 +113,45 @@ impl CueSheet {
 pub struct CueFlacPair {
     pub audio_path: std::path::PathBuf,
     pub cue_path: std::path::PathBuf,
+}
+
+#[derive(Debug)]
+struct PendingCueTrack {
+    number: u32,
+    title: Option<String>,
+    performer: Option<String>,
+    isrc: Option<String>,
+    pregap_cue_frames: Option<u64>,
+    start: Option<(u64, String)>,
+}
+
+impl PendingCueTrack {
+    fn new(number: u32) -> Self {
+        Self {
+            number,
+            title: None,
+            performer: None,
+            isrc: None,
+            pregap_cue_frames: None,
+            start: None,
+        }
+    }
+
+    fn finish(self, input: &str) -> Result<CueTrack, nom::Err<nom::error::Error<&str>>> {
+        let (start_cue_frames, file_reference) = self.start.ok_or_else(|| {
+            nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
+        })?;
+        Ok(CueTrack {
+            number: self.number,
+            title: self.title,
+            performer: self.performer,
+            isrc: self.isrc,
+            file_reference,
+            start_cue_frames,
+            pregap_cue_frames: self.pregap_cue_frames,
+            end_cue_frames: None,
+        })
+    }
 }
 /// Main processor for CUE/FLAC operations
 pub struct CueFlacProcessor;
@@ -221,93 +244,60 @@ impl CueFlacProcessor {
         let mut catalog: Option<String> = None;
         let mut date: Option<String> = None;
         let mut current_file: Option<String> = None;
-        let mut input = input;
+        let mut tracks: Vec<CueTrack> = Vec::new();
+        let mut current_track: Option<PendingCueTrack> = None;
 
-        loop {
-            let stripped = input.trim_start();
-            if stripped.is_empty() {
-                break;
-            }
-            if Self::starts_with_keyword(stripped, "TRACK") {
-                break;
-            }
-            if let Ok((i, _)) = line_ending::<_, nom::error::Error<&str>>(input) {
-                input = i;
+        for raw_line in input.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() {
                 continue;
             }
-            if let Ok((i, _)) = space1::<_, nom::error::Error<&str>>(input) {
-                input = i;
-                continue;
-            }
-            if let Ok((i, name)) = Self::parse_file_line(input) {
-                current_file = Some(name);
-                input = i;
-                continue;
-            }
-            if let Ok((i, kind)) = Self::parse_rem_classified(input) {
-                match kind {
-                    RemKind::Date(d) => date = Some(d),
-                    RemKind::Other => {}
+
+            let track_directive = Self::parse_track_directive(line)?;
+            if let Some((number, audio)) = track_directive {
+                if let Some(track) = current_track.take() {
+                    tracks.push(track.finish(input)?);
                 }
-                input = i;
+                if !audio {
+                    if tracks.is_empty() {
+                        return Self::failure(input, nom::error::ErrorKind::Tag);
+                    }
+                    break;
+                }
+                if current_file.is_none() {
+                    return Self::failure(input, nom::error::ErrorKind::Tag);
+                }
+                current_track = Some(PendingCueTrack::new(number));
                 continue;
             }
-            if let Ok((i, c)) = Self::parse_catalog_line(input) {
-                catalog = Some(c);
-                input = i;
+
+            let file_directive = Self::parse_file_directive(line)?;
+            if let Some(file) = file_directive {
+                current_file = Some(file);
                 continue;
             }
-            if let Ok((i, t)) = Self::parse_title(input) {
-                title = Some(t);
-                input = i;
-                continue;
+
+            match current_track.as_mut() {
+                Some(track) => {
+                    let file_reference = current_file
+                        .as_deref()
+                        .expect("CUE TRACK parsing starts only after FILE is known");
+                    Self::apply_track_line(input, line, track, file_reference)?;
+                }
+                None => {
+                    Self::apply_header_line(
+                        line,
+                        &mut title,
+                        &mut performer,
+                        &mut catalog,
+                        &mut date,
+                    );
+                }
             }
-            if let Ok((i, p)) = Self::parse_performer(input) {
-                performer = Some(p);
-                input = i;
-                continue;
-            }
-            if Self::header_starts_with_known_skipped(stripped) {
-                input = Self::consume_line(input);
-                continue;
-            }
-            let line = Self::peek_line(stripped);
-            warn!("unrecognized CUE header line: {:?}", line);
-            input = Self::consume_line(input);
         }
 
-        // Body: TRACK entries that all read and possibly update
-        // `current_file`. A FILE that appears between tracks shifts every
-        // subsequent track to the new file; a FILE that appears inside a
-        // track body (between INDEX 00 and INDEX 01 — the per-track-rip
-        // convention) shifts only the rest of that body. Each track's
-        // `file_reference` is whichever FILE was current at the moment its
-        // INDEX 01 was parsed.
-        let mut current_file = current_file.ok_or_else(|| {
-            // TRACK before any FILE: no audio file to bind to.
-            nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
-        })?;
-        let mut tracks: Vec<CueTrack> = Vec::new();
-        loop {
-            let stripped = input.trim_start();
-            if stripped.is_empty() {
-                break;
-            }
-            // Trailing non-AUDIO content (e.g. MODE1/2048 data track after
-            // the final AUDIO track) terminates the body once we've parsed
-            // at least one AUDIO track. `parse_track` itself fails at the
-            // `tag("AUDIO")` step for non-AUDIO modes — that's a nom Error
-            // (not Failure), so we stop the loop rather than abort the
-            // parse. Failures from inside a track body (no INDEX 01,
-            // malformed INDEX, etc.) propagate.
-            match Self::parse_track(input, &mut current_file) {
-                Ok((rest, track)) => {
-                    tracks.push(track);
-                    input = rest;
-                }
-                Err(nom::Err::Error(_)) => break,
-                Err(e) => return Err(e),
-            }
+        if let Some(track) = current_track {
+            tracks.push(track.finish(input)?);
         }
         if tracks.is_empty() {
             return Err(nom::Err::Failure(nom::error::Error::new(
@@ -336,7 +326,7 @@ impl CueFlacProcessor {
             }
         }
         Ok((
-            input,
+            "",
             CueSheet {
                 title,
                 performer,
@@ -346,234 +336,141 @@ impl CueFlacProcessor {
             },
         ))
     }
-    /// Parse and skip a REM (comment) line.
-    fn parse_comment_line(input: &str) -> IResult<&str, &str> {
-        let (input, _) = tag("REM")(input)?;
-        let (input, _) = take_until("\n")(input)?;
-        let (input, _) = line_ending(input)?;
-        Ok((input, ""))
-    }
-    /// Parse a REM line and classify the keyword. Returns `RemKind::Other`
-    /// for REM keywords we don't capture (e.g. REM COMMENT, ripper-specific
-    /// extensions); the line is still consumed.
-    fn parse_rem_classified(input: &str) -> IResult<&str, RemKind> {
-        let (input, _) = tag("REM")(input)?;
-        let (input, _) = space1(input)?;
-        let kw_end = input
-            .find(|c: char| c.is_whitespace())
-            .unwrap_or(input.len());
-        let keyword = &input[..kw_end];
-        let after_kw = &input[kw_end..];
-        let value_start = after_kw.trim_start_matches([' ', '\t']);
-        let line_end = value_start.find('\n').unwrap_or(value_start.len());
-        let raw_value = value_start[..line_end].trim_end_matches('\r').trim();
-        let unquoted = match raw_value
-            .strip_prefix('"')
-            .and_then(|s| s.strip_suffix('"'))
-        {
-            Some(s) => s,
-            None => raw_value,
-        };
-        let kind = match keyword {
-            "DATE" => RemKind::Date(unquoted.to_string()),
-            _ => RemKind::Other,
-        };
-        let after_value = &value_start[line_end..];
-        let (after_value, _) = opt(line_ending)(after_value)?;
-        Ok((after_value, kind))
-    }
-    /// Parse a FILE line, returning the referenced filename.
-    /// Handles both quoted (`FILE "foo.flac" WAVE`) and unquoted forms.
-    fn parse_file_line(input: &str) -> IResult<&str, String> {
-        let (input, _) = tag("FILE")(input)?;
-        let (input, _) = space1(input)?;
-        let (input, name) = Self::parse_file_name(input)?;
-        let (input, _) = take_until("\n")(input)?;
-        let (input, _) = line_ending(input)?;
-        Ok((input, name))
-    }
 
-    fn parse_file_name(input: &str) -> IResult<&str, String> {
-        if let Ok((rest, quoted)) = Self::parse_quoted_string(input) {
-            return Ok((rest, quoted.trim().to_string()));
+    fn apply_header_line(
+        line: &str,
+        title: &mut Option<String>,
+        performer: &mut Option<String>,
+        catalog: &mut Option<String>,
+        date: &mut Option<String>,
+    ) {
+        match Self::keyword_and_rest(line) {
+            Some(("REM", rest)) => {
+                if let Some((keyword, value)) = Self::keyword_and_rest(rest) {
+                    if keyword == "DATE" {
+                        *date = Some(Self::strip_optional_quotes(value).to_string());
+                    }
+                }
+            }
+            Some(("CATALOG", rest)) => {
+                *catalog = Some(Self::strip_optional_quotes(rest).to_string());
+            }
+            Some(("TITLE", rest)) => {
+                if let Some(value) = Self::quoted_value(rest) {
+                    *title = Some(value.to_string());
+                }
+            }
+            Some(("PERFORMER", rest)) => {
+                if let Some(value) = Self::quoted_value(rest) {
+                    *performer = Some(value.to_string());
+                }
+            }
+            Some((keyword, _)) if Self::header_keyword_is_known_skipped(keyword) => {}
+            _ => warn!("unrecognized CUE header line: {:?}", line),
         }
-        let end = input.find(char::is_whitespace).unwrap_or(input.len());
-        if end == 0 {
-            return Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                nom::error::ErrorKind::TakeTill1,
-            )));
-        }
-        Ok((&input[end..], input[..end].to_string()))
     }
-    /// Parse a CATALOG line, returning the catalog number (UPC/EAN/MCN).
-    fn parse_catalog_line(input: &str) -> IResult<&str, String> {
-        let (input, _) = tag("CATALOG")(input)?;
-        let (input, _) = space1(input)?;
-        let line_end = input.find('\n').unwrap_or(input.len());
-        let raw = input[..line_end].trim_end_matches('\r').trim();
-        let value = match raw.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
-            Some(s) => s.to_string(),
-            None => raw.to_string(),
-        };
-        let after = &input[line_end..];
-        let (after, _) = opt(line_ending)(after)?;
-        Ok((after, value))
-    }
-    /// Parse TITLE line
-    fn parse_title(input: &str) -> IResult<&str, String> {
-        let (input, _) = many0(alt((line_ending, space1, Self::parse_comment_line)))(input)?;
-        let (input, _) = tag("TITLE")(input)?;
-        let (input, _) = space1(input)?;
-        let (input, title) = Self::parse_quoted_string(input)?;
-        let (input, _) = opt(line_ending)(input)?;
-        Ok((input, title))
-    }
-    /// Parse PERFORMER line
-    fn parse_performer(input: &str) -> IResult<&str, String> {
-        let (input, _) = many0(alt((line_ending, space1, Self::parse_comment_line)))(input)?;
-        let (input, _) = tag("PERFORMER")(input)?;
-        let (input, _) = space1(input)?;
-        let (input, performer) = Self::parse_quoted_string(input)?;
-        let (input, _) = opt(line_ending)(input)?;
-        Ok((input, performer))
-    }
-    /// Parse a single TRACK entry as a per-line classifier. `current_file`
-    /// is read-write state shared with the caller — the track's
-    /// `file_reference` is whichever value `current_file` held when INDEX 01
-    /// was parsed (the file where the track actually starts), and any FILE
-    /// directive encountered inside the body updates `current_file` for the
-    /// rest of this track and every track that follows.
-    ///
-    /// Only AUDIO tracks are parsed; non-AUDIO modes (MODE1/2048, MODE2/2352,
-    /// etc.) cause `parse_track` to fail with a nom Error so the caller's
-    /// loop terminates. Spec-known commands within a track body can appear
-    /// in any order (TITLE, PERFORMER, ISRC, FLAGS, PREGAP, INDEX 00–99,
-    /// POSTGAP, plus CD-Text keywords). FILE may also appear inside the
-    /// body (the per-track-rip convention puts a track's INDEX 00 at the
-    /// end of file N and its INDEX 01 at the start of file N+1, with FILE
-    /// sitting between the two INDEX lines). Unknown commands (typos,
-    /// vendor extensions) emit a warning and are skipped. The track ends
-    /// at the next TRACK keyword or at EOF; INDEX 01 is required.
-    fn parse_track<'a>(input: &'a str, current_file: &mut String) -> IResult<&'a str, CueTrack> {
-        let (input, _) = many0(alt((line_ending, space1, Self::parse_comment_line)))(input)?;
-        let (input, _) = tag("TRACK")(input)?;
-        let (input, _) = space1(input)?;
-        let (input, number) = map_res(digit1, |s: &str| s.parse::<u32>())(input)?;
-        let (input, _) = space1(input)?;
-        let (input, _) = tag("AUDIO")(input)?;
-        let (input, _) = opt(take_until("\n"))(input)?;
-        let (mut input, _) = opt(line_ending)(input)?;
 
-        let mut title: Option<String> = None;
-        let mut performer: Option<String> = None;
-        let mut isrc: Option<String> = None;
-        let mut pregap_cue_frames: Option<u64> = None;
-        let mut start: Option<(u64, String)> = None;
-
-        loop {
-            let stripped = input.trim_start();
-            if stripped.is_empty() {
-                break;
+    fn apply_track_line<'a>(
+        input: &'a str,
+        line: &str,
+        track: &mut PendingCueTrack,
+        current_file: &str,
+    ) -> Result<(), nom::Err<nom::error::Error<&'a str>>> {
+        match Self::keyword_and_rest(line) {
+            Some(("REM", _)) => {}
+            Some(("TITLE", rest)) => {
+                if let Some(value) = Self::quoted_value(rest) {
+                    track.title = Some(value.to_string());
+                }
             }
-            if Self::starts_with_keyword(stripped, "TRACK") {
-                break;
+            Some(("PERFORMER", rest)) => {
+                if let Some(value) = Self::quoted_value(rest) {
+                    track.performer = Some(value.to_string());
+                }
             }
-            if let Ok((i, _)) = line_ending::<_, nom::error::Error<&str>>(input) {
-                input = i;
-                continue;
+            Some(("ISRC", rest)) => {
+                let code = rest.split_whitespace().next().ok_or_else(|| {
+                    nom::Err::Failure(nom::error::Error::new(
+                        input,
+                        nom::error::ErrorKind::TakeTill1,
+                    ))
+                })?;
+                track.isrc = Some(code.to_string());
             }
-            if let Ok((i, _)) = space1::<_, nom::error::Error<&str>>(input) {
-                input = i;
-                continue;
-            }
-            if let Ok((i, _)) = Self::parse_comment_line(input) {
-                input = i;
-                continue;
-            }
-            if let Ok((i, name)) = Self::parse_file_line(input) {
-                *current_file = name;
-                input = i;
-                continue;
-            }
-            if let Ok((i, t)) = Self::parse_title(input) {
-                title = Some(t);
-                input = i;
-                continue;
-            }
-            if let Ok((i, p)) = Self::parse_performer(input) {
-                performer = Some(p);
-                input = i;
-                continue;
-            }
-            if let Ok((i, code)) = Self::parse_isrc_line(input) {
-                isrc = Some(code);
-                input = i;
-                continue;
-            }
-            if let Ok((i, (idx_num, frames))) = Self::parse_index_line(input) {
-                match idx_num {
-                    0 => pregap_cue_frames = Some(frames),
-                    1 => start = Some((frames, current_file.clone())),
+            Some(("INDEX", rest)) => {
+                let (index_number, cue_frames) = Self::parse_index_values(input, rest)?;
+                match index_number {
+                    0 => track.pregap_cue_frames = Some(cue_frames),
+                    1 => {
+                        track.start = Some((cue_frames, current_file.to_string()));
+                    }
                     _ => {}
                 }
-                input = i;
-                continue;
             }
-            if Self::track_starts_with_known_skipped(stripped) {
-                input = Self::consume_line(input);
-                continue;
-            }
-            let line = Self::peek_line(stripped);
-            warn!("unrecognized CUE line in track {}: {:?}", number, line);
-            input = Self::consume_line(input);
+            Some((keyword, _)) if Self::track_keyword_is_known_skipped(keyword) => {}
+            _ => warn!(
+                "unrecognized CUE line in track {}: {:?}",
+                track.number, line
+            ),
         }
+        Ok(())
+    }
 
-        let (start_cue_frames, file_reference) = start.ok_or_else(|| {
+    fn parse_track_directive(
+        input: &str,
+    ) -> Result<Option<(u32, bool)>, nom::Err<nom::error::Error<&str>>> {
+        let Some(("TRACK", rest)) = Self::keyword_and_rest(input) else {
+            return Ok(None);
+        };
+        let mut parts = rest.split_whitespace();
+        let number = Self::parse_u32_token(input, parts.next())?;
+        let mode = parts.next().ok_or_else(|| {
             nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
         })?;
+        Ok(Some((number, mode == "AUDIO")))
+    }
 
-        Ok((
-            input,
-            CueTrack {
-                number,
-                title,
-                performer,
-                isrc,
-                file_reference,
-                start_cue_frames,
-                pregap_cue_frames,
-                end_cue_frames: None,
-            },
-        ))
+    fn parse_file_directive(
+        input: &str,
+    ) -> Result<Option<String>, nom::Err<nom::error::Error<&str>>> {
+        let Some(("FILE", rest)) = Self::keyword_and_rest(input) else {
+            return Ok(None);
+        };
+        Ok(Some(Self::parse_file_name_value(input, rest)?))
     }
-    /// Parse `ISRC <code>` and return the code (first whitespace-delimited
-    /// token after `ISRC`). Per spec the code is 12 alphanumeric characters
-    /// (CCXXXYYNNNNN); we don't validate format here, just extract.
-    fn parse_isrc_line(input: &str) -> IResult<&str, String> {
-        let (input, _) = many0(alt((line_ending, space1, Self::parse_comment_line)))(input)?;
-        let (input, _) = tag("ISRC")(input)?;
-        let (input, _) = space1(input)?;
-        let (input, code) = nom::bytes::complete::take_till1(|c: char| c.is_whitespace())(input)?;
-        let code = code.to_string();
-        let (input, _) = opt(take_until("\n"))(input)?;
-        let (input, _) = opt(line_ending)(input)?;
-        Ok((input, code))
+
+    fn parse_index_values<'a>(
+        input: &'a str,
+        rest: &str,
+    ) -> Result<(u32, u64), nom::Err<nom::error::Error<&'a str>>> {
+        let mut parts = rest.split_whitespace();
+        let index_number = Self::parse_u32_token(input, parts.next())?;
+        let time = parts.next().ok_or_else(|| {
+            nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+        })?;
+        let (_, cue_frames) = Self::parse_time(time).map_err(|_| {
+            nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+        })?;
+        Ok((index_number, cue_frames))
     }
-    /// Parse `INDEX <n> mm:ss:ff` and return the index number and frames.
-    fn parse_index_line(input: &str) -> IResult<&str, (u32, u64)> {
-        let (input, _) = many0(alt((line_ending, space1, Self::parse_comment_line)))(input)?;
-        let (input, _) = tag("INDEX")(input)?;
-        let (input, _) = space1(input)?;
-        let (input, idx_num) = map_res(digit1, |s: &str| s.parse::<u32>())(input)?;
-        let (input, _) = space1(input)?;
-        let (input, frames) = Self::parse_time(input)?;
-        let (input, _) = opt(line_ending)(input)?;
-        Ok((input, (idx_num, frames)))
+
+    fn parse_u32_token<'a>(
+        input: &'a str,
+        token: Option<&str>,
+    ) -> Result<u32, nom::Err<nom::error::Error<&'a str>>> {
+        token
+            .ok_or_else(|| {
+                nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+            })?
+            .parse::<u32>()
+            .map_err(|_| {
+                nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+            })
     }
+
     /// Spec-known commands valid inside a TRACK body that we don't store.
     /// Recognized so they don't trigger the unknown-line warning.
-    fn track_starts_with_known_skipped(input: &str) -> bool {
+    fn track_keyword_is_known_skipped(keyword: &str) -> bool {
         const TRACK_BODY_SKIPPED: &[&str] = &[
             "FLAGS",
             "PREGAP",
@@ -590,14 +487,12 @@ impl CueFlacProcessor {
             "UPC_EAN",
             "SIZE_INFO",
         ];
-        TRACK_BODY_SKIPPED
-            .iter()
-            .any(|kw| Self::starts_with_keyword(input, kw))
+        TRACK_BODY_SKIPPED.contains(&keyword)
     }
     /// Spec-known global-section commands we don't store. CD-Text keywords
     /// can also appear at the global level; CDTEXTFILE references an
     /// external binary CD-Text file.
-    fn header_starts_with_known_skipped(input: &str) -> bool {
+    fn header_keyword_is_known_skipped(keyword: &str) -> bool {
         const HEADER_SKIPPED: &[&str] = &[
             "CDTEXTFILE",
             "SONGWRITER",
@@ -611,50 +506,92 @@ impl CueFlacProcessor {
             "UPC_EAN",
             "SIZE_INFO",
         ];
-        HEADER_SKIPPED
-            .iter()
-            .any(|kw| Self::starts_with_keyword(input, kw))
+        HEADER_SKIPPED.contains(&keyword)
     }
-    /// Whether `input` begins with `keyword` followed by whitespace or EOF
-    /// (so that "TRACKBALL" doesn't match keyword "TRACK").
-    fn starts_with_keyword(input: &str, keyword: &str) -> bool {
-        if !input.starts_with(keyword) {
-            return false;
+
+    fn keyword_and_rest(input: &str) -> Option<(&str, &str)> {
+        let input = input.trim_start();
+        let end = input.find(char::is_whitespace).unwrap_or(input.len());
+        if end == 0 {
+            return None;
         }
-        match input[keyword.len()..].chars().next() {
-            None => true,
-            Some(c) => c.is_whitespace(),
+        Some((&input[..end], input[end..].trim_start()))
+    }
+
+    fn quoted_value(input: &str) -> Option<&str> {
+        let input = input.trim_start();
+        let after_open = input.strip_prefix('"')?;
+        let end = after_open.find('"')?;
+        Some(&after_open[..end])
+    }
+
+    fn strip_optional_quotes(input: &str) -> &str {
+        let input = input.trim();
+        if let Some(value) = Self::quoted_value(input) {
+            value
+        } else {
+            input
         }
     }
-    /// Advance past the next line ending. If no line ending, returns "".
-    fn consume_line(input: &str) -> &str {
-        match input.find('\n') {
-            Some(idx) => &input[idx + 1..],
-            None => "",
+
+    fn parse_file_name_value<'a>(
+        input: &'a str,
+        rest: &str,
+    ) -> Result<String, nom::Err<nom::error::Error<&'a str>>> {
+        let rest = rest.trim_start();
+        if let Some(value) = Self::quoted_value(rest) {
+            return Ok(value.trim().to_string());
         }
+        let name = rest.split_whitespace().next().ok_or_else(|| {
+            nom::Err::Failure(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::TakeTill1,
+            ))
+        })?;
+        Ok(name.to_string())
     }
-    /// Return the next line of input without trailing CR/LF, without consuming.
-    fn peek_line(input: &str) -> &str {
-        let end = input.find('\n').unwrap_or(input.len());
-        let line = &input[..end];
-        line.strip_suffix('\r').unwrap_or(line)
-    }
-    /// Parse quoted string
-    fn parse_quoted_string(input: &str) -> IResult<&str, String> {
-        let (input, _) = tag("\"")(input)?;
-        let (input, content) = take_until("\"")(input)?;
-        let (input, _) = tag("\"")(input)?;
-        Ok((input, content.to_string()))
-    }
+
     /// Parse time in MM:SS:FF format and return total CUE frames (1/75th second).
     fn parse_time(input: &str) -> IResult<&str, u64> {
-        let (input, minutes) = map_res(digit1, |s: &str| s.parse::<u64>())(input)?;
-        let (input, _) = tag(":")(input)?;
-        let (input, seconds) = map_res(digit1, |s: &str| s.parse::<u64>())(input)?;
-        let (input, _) = tag(":")(input)?;
-        let (input, frames) = map_res(digit1, |s: &str| s.parse::<u64>())(input)?;
+        let mut parts = input.splitn(3, ':');
+        let minutes = Self::parse_u64_time_field(input, parts.next())?;
+        let seconds = Self::parse_u64_time_field(input, parts.next())?;
+        let frames_and_rest = parts.next().ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+        })?;
+        let frame_end = frames_and_rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(frames_and_rest.len());
+        if frame_end == 0 {
+            return Self::error(input, nom::error::ErrorKind::Digit);
+        }
+        let frames = frames_and_rest[..frame_end].parse::<u64>().map_err(|_| {
+            nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+        })?;
         let total_cue_frames = (minutes * 60 + seconds) * 75 + frames;
-        Ok((input, total_cue_frames))
+        Ok((&frames_and_rest[frame_end..], total_cue_frames))
+    }
+
+    fn parse_u64_time_field<'a>(
+        input: &'a str,
+        token: Option<&str>,
+    ) -> Result<u64, nom::Err<nom::error::Error<&'a str>>> {
+        token
+            .ok_or_else(|| {
+                nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+            })?
+            .parse::<u64>()
+            .map_err(|_| {
+                nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Digit))
+            })
+    }
+
+    fn error<T>(input: &str, kind: nom::error::ErrorKind) -> IResult<&str, T> {
+        Err(nom::Err::Error(nom::error::Error::new(input, kind)))
+    }
+
+    fn failure<T>(input: &str, kind: nom::error::ErrorKind) -> IResult<&str, T> {
+        Err(nom::Err::Failure(nom::error::Error::new(input, kind)))
     }
 }
 #[cfg(test)]

--- a/bae-core/src/cue_flac/tests.rs
+++ b/bae-core/src/cue_flac/tests.rs
@@ -13,50 +13,6 @@ fn test_parse_time() {
     }
 }
 #[test]
-fn test_parse_quoted_string() {
-    let result = CueFlacProcessor::parse_quoted_string("\"Test Album\"");
-    assert!(result.is_ok());
-    let (_, string) = result.unwrap();
-    assert_eq!(string, "Test Album");
-}
-#[test]
-fn test_parse_quoted_string_with_special_chars() {
-    let result = CueFlacProcessor::parse_quoted_string(
-        "\"Track with Sections: i. First Part / ii. Second Part / iii. Third Part\"",
-    );
-    assert!(result.is_ok());
-    let (_, string) = result.unwrap();
-    assert_eq!(
-        string,
-        "Track with Sections: i. First Part / ii. Second Part / iii. Third Part",
-    );
-}
-#[test]
-fn test_parse_comment_line() {
-    let input = "REM GENRE \"Genre Name\"\n";
-    let result = CueFlacProcessor::parse_comment_line(input);
-    assert!(result.is_ok());
-    let (remaining, _) = result.unwrap();
-    assert_eq!(remaining, "");
-}
-#[test]
-fn test_parse_file_line() {
-    // FILE lines: a quoted name keeps its spaces; an unquoted name stops at
-    // the first whitespace.
-    let cases = [
-        (
-            "FILE \"Artist Name - Album Title.flac\" WAVE\n",
-            "Artist Name - Album Title.flac",
-        ),
-        ("FILE album.ape WAVE\n", "album.ape"),
-    ];
-    for (input, expected) in cases {
-        let (remaining, name) = CueFlacProcessor::parse_file_line(input).unwrap();
-        assert_eq!(remaining, "", "input: {input}");
-        assert_eq!(name, expected, "input: {input}");
-    }
-}
-#[test]
 fn parse_multi_file_cue_stamps_per_track_file_reference() {
     // One FILE per TRACK, the spec shape used by lossy-format rips
     // (rippers don't concatenate per-track files to avoid re-encoding).

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -1234,8 +1234,8 @@ mod tests {
         // 0.5s of stereo 44.1kHz silence is enough for FFmpeg to emit a
         // valid MP3 the tag writer can attach to.
         let samples = vec![0i32; 44_100 / 2 * 2];
-        let mp3_bytes = crate::audio_codec::encode_to_mp3(&samples, 44_100, 2, 128_000, &cancel)
-            .expect("encode mp3");
+        let mp3_bytes =
+            crate::audio_codec::encode_to_mp3(&samples, 44_100, 2, &cancel).expect("encode mp3");
 
         let temp = TempDir::new().unwrap();
         let mp3_path = temp.path().join("01.mp3");

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -1064,6 +1064,19 @@ impl ImportService {
         let cover_winner = remote_cover_image
             .or(local_cover_image)
             .or(embedded_cover_image);
+        // Resize the winning cover to a ≤600px JPEG thumbnail — one funnel for
+        // all three sources — and patch the record to describe the stored bytes:
+        // the resize always emits JPEG, so the row and the `cloud_path` extension
+        // `finalize_import_atomic` derives from it must say JPEG too.
+        let cover_winner = match cover_winner {
+            Some((mut image, bytes)) => {
+                let bytes = crate::util::cover::resize_cover(&bytes)?;
+                image.content_type = crate::util::content_type::ContentType::Jpeg;
+                image.file_size = bytes.len() as i64;
+                Some((image, bytes))
+            }
+            None => None,
+        };
         let library_image = cover_winner
             .as_ref()
             .map(|(image, bytes)| (image, bytes.as_slice()));

--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -7,11 +7,10 @@ use tracing::{debug, info};
 /// Output format for track export.
 pub enum ExportFormat {
     Flac,
-    Mp3 { bitrate: u32 },
+    Mp3,
 }
 
-/// Standard bitrate for MP3 track export, in bits per second (320 kbit/s).
-pub const MP3_EXPORT_BITRATE: u32 = 320_000;
+pub use crate::audio_codec::MP3_EXPORT_BITRATE;
 
 /// Render a single-track export's suggested filename stem (no extension) from a
 /// template and the track's tag data. Supported tokens:
@@ -197,11 +196,10 @@ impl ExportService {
                     &cancel_for_blocking,
                 )
                 .map_err(|e| format!("Failed to encode FLAC: {e}"))?,
-                ExportFormat::Mp3 { bitrate } => crate::audio_codec::encode_to_mp3(
+                ExportFormat::Mp3 => crate::audio_codec::encode_to_mp3(
                     decoded_pcm.raw_samples(),
                     decoded_pcm.sample_rate(),
                     decoded_pcm.channels(),
-                    bitrate,
                     &cancel_for_blocking,
                 )
                 .map_err(|e| format!("Failed to encode MP3: {e}"))?,
@@ -226,7 +224,7 @@ impl ExportService {
 
             let tag_type = match format {
                 ExportFormat::Flac => lofty::tag::TagType::VorbisComments,
-                ExportFormat::Mp3 { .. } => lofty::tag::TagType::Id3v2,
+                ExportFormat::Mp3 => lofty::tag::TagType::Id3v2,
             };
 
             write_tags(

--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -258,9 +258,6 @@ impl ExportService {
     }
 }
 
-/// Maximum dimension for embedded cover art.
-const COVER_MAX_SIZE: u32 = 600;
-
 /// Write metadata tags to an encoded audio file. Each tag is written only when
 /// the user's `metadata` selection includes it; cover art is governed by
 /// `cover_data` being `Some` (the plan omits the bytes when it's deselected),
@@ -323,10 +320,10 @@ fn write_tags(
     }
 
     if let Some(data) = cover_data {
-        let resized = resize_cover(data)?;
-
+        // The stored cover is already a ≤600 JPEG (resized at store time), so
+        // embed its bytes directly — no second resize/JPEG pass here.
         tag.push_picture(
-            Picture::unchecked(resized)
+            Picture::unchecked(data.to_vec())
                 .pic_type(PictureType::CoverFront)
                 .build(),
         );
@@ -340,33 +337,6 @@ fn write_tags(
 
     debug!("Wrote metadata tags to {}", path.display());
     Ok(())
-}
-
-/// Resize cover art to fit within COVER_MAX_SIZE, encoded as JPEG.
-fn resize_cover(data: &[u8]) -> Result<Vec<u8>, String> {
-    let img = image::load_from_memory(data)
-        .map_err(|e| format!("Failed to decode cover image: {}", e))?;
-
-    let (w, h) = (img.width(), img.height());
-
-    let img = if w > COVER_MAX_SIZE || h > COVER_MAX_SIZE {
-        debug!(
-            "Resizing cover art from {}x{} to fit {}x{}",
-            w, h, COVER_MAX_SIZE, COVER_MAX_SIZE
-        );
-        img.resize(
-            COVER_MAX_SIZE,
-            COVER_MAX_SIZE,
-            image::imageops::FilterType::Lanczos3,
-        )
-    } else {
-        img
-    };
-
-    let mut buf = std::io::Cursor::new(Vec::new());
-    img.write_to(&mut buf, image::ImageFormat::Jpeg)
-        .map_err(|e| format!("Failed to encode cover as JPEG: {}", e))?;
-    Ok(buf.into_inner())
 }
 
 /// Decode a track's source audio (already read into the plan) to PCM.

--- a/bae-core/src/library/manager/image.rs
+++ b/bae-core/src/library/manager/image.rs
@@ -95,7 +95,9 @@ impl LibraryManager {
         release_id: &str,
         selection: CoverSelection,
     ) -> Result<(), LibraryError> {
-        let (bytes, content_type, source, source_url) = match selection {
+        // The source content type is discarded: every stored cover is resized to
+        // JPEG below, so only the bytes, provenance, and URL carry through.
+        let (bytes, source, source_url) = match selection {
             CoverSelection::ReleaseImage { file_id } => {
                 let file = self
                     .get_file_by_id(&file_id)
@@ -106,24 +108,26 @@ impl LibraryManager {
                 // read (the user's own file when Local, the cache/cloud when Remote).
                 let bytes = self.read_release_blob(&file).await?;
                 let source_url = format!("release://{}", file.original_filename);
-                (
-                    bytes,
-                    file.content_type.clone(),
-                    "local".to_string(),
-                    Some(source_url),
-                )
+                (bytes, "local".to_string(), Some(source_url))
             }
             CoverSelection::RemoteCover { url, source } => {
-                let (bytes, content_type) =
+                let (bytes, _content_type) =
                     crate::import::cover_art::download_cover_art_bytes(&url)
                         .await
                         .map_err(|e| {
                             LibraryError::Import(format!("Failed to download cover: {e}"))
                         })?;
 
-                (bytes, content_type, source.as_str().to_string(), Some(url))
+                (bytes, source.as_str().to_string(), Some(url))
             }
         };
+
+        // Resize to a ≤600px JPEG thumbnail before deriving the storage key and
+        // record — the stored bytes, their format, and size all describe the
+        // thumbnail, not the source. The resize always emits JPEG.
+        let bytes = crate::util::cover::resize_cover(&bytes)
+            .map_err(|e| LibraryError::Import(format!("Failed to resize cover: {e}")))?;
+        let content_type = crate::util::content_type::ContentType::Jpeg;
 
         // Record the cover blob and row in one coven write. The cover's `id` IS
         // the release id. Under a

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -852,6 +852,79 @@ async fn gallery_includes_cloud_only_image_files_with_no_local_path() {
     );
 }
 
+/// `change_cover` resizes whatever the user picks to a ≤600 JPEG thumbnail
+/// before storing it: a 900×300 PNG release image lands as a 600×200 JPEG blob
+/// (downscaled to fit 600, aspect kept), and the `covers` row records JPEG.
+#[tokio::test]
+async fn change_cover_stores_a_resized_jpeg_thumbnail() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let mut release = create_test_release(&album.id);
+    release.remote = false;
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+
+    // An oversized non-JPEG release image on disk, registered as the release's
+    // user-provided file so `change_cover` reads it back through coven.
+    let source_dir = TempDir::new().unwrap();
+    let cover_bytes = {
+        let img = ::image::RgbImage::from_pixel(900, 300, ::image::Rgb([20, 160, 90]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        ::image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, ::image::ImageFormat::Png)
+            .unwrap();
+        buf.into_inner()
+    };
+    std::fs::write(source_dir.path().join("art.png"), &cover_bytes).unwrap();
+    let file = DbFile::new(
+        &release.id,
+        "art.png",
+        cover_bytes.len() as i64,
+        ContentType::Png,
+        Uuid::new_v4().to_string(),
+        Utc::now(),
+    );
+    manager.add_file(&file).await.unwrap();
+    manager
+        .database
+        .register_release_external_refs_for_test(&release.id, &source_dir.path().to_string_lossy())
+        .await
+        .unwrap();
+
+    manager
+        .change_cover(
+            &album.id,
+            &release.id,
+            CoverSelection::ReleaseImage {
+                file_id: file.id.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // The stored blob decodes as a ≤600 JPEG, not the 900×300 PNG source.
+    let stored = manager
+        .read_cover_image_blob(&release.id)
+        .await
+        .unwrap()
+        .expect("cover blob stored");
+    assert_eq!(
+        ::image::guess_format(&stored).unwrap(),
+        ::image::ImageFormat::Jpeg
+    );
+    let decoded = ::image::load_from_memory(&stored).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), (600, 200));
+
+    // The row describes the stored thumbnail: JPEG, and its size matches.
+    let row = manager
+        .get_library_image(&release.id, &LibraryImageType::Cover)
+        .await
+        .unwrap()
+        .expect("cover row stored");
+    assert_eq!(row.content_type, ContentType::Jpeg);
+    assert_eq!(row.file_size, stored.len() as i64);
+}
+
 /// Queueing an album expands to its PRIMARY release's tracks, not the
 /// earliest-imported one. When the user picks a non-default primary (e.g. a
 /// later remaster over the original vinyl rip), enqueueing the album must

--- a/bae-core/src/playback/service/seek.rs
+++ b/bae-core/src/playback/service/seek.rs
@@ -29,6 +29,7 @@ impl PlaybackService {
                 "Seek: Skipping seek to same position (difference: {:?} < 100ms)",
                 position_diff
             );
+            self.emit_position_display(position.as_millis() as u64, track_id);
             return;
         }
 

--- a/bae-core/src/text_encoding.rs
+++ b/bae-core/src/text_encoding.rs
@@ -18,29 +18,11 @@ pub struct DecodedText {
 /// 2. No BOM: try UTF-8
 /// 3. Not valid UTF-8: chardetng detection, decode via encoding_rs
 pub fn decode_text(bytes: &[u8]) -> DecodedText {
-    // UTF-8 BOM
-    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
-        return DecodedText {
-            text: String::from_utf8_lossy(&bytes[3..]).into_owned(),
-            encoding: "UTF-8".to_string(),
-        };
-    }
-
-    // UTF-16 LE BOM
-    if bytes.starts_with(&[0xFF, 0xFE]) {
-        let (decoded, _, _) = encoding_rs::UTF_16LE.decode(&bytes[2..]);
+    if let Some((encoding, bom_len)) = encoding_rs::Encoding::for_bom(bytes) {
+        let (decoded, _, _) = encoding.decode(&bytes[bom_len..]);
         return DecodedText {
             text: decoded.into_owned(),
-            encoding: "UTF-16LE".to_string(),
-        };
-    }
-
-    // UTF-16 BE BOM
-    if bytes.starts_with(&[0xFE, 0xFF]) {
-        let (decoded, _, _) = encoding_rs::UTF_16BE.decode(&bytes[2..]);
-        return DecodedText {
-            text: decoded.into_owned(),
-            encoding: "UTF-16BE".to_string(),
+            encoding: encoding.name().to_string(),
         };
     }
 

--- a/bae-core/src/util/cover.rs
+++ b/bae-core/src/util/cover.rs
@@ -1,0 +1,82 @@
+//! Cover art resizing for storage and export.
+
+use tracing::debug;
+
+/// Maximum dimension for a stored/embedded cover thumbnail.
+const COVER_MAX_SIZE: u32 = 600;
+
+/// Resize cover art to fit within COVER_MAX_SIZE, encoded as JPEG.
+pub fn resize_cover(data: &[u8]) -> Result<Vec<u8>, String> {
+    let img = image::load_from_memory(data)
+        .map_err(|e| format!("Failed to decode cover image: {}", e))?;
+
+    let (w, h) = (img.width(), img.height());
+
+    let img = if w > COVER_MAX_SIZE || h > COVER_MAX_SIZE {
+        debug!(
+            "Resizing cover art from {}x{} to fit {}x{}",
+            w, h, COVER_MAX_SIZE, COVER_MAX_SIZE
+        );
+        img.resize(
+            COVER_MAX_SIZE,
+            COVER_MAX_SIZE,
+            image::imageops::FilterType::Lanczos3,
+        )
+    } else {
+        img
+    };
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    img.write_to(&mut buf, image::ImageFormat::Jpeg)
+        .map_err(|e| format!("Failed to encode cover as JPEG: {}", e))?;
+    Ok(buf.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a solid-color image of the given dimensions to PNG bytes, so the
+    /// resizer's input is a real decodable image of a non-JPEG format.
+    fn png_source(width: u32, height: u32) -> Vec<u8> {
+        let img = image::RgbImage::from_pixel(width, height, image::Rgb([120, 40, 200]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+        buf.into_inner()
+    }
+
+    /// Decode resized bytes to their real pixel dimensions and confirm JPEG.
+    fn decoded_dims(bytes: &[u8]) -> (u32, u32) {
+        let format = image::guess_format(bytes).unwrap();
+        assert_eq!(format, image::ImageFormat::Jpeg, "output must be JPEG");
+        let img = image::load_from_memory(bytes).unwrap();
+        (img.width(), img.height())
+    }
+
+    #[test]
+    fn square_large_downscales_to_600() {
+        let out = resize_cover(&png_source(1200, 1200)).unwrap();
+        assert_eq!(decoded_dims(&out), (600, 600));
+    }
+
+    #[test]
+    fn wide_source_keeps_aspect_no_pad() {
+        let out = resize_cover(&png_source(1200, 600)).unwrap();
+        assert_eq!(decoded_dims(&out), (600, 300));
+    }
+
+    #[test]
+    fn small_source_is_not_upscaled() {
+        // The load-bearing assertion: a sub-600 source keeps its dimensions —
+        // resize downscales only, it never enlarges.
+        let out = resize_cover(&png_source(300, 300)).unwrap();
+        assert_eq!(decoded_dims(&out), (300, 300));
+    }
+
+    #[test]
+    fn garbage_bytes_error() {
+        assert!(resize_cover(&[0u8; 16]).is_err());
+    }
+}

--- a/bae-core/src/util/mod.rs
+++ b/bae-core/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod content_type;
 pub mod content_type_hint;
+pub mod cover;
 pub mod format;
 pub mod fs;
 pub mod http;

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -140,16 +140,25 @@ fn generate_tagged_album_files(
     }
 }
 
-/// A minimal valid JPEG (SOI/APP0/DQT/SOF0/EOI) used as embedded cover
-/// data — the import never decodes it, it only stores the bytes.
-const EMBEDDED_JPEG: &[u8] = &[
-    0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
-    0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
-];
+/// Embedded cover width/height for the fixture below.
+const EMBEDDED_COVER_DIMS: (u32, u32) = (64, 48);
 
-/// Like `generate_tagged_album_files`, but also embeds `EMBEDDED_JPEG` as
-/// a front cover in every file — a tagged rip whose only artwork is
-/// embedded in the audio.
+/// A real, decodable JPEG cover (solid color, [`EMBEDDED_COVER_DIMS`]) embedded
+/// in test audio. The store path decodes every cover and re-encodes it to a
+/// ≤600 JPEG, so fixtures must be genuine images, not hand-written JPEG headers.
+fn embedded_cover_jpeg() -> Vec<u8> {
+    let (w, h) = EMBEDDED_COVER_DIMS;
+    let img = image::RgbImage::from_pixel(w, h, image::Rgb([200, 60, 40]));
+    let mut buf = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(&mut buf, image::ImageFormat::Jpeg)
+        .unwrap();
+    buf.into_inner()
+}
+
+/// Like `generate_tagged_album_files`, but also embeds a real JPEG cover
+/// (`embedded_cover_jpeg`) as the front cover in every file — a tagged rip
+/// whose only artwork is embedded in the audio.
 fn generate_tagged_album_files_with_embedded_cover(
     dir: &Path,
     album_title: &str,
@@ -176,7 +185,7 @@ fn generate_tagged_album_files_with_embedded_cover(
         tag.insert_text(ItemKey::AlbumArtist, album_artist.to_string());
         tag.set_track(t.track_number);
         tag.push_picture(
-            Picture::unchecked(EMBEDDED_JPEG.to_vec())
+            Picture::unchecked(embedded_cover_jpeg())
                 .pic_type(PictureType::CoverFront)
                 .mime_type(MimeType::Jpeg)
                 .build(),
@@ -192,16 +201,23 @@ fn generate_album_with_cover(dir: &Path, filenames: &[&str]) {
     generate_album_files(dir, filenames);
     let scans = dir.join("scans");
     fs::create_dir_all(&scans).unwrap();
-    let jpeg: Vec<u8> = vec![
-        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00,
-        0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06,
-        0x05, 0x08, 0x07, 0x07, 0x07, 0x09, 0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B,
-        0x0C, 0x19, 0x12, 0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
-        0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29, 0x2C, 0x30, 0x31,
-        0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32, 0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF,
-        0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xD9,
-    ];
-    fs::write(scans.join("back.jpg"), &jpeg).unwrap();
+    fs::write(scans.join("back.jpg"), embedded_cover_jpeg()).unwrap();
+}
+
+/// Like `generate_album_with_cover`, but the folder image is an oversized
+/// (1000×1000) PNG — a source that must be downscaled and re-encoded to JPEG at
+/// store time. Returns the selection path for the cover.
+fn generate_album_with_oversized_cover(dir: &Path, filenames: &[&str]) -> String {
+    generate_album_files(dir, filenames);
+    let scans = dir.join("scans");
+    fs::create_dir_all(&scans).unwrap();
+    let img = image::RgbImage::from_pixel(1000, 1000, image::Rgb([20, 160, 90]));
+    let mut buf = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(&mut buf, image::ImageFormat::Png)
+        .unwrap();
+    fs::write(scans.join("cover.png"), buf.into_inner()).unwrap();
+    "scans/cover.png".to_string()
 }
 
 fn discogs_release(title: &str, tracks: &[&str]) -> DiscogsRelease {
@@ -931,6 +947,65 @@ async fn import_with_cover_art() {
         .await
         .expect("cover blob should be readable");
     assert!(!cover_bytes.is_empty(), "cover bytes should not be empty");
+}
+
+/// An oversized folder cover is resized to a ≤600 JPEG thumbnail at import: the
+/// stored blob decodes to 600×600 JPEG (from a 1000×1000 PNG source) and the
+/// `covers` row records JPEG, not the source PNG.
+#[tokio::test]
+#[serial]
+async fn import_resizes_oversized_cover_to_jpeg_thumbnail() {
+    support::tracing_init();
+
+    let release = discogs_release("Oversized Cover Album", &["Track"]);
+    let release_id_key = seed_discogs_test_release(release);
+    let f = ImportFixture::new().await;
+
+    let album_dir = f.temp_path().join("album");
+    fs::create_dir_all(&album_dir).unwrap();
+    let cover_path = generate_album_with_oversized_cover(&album_dir, &["01 Track.flac"]);
+
+    let import_id = uuid::Uuid::new_v4().to_string();
+    f.handle
+        .send_command(ImportCommand::Folder {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir,
+            selected_cover: Some(CoverSelection::Local(cover_path)),
+            storage_mode: StorageMode::Local,
+            pin: false,
+            identity_choice: IdentityChoice::Exact {
+                release_ref: MetadataRef::new(release_id_key, MetadataSource::Discogs),
+            },
+            user_edit: None,
+        })
+        .unwrap();
+
+    let mut progress_rx = f.handle.subscribe_import(import_id);
+    let (release_id, _) = support::wait_for_import_complete(&mut progress_rx).await;
+
+    // The row records the stored format (JPEG), not the source PNG.
+    let cover =
+        f.db.find_library_image(&release_id, &LibraryImageType::Cover)
+            .await
+            .unwrap()
+            .expect("cover image in DB");
+    assert_eq!(
+        cover.content_type,
+        bae_core::util::content_type::ContentType::Jpeg
+    );
+
+    // The stored blob is a ≤600 JPEG downscaled from the 1000×1000 PNG source.
+    let cover_bytes = support::read_cover_image_blob(&f.db, &f.library_manager, &release_id)
+        .await
+        .expect("cover blob should be readable");
+    assert_eq!(
+        image::guess_format(&cover_bytes).unwrap(),
+        image::ImageFormat::Jpeg
+    );
+    let decoded = image::load_from_memory(&cover_bytes).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), (600, 600));
+    assert_eq!(cover.file_size, cover_bytes.len() as i64);
 }
 
 /// On a browsable home the readable cloud_path is computed AT IMPORT — for every
@@ -1722,10 +1797,17 @@ async fn unknown_import_seeds_embedded_cover_when_no_folder_image() {
         "cover must be sourced from the embedded picture"
     );
 
+    // The embedded picture (≤600) keeps its dimensions but the store path
+    // re-encodes it to JPEG, so assert on the decoded image, not raw bytes.
     let bytes = support::read_cover_image_blob(&f.db, &f.library_manager, &release_id)
         .await
         .expect("cover blob readable");
-    assert_eq!(bytes, EMBEDDED_JPEG, "cover bytes are the embedded picture");
+    assert_eq!(
+        image::guess_format(&bytes).unwrap(),
+        image::ImageFormat::Jpeg
+    );
+    let decoded = image::load_from_memory(&bytes).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), EMBEDDED_COVER_DIMS);
 }
 
 /// A folder image outranks the embedded picture: when both exist, the
@@ -1752,7 +1834,7 @@ async fn unknown_import_folder_image_wins_over_embedded_cover() {
     // selection — the auto-pick must still prefer this folder image.
     let scans = album_dir.join("scans");
     fs::create_dir_all(&scans).unwrap();
-    fs::write(scans.join("cover.jpg"), EMBEDDED_JPEG).unwrap();
+    fs::write(scans.join("cover.jpg"), embedded_cover_jpeg()).unwrap();
 
     let import_id = uuid::Uuid::new_v4().to_string();
     f.handle

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -2016,6 +2016,19 @@ async fn test_same_position_seek_keeps_position_updates_flowing() {
         .unwrap_or(2000);
     let same_position = Duration::from_millis(current_pos_ms + 50);
     fixture.playback_handle.seek(same_position);
+    let seeked_position = fixture.wait_for_seeked(Duration::from_secs(2)).await;
+    assert!(
+        seeked_position.is_some(),
+        "Should receive Seeked event when position difference < 100ms",
+    );
+    if let Some(seeked_position) = seeked_position {
+        let diff = Duration::from_millis(seeked_position).abs_diff(same_position);
+        assert!(
+            diff < Duration::from_millis(100),
+            "Seeked display should stay near the requested position, got {:?}",
+            diff,
+        );
+    }
     tokio::time::sleep(Duration::from_millis(500)).await;
     let position_update = fixture
         .wait_for_position_update(Duration::from_secs(2))

--- a/bae-macos/bae/bae/Services/PlaybackStore.swift
+++ b/bae-macos/bae/bae/Services/PlaybackStore.swift
@@ -117,10 +117,7 @@ class PlaybackStore {
             return playbackPosition?.snapshot
         }
         if case .projected(let projected, let pendingSeek) = playbackPosition {
-            if !pendingSeek.acceptsProgress(
-                trackId: trackId,
-                positionMs: positionMs
-            ) {
+            if pendingSeek.matches(trackId: trackId) {
                 return projected
             }
         }
@@ -192,8 +189,7 @@ class PlaybackStore {
             progress: clampedRatio
         )
         let pendingSeek = PendingSeek(
-            trackId: nowPlaying.track?.trackId,
-            targetPositionMs: targetPositionMs
+            trackId: nowPlaying.track?.trackId
         )
         return publish(snapshot, state: .projected(snapshot, pendingSeek))
     }
@@ -237,18 +233,9 @@ private enum PlaybackPositionState {
 
 private struct PendingSeek {
     let trackId: String?
-    let targetPositionMs: UInt64
-    private static let targetAcceptanceWindowMs: UInt64 = 100
 
-    func acceptsProgress(trackId: String, positionMs: UInt64) -> Bool {
-        guard self.trackId == nil || self.trackId == trackId else {
-            return false
-        }
-        let distanceFromTarget =
-            positionMs > targetPositionMs
-            ? positionMs - targetPositionMs
-            : targetPositionMs - positionMs
-        return distanceFromTarget <= Self.targetAcceptanceWindowMs
+    func matches(trackId: String) -> Bool {
+        self.trackId == nil || self.trackId == trackId
     }
 }
 

--- a/bae-macos/bae/bae/Views/SeekSlider.swift
+++ b/bae-macos/bae/bae/Views/SeekSlider.swift
@@ -10,9 +10,9 @@ class SeekSlider: NSSlider {
     override func mouseDown(with event: NSEvent) {
         // NSSlider's default click-on-track is a page-step increment toward
         // the click, not a jump-to-click. That moves doubleValue only a tiny
-        // amount, so the resulting seek gets rejected as a same-position
-        // seek (< 100ms diff). Compute the click position synchronously so
-        // click and drag both commit to the clicked location.
+        // amount, so core treats the result as a same-position seek. Compute
+        // the click position synchronously so click and drag both commit to
+        // the clicked location.
         if let cell = cell as? NSSliderCell {
             let point = convert(event.locationInWindow, from: nil)
             let knobRect = cell.knobRect(flipped: isFlipped)

--- a/bae-macos/bae/baeTests/PlaybackStoreTests.swift
+++ b/bae-macos/bae/baeTests/PlaybackStoreTests.swift
@@ -176,8 +176,8 @@ struct PlaybackStoreSeekProjectionTests {
         let projected = store.projectSeek(ratio: 0.75)
 
         #expect(projected?.positionMs == 75_000)
-        expectPosition(
-            store.playbackPositionSubject.value,
+        expectStorePosition(
+            store,
             progress: 0.75,
             elapsed: "1:15",
             remaining: "-0:25"
@@ -188,22 +188,24 @@ struct PlaybackStoreSeekProjectionTests {
             progress: 0.2
         )
         #expect(stale.positionMs == 75_000)
-        expectPosition(
-            store.playbackPositionSubject.value,
-            progress: 0.75,
-            elapsed: "1:15",
-            remaining: "-0:25"
+
+        let nearTargetProgress = store.updatePlaybackPosition(
+            positionMs: 75_050,
+            durationMs: 100_000,
+            progress: 0.7505
         )
 
+        #expect(nearTargetProgress.positionMs == 75_000)
+
         let stillProjected = store.updatePlaybackPosition(
-            positionMs: 76_000,
+            positionMs: 80_000,
             durationMs: 100_000,
-            progress: 0.76
+            progress: 0.8
         )
 
         #expect(stillProjected.positionMs == 75_000)
-        expectPosition(
-            store.playbackPositionSubject.value,
+        expectStorePosition(
+            store,
             progress: 0.75,
             elapsed: "1:15",
             remaining: "-0:25"
@@ -216,8 +218,8 @@ struct PlaybackStoreSeekProjectionTests {
         )
 
         #expect(accepted.positionMs == 76_000)
-        expectPosition(
-            store.playbackPositionSubject.value,
+        expectStorePosition(
+            store,
             progress: 0.76,
             elapsed: "1:16",
             remaining: "-0:24"
@@ -290,7 +292,21 @@ struct PlaybackStoreSeekProjectionTests {
             remaining: "-1:15"
         )
 
-        let accepted = store.updatePlaybackPosition(
+        let reachedTargetProgress = store.updatePlaybackPosition(
+            positionMs: 25_100,
+            durationMs: 100_000,
+            progress: 0.251
+        )
+
+        #expect(reachedTargetProgress.positionMs == 25_000)
+        expectPosition(
+            store.playbackPositionSubject.value,
+            progress: 0.25,
+            elapsed: "0:25",
+            remaining: "-1:15"
+        )
+
+        let accepted = store.updatePlaybackSeeked(
             positionMs: 25_100,
             durationMs: 100_000,
             progress: 0.251
@@ -330,7 +346,15 @@ struct PlaybackStoreSeekProjectionTests {
             remaining: "-1:15"
         )
 
-        let accepted = store.updatePlaybackPosition(
+        let reachedTargetProgress = store.updatePlaybackPosition(
+            positionMs: 25_100,
+            durationMs: 100_000,
+            progress: 0.251
+        )
+
+        #expect(reachedTargetProgress.positionMs == 25_000)
+
+        let accepted = store.updatePlaybackSeeked(
             positionMs: 25_100,
             durationMs: 100_000,
             progress: 0.251
@@ -419,6 +443,21 @@ private func expectPosition(
     #expect(actualProgress == progress)
     #expect(actualElapsed == elapsed)
     #expect(actualRemaining == remaining)
+}
+
+@MainActor
+private func expectStorePosition(
+    _ store: PlaybackStore,
+    progress: Double,
+    elapsed: String,
+    remaining: String
+) {
+    expectPosition(
+        store.playbackPositionSubject.value,
+        progress: progress,
+        elapsed: elapsed,
+        remaining: remaining
+    )
 }
 
 extension PlaybackStore {

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -31,7 +31,6 @@ public sealed partial class MainWindow : Window
 {
     private const uint PositionUpdateIntervalMs = 250;
     private const ulong FirstPageSize = 500;
-    private const ulong SeekTargetWindowMs = 100;
 
     // LabelKey is a chrome key resolved to the localized menu label at display
     // time; Field is the locale-free sort identifier the FFI expects (never
@@ -1557,14 +1556,6 @@ public sealed partial class MainWindow : Window
         }
     }
 
-    private static bool IsNearSeekTarget(BaeEvent evt, SeekProjection projection)
-    {
-        var distance = evt.PositionMs > projection.TargetPositionMs
-            ? evt.PositionMs - projection.TargetPositionMs
-            : projection.TargetPositionMs - evt.PositionMs;
-        return distance <= SeekTargetWindowMs;
-    }
-
     private bool PlaybackPositionTargetsCurrentTrack(BaeEvent evt)
     {
         if (evt.TrackId is null)
@@ -1595,7 +1586,7 @@ public sealed partial class MainWindow : Window
 
         if (projection is not null)
         {
-            if (projection.TrackId != evt.TrackId || !IsNearSeekTarget(evt, projection))
+            if (projection.TrackId == evt.TrackId)
             {
                 RenderSeekPosition(
                     projection.Progress,
@@ -1603,10 +1594,9 @@ public sealed partial class MainWindow : Window
                     projection.DurationMs);
                 return;
             }
-            projection = null;
         }
 
-        ApplyPlaybackPositionSnapshot(evt, projection);
+        ApplyPlaybackPositionSnapshot(evt, null);
     }
 
     private void RenderPlaybackSeeked(BaeEvent evt)


### PR DESCRIPTION
Scrub projections were still being cleared by ordinary playback progress once the tick landed near the requested target. That left the UI able to jump back or forward while core was still buffering or seeking.

This keeps projected seek position owned by the platform stores until core emits the distinct `PlaybackSeeked` event for the same track, and makes same-position seeks emit that display event too. iOS uses the shared Swift `PlaybackStore`, so the Apple-side fix covers both macOS and iOS.

Test plan:
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testBaeiumDebugUnitTest --tests fm.bae.app.playback.PlaybackSeekProjectionTest --no-daemon`
- `xcodebuild -project bae.xcodeproj -scheme bae -derivedDataPath .build/derivedData -only-testing:baeTests/PlaybackStoreSeekProjectionTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --features test-utils test_same_position_seek_keeps_position_updates_flowing --test test_playback_behavior -- --nocapture`
- `cargo fmt --check`
- `ktlint "app/src/main/java/fm/bae/app/playback/BaeCorePlayer.kt" "app/src/test/java/fm/bae/app/playback/PlaybackSeekProjectionTest.kt"`
- `swiftlint lint --strict --config .swiftlint.yml bae-macos/bae/bae/Services/PlaybackStore.swift bae-macos/bae/bae/Views/SeekSlider.swift bae-macos/bae/baeTests/PlaybackStoreTests.swift`
- `xcrun swift-format lint -s bae-macos/bae/bae/Services/PlaybackStore.swift bae-macos/bae/bae/Views/SeekSlider.swift bae-macos/bae/baeTests/PlaybackStoreTests.swift`

Rules review:
- `code-rules-review` local diff with `--reviewer claude --model claude-sonnet-4-6`: 41 rules returned zero findings. `never-mask-errors-with-defaults` hung twice under Sonnet 4.6; manually inspected the diff for masked defaults / swallowed errors and found none.

Not run locally:
- Windows `dotnet format whitespace bae-windows/bae-windows.csproj --verify-no-changes`: `dotnet` is not installed on this machine.