### PR TITLE
Preserve barcode lookup failures

### DIFF
--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1194,6 +1194,9 @@ pub enum BridgeBarcodeProgress {
     Done {
         n_results: u32,
     },
+    Failed {
+        failure: BridgeLookupFailure,
+    },
     /// No artwork to scan.
     Skipped,
 }
@@ -3120,6 +3123,9 @@ fn barcode_progress_to_bridge(p: bae_core::identify::BarcodeProgress) -> BridgeB
         BarcodeProgress::Done { results, .. } => BridgeBarcodeProgress::Done {
             n_results: results.len() as u32,
         },
+        BarcodeProgress::Failed { failure } => BridgeBarcodeProgress::Failed {
+            failure: lookup_failure_to_bridge(failure),
+        },
         BarcodeProgress::Skipped => BridgeBarcodeProgress::Skipped,
     }
 }
@@ -3819,6 +3825,27 @@ mod loc_key_coverage {
                 "catalog key `{key}` has no producer — delete it or add a producer \
                  (a bridge_*_key fn) or list it in DIRECT_KEYS"
             );
+        }
+    }
+}
+
+#[cfg(all(test, not(any(target_os = "ios", target_os = "android"))))]
+mod identify_progress_tests {
+    use super::*;
+
+    #[test]
+    fn barcode_progress_failure_crosses_bridge() {
+        let progress = bae_core::identify::BarcodeProgress::Failed {
+            failure: bae_core::signals::LookupFailure::Diagnostic {
+                detail: "provider lookup failed".to_string(),
+            },
+        };
+
+        match barcode_progress_to_bridge(progress) {
+            BridgeBarcodeProgress::Failed {
+                failure: BridgeLookupFailure::Diagnostic { detail },
+            } => assert_eq!(detail, "provider lookup failed"),
+            other => panic!("expected failed barcode progress, got {other:?}"),
         }
     }
 }

--- a/bae-core/src/identify/service.rs
+++ b/bae-core/src/identify/service.rs
@@ -8,6 +8,7 @@ use super::state::{step, Effect, ExcludedSignal, IdentifyEvent, IdentifyState};
 use crate::import::cover_art::CoverArtArchiveClient;
 use crate::import::ImportEvent;
 use crate::library::LibraryManager;
+use crate::signals::LookupFailure;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
@@ -39,6 +40,7 @@ fn barcode_lookup_failed(barcode: String, message: String) -> IdentifyEvent {
     debug!("Barcode lookup failed for {barcode}: {message}");
     IdentifyEvent::BarcodeLookupFailed {
         for_barcode: barcode,
+        failure: LookupFailure::Diagnostic { detail: message },
     }
 }
 

--- a/bae-core/src/identify/state.rs
+++ b/bae-core/src/identify/state.rs
@@ -83,6 +83,9 @@ pub enum BarcodeProgress {
         matched: Option<String>,
         results: Vec<(MetadataResult, LibraryStatus)>,
     },
+    Failed {
+        failure: LookupFailure,
+    },
     /// No artwork to scan. The signal pipe is "absent" rather than empty —
     /// combine treats it the same as `Done { results: [] }`.
     Skipped,
