### PR TITLE
Preserve DiscID count on lookup failure

### DIFF
--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -3118,7 +3118,7 @@ fn discid_progress_to_bridge(p: bae_core::identify::DiscidProgress) -> BridgeDis
             n_results: results.len() as u32,
         },
         DiscidProgress::Skipped { .. } => BridgeDiscidProgress::Skipped,
-        DiscidProgress::Failed { failure } => BridgeDiscidProgress::Failed {
+        DiscidProgress::Failed { failure, .. } => BridgeDiscidProgress::Failed {
             failure: lookup_failure_to_bridge(failure),
         },
     }

--- a/bae-core/src/identify/service.rs
+++ b/bae-core/src/identify/service.rs
@@ -321,7 +321,13 @@ fn dispatch_effect(
                         );
                     }
                     Err(failure) => {
-                        emit_step(&event_tx, IdentifyEvent::DiscidLookupFailed { failure });
+                        emit_step(
+                            &event_tx,
+                            IdentifyEvent::DiscidLookupFailed {
+                                failure,
+                                track_count,
+                            },
+                        );
                     }
                 }
             });

--- a/bae-core/src/identify/state.rs
+++ b/bae-core/src/identify/state.rs
@@ -43,6 +43,7 @@ pub enum DiscidProgress {
     },
     Failed {
         failure: LookupFailure,
+        track_count: u32,
     },
 }
 
@@ -443,7 +444,7 @@ fn discid_progress_state(progress: &DiscidProgress) -> SignalState {
         DiscidProgress::Computing | DiscidProgress::LookingUp => SignalState::LookingUp,
         DiscidProgress::Done { results, .. } => found_or_no_match(results.len() as u32),
         DiscidProgress::Skipped { .. } => SignalState::Skipped,
-        DiscidProgress::Failed { failure } => SignalState::Failed {
+        DiscidProgress::Failed { failure, .. } => SignalState::Failed {
             failure: failure.clone(),
         },
     }
@@ -530,6 +531,7 @@ pub enum IdentifyEvent {
     },
     DiscidLookupFailed {
         failure: LookupFailure,
+        track_count: u32,
     },
 
     // ── Barcode lookup completion ───────────────────────────────────
@@ -626,9 +628,15 @@ pub fn step(state: IdentifyState, event: IdentifyEvent) -> (IdentifyState, Vec<E
                 barcode,
                 context,
             },
-            IdentifyEvent::DiscidLookupFailed { failure },
+            IdentifyEvent::DiscidLookupFailed {
+                failure,
+                track_count,
+            },
         ) => settle_if_ready(IdentifyState::Triangulating {
-            discid: DiscidProgress::Failed { failure },
+            discid: DiscidProgress::Failed {
+                failure,
+                track_count,
+            },
             barcode,
             context,
         }),
@@ -828,8 +836,12 @@ fn start_discid_progress(signal: &DiscIdSignal, effects: &mut Vec<Effect>) -> Di
         DiscIdSignal::Absent { track_count } => DiscidProgress::Skipped {
             track_count: *track_count,
         },
-        DiscIdSignal::Failed { failure, .. } => DiscidProgress::Failed {
+        DiscIdSignal::Failed {
+            failure,
+            track_count,
+        } => DiscidProgress::Failed {
             failure: failure.clone(),
+            track_count: *track_count,
         },
     }
 }
@@ -987,7 +999,8 @@ fn settled_track_count(discid: &DiscidProgress) -> u32 {
     match discid {
         DiscidProgress::Done { track_count, .. } => *track_count,
         DiscidProgress::Skipped { track_count } => *track_count,
-        _ => 0,
+        DiscidProgress::Failed { track_count, .. } => *track_count,
+        DiscidProgress::Computing | DiscidProgress::LookingUp => 0,
     }
 }
 

--- a/bae-core/src/identify/state/tests.rs
+++ b/bae-core/src/identify/state/tests.rs
@@ -394,6 +394,32 @@ fn barcode_lookup_failure_settles_failed() {
 }
 
 #[test]
+fn failed_discid_lookup_preserves_track_count() {
+    let (state, _) = update(
+        started(),
+        signals(
+            DiscIdSignal::Computed {
+                disc_id: "d".to_string(),
+                track_count: 5,
+            },
+            BarcodeSignal::Absent,
+            &[],
+        ),
+    );
+    let (state, _) = step(
+        state,
+        IdentifyEvent::DiscidLookupFailed {
+            failure: LookupFailure::Provider { status: Some(503) },
+            track_count: 5,
+        },
+    );
+    match state {
+        IdentifyState::NotFoundAnywhere { context } => assert_eq!(context.track_count, 5),
+        other => panic!("expected NotFoundAnywhere, got {other:?}"),
+    }
+}
+
+#[test]
 fn catalog_filter_narrows_and_flags_provenance() {
     let (state, _) = update(
         started(),
@@ -876,6 +902,7 @@ fn toolbar_shows_failed_disc_id_lookup() {
         state,
         IdentifyEvent::DiscidLookupFailed {
             failure: LookupFailure::Provider { status: Some(503) },
+            track_count: 5,
         },
     );
     let disc = state


### PR DESCRIPTION
A failed DiscID lookup already knows the candidate track count from the lookup request, but the failed progress/event shape dropped it before settle. That reset terminal identify state to `0`, so barcode/manual surfaces lost the local track count even though extraction had computed it.

This carries the count through failed DiscID lookup events and failed DiscID progress, while keeping the bridge failure payload unchanged because the containing identify state already carries the track count.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core identify::state::tests::failed_discid_lookup_preserves_track_count --features test-utils` (failed before fix, passes after)
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core identify::state::tests --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-bridge --features oauth-providers,cloudkit`
- Codex rules review: Spark quota blocked until Jul 6 11:00 PM; `gpt-5.5` local diff review returned zero findings after rerunning one hung slug; targeted bridge/type rerun returned zero findings.
- Pre-commit hook passed.