### PR TITLE
Move playback progress into native leaves

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/ExpandedNowPlayingScreen.kt
@@ -185,25 +185,10 @@ private fun ExpandedTrackInfo(
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
 private fun ExpandedSeekSection(player: fm.bae.app.playback.BaeCorePlayer) {
-    val position by player.position.collectAsState()
-    NowPlayingSeekSlider(
-        position = position,
+    PlaybackProgressAndroidView(
         player = player,
         modifier = Modifier.fillMaxWidth(),
     )
-    Row(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = position.elapsedLabel,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            text = position.remainingLabel,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
 }
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)

--- a/bae-android/app/src/main/java/fm/bae/app/ui/NowPlayingBar.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/NowPlayingBar.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -40,7 +39,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.media3.common.C
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
 import fm.bae.app.coreString
@@ -59,9 +57,6 @@ import uniffi.bae_bridge.BridgeRepeatMode
 fun NowPlayingBar(session: OpenLibrary) {
     val player = session.playback
     val nowPlaying by player.nowPlaying.collectAsState()
-    val isPlaying by player.isPlaying.collectAsState()
-    val isLoading by player.isLoading.collectAsState()
-    val position by player.position.collectAsState()
     val repeatMode by player.repeatMode.collectAsState()
 
     val track = nowPlaying ?: return
@@ -100,7 +95,10 @@ fun NowPlayingBar(session: OpenLibrary) {
                     onOpenQueue = { queueOpen = true },
                 )
             }
-            NowPlayingSeekRow(position = position, player = player)
+            PlaybackProgressAndroidView(
+                player = player,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }
@@ -216,54 +214,4 @@ private fun NowPlayingTransportButtons(
                 },
         )
     }
