### PR TITLE
Stop masking import scan and cover failures

### DIFF
--- a/bae-automation/src/lib.rs
+++ b/bae-automation/src/lib.rs
@@ -780,6 +780,7 @@ impl AutomationState {
             } => self.update_candidate(candidate_key, |candidate| {
                 candidate.common_mut().skipped = skipped;
             }),
+            ScanEvent::Failed { error } => self.fail_event_indexing(error),
             ScanEvent::Finished => {}
         }
     }
@@ -981,8 +982,12 @@ impl Automation {
                     .map_err(AutomationError::import)?;
                 let wait_for_finish = async {
                     while let Some(event) = rx.recv().await {
-                        if matches!(event, ScanEvent::Finished) {
-                            return Ok::<(), AutomationError>(());
+                        match event {
+                            ScanEvent::Finished => return Ok::<(), AutomationError>(()),
+                            ScanEvent::Failed { error } => {
+                                return Err(AutomationError::import(error));
+                            }
+                            _ => {}
                         }
                     }
                     Err(AutomationError::Unavailable(

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -11,11 +11,12 @@ use crate::cue_flac::CueFlacProcessor;
 use crate::util::content_type_hint::ContentTypeHint;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fmt;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
-const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "gif", "bmp"];
 const DOCUMENT_EXTENSIONS: &[&str] = &["cue", "log", "txt", "m3u", "m3u8"];
 
 /// Extensions used by download clients and browsers to mark an
@@ -274,6 +275,32 @@ pub struct FileTree {
     dirs: BTreeMap<PathBuf, DirEntry>,
 }
 
+#[derive(Debug)]
+pub enum FolderScanError {
+    Io { path: PathBuf, source: io::Error },
+    Other(String),
+}
+
+impl FolderScanError {
+    fn io(path: impl Into<PathBuf>, source: io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+}
+
+impl fmt::Display for FolderScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(f, "{}: {source}", path.display()),
+            Self::Other(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for FolderScanError {}
+
 #[derive(Debug, Default)]
 struct DirEntry {
     files: Vec<usize>,
@@ -292,17 +319,22 @@ impl FileTree {
 
     /// Build a FileTree by recursively walking the filesystem from `root`.
     /// Skips hidden files/directories (names starting with '.') and noise files.
-    pub(crate) fn from_filesystem(root: &Path) -> Result<Self, String> {
+    pub(crate) fn from_filesystem(root: &Path) -> Result<Self, FolderScanError> {
         let mut files = Vec::new();
         Self::walk_dir(root, root, &mut files)?;
         Ok(Self::new(files))
     }
 
-    fn walk_dir(current: &Path, root: &Path, files: &mut Vec<FileEntry>) -> Result<(), String> {
-        let entries = fs::read_dir(current)
-            .map_err(|e| format!("Failed to read dir {:?}: {}", current, e))?;
+    fn walk_dir(
+        current: &Path,
+        root: &Path,
+        files: &mut Vec<FileEntry>,
+    ) -> Result<(), FolderScanError> {
+        let entries =
+            fs::read_dir(current).map_err(|source| FolderScanError::io(current, source))?;
 
-        for entry in entries.flatten() {
+        for entry in entries {
+            let entry = entry.map_err(|source| FolderScanError::io(current, source))?;
             let path = entry.path();
 
             // Skip hidden files and directories (including .bae/)
@@ -312,26 +344,27 @@ impl FileTree {
                 }
             }
 
-            if path.is_file() {
+            let metadata = entry
+                .metadata()
+                .map_err(|source| FolderScanError::io(path.clone(), source))?;
+
+            if metadata.is_file() {
                 if is_noise_file(&path) {
                     continue;
                 }
 
-                let size = entry
-                    .metadata()
-                    .map_err(|e| format!("Failed to read metadata for {:?}: {}", path, e))?
-                    .len();
+                let size = metadata.len();
 
                 let relative = path
                     .strip_prefix(root)
-                    .map_err(|e| format!("Failed to strip prefix: {}", e))?
+                    .map_err(|e| FolderScanError::Other(format!("Failed to strip prefix: {e}")))?
                     .to_path_buf();
 
                 files.push(FileEntry {
                     path: relative,
                     size,
                 });
-            } else if path.is_dir() {
+            } else if metadata.is_dir() {
                 Self::walk_dir(&path, root, files)?;
             }
         }
@@ -450,10 +483,7 @@ fn cue_pair_codec_label(ext: &str) -> &'static str {
 
 /// Check if a file is an image/artwork file
 fn is_image_file(path: &Path) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| IMAGE_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
-        .unwrap_or(false)
+    ContentTypeHint::path_is_raster_image(path)
 }
 
 /// Check if a file is a document file (.cue, .log, .txt, .m3u)
@@ -1040,7 +1070,10 @@ where
 /// Scan a folder and invoke `on_item` for each leaf: a valid release candidate,
 /// or an invalid one (looked like a release but failed validation). Both carry
 /// `watched_folder_path` stamped from the scan root.
-pub fn scan_for_candidates_with_callback<F>(root: PathBuf, mut on_item: F) -> Result<(), String>
+pub fn scan_for_candidates_with_callback<F>(
+    root: PathBuf,
+    mut on_item: F,
+) -> Result<(), FolderScanError>
 where
     F: FnMut(ScanItem),
 {
@@ -1071,6 +1104,7 @@ where
             }));
         }
     })
+    .map_err(FolderScanError::Other)
 }
 
 /// Collect all files from a release directory and categorize them.
@@ -1079,7 +1113,7 @@ where
 /// and categorizes them into audio (CUE/FLAC pairs or track files), artwork, and documents.
 /// Unrecognized file types are ignored.
 pub fn collect_release_candidate_files(release_root: &Path) -> Result<CategorizedFiles, String> {
-    let tree = FileTree::from_filesystem(release_root)?;
+    let tree = FileTree::from_filesystem(release_root).map_err(|e| e.to_string())?;
     // An invalid folder can't be imported: surface its reason as the error so
     // the import-commit caller fails with why the folder is unusable.
     match categorize_files_from_tree(&tree, &PathBuf::new(), release_root)? {

--- a/bae-core/src/import/folder_scanner/tests.rs
+++ b/bae-core/src/import/folder_scanner/tests.rs
@@ -166,6 +166,7 @@ fn test_collect_release_candidate_files_skips_hidden_and_bae() {
     // Create visible files
     std::fs::write(root.join("track.flac"), fake_flac()).unwrap();
     std::fs::write(root.join("cover.jpg"), [0xFF, 0xD8, 0xFF, 0xE0]).unwrap();
+    std::fs::write(root.join("back.bmp"), b"BMvalid bmp marker").unwrap();
 
     // Create hidden file that should be ignored
     std::fs::write(root.join(".DS_Store"), b"mac junk").unwrap();
@@ -192,9 +193,36 @@ fn test_collect_release_candidate_files_skips_hidden_and_bae() {
         .iter()
         .map(|f| f.relative_path.as_str())
         .collect();
-    assert_eq!(artwork_paths, vec!["cover.jpg"]);
+    assert_eq!(artwork_paths, vec!["back.bmp", "cover.jpg"]);
 
     assert!(files.documents.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_child_directory_fails_scan() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+    let blocked = root.join("blocked");
+    std::fs::create_dir(&blocked).unwrap();
+    std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let err = match FileTree::from_filesystem(root) {
+        Ok(_) => panic!("unreadable directory should fail the scan"),
+        Err(err) => err,
+    };
+
+    std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    match err {
+        FolderScanError::Io { path, source } => {
+            assert_eq!(path, blocked);
+            assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+        }
+        FolderScanError::Other(message) => panic!("expected IO error, got {message}"),
+    }
 }
 
 #[test]

--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -186,6 +186,11 @@ pub enum ScanEvent {
         candidate_key: String,
         skipped: bool,
     },
+    /// A folder scan could not read the watched root. Previous candidates are
+    /// left in place because the scan did not produce a replacement snapshot.
+    Failed {
+        error: String,
+    },
     Finished,
 }
 

--- a/bae-core/src/import/service/cover_image.rs
+++ b/bae-core/src/import/service/cover_image.rs
@@ -3,11 +3,8 @@
 //! Builds the `DbLibraryImage` record (and its bytes) for a local cover,
 //! ranking folder images so `cover`/`front` wins when the user made no pick.
 
-use std::path::Path;
-
-use tracing::{error, info};
-
 use crate::import::types::DiscoveredFile;
+use crate::util::content_type_hint::ContentTypeHint;
 
 use super::format_prep::resolve_file_content_type;
 use super::ImportService;
@@ -23,66 +20,50 @@ impl ImportService {
         &self,
         release_id: &str,
         discovered_files: &[DiscoveredFile],
-        cover_image_path: Option<&Path>,
+        selected_cover_path: Option<&str>,
     ) -> Result<Option<(crate::db::DbLibraryImage, Vec<u8>)>, String> {
         use crate::db::{DbLibraryImage, LibraryImageType};
 
-        let image_extensions = ["jpg", "jpeg", "png", "gif", "webp"];
-        let mut image_files: Vec<(&DiscoveredFile, String)> = Vec::new();
+        let mut image_files: Vec<(&DiscoveredFile, &str)> = Vec::new();
         for f in discovered_files {
-            let is_image = f
-                .path
-                .extension()
-                .and_then(|e| e.to_str())
-                .map(|e| image_extensions.contains(&e.to_lowercase().as_str()))
-                .unwrap_or(false);
-            if is_image {
-                let relative_path = self.get_relative_image_path(&f.path)?;
-                image_files.push((f, relative_path));
+            if ContentTypeHint::path_is_raster_image(&f.path) {
+                image_files.push((f, f.relative_path.as_str()));
             }
         }
 
-        if image_files.is_empty() {
-            return Ok(None);
-        }
-
-        // Determine which file is the cover: match by absolute path if provided.
-        let selected_cover = if let Some(selected_path) = cover_image_path {
-            let found = image_files
-                .iter()
-                .find(|(f, _)| f.path.as_path() == selected_path);
-            if found.is_none() {
-                info!(
-                    "Selected cover {:?} not found among images, using priority",
-                    selected_path
-                );
-            }
-            found
+        let selected_cover = if let Some(selected_path) = selected_cover_path {
+            Some(
+                image_files
+                    .iter()
+                    .find(|(f, _)| f.relative_path == selected_path)
+                    .ok_or_else(|| {
+                        format!(
+                            "Selected cover {} not found among discovered images",
+                            selected_path
+                        )
+                    })?,
+            )
         } else {
-            None
-        };
-
-        let (cover_file, relative_path) = selected_cover.unwrap_or_else(|| {
             image_files
                 .iter()
                 .min_by_key(|(_, relative_path)| Self::image_cover_priority(relative_path))
-                .expect("image_files is non-empty after earlier check")
-        });
+        };
+
+        let Some((cover_file, relative_path)) = selected_cover else {
+            return Ok(None);
+        };
+
         let content_type = resolve_file_content_type(&cover_file.path)?;
         let source_url = format!("release://{}", relative_path);
 
         // Read the cover bytes from the user's folder; the caller stores them in
         // coven's local store and writes the row.
-        let bytes = match std::fs::read(&cover_file.path) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                error!(
-                    "Failed to read cover art {}: {e}",
-                    cover_file.path.display()
-                );
-                return Ok(None);
-            }
-        };
+        let bytes = std::fs::read(&cover_file.path).map_err(|e| {
+            format!(
+                "Failed to read cover art {}: {e}",
+                cover_file.path.display()
+            )
+        })?;
 
         let now = self.library_manager.clock().now();
         let db_image = DbLibraryImage {
@@ -108,20 +89,5 @@ impl ImportService {
             return 0;
         }
         1
-    }
-
-    fn get_relative_image_path(&self, path: &std::path::Path) -> Result<String, String> {
-        let filename = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| format!("Invalid filename: {:?}", path))?;
-        if let Some(parent) = path.parent() {
-            if let Some(parent_name) = parent.file_name().and_then(|n| n.to_str()) {
-                if parent_name == "scans" || parent_name == "artwork" || parent_name == "images" {
-                    return Ok(format!("{}/{}", parent_name, filename));
-                }
-            }
-        }
-        Ok(filename.to_string())
     }
 }

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -12,7 +12,7 @@ use {
     },
     crate::import::folder_registry::ImportFolderRegistry,
     crate::import::folder_scanner::{
-        scan_for_candidates_with_callback, InvalidCandidate, ScanItem,
+        scan_for_candidates_with_callback, FolderScanError, InvalidCandidate, ScanItem,
     },
     crate::import::track_to_file_mapper::map_tracks_to_files,
     crate::import::types::{CoverSelection, DiscoveredFile, ImportPhase, PrepareStep, TrackFile},
@@ -192,8 +192,9 @@ impl ImportService {
     /// Re-scan `root` and reconcile against the candidate keys last emitted for
     /// it: emit every current candidate (the reducer keeps in-progress state for
     /// ones it already holds) and `CandidateRemoved` for any that vanished. A
-    /// scan error (folder unreadable/deleted) reconciles to empty, removing all
-    /// of the folder's candidates.
+    /// missing root reconciles to empty, removing all of the folder's candidates;
+    /// other scan errors keep the previous candidate set so a transient fault
+    /// does not report the folder as deleted.
     async fn rescan_and_reconcile(
         root: &Path,
         last_keys: &mut HashMap<PathBuf, HashSet<String>>,
@@ -213,17 +214,37 @@ impl ImportService {
         })
         .await;
 
+        let emit_scan_failed = |message: String| {
+            send_event(
+                event_tx,
+                crate::import::handle::ImportEvent::Scan(ScanEvent::Failed { error: message }),
+            );
+        };
+
         let (mut candidates, invalid_candidates): (_, Vec<InvalidCandidate>) = match scanned {
             Ok(Ok(split)) => split,
-            Ok(Err(e)) => {
-                warn!(
-                    "re-scan of {} failed ({e}); removing its candidates",
-                    root.display()
-                );
-                (Vec::new(), Vec::new())
-            }
+            Ok(Err(e)) => match &e {
+                FolderScanError::Io { path, source }
+                    if path == root && source.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    warn!(
+                        "re-scan of {} found the folder missing ({e}); removing its candidates",
+                        root.display()
+                    );
+                    (Vec::new(), Vec::new())
+                }
+                _ => {
+                    warn!(
+                        "re-scan of {} failed ({e}); keeping previous candidates",
+                        root.display()
+                    );
+                    emit_scan_failed(e.to_string());
+                    return;
+                }
+            },
             Err(e) => {
                 error!("folder scan task panicked for {}: {e}", root.display());
+                emit_scan_failed(format!("Folder scan task failed: {e}"));
                 return;
             }
         };
@@ -241,14 +262,15 @@ impl ImportService {
             {
                 Ok(is_added) => is_added,
                 Err(e) => {
-                    // A DB read fault leaves the candidate as "not added" rather
-                    // than dropping it — the user still sees it under "New" and
-                    // can act on it; the next re-scan retries the lookup.
                     warn!(
-                        "added-state lookup failed for {}; treating as not added: {e}",
+                        "added-state lookup failed for {}; scan failed: {e}",
                         candidate.path.display()
                     );
-                    false
+                    emit_scan_failed(format!(
+                        "Added-state lookup failed for {}: {e}",
+                        candidate.path.display()
+                    ));
+                    return;
                 }
             };
         }
@@ -640,16 +662,8 @@ impl ImportService {
         let tracks_to_files =
             map_tracks_to_files(std::mem::take(&mut prepared.db_tracks), &categorized)?;
 
-        // Resolve local cover path from discovered files
-        let cover_image_path = match &selected_cover {
-            Some(CoverSelection::Local(filename)) => discovered_files.iter().find_map(|f| {
-                let path_str = f.path.to_string_lossy();
-                if path_str.ends_with(filename) {
-                    Some(f.path.clone())
-                } else {
-                    None
-                }
-            }),
+        let selected_cover_path = match &selected_cover {
+            Some(CoverSelection::Local(path)) => Some(path.as_str()),
             _ => None,
         };
 
@@ -735,7 +749,7 @@ impl ImportService {
             &mut prepared,
             &discovered_files,
             &tracks_to_files,
-            cover_image_path.as_deref(),
+            selected_cover_path,
             &import_id,
             &candidate_key,
             embedded_cover,
@@ -811,7 +825,7 @@ impl ImportService {
         prepared: &mut PreparedMetadata,
         discovered_files: &[DiscoveredFile],
         tracks_to_files: &[TrackFile],
-        cover_image_path: Option<&Path>,
+        selected_cover_path: Option<&str>,
         import_id: &str,
         candidate_key: &str,
         embedded_cover: Option<(Vec<u8>, crate::util::content_type::ContentType)>,
@@ -979,7 +993,7 @@ impl ImportService {
             None => match self.build_cover_image_record(
                 &db_release.id,
                 discovered_files,
-                cover_image_path,
+                selected_cover_path,
             )? {
                 Some(local) => Some(local),
                 None => embedded_cover.map(|(bytes, content_type)| {

--- a/bae-core/src/import/service/tests.rs
+++ b/bae-core/src/import/service/tests.rs
@@ -1,6 +1,51 @@
 use super::*;
+use crate::config::{Config, ConfigHandle};
+use crate::db::Database;
+use crate::keys::KeyService;
 use coven::FixedClock;
 use coven::SequentialIdProvider;
+use tempfile::TempDir;
+
+async fn setup_import_service() -> (ImportService, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
+        .await
+        .unwrap();
+    let library_dir = coven::LibraryDir::new(temp_dir.path());
+    let library_id = format!("test-{}", temp_dir.path().display());
+    let config = Config::with_defaults(
+        library_id.clone(),
+        "test-device".to_string(),
+        library_dir.clone(),
+        "Test Library".to_string(),
+    );
+    crate::config::install_test_keyring();
+    let manager = LibraryManager::new(
+        database,
+        library_dir,
+        Arc::new(ConfigHandle::new(config)),
+        KeyService::new(library_id),
+        Arc::new(coven::SystemClock),
+        Arc::new(coven::UuidProvider),
+        tokio::runtime::Handle::current(),
+    );
+    let (_commands_tx, commands_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (event_tx, _) = tokio::sync::broadcast::channel(16);
+    (
+        ImportService {
+            commands_rx,
+            event_tx,
+            library_manager: manager,
+        },
+        temp_dir,
+    )
+}
+
+fn write_test_jpeg(path: &Path) {
+    let image = ::image::RgbImage::from_pixel(1, 1, ::image::Rgb([0, 0, 0]));
+    image.save(path).unwrap();
+}
 
 #[test]
 fn affected_roots_maps_changed_paths_to_their_watched_roots() {
@@ -71,6 +116,195 @@ fn image_cover_priority_ranks_front_and_cover_first() {
     assert_eq!(ImportService::image_cover_priority("Back.jpg"), 1);
     assert_eq!(ImportService::image_cover_priority("inlay.png"), 1);
     assert_eq!(ImportService::image_cover_priority("disc1.jpg"), 1);
+}
+
+#[tokio::test]
+async fn explicit_bmp_cover_is_selected() {
+    let (service, tmp) = setup_import_service().await;
+    let bmp = tmp.path().join("cover.bmp");
+    let jpg = tmp.path().join("front.jpg");
+    std::fs::write(&bmp, b"bmp bytes").unwrap();
+    std::fs::write(&jpg, b"jpg bytes").unwrap();
+    let discovered = vec![
+        DiscoveredFile {
+            path: bmp.clone(),
+            relative_path: "cover.bmp".to_string(),
+            size: 9,
+        },
+        DiscoveredFile {
+            path: jpg,
+            relative_path: "front.jpg".to_string(),
+            size: 9,
+        },
+    ];
+
+    let (image, bytes) = service
+        .build_cover_image_record("release-1", &discovered, Some("cover.bmp"))
+        .unwrap()
+        .expect("selected cover should build a record");
+
+    assert_eq!(
+        image.content_type,
+        crate::util::content_type::ContentType::Bmp
+    );
+    assert_eq!(image.source_url.as_deref(), Some("release://cover.bmp"));
+    assert_eq!(bytes, b"bmp bytes");
+}
+
+#[tokio::test]
+async fn explicit_local_cover_missing_from_discovered_images_is_an_error() {
+    let (service, tmp) = setup_import_service().await;
+    let fallback = tmp.path().join("front.jpg");
+    std::fs::write(&fallback, b"jpg bytes").unwrap();
+    let discovered = vec![DiscoveredFile {
+        path: fallback,
+        relative_path: "front.jpg".to_string(),
+        size: 9,
+    }];
+
+    let err = service
+        .build_cover_image_record("release-1", &discovered, Some("cover.bmp"))
+        .unwrap_err();
+
+    assert!(
+        err.contains("Selected cover") && err.contains("not found"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_local_cover_with_no_discovered_images_is_an_error() {
+    let (service, _tmp) = setup_import_service().await;
+
+    let err = service
+        .build_cover_image_record("release-1", &[], Some("cover.bmp"))
+        .unwrap_err();
+
+    assert!(
+        err.contains("Selected cover") && err.contains("not found"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn selected_local_cover_path_must_match_discovered_file() {
+    let (service, tmp) = setup_import_service().await;
+    let folder = tmp.path().join("release");
+    std::fs::create_dir(&folder).unwrap();
+    write_test_jpeg(&folder.join("front.jpg"));
+    std::fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/flac/01 Test Track 1.flac"),
+        folder.join("01.flac"),
+    )
+    .unwrap();
+
+    let result = service
+        .prepare_and_run_folder_import(
+            "import-1".to_string(),
+            folder.to_string_lossy().into_owned(),
+            folder,
+            Some(CoverSelection::Local("cover.bmp".to_string())),
+            StorageMode::Local,
+            false,
+            crate::import::IdentityChoice::Unknown,
+            None,
+        )
+        .await;
+
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("Selected cover cover.bmp not found"),
+        "got: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unreadable_selected_cover_is_an_error() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (service, tmp) = setup_import_service().await;
+    let cover = tmp.path().join("cover.jpg");
+    std::fs::write(&cover, b"jpg bytes").unwrap();
+    std::fs::set_permissions(&cover, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let discovered = vec![DiscoveredFile {
+        path: cover.clone(),
+        relative_path: "cover.jpg".to_string(),
+        size: 9,
+    }];
+
+    let result = service.build_cover_image_record("release-1", &discovered, Some("cover.jpg"));
+
+    std::fs::set_permissions(&cover, std::fs::Permissions::from_mode(0o600)).unwrap();
+    let err = result.unwrap_err();
+    assert!(err.contains("Failed to read cover art"), "got: {err}");
+}
+
+async fn rescan_seeded_root(
+    service: &ImportService,
+    root: &Path,
+) -> (
+    HashMap<PathBuf, HashSet<String>>,
+    tokio::sync::broadcast::Receiver<crate::import::handle::ImportEvent>,
+) {
+    let mut last_keys =
+        HashMap::from([(root.to_path_buf(), HashSet::from(["old-key".to_string()]))]);
+    let (event_tx, events) = tokio::sync::broadcast::channel(16);
+    let folder_registry = Arc::new(Mutex::new(
+        crate::import::folder_registry::ImportFolderRegistry::load(
+            service.library_manager.library_dir(),
+        ),
+    ));
+
+    ImportService::rescan_and_reconcile(
+        root,
+        &mut last_keys,
+        &event_tx,
+        &service.library_manager,
+        &folder_registry,
+    )
+    .await;
+
+    (last_keys, events)
+}
+
+#[tokio::test]
+async fn rescan_missing_root_removes_previous_candidates() {
+    let (service, tmp) = setup_import_service().await;
+    let root = tmp.path().join("missing-root");
+    let (last_keys, mut events) = rescan_seeded_root(&service, &root).await;
+
+    match events.recv().await.unwrap() {
+        crate::import::handle::ImportEvent::Scan(ScanEvent::CandidateRemoved { candidate_key }) => {
+            assert_eq!(candidate_key, "old-key");
+        }
+        event => panic!("expected candidate removal, got {event:?}"),
+    }
+    assert!(matches!(
+        events.recv().await.unwrap(),
+        crate::import::handle::ImportEvent::Scan(ScanEvent::Finished)
+    ));
+    assert!(last_keys.get(&root).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn rescan_non_directory_root_keeps_previous_candidates() {
+    let (service, tmp) = setup_import_service().await;
+    let root = tmp.path().join("not-a-directory");
+    std::fs::write(&root, b"not a directory").unwrap();
+    let (last_keys, mut events) = rescan_seeded_root(&service, &root).await;
+
+    match events.recv().await.unwrap() {
+        crate::import::handle::ImportEvent::Scan(ScanEvent::Failed { error }) => {
+            assert!(
+                error.to_lowercase().contains("not a directory"),
+                "got: {error}"
+            );
+        }
+        event => panic!("expected scan failure, got {event:?}"),
+    }
+    assert_eq!(last_keys.get(&root).unwrap().len(), 1);
+    assert!(last_keys.get(&root).unwrap().contains("old-key"));
 }
 
 #[test]

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -292,6 +292,11 @@ impl UiEventBus {
                                 skipped,
                             });
                         }
+                        ScanEvent::Failed { error } => {
+                            bus.emit(UiBusEvent::Error {
+                                error: crate::ui::UiError::import(error),
+                            });
+                        }
                         ScanEvent::Finished => {
                             bus.emit(UiBusEvent::ScanFinished);
                         }

--- a/bae-core/src/util/content_type_hint.rs
+++ b/bae-core/src/util/content_type_hint.rs
@@ -81,6 +81,18 @@ impl ContentTypeHint {
         )
     }
 
+    pub fn is_raster_image(&self) -> bool {
+        self.is_image() && !matches!(self, Self::Svg)
+    }
+
+    /// Whether `path`'s extension classifies as a raster image. Returns `false`
+    /// for paths with no extension, non-UTF-8 extensions, and SVG.
+    pub fn path_is_raster_image(path: &Path) -> bool {
+        path.extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| Self::from_extension(e).is_raster_image())
+    }
+
     /// Convert image hints to the equivalent probe-verified `ContentType`.
     ///
     /// Image extensions predict codecs reliably (a `.png` file's bytes are
@@ -246,6 +258,32 @@ mod tests {
         assert!(!ContentTypeHint::PlainText.is_image());
         assert!(!ContentTypeHint::Pdf.is_image());
         assert!(!ContentTypeHint::Unknown("svg2".to_string()).is_image());
+    }
+
+    #[test]
+    fn is_raster_image_membership() {
+        assert!(ContentTypeHint::Jpeg.is_raster_image());
+        assert!(ContentTypeHint::Png.is_raster_image());
+        assert!(ContentTypeHint::Gif.is_raster_image());
+        assert!(ContentTypeHint::Webp.is_raster_image());
+        assert!(ContentTypeHint::Bmp.is_raster_image());
+
+        assert!(!ContentTypeHint::Svg.is_raster_image());
+        assert!(!ContentTypeHint::Flac.is_raster_image());
+        assert!(!ContentTypeHint::PlainText.is_raster_image());
+        assert!(!ContentTypeHint::Pdf.is_raster_image());
+        assert!(!ContentTypeHint::Unknown("svg2".to_string()).is_raster_image());
+    }
+
+    #[test]
+    fn path_is_raster_image_membership() {
+        assert!(ContentTypeHint::path_is_raster_image(Path::new(
+            "cover.bmp"
+        )));
+        assert!(!ContentTypeHint::path_is_raster_image(Path::new(
+            "cover.svg"
+        )));
+        assert!(!ContentTypeHint::path_is_raster_image(Path::new("README")));
     }
 
     #[test]


### PR DESCRIPTION
Issue #223 flagged several import fallback paths that were still current: local cover selection could fall through to ranked artwork, scanner artwork classification had drifted from the cover pipeline, and watched-folder scan failures could be reported as completed scans.

This change makes explicit cover picks fail when the selected relative path is absent or unreadable, uses one raster-image classifier for scanner and import cover selection, and emits scan failures instead of publishing an incomplete snapshot. Missing watched roots still reconcile to empty because that is the on-disk state; other scan failures leave the previous candidate set untouched and surface an error.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --lib import::service::tests:: --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --lib import::folder_scanner::tests:: --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --lib util::content_type_hint::tests:: --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-automation`
- pre-commit hook: cargo fmt, bae-core clippy lib/tests, bae-bridge clippy, loc-gen check