@@ -92,7 +95,9 @@ impl BarcodeProgress {
     pub fn is_settled(&self) -> bool {
         matches!(
             self,
-            BarcodeProgress::Done { .. } | BarcodeProgress::Skipped
+            BarcodeProgress::Done { .. }
+                | BarcodeProgress::Failed { .. }
+                | BarcodeProgress::Skipped
         )
     }
 
@@ -157,6 +162,8 @@ pub struct SignalsContext {
     pub discid_results: Vec<(MetadataResult, LibraryStatus)>,
     /// The barcode lookup's results, once settled.
     pub barcode_results: Vec<(MetadataResult, LibraryStatus)>,
+    /// The barcode lookup failure, once settled by an error.
+    pub barcode_failure: Option<LookupFailure>,
     /// Which barcode produced `barcode_results`. `None` until matched.
     pub matched_barcode: Option<String>,
     /// The candidate's local track count.
@@ -174,6 +181,7 @@ impl SignalsContext {
             excluded: HashSet::new(),
             discid_results: Vec::new(),
             barcode_results: Vec::new(),
+            barcode_failure: None,
             matched_barcode: None,
             track_count: 0,
         }
@@ -194,10 +202,12 @@ impl SignalsContext {
         &mut self,
         discid_results: Vec<(MetadataResult, LibraryStatus)>,
         barcode_results: Vec<(MetadataResult, LibraryStatus)>,
+        barcode_failure: Option<LookupFailure>,
         matched_barcode: Option<String>,
     ) {
         self.discid_results = discid_results;
         self.barcode_results = barcode_results;
+        self.barcode_failure = barcode_failure;
         self.matched_barcode = matched_barcode;
     }
 
@@ -444,6 +454,9 @@ fn barcode_progress_state(progress: &BarcodeProgress) -> SignalState {
     match progress {
         BarcodeProgress::Scanning | BarcodeProgress::LookingUp { .. } => SignalState::LookingUp,
         BarcodeProgress::Done { results, .. } => found_or_no_match(results.len() as u32),
+        BarcodeProgress::Failed { failure } => SignalState::Failed {
+            failure: failure.clone(),
+        },
         BarcodeProgress::Skipped => SignalState::Skipped,
     }
 }
@@ -465,7 +478,11 @@ fn settled_identity_state(
 
 /// Settled barcode badge state from the context's recorded barcode results.
 fn barcode_settled_state(context: &SignalsContext) -> SignalState {
-    if context.barcode_codes.is_empty() {
+    if let Some(failure) = &context.barcode_failure {
+        SignalState::Failed {
+            failure: failure.clone(),
+        }
+    } else if context.barcode_codes.is_empty() {
         SignalState::Skipped
     } else {
         found_or_no_match(context.barcode_results.len() as u32)
@@ -525,6 +542,7 @@ pub enum IdentifyEvent {
     },
     BarcodeLookupFailed {
         for_barcode: String,
+        failure: LookupFailure,
     },
 
     /// User toggled a signal in the toolbar — included or excluded it from
@@ -663,8 +681,8 @@ pub fn step(state: IdentifyState, event: IdentifyEvent) -> (IdentifyState, Vec<E
             context,
         }),
 
-        // A miss or per-barcode failure advances the queue. The barcode phase
-        // only settles empty once every candidate code has been tried.
+        // A miss advances the queue. The barcode phase only settles empty
+        // once every candidate code has been tried.
         (
             IdentifyState::Triangulating {
                 discid,
@@ -677,8 +695,7 @@ pub fn step(state: IdentifyState, event: IdentifyEvent) -> (IdentifyState, Vec<E
                     },
                 context,
             },
-            IdentifyEvent::BarcodeLookupMissed { for_barcode }
-            | IdentifyEvent::BarcodeLookupFailed { for_barcode },
+            IdentifyEvent::BarcodeLookupMissed { for_barcode },
         ) if for_barcode == current => {
             if remaining.is_empty() {
                 settle_if_ready(IdentifyState::Triangulating {
@@ -706,6 +723,28 @@ pub fn step(state: IdentifyState, event: IdentifyEvent) -> (IdentifyState, Vec<E
                 )
             }
         }
+
+        (
+            IdentifyState::Triangulating {
+                discid,
+                barcode:
+                    BarcodeProgress::LookingUp {
+                        current,
+                        position: _,
+                        total: _,
+                        remaining: _,
+                    },
+                context,
+            },
+            IdentifyEvent::BarcodeLookupFailed {
+                for_barcode,
+                failure,
+            },
+        ) if for_barcode == current => settle_if_ready(IdentifyState::Triangulating {
+            discid,
+            barcode: BarcodeProgress::Failed { failure },
+            context,
+        }),
 
         // Unhandled event in Triangulating (stale barcode response, or an
         // event this state doesn't act on) — keep state.
@@ -838,9 +877,14 @@ fn settle_if_ready(state: IdentifyState) -> (IdentifyState, Vec<Effect>) {
 
     let track_count = settled_track_count(&discid);
     context.track_count = track_count;
+    let barcode_failure = match &barcode {
+        BarcodeProgress::Failed { failure } => Some(failure.clone()),
+        _ => None,
+    };
     context.record_results(
         discid.results(),
         barcode.results(),
+        barcode_failure,
         barcode.matched_barcode().map(str::to_string),
     );
 
@@ -907,6 +951,7 @@ fn rerun(mut context: SignalsContext) -> (IdentifyState, Vec<Effect>) {
     // A fresh run discards prior results; they're recomputed as lookups land.
     context.discid_results = Vec::new();
     context.barcode_results = Vec::new();
+    context.barcode_failure = None;
     context.matched_barcode = None;
 
     let mut effects = Vec::new();

--- a/bae-core/src/identify/state/tests.rs
+++ b/bae-core/src/identify/state/tests.rs
@@ -334,11 +334,14 @@ fn stale_barcode_response_is_ignored() {
             for_barcode: "A".to_string(),
         },
     );
-    // A late duplicate "A" arrives; current is "B", so it's dropped.
+    // A late failed "A" arrives; current is "B", so it's dropped.
     let (state, effects) = step(
         state,
-        IdentifyEvent::BarcodeLookupMissed {
+        IdentifyEvent::BarcodeLookupFailed {
             for_barcode: "A".to_string(),
+            failure: LookupFailure::Diagnostic {
+                detail: "provider lookup failed".to_string(),
+            },
         },
     );
     assert!(effects.is_empty());
@@ -352,11 +355,14 @@ fn stale_barcode_response_is_ignored() {
 }
 
 #[test]
-fn barcode_lookup_failure_advances_like_a_miss() {
+fn barcode_lookup_failure_settles_failed() {
     let (state, effects) = update(
         started(),
         signals(
-            DiscIdSignal::Absent { track_count: 0 },
+            DiscIdSignal::Computed {
+                disc_id: "d".to_string(),
+                track_count: 0,
+            },
             BarcodeSignal::Settled {
                 codes: artwork_codes(&["A", "B"]),
             },
@@ -367,37 +373,24 @@ fn barcode_lookup_failure_advances_like_a_miss() {
         .iter()
         .any(|e| matches!(e, Effect::LookupBarcode { barcode } if barcode == "A")));
 
-    // The first code's lookup fails (a provider outage) — iteration should
-    // continue to "B" exactly as a miss would, not abort the whole pipe.
+    let failure = LookupFailure::Diagnostic {
+        detail: "provider lookup failed".to_string(),
+    };
     let (state, effects) = step(
         state,
         IdentifyEvent::BarcodeLookupFailed {
             for_barcode: "A".to_string(),
+            failure: failure.clone(),
         },
     );
-    assert!(effects
-        .iter()
-        .any(|e| matches!(e, Effect::LookupBarcode { barcode } if barcode == "B")));
+    assert!(effects.is_empty());
     match &state {
         IdentifyState::Triangulating {
-            barcode: BarcodeProgress::LookingUp { current, .. },
+            barcode: BarcodeProgress::Failed { failure: actual },
             ..
-        } => assert_eq!(current, "B"),
-        other => panic!("expected LookingUp B, got {other:?}"),
+        } => assert_eq!(actual, &failure),
+        other => panic!("expected failed barcode progress, got {other:?}"),
     }
-
-    // The last code also fails with nothing left in the queue — the barcode
-    // pipe settles as a clean miss rather than stranding the pipeline.
-    let (state, _) = step(
-        state,
-        IdentifyEvent::BarcodeLookupFailed {
-            for_barcode: "B".to_string(),
-        },
-    );
-    assert!(
-        !matches!(state, IdentifyState::Triangulating { .. }),
-        "pipeline should have settled after the last barcode failed, got {state:?}"
-    );
 }
 
 #[test]
@@ -896,6 +889,70 @@ fn toolbar_shows_failed_disc_id_lookup() {
             failure: LookupFailure::Provider { status: Some(503) }
         }
     );
+}
+
+#[test]
+fn toolbar_shows_failed_barcode_lookup() {
+    let (state, _) = update(
+        started(),
+        signals(
+            DiscIdSignal::Computed {
+                disc_id: "disc-hash".to_string(),
+                track_count: 5,
+            },
+            BarcodeSignal::Settled {
+                codes: artwork_codes(&["012345678905"]),
+            },
+            &[],
+        ),
+    );
+    let failure = LookupFailure::Diagnostic {
+        detail: "provider lookup failed".to_string(),
+    };
+    let (state, _) = step(
+        state,
+        IdentifyEvent::BarcodeLookupFailed {
+            for_barcode: "012345678905".to_string(),
+            failure: failure.clone(),
+        },
+    );
+    let barcode = state
+        .toolbar()
+        .into_iter()
+        .find(|s| s.kind == SignalKind::Barcode)
+        .expect("barcode badge");
+    assert_eq!(barcode.state, SignalState::Failed { failure });
+}
+
+#[test]
+fn toolbar_keeps_failed_barcode_lookup_after_settle() {
+    let (state, _) = update(
+        started(),
+        signals(
+            DiscIdSignal::Absent { track_count: 5 },
+            BarcodeSignal::Settled {
+                codes: artwork_codes(&["012345678905"]),
+            },
+            &[],
+        ),
+    );
+    let failure = LookupFailure::Diagnostic {
+        detail: "provider lookup failed".to_string(),
+    };
+    let (state, _) = step(
+        state,
+        IdentifyEvent::BarcodeLookupFailed {
+            for_barcode: "012345678905".to_string(),
+            failure: failure.clone(),
+        },
+    );
+    assert!(matches!(state, IdentifyState::NotFoundAnywhere { .. }));
+    let barcode = state
+        .toolbar()
+        .into_iter()
+        .find(|s| s.kind == SignalKind::Barcode)
+        .expect("barcode badge");
+    assert_eq!(barcode.state, SignalState::Failed { failure });
 }
 
 #[test]

--- a/bae-macos/bae/bae/Services/Store/IdentifyState.swift
+++ b/bae-macos/bae/bae/Services/Store/IdentifyState.swift
@@ -42,6 +42,7 @@ enum BarcodeProgress: Equatable {
     case scanning
     case lookingUp(current: String, position: UInt32, total: UInt32)
     case done(nResults: UInt32)
+    case failed(failure: LookupFailure)
     case skipped
 
     init(bridge: BridgeBarcodeProgress) {
@@ -54,6 +55,8 @@ enum BarcodeProgress: Equatable {
                 total: total,
             )
         case .done(let n): self = .done(nResults: n)
+        case .failed(let failure):
+            self = .failed(failure: LookupFailure(bridge: failure))
         case .skipped: self = .skipped
         }
     }


### PR DESCRIPTION
Barcode lookup failures were handled as misses, so provider/local errors drained the queue and surfaced as no match. This adds a failed barcode progress state, carries the typed failure through the reducer, bridge, and macOS state mirror, and keeps the toolbar failure visible after settlement.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core toolbar_keeps_failed_barcode_lookup_after_settle --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core barcode_lookup_failure --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core toolbar_shows_failed_barcode_lookup --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core stale_barcode_response_is_ignored --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-bridge barcode_progress_failure_crosses_bridge`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `cd bae-macos/bae && xcodebuild -project bae.xcodeproj -scheme bae -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -derivedDataPath .build/derivedData -scmProvider system -disablePackageRepositoryCache -skipPackageUpdates -disableAutomaticPackageResolution build`
- pre-commit hook
- rules review: errors=0 findings=0