-}
-
-@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-@Composable
-private fun NowPlayingSeekRow(
-    position: fm.bae.app.playback.PlaybackPosition,
-    player: fm.bae.app.playback.BaeCorePlayer,
-) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = position.elapsedLabel,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        NowPlayingSeekSlider(
-            position = position,
-            player = player,
-            modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
-        )
-        Text(
-            text = position.remainingLabel,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-@Composable
-fun NowPlayingSeekSlider(
-    position: fm.bae.app.playback.PlaybackPosition,
-    player: fm.bae.app.playback.BaeCorePlayer,
-    modifier: Modifier = Modifier,
-) {
-    // While dragging, follow the finger; the progress events would otherwise snap
-    // the thumb back mid-drag. Null means "not dragging".
-    var dragRatio by remember { mutableStateOf<Float?>(null) }
-    val shownRatio = dragRatio ?: position.progress.toFloat().coerceIn(0f, 1f)
-    Slider(
-        value = shownRatio,
-        onValueChange = { dragRatio = it },
-        onValueChangeFinished = {
-            dragRatio?.let { ratio ->
-                val duration = player.duration
-                if (duration != C.TIME_UNSET && duration > 0L) player.seekTo((ratio * duration).toLong())
-            }
-            dragRatio = null
-        },
-        modifier = modifier,
-    )
 }

--- a/bae-android/app/src/main/java/fm/bae/app/ui/PlaybackProgressAndroidView.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/PlaybackProgressAndroidView.kt
@@ -1,0 +1,172 @@
+package fm.bae.app.ui
+
+import android.content.Context
+import android.graphics.Typeface
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.SeekBar
+import android.widget.TextView
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.C
+import fm.bae.app.playback.BaeCorePlayer
+import fm.bae.app.playback.PlaybackPosition
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+private const val SEEK_BAR_MAX = 10_000
+private const val TIME_LABEL_TEXT_SIZE_SP = 11f
+private const val TIME_LABEL_WIDTH_DP = 48
+
+@Composable
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+fun PlaybackProgressAndroidView(
+    player: BaeCorePlayer,
+    modifier: Modifier = Modifier,
+) {
+    AndroidView(
+        modifier = modifier,
+        factory = { context -> PlaybackProgressView(context) },
+        update = { view ->
+            view.bind(
+                position = player.position,
+                onSeekRatio = { ratio ->
+                    val duration = player.duration
+                    if (duration != C.TIME_UNSET && duration > 0L) {
+                        player.seekTo((ratio * duration).toLong())
+                    }
+                },
+            )
+        },
+    )
+}
+
+internal class PlaybackProgressView(
+    context: Context,
+) : LinearLayout(context) {
+    internal val elapsedTextView: TextView = timeLabel()
+    internal val seekBar: SeekBar =
+        SeekBar(context).apply {
+            max = SEEK_BAR_MAX
+            setOnSeekBarChangeListener(
+                object : SeekBar.OnSeekBarChangeListener {
+                    override fun onProgressChanged(
+                        seekBar: SeekBar,
+                        progress: Int,
+                        fromUser: Boolean,
+                    ) = Unit
+
+                    override fun onStartTrackingTouch(seekBar: SeekBar) {
+                        beginTracking()
+                    }
+
+                    override fun onStopTrackingTouch(seekBar: SeekBar) {
+                        finishTracking()
+                    }
+                },
+            )
+        }
+    internal val remainingTextView: TextView = timeLabel()
+
+    var onSeekRatio: (Double) -> Unit = {}
+
+    private var isDragging = false
+    private var position: Flow<PlaybackPosition>? = null
+    private var positionJob: Job? = null
+
+    init {
+        orientation = HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        layoutParams =
+            LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        addView(elapsedTextView)
+        addView(
+            seekBar,
+            LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+        )
+        addView(remainingTextView)
+    }
+
+    fun setPosition(position: PlaybackPosition) {
+        elapsedTextView.text = position.elapsedLabel
+        remainingTextView.text = position.remainingLabel
+        if (!isDragging) {
+            seekBar.progress = progressToSeekBar(position.progress)
+        }
+    }
+
+    fun bind(
+        position: Flow<PlaybackPosition>,
+        onSeekRatio: (Double) -> Unit,
+    ) {
+        this.onSeekRatio = onSeekRatio
+        if (this.position === position && positionJob?.isActive == true) {
+            return
+        }
+        this.position = position
+        positionJob?.cancel()
+        positionJob =
+            CoroutineScope(Dispatchers.Main.immediate).launch {
+                position.collect { setPosition(it) }
+            }
+    }
+
+    override fun onDetachedFromWindow() {
+        positionJob?.cancel()
+        positionJob = null
+        position = null
+        super.onDetachedFromWindow()
+    }
+
+    internal fun beginTracking() {
+        isDragging = true
+    }
+
+    internal fun finishTracking() {
+        val ratio = seekBar.progress.toDouble() / seekBar.max.toDouble()
+        isDragging = false
+        onSeekRatio(ratio)
+    }
+
+    private fun timeLabel(): TextView =
+        TextView(context).apply {
+            typeface = Typeface.MONOSPACE
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, TIME_LABEL_TEXT_SIZE_SP)
+            setTextColor(resolveThemeColor(android.R.attr.textColorSecondary))
+            gravity = Gravity.CENTER
+            layoutParams =
+                LayoutParams(
+                    dp(TIME_LABEL_WIDTH_DP),
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+        }
+
+    private fun progressToSeekBar(progress: Double): Int =
+        progress
+            .coerceIn(0.0, 1.0)
+            .times(seekBar.max.toDouble())
+            .toInt()
+
+    private fun dp(value: Int): Int =
+        TypedValue
+            .applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                value.toFloat(),
+                resources.displayMetrics,
+            ).toInt()
+
+    private fun resolveThemeColor(attribute: Int): Int {
+        val outValue = TypedValue()
+        context.theme.resolveAttribute(attribute, outValue, true)
+        return outValue.data
+    }
+}

