### PR TITLE
Update Windows FFI for current core shapes

### DIFF
--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -10,8 +10,6 @@ pub enum ExportFormat {
     Mp3,
 }
 
-pub use crate::audio_codec::MP3_EXPORT_BITRATE;
-
 /// Render a single-track export's suggested filename stem (no extension) from a
 /// template and the track's tag data. Supported tokens:
 /// `{title} {artist} {album} {year} {track_number} {disc_number} {track_total}`.

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -13,7 +13,7 @@ pub mod upload_throughput;
 pub use app_services::*;
 pub use download_snapshot::{DownloadOp, DownloadProgress, DownloadSnapshot, DownloadState};
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
-pub use export::{ExportFormat, MP3_EXPORT_BITRATE};
+pub use export::ExportFormat;
 pub use export_snapshot::{ExportOp, ExportProgress, ExportSnapshot, ExportState};
 pub use manager::*;
 pub use outbox_snapshot::{

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -698,9 +698,7 @@ pub unsafe extern "C" fn bae_export_track(
     };
     let format = match format.as_str() {
         "flac" => ExportFormat::Flac,
-        "mp3" => ExportFormat::Mp3 {
-            bitrate: bae_core::library::MP3_EXPORT_BITRATE,
-        },
+        "mp3" => ExportFormat::Mp3,
         other => return error_cstring(&format!("unknown export format: {other}")),
     };
     let app = &handle.0;
@@ -3032,7 +3030,7 @@ enum FfiEvent {
     CandidateAdded {
         key: String,
         name: String,
-        track_count: Option<u32>,
+        track_count: u32,
         format: String,
         audio_paths: Vec<String>,
     },

--- a/bae-windows/BaeEvent.cs
+++ b/bae-windows/BaeEvent.cs
@@ -60,7 +60,7 @@ public sealed class BaeEvent
     // Scan-candidate events.
     public string? Key { get; set; }
     public string? Name { get; set; }
-    public int? TrackCount { get; set; }
+    public int TrackCount { get; set; }
     public string? Format { get; set; }
     public List<string>? AudioPaths { get; set; }
 

--- a/bae-windows/ImportCandidate.cs
+++ b/bae-windows/ImportCandidate.cs
@@ -11,7 +11,7 @@ public sealed class ImportCandidate
 {
     public string Key { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-    public int? TrackCount { get; set; }
+    public int TrackCount { get; set; }
     public string Format { get; set; } = string.Empty;
 
     /// <summary>The auto-identification status, e.g. "identifying…" / "found (3)".</summary>
@@ -35,10 +35,7 @@ public sealed class ImportCandidate
     public override string ToString()
     {
         var parts = new List<string> { Name };
-        if (TrackCount is int count)
-        {
-            parts.Add($"{count} tracks");
-        }
+        parts.Add(Loc.Chrome("import.candidate.tracks", "count", TrackCount));
 
         if (!string.IsNullOrEmpty(Format))
         {

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>العودة إلى البحث</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>اختر المجلد وافحص</value></data>
   <data name="import.complete" xml:space="preserve"><value>تم الاستيراد</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>تأكيد الاستيراد</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>افحص واستورد</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>أسقِط مجلدًا للاستيراد</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Обратно към търсенето</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>изберете папка и сканирайте</value></data>
   <data name="import.complete" xml:space="preserve"><value>внесено</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>потвърждаване на внасянето</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>сканиране и внасяне</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>пуснете папка за внасяне</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Zpět na vyhledávání</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>vybrat složku a skenovat</value></data>
   <data name="import.complete" xml:space="preserve"><value>importováno</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>potvrdit import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>skenovat a importovat</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>přetáhněte složku k importu</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Zurück zur Suche</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>Ordner wählen &amp; scannen</value></data>
   <data name="import.complete" xml:space="preserve"><value>importiert</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>Import bestätigen</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scannen &amp; importieren</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>Ordner zum Importieren ablegen</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -71,6 +71,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Volver a la búsqueda</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>elegir carpeta y analizar</value></data>
   <data name="import.complete" xml:space="preserve"><value>importado</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirmar importación</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>analizar e importar</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>suelta una carpeta para importar</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Retour à la recherche</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choisir un dossier et analyser</value></data>
   <data name="import.complete" xml:space="preserve"><value>importé</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirmer l'import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>analyser et importer</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>déposez un dossier à importer</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>חזרה לחיפוש</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>בחרו תיקייה וסרקו</value></data>
   <data name="import.complete" xml:space="preserve"><value>יובא</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>אישור ייבוא</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>סרוק וייבא</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>גררו תיקייה לייבוא</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Natrag na pretraživanje</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>odaberi mapu i skeniraj</value></data>
   <data name="import.complete" xml:space="preserve"><value>uvezeno</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>potvrdi uvoz</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>skeniraj i uvezi</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>ispustite mapu za uvoz</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>検索に戻る</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>フォルダを選択してスキャン</value></data>
   <data name="import.complete" xml:space="preserve"><value>取り込み完了</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>取り込みを確認</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>スキャンして取り込む</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>フォルダをドロップして取り込む</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>검색으로 돌아가기</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>폴더 선택 및 스캔</value></data>
   <data name="import.complete" xml:space="preserve"><value>가져옴</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>가져오기 확인</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>스캔 및 가져오기</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>가져올 폴더를 놓으세요</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Powrót do wyszukiwania</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>wybierz folder i skanuj</value></data>
   <data name="import.complete" xml:space="preserve"><value>zaimportowano</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>potwierdź import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>skanuj i importuj</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>upuść folder do importu</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Voltar à busca</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>escolher pasta e verificar</value></data>
   <data name="import.complete" xml:space="preserve"><value>importado</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirmar importação</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>verificar e importar</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>solte uma pasta para importar</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Назад до пошуку</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>вибрати теку та сканувати</value></data>
   <data name="import.complete" xml:space="preserve"><value>імпортовано</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>підтвердити імпорт</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>сканувати та імпортувати</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>перетягніть теку для імпорту</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>返回搜索</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>选择文件夹并扫描</value></data>
   <data name="import.complete" xml:space="preserve"><value>已导入</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>确认导入</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>扫描并导入</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>拖入文件夹以导入</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -67,6 +67,7 @@
   <data name="import.back_to_search" xml:space="preserve"><value>Back to Search</value></data>
   <data name="import.choose_folder" xml:space="preserve"><value>choose folder &amp;amp; scan</value></data>
   <data name="import.complete" xml:space="preserve"><value>imported</value></data>
+  <data name="import.candidate.tracks" xml:space="preserve"><value>{count, plural, one {# track} other {# tracks}}</value></data>
   <data name="import.confirm_title" xml:space="preserve"><value>confirm import</value></data>
   <data name="import.drop_caption" xml:space="preserve"><value>scan &amp;amp; import</value></data>
   <data name="import.drop_folder_only" xml:space="preserve"><value>drop a folder to import</value></data>


### PR DESCRIPTION
Windows FFI still constructed the older MP3 export variant after core moved the bitrate into the encoder, and the candidate event shape still modeled a missing track count even though folder candidates always carry parsed audio content. This updates the Windows FFI and C# model to match the current core shape, removes the stale bitrate re-export, and localizes the candidate track-count label through the Windows resource catalog.

Test plan:
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-windows-ffi`
- `xmllint --noout bae-windows/Strings/*/Resources.resw`
- `.NET SDK unavailable locally; Windows build covered by CI`