### PR TITLE
Abort signal extraction when fast pass panics

### DIFF
--- a/bae-core/src/signals/service.rs
+++ b/bae-core/src/signals/service.rs
@@ -152,16 +152,11 @@ async fn run_extraction(
         // artwork OCR.
         ExtractionSource::Folder(folder) => {
             let fast_folder = folder.clone();
-            let fast =
-                match tokio::task::spawn_blocking(move || gather_non_ocr_sources(&fast_folder))
-                    .await
-                {
-                    Ok(v) => v,
-                    Err(e) => {
-                        warn!("signals: fast-pass spawn_blocking failed: {e}");
-                        FastPass::empty()
-                    }
-                };
+            let Some(fast) =
+                run_fast_pass_blocking(move || gather_non_ocr_sources(&fast_folder)).await
+            else {
+                return;
+            };
             let mut pool = Pool::default();
             for line in fast.lines {
                 pool.push(line);
@@ -234,6 +229,19 @@ async fn run_extraction(
                 },
             )
             .await;
+        }
+    }
+}
+
+async fn run_fast_pass_blocking<F>(task: F) -> Option<FastPass>
+where
+    F: FnOnce() -> FastPass + Send + 'static,
+{
+    match tokio::task::spawn_blocking(task).await {
+        Ok(fast) => Some(fast),
+        Err(e) => {
+            error!("signals: fast-pass spawn_blocking failed: {e}; aborting extraction");
+            None
         }
     }
 }

--- a/bae-core/src/signals/service/tests.rs
+++ b/bae-core/src/signals/service/tests.rs
@@ -318,6 +318,17 @@ async fn missing_folder_settles_gracefully() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn fast_pass_join_error_aborts_without_empty_snapshot() {
+    let fast_pass =
+        run_fast_pass_blocking(|| -> FastPass { panic!("fast-pass blocking task panicked") }).await;
+
+    assert!(
+        fast_pass.is_none(),
+        "fast-pass JoinError must abort the extraction run",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn cue_fields_land_in_fast_pass() {
     let tmp = TempDir::new().unwrap();
     let folder = tmp.path().join("Some Folder");


### PR DESCRIPTION
A panic in the folder fast-pass blocking task was converted into an empty fast pass, which let extraction emit empty signals as though nothing was present. This keeps ordinary folder scan failures inside the fast pass unchanged, but treats a task `JoinError` as an extraction failure and aborts before emitting a snapshot.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core fast_pass_join_error --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core missing_folder_settles_gracefully --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `cargo fmt --all`
- pre-commit hook
- rules review: errors=0 findings=0