--- a/bae-android/app/src/test/java/fm/bae/app/ui/PlaybackProgressViewTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/ui/PlaybackProgressViewTest.kt
@@ -1,0 +1,57 @@
+package fm.bae.app.ui
+
+import fm.bae.app.playback.PlaybackPosition
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class PlaybackProgressViewTest {
+    @Test
+    fun setPositionUpdatesProgressAndLabels() {
+        val view = PlaybackProgressView(RuntimeEnvironment.getApplication())
+
+        view.setPosition(
+            PlaybackPosition(
+                progress = 0.25,
+                elapsedLabel = "1:00",
+                remainingLabel = "-3:00",
+            ),
+        )
+
+        assertEquals("1:00", view.elapsedTextView.text.toString())
+        assertEquals("-3:00", view.remainingTextView.text.toString())
+        assertEquals(2_500, view.seekBar.progress)
+    }
+
+    @Test
+    fun setPositionDoesNotMoveThumbWhileDragging() {
+        val view = PlaybackProgressView(RuntimeEnvironment.getApplication())
+        view.setPosition(PlaybackPosition(0.20, "0:20", "-1:40"))
+
+        view.beginTracking()
+        view.seekBar.progress = 7_000
+        view.setPosition(PlaybackPosition(0.30, "0:30", "-1:30"))
+
+        assertEquals("0:30", view.elapsedTextView.text.toString())
+        assertEquals("-1:30", view.remainingTextView.text.toString())
+        assertEquals(7_000, view.seekBar.progress)
+    }
+
+    @Test
+    fun finishTrackingCallsSeekCallbackWithCurrentRatio() {
+        val view = PlaybackProgressView(RuntimeEnvironment.getApplication())
+        val ratios = mutableListOf<Double>()
+        view.onSeekRatio = { ratio -> ratios += ratio }
+
+        view.beginTracking()
+        view.seekBar.progress = 6_250
+        view.finishTracking()
+
+        assertEquals(listOf(0.625), ratios)
+    }
+}

--- a/bae-ios/bae/bae/Views/ProgressBar.swift
+++ b/bae-ios/bae/bae/Views/ProgressBar.swift
@@ -1,61 +1,129 @@
 import Combine
 import SwiftUI
+import UIKit
 
