### PR TITLE
Report real download progress

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/AppSession.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/AppSession.kt
@@ -6,8 +6,10 @@ import android.os.Looper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import fm.bae.app.data.ConfigStore
+import fm.bae.app.data.DownloadStore
 import fm.bae.app.data.Library
 import fm.bae.app.data.LibraryStore
+import fm.bae.app.data.OpenLibraryStores
 import fm.bae.app.data.UiEventReducer
 import fm.bae.app.playback.BaeCorePlayer
 import fm.bae.app.playback.PlaybackService
@@ -44,14 +46,16 @@ private const val POSITION_UPDATE_INTERVAL_MS = 200u
 class OpenLibrary(
     val libraryId: String,
     val appHandle: AppHandle,
-    val libraryStore: LibraryStore,
-    val configStore: ConfigStore,
+    private val stores: OpenLibraryStores,
     val playback: BaeCorePlayer,
     private val appContext: Context,
 ) {
     // Library is always a thin wrapper around appHandle; construct it here rather
     // than requiring callers to pass a separately-constructed instance.
     val library = Library(appHandle)
+    val libraryStore: LibraryStore get() = stores.library
+    val configStore: ConfigStore get() = stores.config
+    val downloadStore: DownloadStore get() = stores.downloads
 
     /**
      * Subscribe to the live event stream, routing playback variants into the
@@ -71,8 +75,7 @@ class OpenLibrary(
                     scope.launch(Dispatchers.Main) {
                         UiEventReducer.reduce(
                             event,
-                            libraryStore,
-                            configStore,
+                            stores,
                             playback,
                             LocaleErrorLines(appContext),
                         )
@@ -256,8 +259,12 @@ object AppSessionHolder {
         OpenLibrary(
             libraryId = libraryId,
             appHandle = handle,
-            libraryStore = LibraryStore(),
-            configStore = ConfigStore(config, handle.isSyncReady()),
+            stores =
+                OpenLibraryStores(
+                    library = LibraryStore(),
+                    config = ConfigStore(config, handle.isSyncReady()),
+                    downloads = DownloadStore(handle.getDownloadSnapshot()),
+                ),
             playback =
                 BaeCorePlayer(
                     applicationLooper = Looper.getMainLooper(),

--- a/bae-android/app/src/main/java/fm/bae/app/data/DownloadStore.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/DownloadStore.kt
@@ -1,0 +1,21 @@
+package fm.bae.app.data
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import uniffi.bae_bridge.BridgeDownloadSnapshot
+
+/**
+ * Mirror of core's in-memory download queue snapshot. Core emits the full
+ * snapshot on every queue change; Compose renders the bridge payload directly.
+ */
+class DownloadStore(
+    initialSnapshot: BridgeDownloadSnapshot,
+) {
+    private val _snapshot = MutableStateFlow(initialSnapshot)
+    val snapshot: StateFlow<BridgeDownloadSnapshot> = _snapshot.asStateFlow()
+
+    fun setSnapshot(snapshot: BridgeDownloadSnapshot) {
+        _snapshot.value = snapshot
+    }
+}

--- a/bae-android/app/src/main/java/fm/bae/app/data/OpenLibraryStores.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/OpenLibraryStores.kt
@@ -1,0 +1,7 @@
+package fm.bae.app.data
+
+class OpenLibraryStores(
+    val library: LibraryStore,
+    val config: ConfigStore,
+    val downloads: DownloadStore,
+)

--- a/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/UiEventReducer.kt
@@ -9,8 +9,8 @@ private const val TAG = "bae.UiEventReducer"
 private val logger = BaeLogger(TAG)
 
 /**
- * Reduces [BridgeUiEvent]s into the [LibraryStore], [ConfigStore], and the
- * playback [PlaybackEventSink] (the [fm.bae.app.playback.BaeCorePlayer]).
+ * Reduces [BridgeUiEvent]s into the open library stores and the playback
+ * [PlaybackEventSink] (the [fm.bae.app.playback.BaeCorePlayer]).
  *
  * bae-core owns playback on Android, so the playback / queue / repeat / volume /
  * mute variants project into the [PlaybackEventSink]. Library, config, sync, and
@@ -24,8 +24,7 @@ private val logger = BaeLogger(TAG)
 object UiEventReducer {
     fun reduce(
         event: BridgeUiEvent,
-        libraryStore: LibraryStore,
-        configStore: ConfigStore,
+        stores: OpenLibraryStores,
         player: PlaybackEventSink,
         errors: ErrorLines,
     ) {
@@ -36,7 +35,9 @@ object UiEventReducer {
             is BridgeUiEvent.ReleaseAdded,
             is BridgeUiEvent.ReleaseUpdated,
             is BridgeUiEvent.ReleaseRemoved,
-            -> reduceLibrary(event, libraryStore)
+            -> {
+                reduceLibrary(event, stores.library)
+            }
 
             is BridgeUiEvent.PlaybackLoading,
             is BridgeUiEvent.PlaybackPlaying,
@@ -49,18 +50,28 @@ object UiEventReducer {
             is BridgeUiEvent.QueueUpdated,
             is BridgeUiEvent.VolumeChanged,
             is BridgeUiEvent.MuteChanged,
-            -> reducePlayback(event, player, configStore, errors)
+            -> {
+                reducePlayback(event, player, stores.config, errors)
+            }
 
             is BridgeUiEvent.ConfigChanged,
             is BridgeUiEvent.SyncingChanged,
             is BridgeUiEvent.SyncError,
             is BridgeUiEvent.Error,
             BridgeUiEvent.ErrorCleared,
-            -> reduceConfig(event, configStore, errors)
+            -> {
+                reduceConfig(event, stores.config, errors)
+            }
+
+            is BridgeUiEvent.DownloadQueueChanged -> {
+                stores.downloads.setSnapshot(event.snapshot)
+            }
 
             // Desktop-only events (import/scan/candidate/preview) never fire
             // on mobile; log if one ever does so a future mobile-firing event is visible.
-            else -> logger.debug("ignoring ${event::class.simpleName}")
+            else -> {
+                logger.debug("ignoring ${event::class.simpleName}")
+            }
         }
     }
 

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -19,11 +21,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import fm.bae.app.BaeLogger
 import fm.bae.app.OpenLibrary
 import fm.bae.app.R
+import fm.bae.app.coreString
+import fm.bae.app.data.DownloadStore
+import fm.bae.app.formatFileSize
 import uniffi.bae_bridge.BridgeComposerSortCriterion
 import uniffi.bae_bridge.BridgeComposerSortField
+import uniffi.bae_bridge.BridgeDownloadOp
+import uniffi.bae_bridge.BridgeDownloadState
 import uniffi.bae_bridge.BridgeSortCriterion
 import uniffi.bae_bridge.BridgeSortDirection
 import uniffi.bae_bridge.BridgeSortField
@@ -77,6 +85,7 @@ internal fun LibraryBrowser(
             onShuffleLibrary = { session.playLibraryShuffledOrReport(appContext) },
             onSettings = onSettings,
         )
+        DownloadProgressStrip(session.downloadStore)
         LibraryBrowserContent(
             modifier = Modifier.fillMaxWidth().weight(1f),
             session = session,
@@ -96,6 +105,72 @@ internal fun LibraryBrowser(
         )
         NowPlayingBar(session = session)
     }
+}
+
+@Composable
+private fun DownloadProgressStrip(downloadStore: DownloadStore) {
+    val snapshot by downloadStore.snapshot.collectAsState()
+    Column(modifier = Modifier.fillMaxWidth()) {
+        for (download in snapshot.downloads) {
+            DownloadProgressRow(download)
+        }
+    }
+}
+
+@Composable
+private fun DownloadProgressRow(download: BridgeDownloadOp) {
+    val context = LocalContext.current
+    val progress =
+        when (val state = download.state) {
+            is BridgeDownloadState.Active -> {
+                state.progress
+            }
+
+            is BridgeDownloadState.Failed -> {
+                Text(
+                    text = state.error,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                return
+            }
+
+            else -> {
+                return
+            }
+        }
+    Column {
+        LinearProgressIndicator(
+            progress = { progress.fraction.toFloat() },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            text =
+                context.coreString(
+                    "core.download.bytes_progress",
+                    mapOf(
+                        "done" to progress.bytesDone.formatDownloadBytes(context),
+                        "total" to progress.bytesTotal.formatDownloadBytes(context),
+                    ),
+                ),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun ULong.formatDownloadBytes(context: Context): String {
+    val byteCount = requireDownloadByteCountInDisplayRange()
+    return context.formatFileSize(byteCount)
+}
+
+private fun ULong.requireDownloadByteCountInDisplayRange(): Long {
+    require(this <= Long.MAX_VALUE.toULong()) {
+        "download byte count exceeds display range"
+    }
+    return toLong()
 }
 
 private fun OpenLibrary.playLibraryShuffledOrReport(appContext: Context) {

--- a/bae-android/app/src/test/java/fm/bae/app/BridgeFixtures.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/BridgeFixtures.kt
@@ -6,6 +6,8 @@ import uniffi.bae_bridge.BridgeAlbumSearchResult
 import uniffi.bae_bridge.BridgeComposerSummary
 import uniffi.bae_bridge.BridgeConfig
 import uniffi.bae_bridge.BridgeDiscogsTokenStatus
+import uniffi.bae_bridge.BridgeDownloadProgress
+import uniffi.bae_bridge.BridgeDownloadSnapshot
 import uniffi.bae_bridge.BridgeExportLocation
 import uniffi.bae_bridge.BridgeExportMetadata
 import uniffi.bae_bridge.BridgeGalleryItem
@@ -141,6 +143,23 @@ object BridgeFixtures {
             tracks = tracks,
             composers = composers,
             works = works,
+        )
+
+    fun downloadSnapshot(
+        queued: UInt = 0u,
+        active: UInt = 0u,
+        failed: UInt = 0u,
+        paused: Boolean = false,
+    ): BridgeDownloadSnapshot =
+        BridgeDownloadSnapshot(
+            downloads = emptyList(),
+            total =
+                BridgeDownloadProgress(
+                    queued = queued,
+                    active = active,
+                    failed = failed,
+                ),
+            paused = paused,
         )
 
     fun config(libraryId: String = "lib-1"): BridgeConfig =

--- a/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/data/UiEventReducerTest.kt
@@ -16,7 +16,12 @@ import uniffi.bae_bridge.BridgeRepeatMode
 import uniffi.bae_bridge.BridgeUiEvent
 
 class UiEventReducerTest {
-    private fun stores(): Pair<LibraryStore, ConfigStore> = LibraryStore() to ConfigStore(BridgeFixtures.config(), initialSyncReady = false)
+    private fun stores(): OpenLibraryStores =
+        OpenLibraryStores(
+            library = LibraryStore(),
+            config = ConfigStore(BridgeFixtures.config(), initialSyncReady = false),
+            downloads = DownloadStore(BridgeFixtures.downloadSnapshot()),
+        )
 
     // These tests exercise the library-routing arm; the playback sink is a no-op
     // (a real BaeCorePlayer needs a live AppHandle, which unit tests don't have —
@@ -71,14 +76,24 @@ class UiEventReducerTest {
             override fun line(error: BridgeException) = ""
         }
 
+    private fun reduce(
+        event: BridgeUiEvent,
+        stores: OpenLibraryStores,
+        player: PlaybackEventSink = noopPlayer,
+        errors: ErrorLines = noopErrors,
+    ) {
+        UiEventReducer.reduce(event, stores, player, errors)
+    }
+
     @Test
     fun albumAddedRoutesIntoLibraryStoreAndBumpsGeneration() {
-        val (library, config) = stores()
+        val stores = stores()
+        val library = stores.library
         val detail = BridgeFixtures.albumDetail(BridgeFixtures.album(id = "alb-1"))
         val generationBefore = library.generation.value
         val composerGenerationBefore = library.composerGeneration.value
 
-        UiEventReducer.reduce(BridgeUiEvent.AlbumAdded(detail), library, config, noopPlayer, noopErrors)
+        reduce(BridgeUiEvent.AlbumAdded(detail), stores)
 
         assertNotNull("album should be interned", library.albumDetail("alb-1"))
         assertEquals(detail, library.albumDetail("alb-1"))
@@ -88,19 +103,17 @@ class UiEventReducerTest {
 
     @Test
     fun releaseChangesRefreshComposerPagesWithoutRebuildingAlbumPages() {
-        val (library, config) = stores()
+        val stores = stores()
+        val library = stores.library
         val album = BridgeFixtures.album(id = "alb-1", releaseIds = listOf("rel-1", "rel-2"))
         val detail = BridgeFixtures.albumDetail(album, releases = listOf(BridgeFixtures.release(id = "rel-1", albumId = "alb-1")))
-        UiEventReducer.reduce(BridgeUiEvent.AlbumAdded(detail), library, config, noopPlayer, noopErrors)
+        reduce(BridgeUiEvent.AlbumAdded(detail), stores)
         val albumGeneration = library.generation.value
         val composerGeneration = library.composerGeneration.value
 
-        UiEventReducer.reduce(
+        reduce(
             BridgeUiEvent.ReleaseAdded(album = album, release = BridgeFixtures.release(id = "rel-2", albumId = "alb-1")),
-            library,
-            config,
-            noopPlayer,
-            noopErrors,
+            stores,
         )
 
         assertEquals(albumGeneration, library.generation.value)
@@ -109,17 +122,15 @@ class UiEventReducerTest {
 
     @Test
     fun releaseUpdatedForAbsentAlbumIsDroppedWithoutThrowing() {
-        val (library, config) = stores()
+        val stores = stores()
+        val library = stores.library
         val release = BridgeFixtures.release(id = "rel-x", albumId = "alb-absent")
 
         // No album was ever added, so this targets an un-interned album. The
         // handler logs the skip and leaves the store untouched — it must not throw.
-        UiEventReducer.reduce(
+        reduce(
             BridgeUiEvent.ReleaseUpdated(albumId = "alb-absent", release = release),
-            library,
-            config,
-            noopPlayer,
-            noopErrors,
+            stores,
         )
 
         assertNull(library.albumDetail("alb-absent"))
@@ -128,22 +139,37 @@ class UiEventReducerTest {
 
     @Test
     fun syncingChangedRoutesIntoConfigStore() {
-        val (library, config) = stores()
+        val stores = stores()
+        val config = stores.config
         assertEquals(false, config.syncing.value)
 
         // config.syncing is the flow the library screen observes to show or hide
         // its sync indicator, so the reducer must mirror the SyncingChanged
         // signal onto it.
-        UiEventReducer.reduce(BridgeUiEvent.SyncingChanged(syncing = true), library, config, noopPlayer, noopErrors)
+        reduce(BridgeUiEvent.SyncingChanged(syncing = true), stores)
         assertEquals(true, config.syncing.value)
 
-        UiEventReducer.reduce(BridgeUiEvent.SyncingChanged(syncing = false), library, config, noopPlayer, noopErrors)
+        reduce(BridgeUiEvent.SyncingChanged(syncing = false), stores)
         assertEquals(false, config.syncing.value)
     }
 
     @Test
+    fun downloadQueueChangedRoutesIntoDownloadStore() {
+        val stores = stores()
+        val downloads = stores.downloads
+        val snapshot = BridgeFixtures.downloadSnapshot(queued = 1u, active = 1u, paused = true)
+
+        reduce(
+            BridgeUiEvent.DownloadQueueChanged(snapshot),
+            stores,
+        )
+
+        assertEquals(snapshot, downloads.snapshot.value)
+    }
+
+    @Test
     fun playbackLoadingForwardsResolvedTrackMetadataToThePlayer() {
-        val (library, config) = stores()
+        val stores = stores()
         var received: BridgeLoadingTrackInfo? = null
         val sink =
             object : PlaybackEventSink by noopPlayer {
@@ -166,12 +192,10 @@ class UiEventReducerTest {
 
         // The player needs the resolved metadata to project a current track during
         // loading; the reducer must forward it rather than drop it.
-        UiEventReducer.reduce(
+        reduce(
             BridgeUiEvent.PlaybackLoading(trackId = "t1", track = info),
-            library,
-            config,
+            stores,
             sink,
-            noopErrors,
         )
 
         assertEquals("Track Title", received?.trackTitle)
@@ -179,7 +203,7 @@ class UiEventReducerTest {
 
     @Test
     fun playbackSeekedRoutesIntoThePlayer() {
-        val (library, config) = stores()
+        val stores = stores()
         var receivedTrackId: String? = null
         var receivedPositionMs: Long? = null
         val sink =
@@ -195,17 +219,15 @@ class UiEventReducerTest {
                 }
             }
 
-        UiEventReducer.reduce(
+        reduce(
             BridgeUiEvent.PlaybackSeeked(
                 trackId = "t1",
                 positionMs = 75_000uL,
                 durationMs = 100_000uL,
                 progress = 0.75,
             ),
-            library,
-            config,
+            stores,
             sink,
-            noopErrors,
         )
 
         assertEquals("t1", receivedTrackId)

--- a/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackServiceTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/playback/PlaybackServiceTest.kt
@@ -6,7 +6,9 @@ import fm.bae.app.AppSessionHolder
 import fm.bae.app.BridgeFixtures
 import fm.bae.app.OpenLibrary
 import fm.bae.app.data.ConfigStore
+import fm.bae.app.data.DownloadStore
 import fm.bae.app.data.LibraryStore
+import fm.bae.app.data.OpenLibraryStores
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -99,8 +101,12 @@ class PlaybackServiceTest {
         return OpenLibrary(
             libraryId = "lib-1",
             appHandle = handle,
-            libraryStore = LibraryStore(),
-            configStore = ConfigStore(BridgeFixtures.config(), initialSyncReady = false),
+            stores =
+                OpenLibraryStores(
+                    library = LibraryStore(),
+                    config = ConfigStore(BridgeFixtures.config(), initialSyncReady = false),
+                    downloads = DownloadStore(BridgeFixtures.downloadSnapshot()),
+                ),
             playback =
                 BaeCorePlayer(
                     applicationLooper = looper,

--- a/bae-bridge/loc/catalog.toml
+++ b/bae-bridge/loc/catalog.toml
@@ -1806,6 +1806,43 @@ ml = "{done} of {total}"
 pa = "{done} of {total}"
 th = "{done} of {total}"
 
+[messages."core.download.bytes_progress"]
+comment = "Download queue: bytes downloaded of the total ({done}/{total} are pre-formatted byte counts)."
+args = { done = "Str", total = "Str" }
+value = "{done} of {total}"
+
+[messages."core.download.bytes_progress".translations]
+es = "{done} de {total}"
+fr = "{done} sur {total}"
+de = "{done} von {total}"
+pt-BR = "{done} de {total}"
+ja = "{total}中{done}"
+ko = "{done}/{total}"
+zh-Hans = "{done}/{total}"
+ar = "{done} من {total}"
+he = "{done} מתוך {total}"
+uk = "{done} з {total}"
+bg = "{done} от {total}"
+pl = "{done} z {total}"
+cs = "{done} z {total}"
+hr = "{done} od {total}"
+zh-Hant = "{done} of {total}"
+it = "{done} of {total}"
+tr = "{done} of {total}"
+vi = "{done} of {total}"
+nl = "{done} of {total}"
+hi = "{done} of {total}"
+bn = "{done} of {total}"
+ta = "{done} of {total}"
+te = "{done} of {total}"
+mr = "{done} of {total}"
+ur = "{done} of {total}"
+gu = "{done} of {total}"
+kn = "{done} of {total}"
+ml = "{done} of {total}"
+pa = "{done} of {total}"
+th = "{done} of {total}"
+
 [messages."core.outbox.throughput"]
 comment = "Storage queue: upload speed ({rate} is a pre-formatted byte count, e.g. '5.2 MB')."
 args = { rate = "Str" }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1604,7 +1604,10 @@ fn convert_upload_activity(
 fn convert_download_snapshot(
     snapshot: bae_core::library::DownloadSnapshot,
 ) -> crate::types::BridgeDownloadSnapshot {
-    use crate::types::{BridgeDownloadOp, BridgeDownloadSnapshot, BridgeDownloadState};
+    use crate::types::{
+        BridgeDownloadOp, BridgeDownloadSnapshot, BridgeDownloadState,
+        BridgeDownloadTransferProgress,
+    };
     use bae_core::library::DownloadState;
 
     let downloads = snapshot
@@ -1613,7 +1616,13 @@ fn convert_download_snapshot(
         .map(|op| {
             let state = match op.state {
                 DownloadState::Queued => BridgeDownloadState::Queued,
-                DownloadState::Active { .. } => BridgeDownloadState::Active,
+                DownloadState::Active { progress } => BridgeDownloadState::Active {
+                    progress: BridgeDownloadTransferProgress {
+                        bytes_done: progress.bytes_done,
+                        bytes_total: progress.bytes_total,
+                        fraction: progress.fraction,
+                    },
+                },
                 DownloadState::Failed { error } => BridgeDownloadState::Failed { error },
             };
             BridgeDownloadOp {

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1662,11 +1662,24 @@ pub struct BridgeUploadProgress {
 }
 
 /// A queued download's state.
-#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
 pub enum BridgeDownloadState {
     Queued,
-    Active,
-    Failed { error: String },
+    Active {
+        progress: BridgeDownloadTransferProgress,
+    },
+    Failed {
+        error: String,
+    },
+}
+
+/// Byte progress for the active download. Mirrors the payload emitted by the
+/// transfer reading the release's blobs.
+#[derive(Debug, Clone, Default, PartialEq, uniffi::Record)]
+pub struct BridgeDownloadTransferProgress {
+    pub bytes_done: u64,
+    pub bytes_total: u64,
+    pub fraction: f64,
 }
 
 /// One queued download — a whole release being pinned. Mirror of bae-core's
@@ -3501,6 +3514,7 @@ mod loc_key_coverage {
         "core.queue.exporting",
         "core.queue.failed",
         "core.queue.queued",
+        "core.download.bytes_progress",
         "core.outbox.pending_deletes",
         "core.outbox.bytes_progress",
         "core.outbox.throughput",

--- a/bae-core/src/library/download_snapshot.rs
+++ b/bae-core/src/library/download_snapshot.rs
@@ -7,10 +7,44 @@ use super::release_queue::{
     ReleaseQueueState,
 };
 
-pub type DownloadState = ReleaseQueueState<()>;
-pub type DownloadOp = ReleaseQueueOp<(), ()>;
+use super::LibraryError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DownloadTransferProgress {
+    pub bytes_done: u64,
+    pub bytes_total: u64,
+    pub fraction: f64,
+}
+
+impl DownloadTransferProgress {
+    pub fn new(release_id: &str, bytes_done: u64, bytes_total: u64) -> Result<Self, LibraryError> {
+        if bytes_total == 0 {
+            return Err(LibraryError::Storage(format!(
+                "pin release {release_id}: byte total is zero"
+            )));
+        }
+        if bytes_done > bytes_total {
+            return Err(LibraryError::Storage(format!(
+                "pin release {release_id}: bytes done exceeds byte total"
+            )));
+        }
+        if bytes_total > i64::MAX as u64 {
+            return Err(LibraryError::Storage(format!(
+                "pin release {release_id}: byte total exceeds display range"
+            )));
+        }
+        Ok(Self {
+            bytes_done,
+            bytes_total,
+            fraction: bytes_done as f64 / bytes_total as f64,
+        })
+    }
+}
+
+pub type DownloadState = ReleaseQueueState<DownloadTransferProgress>;
+pub type DownloadOp = ReleaseQueueOp<(), DownloadTransferProgress>;
 pub type DownloadProgress = ReleaseQueueProgress;
-pub type DownloadSnapshot = ReleaseQueueSnapshot<(), ()>;
+pub type DownloadSnapshot = ReleaseQueueSnapshot<(), DownloadTransferProgress>;
 
 pub fn build_download_snapshot(downloads: &[DownloadOp], paused: bool) -> DownloadSnapshot {
     build_release_queue_snapshot(downloads, paused)

--- a/bae-core/src/library/manager/coven_blobs.rs
+++ b/bae-core/src/library/manager/coven_blobs.rs
@@ -175,13 +175,43 @@ impl LibraryManager {
     /// `storage/pinned/` (from the evictable cache if already there, else the
     /// cloud). Idempotent. Pinned-ness is coven cache state — there is no bae flag.
     /// The low-level cache op behind the "Pin" transition.
-    pub(crate) async fn pin_release_blobs(&self, release_id: &str) -> Result<(), LibraryError> {
+    pub(crate) async fn pin_release_blobs_with_progress(
+        &self,
+        release_id: &str,
+        mut on_progress: impl FnMut(crate::library::DownloadTransferProgress),
+    ) -> Result<(), LibraryError> {
         let files = self.database.get_files_for_release(release_id).await?;
+        let bytes_total = download_total_bytes(release_id, &files)?;
+        let mut emit_progress = |bytes_done| {
+            on_progress(crate::library::DownloadTransferProgress::new(
+                release_id,
+                bytes_done,
+                bytes_total,
+            )?);
+            Ok::<(), LibraryError>(())
+        };
+        emit_progress(0)?;
+
         let blobs: Vec<_> = files.iter().map(Self::release_file_blob_ref).collect();
         self.handle
             .pin(&blobs)
             .await
-            .map_err(|e| LibraryError::Storage(format!("pin release {release_id}: {e}")))
+            .map_err(|e| LibraryError::Storage(format!("pin release {release_id}: {e}")))?;
+        emit_progress(bytes_total)?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn initial_download_progress(
+        &self,
+        release_id: &str,
+    ) -> Result<crate::library::DownloadTransferProgress, LibraryError> {
+        let files = self.database.get_files_for_release(release_id).await?;
+        crate::library::DownloadTransferProgress::new(
+            release_id,
+            0,
+            download_total_bytes(release_id, &files)?,
+        )
     }
 
     /// Unpin a remote release's blobs: coven moves every blob from
@@ -225,4 +255,28 @@ fn image_ref_map(
             )
         })
         .collect()
+}
+
+fn download_file_sizes(release_id: &str, files: &[DbFile]) -> Result<Vec<u64>, LibraryError> {
+    files
+        .iter()
+        .map(|file| {
+            u64::try_from(file.file_size).map_err(|_| {
+                LibraryError::Storage(format!(
+                    "pin release {release_id}: file {} has negative size",
+                    file.id
+                ))
+            })
+        })
+        .collect()
+}
+
+fn download_total_bytes(release_id: &str, files: &[DbFile]) -> Result<u64, LibraryError> {
+    download_file_sizes(release_id, files)?
+        .iter()
+        .try_fold(0u64, |total, file_size| {
+            total.checked_add(*file_size).ok_or_else(|| {
+                LibraryError::Storage(format!("pin release {release_id}: byte total overflow"))
+            })
+        })
 }

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -129,7 +129,7 @@ impl LibraryManager {
         // Flip to Active and register the abort handle atomically. If a cancel
         // removed the entry in the gap since we picked it, abort the task we just
         // spawned and bail — nothing was written.
-        if !self.export_queue.activate(&release_id, abort.clone()) {
+        if !self.export_queue.activate(&release_id, abort.clone(), 0) {
             abort.abort();
             debug!("Export for {release_id} cancelled before it started; aborting");
             return;

--- a/bae-core/src/library/manager/locality.rs
+++ b/bae-core/src/library/manager/locality.rs
@@ -257,7 +257,7 @@ impl LibraryManager {
                 self.download_queue.wait().await;
                 continue;
             };
-            self.run_queued_pin(&op.release_id).await;
+            self.run_queued_pin(&op).await;
         }
     }
 
@@ -271,22 +271,35 @@ impl LibraryManager {
     /// cancel removes the queue entry; on its way out the drain sees the channel
     /// close, and we check whether the entry is still present before recording a
     /// failure — a cancelled download isn't a failure.
-    async fn run_queued_pin(&self, release_id: &str) {
+    async fn run_queued_pin(&self, op: &crate::library::DownloadOp) {
         use crate::storage::local::transfer::TransferService;
 
+        let release_id = op.release_id.as_str();
+        let initial_progress = match self.initial_download_progress(release_id).await {
+            Ok(progress) => progress,
+            Err(error) => {
+                error!("Pin failed for release {release_id}: {error}");
+                self.download_queue
+                    .mark_failed(release_id, error.to_string());
+                self.emit_download_queue_changed();
+                return;
+            }
+        };
         let transfer = TransferService::new(self.clone());
         let (rx, pin_task) = transfer.pin_release_task(release_id.to_string());
         let abort = pin_task.abort_handle();
         // Flip to Active and register the abort handle atomically. If a cancel
         // removed the entry in the gap since we picked it, abort the task we
         // just spawned and bail — the release stays cloud-only.
-        if !self.download_queue.activate(release_id, abort.clone()) {
+        if !self
+            .download_queue
+            .activate(release_id, abort.clone(), initial_progress)
+        {
             abort.abort();
             debug!("Pin for {release_id} cancelled before it started; aborting");
             return;
         }
         self.emit_download_queue_changed();
-
         // Drive the pin through the shared transfer driver; the inline
         // `ReleaseTransferProgress` bar is emitted by `drive_transfer` itself.
         let outcome = self
@@ -455,6 +468,21 @@ impl LibraryManager {
                         release_id: release_id.to_string(),
                         action,
                     });
+                }
+                TransferProgress::Progress { progress } => {
+                    if matches!(action, ReleaseStorageAction::Pin) {
+                        if self
+                            .download_queue
+                            .set_active_progress(release_id, progress)
+                        {
+                            self.emit_download_queue_changed();
+                        } else {
+                            tracing::warn!(
+                                release_id,
+                                "ignored download progress for missing active queue row"
+                            );
+                        }
+                    }
                 }
                 TransferProgress::Complete { .. } => break Ok(()),
                 TransferProgress::Failed { error, .. } => break Err(error),

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -1368,6 +1368,24 @@ async fn make_remote_release(
     album_title: &str,
     pin: bool,
 ) -> String {
+    make_remote_release_with_files(
+        manager,
+        dir,
+        album_title,
+        &[("track.flac", b"track-bytes")],
+        pin,
+    )
+    .await
+}
+
+#[cfg(feature = "test-utils")]
+async fn make_remote_release_with_files(
+    manager: &LibraryManager,
+    dir: &std::path::Path,
+    album_title: &str,
+    files: &[(&str, &[u8])],
+    pin: bool,
+) -> String {
     let mut album = create_test_album();
     album.title = album_title.to_string();
     let mut release = create_test_release(&album.id);
@@ -1375,16 +1393,19 @@ async fn make_remote_release(
     manager.database.insert_album(&album).await.unwrap();
     manager.database.insert_release(&release).await.unwrap();
     std::fs::create_dir_all(dir).unwrap();
-    std::fs::write(dir.join("track.flac"), b"track-bytes").unwrap();
-    let file = DbFile::new(
-        &release.id,
-        "track.flac",
-        11,
-        crate::util::content_type::ContentType::Flac,
-        Uuid::new_v4().to_string(),
-        Utc::now(),
-    );
-    manager.add_file(&file).await.unwrap();
+    let created_at = Utc::now();
+    for (index, (name, bytes)) in files.iter().enumerate() {
+        std::fs::write(dir.join(name), bytes).unwrap();
+        let file = DbFile::new(
+            &release.id,
+            name,
+            bytes.len() as i64,
+            crate::util::content_type::ContentType::Flac,
+            format!("{}-test-file-{index}", release.id),
+            created_at,
+        );
+        manager.add_file(&file).await.unwrap();
+    }
     manager
         .database
         .register_release_external_refs_for_test(&release.id, &dir.to_string_lossy())
@@ -1392,7 +1413,7 @@ async fn make_remote_release(
         .unwrap();
     manager.coven_make_remote(&release.id, pin).await.unwrap();
     let n = manager.drain_uploads_for_test().await.unwrap();
-    assert_eq!(n, 1, "the release's one blob uploaded");
+    assert_eq!(n as usize, files.len(), "each release blob uploaded");
     release.id
 }
 
@@ -2034,6 +2055,70 @@ async fn download_queue_failed_pin_retries() {
     manager.cancel_download(&release_id);
     let cleared = wait_for(|| manager.download_snapshot().ops.is_empty()).await;
     assert!(cleared, "cancel removes the entry");
+}
+
+#[cfg(feature = "test-utils")]
+#[tokio::test]
+async fn download_queue_active_pin_reports_file_progress() {
+    let (manager, temp_dir) = setup_test_manager().await;
+    connect_test_cloud(&manager).await;
+    let release_id = make_remote_release_with_files(
+        &manager,
+        &temp_dir.path().join("download-source"),
+        "Test Album",
+        &[("a.flac", b"aaa"), ("b.flac", b"bbbb")],
+        false,
+    )
+    .await;
+    let mut events = manager.subscribe_events();
+
+    manager.enqueue_pins(vec![release_id.clone()]).await;
+
+    let mut saw_initial = false;
+    let mut saw_completed_progress = false;
+    for _ in 0..20 {
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), events.recv())
+            .await
+            .expect("download queue event")
+            .expect("event channel stays open");
+        let LibraryEvent::DownloadQueueChanged { snapshot } = event else {
+            continue;
+        };
+        for op in snapshot.ops {
+            if op.release_id != release_id {
+                continue;
+            }
+            if let crate::library::DownloadState::Active { progress } = op.state {
+                if progress
+                    == (crate::library::DownloadTransferProgress {
+                        bytes_done: 0,
+                        bytes_total: 7,
+                        fraction: 0.0,
+                    })
+                {
+                    saw_initial = true;
+                }
+                if progress
+                    == (crate::library::DownloadTransferProgress {
+                        bytes_done: 7,
+                        bytes_total: 7,
+                        fraction: 1.0,
+                    })
+                {
+                    saw_completed_progress = true;
+                }
+            }
+        }
+        if saw_initial && saw_completed_progress {
+            break;
+        }
+    }
+
+    assert!(saw_initial, "active download starts with known totals");
+    assert!(
+        saw_completed_progress,
+        "active download reports completed file bytes before leaving the queue"
+    );
 }
 
 // ── Export queue ─────────────────────────────────────────────────

--- a/bae-core/src/library/mod.rs
+++ b/bae-core/src/library/mod.rs
@@ -10,7 +10,9 @@ pub(crate) mod sync_controller;
 pub mod sync_events;
 pub mod upload_throughput;
 pub use app_services::*;
-pub use download_snapshot::{DownloadOp, DownloadProgress, DownloadSnapshot, DownloadState};
+pub use download_snapshot::{
+    DownloadOp, DownloadProgress, DownloadSnapshot, DownloadState, DownloadTransferProgress,
+};
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub use export::ExportFormat;
 pub use export_snapshot::{ExportOp, ExportProgress, ExportSnapshot, ExportState};
@@ -32,7 +34,7 @@ use tracing::{debug, warn};
 
 pub use tokio_util::sync::CancellationToken;
 
-pub type DownloadQueue = ReleaseQueue<(), ()>;
+pub type DownloadQueue = ReleaseQueue<(), DownloadTransferProgress>;
 pub type ExportQueue = ReleaseQueue<PathBuf, u8>;
 
 #[derive(Debug, thiserror::Error)]

--- a/bae-core/src/library/release_queue.rs
+++ b/bae-core/src/library/release_queue.rs
@@ -4,11 +4,12 @@
 //! in-memory rows for the queue pane, and support pause, cancel, and retry.
 //! `Extra` carries the operation-specific row payload: downloads use `()`,
 //! exports use their target directory. `Progress` carries the active-row
-//! progress shape: downloads have no determinate progress, exports use percent.
+//! progress shape.
 
 use std::sync::Mutex;
 
 use tokio::sync::Notify;
+use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReleaseQueueState<Progress> {
@@ -73,7 +74,7 @@ struct State<Extra, Progress> {
     active_abort: Option<tokio::task::AbortHandle>,
 }
 
-impl<Extra: Clone, Progress: Clone + Default> ReleaseQueue<Extra, Progress> {
+impl<Extra: Clone, Progress: Clone> ReleaseQueue<Extra, Progress> {
     pub fn new() -> Self {
         Self {
             state: Mutex::new(State {
@@ -131,7 +132,12 @@ impl<Extra: Clone, Progress: Clone + Default> ReleaseQueue<Extra, Progress> {
             .cloned()
     }
 
-    pub fn activate(&self, release_id: &str, abort: tokio::task::AbortHandle) -> bool {
+    pub fn activate(
+        &self,
+        release_id: &str,
+        abort: tokio::task::AbortHandle,
+        progress: Progress,
+    ) -> bool {
         let mut state = self.state.lock().unwrap();
         let Some(op) = state
             .ops
@@ -140,9 +146,7 @@ impl<Extra: Clone, Progress: Clone + Default> ReleaseQueue<Extra, Progress> {
         else {
             return false;
         };
-        op.state = ReleaseQueueState::Active {
-            progress: Progress::default(),
-        };
+        op.state = ReleaseQueueState::Active { progress };
         state.active_abort = Some(abort);
         true
     }
@@ -180,6 +184,17 @@ impl<Extra: Clone, Progress: Clone + Default> ReleaseQueue<Extra, Progress> {
         self.state.lock().unwrap().active_abort = None;
     }
 
+    pub fn set_active_progress(&self, release_id: &str, progress: Progress) -> bool {
+        let mut state = self.state.lock().unwrap();
+        let Some(op) = state.ops.iter_mut().find(|o| {
+            o.release_id == release_id && matches!(o.state, ReleaseQueueState::Active { .. })
+        }) else {
+            return false;
+        };
+        op.state = ReleaseQueueState::Active { progress };
+        true
+    }
+
     pub fn cancel(&self, release_id: &str) -> bool {
         let mut state = self.state.lock().unwrap();
         let was_active = state.ops.iter().any(|o| {
@@ -195,7 +210,7 @@ impl<Extra: Clone, Progress: Clone + Default> ReleaseQueue<Extra, Progress> {
     }
 }
 
-impl<Extra: Clone, Progress: Clone + Default> Default for ReleaseQueue<Extra, Progress> {
+impl<Extra: Clone, Progress: Clone> Default for ReleaseQueue<Extra, Progress> {
     fn default() -> Self {
         Self::new()
     }
@@ -203,9 +218,11 @@ impl<Extra: Clone, Progress: Clone + Default> Default for ReleaseQueue<Extra, Pr
 
 impl<Extra: Clone> ReleaseQueue<Extra, u8> {
     pub fn set_active_percent(&self, release_id: &str, percent: u8) {
-        let mut state = self.state.lock().unwrap();
-        if let Some(op) = state.ops.iter_mut().find(|o| o.release_id == release_id) {
-            op.state = ReleaseQueueState::Active { progress: percent };
+        if !self.set_active_progress(release_id, percent) {
+            warn!(
+                release_id,
+                percent, "ignored active queue percent for missing active release"
+            );
         }
     }
 }
@@ -249,7 +266,7 @@ mod tests {
         q.enqueue(op("rel-b"));
 
         assert_eq!(q.next_queued().map(|o| o.release_id), Some("rel-a".into()));
-        assert!(q.activate("rel-a", dummy_abort()));
+        assert!(q.activate("rel-a", dummy_abort(), 0));
         let ops = q.ops();
         assert_eq!(ops[0].state, ReleaseQueueState::Active { progress: 0 });
         assert_eq!(ops[1].state, ReleaseQueueState::Queued);
@@ -265,7 +282,7 @@ mod tests {
         q.enqueue(op("rel-a"));
         assert_eq!(q.next_queued().map(|o| o.release_id), Some("rel-a".into()));
         q.remove("rel-a");
-        assert!(!q.activate("rel-a", dummy_abort()));
+        assert!(!q.activate("rel-a", dummy_abort(), 0));
     }
 
     #[tokio::test]
@@ -273,7 +290,7 @@ mod tests {
         let q = ReleaseQueue::new();
         q.enqueue(op("rel-a"));
         assert_eq!(q.next_queued().map(|o| o.release_id), Some("rel-a".into()));
-        assert!(q.activate("rel-a", dummy_abort()));
+        assert!(q.activate("rel-a", dummy_abort(), 0));
 
         q.set_active_percent("rel-a", 50);
         assert_eq!(q.ops()[0].state, ReleaseQueueState::Active { progress: 50 });

--- a/bae-core/src/storage/local/transfer.rs
+++ b/bae-core/src/storage/local/transfer.rs
@@ -24,7 +24,7 @@ use std::future::Future;
 
 use crate::album_detail::ReleaseStorageAction;
 use crate::db::DbFile;
-use crate::library::LibraryManager;
+use crate::library::{DownloadTransferProgress, LibraryManager};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
@@ -60,6 +60,8 @@ pub async fn read_release_file_bytes(
 pub enum TransferProgress {
     /// Operation started
     Started,
+    /// Operation reported determinate transfer progress.
+    Progress { progress: DownloadTransferProgress },
     /// Operation completed
     Complete { release_id: String },
     /// Operation failed
@@ -79,8 +81,7 @@ impl TransferService {
     /// Pin a release: have coven fetch its blobs into `storage/pinned/` on a
     /// spawned task. Returns a receiver for progress updates plus the task's
     /// handle, so the download queue worker can abort the fetch when the user
-    /// cancels — a half-finished pin just leaves some blobs in `pinned/` and the
-    /// release reads as not-yet-pinned, so re-pinning resumes idempotently.
+    /// cancels.
     pub fn pin_release_task(
         &self,
         release_id: String,
@@ -91,8 +92,12 @@ impl TransferService {
         self.spawn_transfer(
             release_id,
             ReleaseStorageAction::Pin,
-            |release_id, library_manager| async move {
-                library_manager.pin_release_blobs(&release_id).await?;
+            |release_id, library_manager, tx| async move {
+                library_manager
+                    .pin_release_blobs_with_progress(&release_id, |progress| {
+                        send_progress(&tx, TransferProgress::Progress { progress });
+                    })
+                    .await?;
                 Ok(())
             },
         )
@@ -104,7 +109,7 @@ impl TransferService {
         let (rx, _) = self.spawn_transfer(
             release_id,
             ReleaseStorageAction::Unpin,
-            |release_id, library_manager| async move {
+            |release_id, library_manager, _tx| async move {
                 library_manager.unpin_release_blobs(&release_id).await?;
                 Ok(())
             },
@@ -124,7 +129,7 @@ impl TransferService {
         let (rx, _) = self.spawn_transfer(
             release_id,
             ReleaseStorageAction::MakeRemote,
-            move |release_id, library_manager| async move {
+            move |release_id, library_manager, _tx| async move {
                 // The release reaches `remote = true` only when coven's upload drain
                 // flips it after the last upload lands. That drain runs from the sync
                 // loop, so the loop must be running — otherwise the uploads sit forever
@@ -161,7 +166,7 @@ impl TransferService {
         let (rx, _) = self.spawn_transfer(
             release_id,
             ReleaseStorageAction::MakeLocal,
-            move |release_id, library_manager| async move {
+            move |release_id, library_manager, _tx| async move {
                 tokio::fs::create_dir_all(std::path::Path::new(&new_path)).await?;
 
                 // coven materializes each blob durability-first, flips the gate false,
@@ -187,7 +192,7 @@ impl TransferService {
         tokio::task::JoinHandle<()>,
     )
     where
-        Run: FnOnce(String, LibraryManager) -> Fut + Send + 'static,
+        Run: FnOnce(String, LibraryManager, ProgressTx) -> Fut + Send + 'static,
         Fut: Future<Output = TransferResult> + Send + 'static,
     {
         let (tx, rx) = mpsc::unbounded_channel();
@@ -218,13 +223,13 @@ async fn run_transfer<Fut>(
     action: ReleaseStorageAction,
     library_manager: LibraryManager,
     tx: ProgressTx,
-    run: impl FnOnce(String, LibraryManager) -> Fut,
+    run: impl FnOnce(String, LibraryManager, ProgressTx) -> Fut,
 ) -> TransferResult
 where
     Fut: Future<Output = TransferResult> + Send,
 {
     start_transfer(&release_id, action, &library_manager, &tx).await?;
-    run(release_id.clone(), library_manager).await?;
+    run(release_id.clone(), library_manager, tx.clone()).await?;
     info!(
         action = ?action,
         release_id = %release_id,

--- a/bae-core/tests/test_transfer.rs
+++ b/bae-core/tests/test_transfer.rs
@@ -379,6 +379,26 @@ async fn test_pin_remote_fetches_into_pinned_cache() {
     )
     .await;
     assert!(completed(&events) && !failed(&events), "pin succeeds");
+    assert!(
+        matches!(events.first(), Some(TransferProgress::Started)),
+        "pin starts"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            TransferProgress::Progress { progress }
+                if progress.bytes_done == 0 && progress.bytes_total == 22
+        )),
+        "pin reports known byte total"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            TransferProgress::Progress { progress }
+                if progress.bytes_done == 22 && progress.bytes_total == 22
+        )),
+        "pin reports completed bytes before completion"
+    );
     assert_eq!(
         storage(&mgr, &release_id).await,
         (ReleaseStorageState::Remote, true)

--- a/bae-ios/bae/bae/AppService.swift
+++ b/bae-ios/bae/bae/AppService.swift
@@ -24,6 +24,7 @@ final class AppService: Observable {
     let playbackStore = PlaybackStore()
     let configStore: ConfigStore
     let libraryStore = LibraryStore()
+    let downloadStore: DownloadStore
 
     // ── Domain services (narrow projections of `AppHandle`) ───────────────
 
@@ -39,6 +40,7 @@ final class AppService: Observable {
             config: Config(bridge: config),
             syncReady: appHandle.isSyncReady()
         )
+        downloadStore = DownloadStore(snapshot: appHandle.getDownloadSnapshot())
         // `prefetchRelease` (desktop import flow) is unavailable on iOS, so
         // build the read services from the iOS-available closures explicitly
         // rather than the `init(handle:)` convenience that wires it.
@@ -94,6 +96,7 @@ final class AppService: Observable {
                 playbackStore: playbackStore,
                 configStore: configStore,
                 libraryStore: libraryStore,
+                downloadStore: downloadStore,
                 mediaControlService: mediaControlService,
                 appHandle: appHandle
             )

--- a/bae-ios/bae/bae/ContentView.swift
+++ b/bae-ios/bae/bae/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
                         .environment(service.libraryStore)
                         .environment(service.configStore)
                         .environment(service.playbackStore)
+                        .environment(service.downloadStore)
                         .environment(service.mediaPaths)
                         .environment(service.library)
                         .environment(service.playback)

--- a/bae-ios/bae/bae/DownloadStore.swift
+++ b/bae-ios/bae/bae/DownloadStore.swift
@@ -1,0 +1,12 @@
+import Observation
+
+/// Mirror of core's in-memory download queue snapshot. Core pushes the whole
+/// snapshot on every queue change; views render the bridge payload directly.
+@Observable
+final class DownloadStore {
+    var snapshot: BridgeDownloadSnapshot
+
+    init(snapshot: BridgeDownloadSnapshot) {
+        self.snapshot = snapshot
+    }
+}

--- a/bae-ios/bae/bae/UiEventReducer.swift
+++ b/bae-ios/bae/bae/UiEventReducer.swift
@@ -9,6 +9,7 @@ final class UiEventHandler: UiEventCallback, @unchecked Sendable {
     private let playbackStore: PlaybackStore
     private let configStore: ConfigStore
     private let libraryStore: LibraryStore
+    private let downloadStore: DownloadStore
     private let mediaControlService: MediaControlService
     private let appHandle: AppHandle
 
@@ -16,12 +17,14 @@ final class UiEventHandler: UiEventCallback, @unchecked Sendable {
         playbackStore: PlaybackStore,
         configStore: ConfigStore,
         libraryStore: LibraryStore,
+        downloadStore: DownloadStore,
         mediaControlService: MediaControlService,
         appHandle: AppHandle
     ) {
         self.playbackStore = playbackStore
         self.configStore = configStore
         self.libraryStore = libraryStore
+        self.downloadStore = downloadStore
         self.mediaControlService = mediaControlService
         self.appHandle = appHandle
     }
@@ -30,6 +33,7 @@ final class UiEventHandler: UiEventCallback, @unchecked Sendable {
         let playbackStore = playbackStore
         let configStore = configStore
         let libraryStore = libraryStore
+        let downloadStore = downloadStore
         let mediaControlService = mediaControlService
         let appHandle = appHandle
         Task { @MainActor in
@@ -37,6 +41,7 @@ final class UiEventHandler: UiEventCallback, @unchecked Sendable {
                 playbackStore: playbackStore,
                 configStore: configStore,
                 libraryStore: libraryStore,
+                downloadStore: downloadStore,
                 mediaControlService: mediaControlService,
                 appHandle: appHandle
             )
@@ -52,6 +57,7 @@ struct ReducerContext {
     let playbackStore: PlaybackStore
     let configStore: ConfigStore
     let libraryStore: LibraryStore
+    let downloadStore: DownloadStore
     let mediaControlService: MediaControlService
     let appHandle: AppHandle
 }
@@ -86,6 +92,9 @@ enum UiEventReducer {
 
         case .configChanged, .syncError, .error, .errorCleared:
             reduceConfigAndError(event, into: context)
+
+        case .downloadQueueChanged(let snapshot):
+            context.downloadStore.snapshot = snapshot
 
         default:
             logger.debug("ignoring event \(String(describing: event))")

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -66,6 +66,7 @@ struct LibraryView: View {
             VStack(spacing: 0) {
                 LibraryBanner()
                 LibraryModePicker(mode: $mode)
+                DownloadProgressStrip()
                 content
             }
             .background(Theme.background)
@@ -276,6 +277,42 @@ struct LibraryView: View {
         }
         catch {
             searchError = error.localizedDescription
+        }
+    }
+}
+
+private struct DownloadProgressStrip: View {
+    @Environment(DownloadStore.self)
+    private var downloadStore
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(downloadStore.snapshot.downloads, id: \.releaseId) { op in
+                DownloadProgressRow(op: op)
+            }
+        }
+    }
+}
+
+private struct DownloadProgressRow: View {
+    let op: BridgeDownloadOp
+
+    var body: some View {
+        switch op.state {
+        case .active(let progress):
+            DownloadTransferProgressView(progress: progress)
+                .padding(.horizontal)
+                .padding(.vertical, 6)
+                .background(Theme.surface)
+        case .failed(let error):
+            Text(error)
+                .font(.caption2)
+                .foregroundStyle(.red)
+                .padding(.horizontal)
+                .padding(.vertical, 6)
+                .background(Theme.surface)
+        default:
+            EmptyView()
         }
     }
 }

--- a/bae-ios/bae/project.yml
+++ b/bae-ios/bae/project.yml
@@ -41,6 +41,8 @@ targets:
       - path: ../../bae-macos/bae/bae/ImageLoader.swift
       - path: ../../bae-macos/bae/bae/BridgeSortField+CaseIterable.swift
       - path: ../../bae-macos/bae/bae/BridgeComposerSortField+CaseIterable.swift
+      - path: ../../bae-macos/bae/bae/BridgeDownloadTransferProgress+Derived.swift
+      - path: ../../bae-macos/bae/bae/DownloadTransferProgressView.swift
       - path: ../../bae-macos/bae/bae/DurationClock.swift
       - path: ../../bae-macos/bae/bae/Services/PlaybackStore.swift
       - path: ../../bae-macos/bae/bae/Services/PlaybackPositionEvent.swift

--- a/bae-macos/bae/bae/BridgeDownloadTransferProgress+Derived.swift
+++ b/bae-macos/bae/bae/BridgeDownloadTransferProgress+Derived.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension BridgeDownloadTransferProgress {
+    var bytesText: String {
+        String(
+            format: NSLocalizedString(
+                "core.download.bytes_progress",
+                tableName: "Core",
+                bundle: .main,
+                comment:
+                    "Download progress as transferred bytes out of total bytes"
+            ),
+            bytesDone.formattedDownloadBytes,
+            bytesTotal.formattedDownloadBytes
+        )
+    }
+}
+
+extension UInt64 {
+    fileprivate var formattedDownloadBytes: String {
+        precondition(
+            self <= UInt64(Int64.max),
+            "download byte count exceeds display range"
+        )
+        return Int64(self).formatted(.byteCount(style: .file))
+    }
+}

--- a/bae-macos/bae/bae/DownloadTransferProgressView.swift
+++ b/bae-macos/bae/bae/DownloadTransferProgressView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct DownloadTransferProgressView: View {
+    let progress: BridgeDownloadTransferProgress
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ProgressView(value: progress.fraction)
+                .progressViewStyle(.linear)
+            Text(progress.bytesText)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -254,13 +254,18 @@ private struct DownloadRow: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 16)
 
-            Text(op.title)
-                .lineLimit(1)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
+                    Text(op.title)
+                        .lineLimit(1)
 
-            Text("\(op.fileCount) files · \(op.totalSizeText)")
-                .font(.caption)
-                .monospacedDigit()
-                .foregroundStyle(.secondary)
+                    Text(detailText)
+                        .font(.caption)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+                progressView
+            }
 
             Spacer()
 
@@ -300,6 +305,17 @@ private struct DownloadRow: View {
                 .foregroundStyle(.red)
                 .help(error)
         }
+    }
+
+    @ViewBuilder
+    private var progressView: some View {
+        if case .active(let progress) = op.state {
+            DownloadTransferProgressView(progress: progress)
+        }
+    }
+
+    private var detailText: String {
+        "\(op.fileCount) files · \(op.totalSizeText)"
     }
 }
 

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -2309,8 +2309,17 @@ struct FfiDownloadOp {
     total_size: i64,
     /// "queued", "active", or "failed".
     state: String,
+    /// The active transfer's byte/file progress when `state` is "active".
+    progress: Option<FfiDownloadTransferProgress>,
     /// The failure message when `state` is "failed".
     error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FfiDownloadTransferProgress {
+    bytes_done: u64,
+    bytes_total: u64,
+    fraction: f64,
 }
 
 /// Per-state counts for the download queue, for the pane header's summary and
@@ -2350,10 +2359,18 @@ pub unsafe extern "C" fn bae_download_snapshot(handle: *const BaeHandle) -> *mut
             .ops
             .iter()
             .map(|op| {
-                let (state, error) = match &op.state {
-                    DownloadState::Queued => ("queued", None),
-                    DownloadState::Active { progress: () } => ("active", None),
-                    DownloadState::Failed { error } => ("failed", Some(error.clone())),
+                let (state, progress, error) = match &op.state {
+                    DownloadState::Queued => ("queued", None, None),
+                    DownloadState::Active { progress } => (
+                        "active",
+                        Some(FfiDownloadTransferProgress {
+                            bytes_done: progress.bytes_done,
+                            bytes_total: progress.bytes_total,
+                            fraction: progress.fraction,
+                        }),
+                        None,
+                    ),
+                    DownloadState::Failed { error } => ("failed", None, Some(error.clone())),
                 };
                 FfiDownloadOp {
                     release_id: op.release_id.clone(),
@@ -2361,6 +2378,7 @@ pub unsafe extern "C" fn bae_download_snapshot(handle: *const BaeHandle) -> *mut
                     file_count: op.file_count,
                     total_size: op.total_size,
                     state: state.to_string(),
+                    progress,
                     error,
                 }
             })

--- a/bae-windows-ffi/src/loc.rs
+++ b/bae-windows-ffi/src/loc.rs
@@ -495,6 +495,7 @@ mod tests {
             "core.queue.downloading",
             "core.queue.failed",
             "core.queue.queued",
+            "core.download.bytes_progress",
             "core.outbox.bytes_progress",
             "core.outbox.throughput",
             "core.outbox.eta",

--- a/bae-windows/DownloadSnapshot.cs
+++ b/bae-windows/DownloadSnapshot.cs
@@ -37,6 +37,18 @@ public sealed class DownloadOp
     /// <summary>"queued", "active", or "failed".</summary>
     public string State { get; set; } = string.Empty;
 
+    /// <summary>The active transfer's byte/file progress when <see cref="State"/>
+    /// is "active".</summary>
+    public DownloadTransferProgress? Progress { get; set; }
+
     /// <summary>The failure message when <see cref="State"/> is "failed".</summary>
     public string? Error { get; set; }
+}
+
+/// <summary>Byte and file progress for the active download.</summary>
+public sealed class DownloadTransferProgress
+{
+    public ulong BytesDone { get; set; }
+    public ulong BytesTotal { get; set; }
+    public double Fraction { get; set; }
 }

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -4544,6 +4544,31 @@ public sealed partial class MainWindow : Window
                 _ => Loc.Chrome("download.state.queued"),
             };
 
+            string DownloadDetail(DownloadOp op)
+            {
+                static string DisplayBytes(ulong bytes) =>
+                    Loc.Bytes(checked((long)bytes));
+
+                var parts = new List<string>
+                {
+                    Loc.Chrome("storage.files", "count", op.FileCount),
+                    Loc.Bytes(op.TotalSize),
+                    StateLabel(op),
+                };
+                if (op.Progress is { } progress)
+                {
+                    parts.Add(
+                        Loc.Core(
+                            "core.download.bytes_progress",
+                            new Dictionary<string, object?>
+                            {
+                                ["done"] = DisplayBytes(progress.BytesDone),
+                                ["total"] = DisplayBytes(progress.BytesTotal),
+                            }));
+                }
+                return string.Join(" · ", parts);
+            }
+
             // Header: a label (or "paused"), Retry (only with failures), and a
             // pause/resume toggle — mirroring the outbox panel's band.
             var band = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
@@ -4586,9 +4611,19 @@ public sealed partial class MainWindow : Window
                 labelColumn.Children.Add(new TextBlock { Text = op.Title, TextWrapping = TextWrapping.Wrap });
                 labelColumn.Children.Add(new TextBlock
                 {
-                    Text = $"{Loc.Chrome("storage.files", "count", op.FileCount)} · {Loc.Bytes(op.TotalSize)} · {StateLabel(op)}",
+                    Text = DownloadDetail(op),
                     Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
                 });
+                if (op.Progress is { } progress)
+                {
+                    labelColumn.Children.Add(new ProgressBar
+                    {
+                        Minimum = 0,
+                        Maximum = 1,
+                        Value = progress.Fraction,
+                        Height = 4,
+                    });
+                }
                 Grid.SetColumn(labelColumn, 0);
                 itemGrid.Children.Add(labelColumn);
 


### PR DESCRIPTION
Download rows now carry byte progress from the worker path instead of deriving percent in the UI. Active download state requires a progress payload across core, bridge, Android, Swift, and Windows surfaces, so the UI no longer has to handle an active row with missing progress.

The current coven API still exposes pin completion as one operation, so bae reports deterministic 0/total and total/total around that call; intermediate per-byte updates need coven to expose transfer progress events.

Test plan:
- cargo fmt --all -- --check
- git diff --check
- cargo test -p bae-core download_queue_active_pin_reports_file_progress --features test-utils -- --nocapture
- cargo test -p bae-core test_pin_remote_fetches_into_pinned_cache --features test-utils -- --nocapture
- cargo test -p bae-bridge --lib
- cargo clippy -p bae-core -p bae-bridge -p bae-windows-ffi --features test-utils --all-targets -- -D warnings
- ./gradlew :app:compileFullDebugKotlin :app:compileBaeiumDebugKotlin
- xcodebuild -project bae.xcodeproj -scheme bae -derivedDataPath .build/derivedData build

Blocked locally:
- iOS xcodebuild: iOS 26.2 platform is not installed
- Windows build: dotnet is not installed

Rules review:
- Codex gpt-5.5 targeted pass; Spark quota blocked until July 6, 2026 at 11:00 PM
- Remaining finding is FP: using the shared file-summing progress source for the active seed avoids drift with the pin transfer; using queued total_size would reintroduce a second source of truth.