### PR TITLE
Fail loudly when forgetting a library fails

### DIFF
--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -952,16 +952,6 @@ fn find_library_by_id(bae_dir: &std::path::Path, uuid: &str) -> Option<LibraryDi
     None
 }
 
-/// Absolute path to a library's data directory by its UUID, scanning
-/// `~/.bae/libraries/`. `None` if no directory there carries that id. Used by
-/// `forget_library` to locate the tree it removes.
-pub fn library_data_dir(bae_dir: &std::path::Path, library_id: &str) -> Option<PathBuf> {
-    discover_all_library_paths(bae_dir)
-        .into_iter()
-        .find(|(_, yaml)| yaml.library_id == library_id)
-        .map(|(path, _)| path)
-}
-
 /// Collect all (path, ConfigYaml) pairs from ~/.bae/libraries/.
 fn discover_all_library_paths(bae_dir: &std::path::Path) -> Vec<(PathBuf, ConfigYaml)> {
     let mut results = Vec::new();

--- a/bae-core/src/library/manager/lifecycle.rs
+++ b/bae-core/src/library/manager/lifecycle.rs
@@ -1,7 +1,7 @@
 //! Library-lifecycle operations for [`LibraryManager`]: rename a library,
 //! lock it (forget the active encryption key), and forget a local library
-//! (drop the master key, clear the active-library pointer, and remove its
-//! data directory). These mutate the library's on-disk presence and the
+//! (remove its data directory, clear the active-library pointer, and drop the
+//! master key). These mutate the library's on-disk presence and the
 //! active-library pointer — distinct from the config-access surface in
 //! `config.rs`, which only reads and writes config fields.
 
@@ -38,8 +38,8 @@ impl LibraryManager {
             .map_err(|e| format!("{e}"))
     }
 
-    /// Forget this (local) library on this device: delete its master encryption
-    /// key, clear the active-library pointer, and remove its data directory. The
+    /// Forget this (local) library on this device: remove its data directory,
+    /// clear the active-library pointer, and delete its master encryption key. The
     /// owner's cloud copy (if any) is untouched — this only drops the device's
     /// local presence.
     ///
@@ -48,26 +48,96 @@ impl LibraryManager {
     /// operation. The next launch re-discovers and opens another library (or
     /// onboards) since the active pointer is gone.
     pub fn forget_library(&self) -> Result<(), String> {
-        if let Err(e) = self.key_service.delete_encryption_key() {
-            warn!("Failed to delete encryption key while forgetting library: {e}");
-        }
-
-        let library_id = self.config_handle.config().library_id.clone();
-        let bae_dir = crate::config::bae_dir().map_err(|e| e.to_string())?;
-
+        let config = self.config_handle.config();
+        let library_id = config.library_id.clone();
+        let bae_dir = registered_bae_dir(config.library_dir.as_ref(), &library_id)?;
+        let library_dir = crate::config::registered_library_path(&bae_dir, &library_id);
         let active_pointer = bae_dir.join("active-library");
-        if active_pointer.exists() {
-            if let Err(e) = std::fs::remove_file(&active_pointer) {
-                warn!("Failed to clear active-library pointer: {e}");
+        let remove_active_pointer = active_pointer_matches_library(&active_pointer, &library_id)?;
+
+        match std::fs::remove_dir_all(&library_dir) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(format!(
+                    "Failed to remove library data at {}: {e}",
+                    library_dir.display()
+                ));
             }
         }
 
-        if let Some(dir) = crate::config::library_data_dir(&bae_dir, &library_id) {
-            if let Err(e) = std::fs::remove_dir_all(&dir) {
-                warn!("Failed to remove library data at {}: {e}", dir.display());
-            }
+        if remove_active_pointer {
+            std::fs::remove_file(&active_pointer).map_err(|e| {
+                format!(
+                    "Failed to clear active-library pointer at {}: {e}",
+                    active_pointer.display()
+                )
+            })?;
         }
+
+        self.key_service
+            .delete_encryption_key()
+            .map_err(|e| format!("Failed to delete encryption key: {e}"))?;
 
         Ok(())
     }
+}
+
+fn active_pointer_matches_library(
+    active_pointer: &std::path::Path,
+    library_id: &str,
+) -> Result<bool, String> {
+    let content = match std::fs::read_to_string(active_pointer) {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => {
+            return Err(format!(
+                "Failed to read active-library pointer at {}: {e}",
+                active_pointer.display()
+            ));
+        }
+    };
+    let active_library_id = content.trim();
+    if active_library_id == library_id {
+        return Ok(true);
+    }
+    Err(format!(
+        "active-library pointer at {} points at {active_library_id}, not {library_id}",
+        active_pointer.display()
+    ))
+}
+
+fn registered_bae_dir(
+    library_dir: &std::path::Path,
+    library_id: &str,
+) -> Result<std::path::PathBuf, String> {
+    if library_dir.file_name() != Some(std::ffi::OsStr::new(library_id)) {
+        return Err(format!(
+            "library directory {} does not match library id {library_id}",
+            library_dir.display()
+        ));
+    }
+
+    let libraries_dir = library_dir.parent().ok_or_else(|| {
+        format!(
+            "library directory {} has no libraries parent",
+            library_dir.display()
+        )
+    })?;
+    if libraries_dir.file_name() != Some(std::ffi::OsStr::new("libraries")) {
+        return Err(format!(
+            "library directory {} is not under a libraries directory",
+            library_dir.display()
+        ));
+    }
+
+    libraries_dir
+        .parent()
+        .map(|path| path.to_path_buf())
+        .ok_or_else(|| {
+            format!(
+                "library directory {} has no bae directory parent",
+                library_dir.display()
+            )
+        })
 }

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -61,6 +61,191 @@ async fn setup_test_manager_with_library_id(library_id: &str) -> (LibraryManager
     (manager, temp_dir)
 }
 
+async fn setup_forget_library_manager(library_id: &str, home: &std::path::Path) -> LibraryManager {
+    let bae_dir = home.join(".bae");
+    let library_dir = crate::config::registered_library_path(&bae_dir, library_id);
+    setup_forget_library_manager_at(library_id, library_dir, home).await
+}
+
+async fn setup_forget_library_manager_at(
+    library_id: &str,
+    library_dir: std::path::PathBuf,
+    home: &std::path::Path,
+) -> LibraryManager {
+    let db_path = home.join("manager.db");
+    let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
+        .await
+        .unwrap();
+    let config = Config::with_defaults(
+        library_id.to_string(),
+        "test-device".to_string(),
+        LibraryDir::new(library_dir.clone()),
+        "Test Library".to_string(),
+    );
+    let config_handle = Arc::new(ConfigHandle::new(config));
+    crate::config::install_test_keyring();
+    let key_service = KeyService::new(library_id.to_string());
+    LibraryManager::new(
+        database,
+        LibraryDir::new(library_dir),
+        config_handle,
+        key_service,
+        Arc::new(coven::SystemClock),
+        Arc::new(coven::UuidProvider),
+        tokio::runtime::Handle::current(),
+    )
+}
+
+fn setup_forget_library_home(library_id: &str) -> (TempDir, std::path::PathBuf) {
+    let home = TempDir::new().unwrap();
+    let bae_dir = home.path().join(".bae");
+    let library_dir = crate::config::registered_library_path(&bae_dir, library_id);
+    (home, library_dir)
+}
+
+#[tokio::test]
+async fn forget_library_returns_error_when_registered_path_cannot_be_removed() {
+    let library_id = format!("forget-fails-{}", Uuid::new_v4());
+    let (home, library_path) = setup_forget_library_home(&library_id);
+    let bae_dir = home.path().join(".bae");
+    std::fs::create_dir_all(library_path.parent().unwrap()).unwrap();
+    std::fs::write(&library_path, b"not a directory").unwrap();
+    std::fs::write(bae_dir.join("active-library"), &library_id).unwrap();
+    let manager = setup_forget_library_manager(&library_id, home.path()).await;
+    manager.key_service.set_encryption_key("00").unwrap();
+
+    let err = manager
+        .forget_library()
+        .expect_err("directory removal failure must surface");
+
+    assert!(
+        err.contains("Failed to remove library data"),
+        "error should name the failed library data deletion: {err}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(bae_dir.join("active-library")).unwrap(),
+        library_id
+    );
+    assert_eq!(
+        manager.key_service.get_encryption_key().unwrap().as_deref(),
+        Some("00")
+    );
+}
+
+#[tokio::test]
+async fn forget_library_removes_registered_path_active_pointer_and_key() {
+    let library_id = format!("forget-succeeds-{}", Uuid::new_v4());
+    let (home, library_path) = setup_forget_library_home(&library_id);
+    let bae_dir = home.path().join(".bae");
+    std::fs::create_dir_all(&library_path).unwrap();
+    std::fs::write(library_path.join("config.yaml"), b"library data").unwrap();
+    std::fs::write(bae_dir.join("active-library"), &library_id).unwrap();
+    let manager = setup_forget_library_manager(&library_id, home.path()).await;
+    manager.key_service.set_encryption_key("00").unwrap();
+
+    manager.forget_library().unwrap();
+
+    assert!(!library_path.exists());
+    assert!(!bae_dir.join("active-library").exists());
+    assert!(manager.key_service.get_encryption_key().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn forget_library_accepts_missing_directory_and_pointer_on_retry() {
+    let library_id = format!("forget-retry-{}", Uuid::new_v4());
+    let (home, library_path) = setup_forget_library_home(&library_id);
+    let bae_dir = home.path().join(".bae");
+    std::fs::create_dir_all(&bae_dir).unwrap();
+    let manager = setup_forget_library_manager(&library_id, home.path()).await;
+    manager.key_service.set_encryption_key("00").unwrap();
+
+    manager.forget_library().unwrap();
+
+    assert!(!library_path.exists());
+    assert!(!bae_dir.join("active-library").exists());
+    assert!(manager.key_service.get_encryption_key().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn forget_library_returns_error_when_active_pointer_cannot_be_read() {
+    let library_id = format!("forget-pointer-fails-{}", Uuid::new_v4());
+    let (home, library_path) = setup_forget_library_home(&library_id);
+    let bae_dir = home.path().join(".bae");
+    std::fs::create_dir_all(&library_path).unwrap();
+    std::fs::create_dir(bae_dir.join("active-library")).unwrap();
+    let manager = setup_forget_library_manager(&library_id, home.path()).await;
+    manager.key_service.set_encryption_key("00").unwrap();
+
+    let err = manager
+        .forget_library()
+        .expect_err("active pointer read failure must surface");
+
+    assert!(
+        err.contains("Failed to read active-library pointer"),
+        "error should name the failed active pointer read: {err}"
+    );
+    assert!(library_path.exists());
+    assert!(bae_dir.join("active-library").is_dir());
+    assert_eq!(
+        manager.key_service.get_encryption_key().unwrap().as_deref(),
+        Some("00")
+    );
+}
+
+#[tokio::test]
+async fn forget_library_returns_error_when_active_pointer_names_another_library() {
+    let library_id = format!("forget-pointer-mismatch-{}", Uuid::new_v4());
+    let (home, library_path) = setup_forget_library_home(&library_id);
+    let bae_dir = home.path().join(".bae");
+    std::fs::create_dir_all(&library_path).unwrap();
+    std::fs::write(bae_dir.join("active-library"), "different-library").unwrap();
+    let manager = setup_forget_library_manager(&library_id, home.path()).await;
+    manager.key_service.set_encryption_key("00").unwrap();
+
+    let err = manager
+        .forget_library()
+        .expect_err("active pointer mismatch must surface");
+
+    assert!(
+        err.contains("points at different-library"),
+        "error should name the active pointer mismatch: {err}"
+    );
+    assert!(library_path.exists());
+    assert_eq!(
+        std::fs::read_to_string(bae_dir.join("active-library")).unwrap(),
+        "different-library"
+    );
+    assert_eq!(
+        manager.key_service.get_encryption_key().unwrap().as_deref(),
+        Some("00")
+    );
+}
+
+#[tokio::test]
+async fn forget_library_rejects_unregistered_library_dir() {
+    let library_id = format!("forget-unregistered-{}", Uuid::new_v4());
+    let home = TempDir::new().unwrap();
+    let library_path = home.path().join("external-library");
+    std::fs::create_dir_all(&library_path).unwrap();
+    let manager =
+        setup_forget_library_manager_at(&library_id, library_path.clone(), home.path()).await;
+    manager.key_service.set_encryption_key("00").unwrap();
+
+    let err = manager
+        .forget_library()
+        .expect_err("unregistered library directory must fail loudly");
+
+    assert!(
+        err.contains("does not match library id"),
+        "error should name the unregistered library directory: {err}"
+    );
+    assert!(library_path.exists());
+    assert_eq!(
+        manager.key_service.get_encryption_key().unwrap().as_deref(),
+        Some("00")
+    );
+}
+
 #[tokio::test]
 async fn mcp_config_rejects_port_zero_and_persists_valid_config() {
     let (manager, _temp_dir) = setup_test_manager().await;


### PR DESCRIPTION
`forget_library` used to log deletion failures and still report success, which could leave a registered local library on disk for launch discovery to pick up again. This changes the operation to preflight the registered library shape and active pointer, remove the canonical registered directory, clear the pointer only when it still names that library, and propagate real filesystem or keyring failures to the caller.

It also removes the old config-scanning `library_data_dir` helper so forgetting a library no longer asks discovered config files which directory to delete.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core forget_library_ --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `python3 ~/.codex/agent-instructions/scripts/rules_review/local_codex.py --consumer /Users/dima/dev/bae-forget-library --project bae --local-diff --base origin/main --repo bae-fm/bae --sha $(git rev-parse HEAD) --reviewer codex --model gpt-5.5 --jobs 6 --slug dispatch-on-known-state-not-blind-search --slug never-mask-errors-with-defaults --slug no-self-heal-make-state-correct-or-fail-loud --slug test-the-real-unit-not-a-reconstruction --slug every-bug-fix-starts-with-a-failing-test --slug don-t-duplicate-existing-logic`