-/// The seek slider, driven by the high-frequency position subject so only this
-/// view re-renders on each tick. While dragging, follows the finger; the seek
-/// commits on release. Shared by the compact `NowPlayingBar` and the
-/// `ExpandedNowPlayingView` so both scrub through the one component.
-struct ProgressBar: View {
+/// UIKit-backed playback progress leaf. The compact and expanded players pass
+/// the high-frequency position subject here so ticks mutate UIKit controls
+/// directly instead of invalidating SwiftUI view state.
+struct ProgressBar: UIViewRepresentable {
     let positionSubject: CurrentValueSubject<PlaybackPositionEvent, Never>
     let onSeek: (Double) -> Void
 
-    @State
-    private var progress: Double = 0
-    @State
-    private var elapsed: String = ""
-    @State
-    private var remaining: String = ""
-    @State
-    private var dragRatio: Double?
+    func makeUIView(context _: Context) -> PlaybackProgressUIView {
+        let view = PlaybackProgressUIView()
+        view.onSeek = onSeek
+        view.subscribe(to: positionSubject)
+        return view
+    }
 
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(elapsed)
-                .font(.caption2.monospacedDigit())
-                .foregroundStyle(.secondary)
-            Slider(
-                value: Binding(
-                    get: { dragRatio ?? progress },
-                    set: { dragRatio = $0 }
-                ),
-                in: 0...1,
-                onEditingChanged: { editing in
-                    if !editing, let ratio = dragRatio {
-                        dragRatio = nil
-                        onSeek(ratio)
-                    }
-                }
-            )
-            Text(remaining)
-                .font(.caption2.monospacedDigit())
-                .foregroundStyle(.secondary)
+    func updateUIView(_ view: PlaybackProgressUIView, context _: Context) {
+        view.onSeek = onSeek
+        view.subscribe(to: positionSubject)
+    }
+}
+
+final class PlaybackProgressUIView: UIView {
+    private let elapsedLabel = UILabel()
+    private let slider = UISlider()
+    private let remainingLabel = UILabel()
+
+    var onSeek: (Double) -> Void = { _ in }
+
+    private var isDragging = false
+    private var subject: CurrentValueSubject<PlaybackPositionEvent, Never>?
+    private var cancellable: AnyCancellable?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configureTimeLabel(elapsedLabel)
+        configureTimeLabel(remainingLabel)
+
+        slider.minimumValue = 0
+        slider.maximumValue = 1
+        slider.isContinuous = true
+        slider.translatesAutoresizingMaskIntoConstraints = false
+        slider.addTarget(
+            self,
+            action: #selector(beginDragging),
+            for: .touchDown
+        )
+        slider.addTarget(
+            self,
+            action: #selector(finishDragging),
+            for: [.touchUpInside, .touchUpOutside, .touchCancel]
+        )
+
+        let stack = UIStackView(arrangedSubviews: [
+            elapsedLabel,
+            slider,
+            remainingLabel,
+        ])
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError()
+    }
+
+    private func configureTimeLabel(_ label: UILabel) {
+        label.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.widthAnchor.constraint(equalToConstant: 48).isActive = true
+    }
+
+    func subscribe(to subject: CurrentValueSubject<PlaybackPositionEvent, Never>) {
+        if self.subject === subject {
+            return
         }
-        .onReceive(positionSubject) { event in
-            switch event {
-            case .position(let progress, let elapsed, let remaining):
-                // Ignore ticks while the user is scrubbing so the thumb doesn't
-                // snap back mid-drag.
-                if dragRatio == nil {
-                    self.progress = max(0, min(1, progress))
-                }
-                self.elapsed = elapsed
-                self.remaining = remaining
-            case .reset:
-                progress = 0
-                elapsed = ""
-                remaining = ""
-                dragRatio = nil
+        self.subject = subject
+        cancellable =
+            subject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                self?.apply(event)
             }
+    }
+
+    private func apply(_ event: PlaybackPositionEvent) {
+        switch event {
+        case .position(let progress, let elapsed, let remaining):
+            elapsedLabel.text = elapsed
+            remainingLabel.text = remaining
+            if !isDragging {
+                slider.value = Float(max(0, min(1, progress)))
+            }
+        case .reset:
+            isDragging = false
+            slider.value = 0
+            elapsedLabel.text = ""
+            remainingLabel.text = ""
         }
+    }
+
+    @objc
+    private func beginDragging() {
+        isDragging = true
+    }
+
+    @objc
+    private func finishDragging() {
+        let ratio = Double(slider.value)
+        isDragging = false
+        onSeek(ratio)
     }
 }


### PR DESCRIPTION
Playback progress ticks arrive often enough that broad UI observation turns into avoidable redraw work. macOS already keeps this path at the native-control leaf; this change gives Android and iOS the same shape while leaving Windows unchanged because it already writes directly to named controls.

Android now renders compact and expanded playback progress through one `AndroidView` leaf. The native view owns the position subscription, updates labels and the seek bar directly, and keeps the thumb stable while the user is dragging. iOS `ProgressBar` now wraps a UIKit view that subscribes to the same position subject and mutates labels and the slider without storing each tick in SwiftUI state.

Test plan:
- `env JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_NDK_HOME="$HOME/Library/Android/sdk/ndk/29.0.14206865" ./gradlew :app:testFullDebugUnitTest --tests fm.bae.app.ui.PlaybackProgressViewTest --tests fm.bae.app.playback.PlaybackSeekProjectionTest --no-daemon`
- `ktlint "bae-android/app/src/**/*.kt"`
- `detekt --input bae-android/app/src/main/java --config bae-android/detekt.yml --build-upon-default-config`
- `xcrun swift-format lint -s bae-ios/bae/bae/Views/ProgressBar.swift`
- `swiftlint lint --strict --config .swiftlint.yml bae-ios/bae/bae/Views/ProgressBar.swift`
- `python3 ~/.codex/agent-instructions/scripts/rules_review/local_codex.py --consumer /Users/dima/dev/bae/.worktrees/native-playback-progress-leaves --project bae --local-diff --base origin/main --repo bae-fm/bae --sha f1b0a2fe --reviewer claude --model claude-sonnet-4-6 --jobs 4`
- `python3 ~/.codex/agent-instructions/scripts/rules_review/local_codex.py --consumer /Users/dima/dev/bae/.worktrees/native-playback-progress-leaves --project bae --local-diff --base origin/main --repo bae-fm/bae --sha f1b0a2fe --reviewer claude --model claude-sonnet-4-6 --jobs 2 --slug pub-sub-over-ref-registration --slug dependency-injection`

Local iOS `xcodebuild` did not reach compilation because this machine has simulator SDK 26.2 with only runtime 18.5 available.
