### PR TITLE
Warn on dropped signal snapshots

### DIFF
--- a/bae-core/src/signals/service.rs
+++ b/bae-core/src/signals/service.rs
@@ -37,7 +37,7 @@ use std::sync::{Arc, Mutex};
 use tokio::runtime::Handle;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 /// Where a candidate's signals come from: a folder on disk, or an existing
 /// library release being re-identified.
@@ -498,10 +498,12 @@ fn scanning_signals(
 
 /// Send a `Signals` snapshot on the import event bus.
 fn emit_signals(inner: &ExtractionServiceInner, key: &str, signals: Signals) {
-    let _ = inner.event_tx.send(ImportEvent::SignalsUpdated {
+    if let Err(err) = inner.event_tx.send(ImportEvent::SignalsUpdated {
         candidate_key: key.to_string(),
         signals,
-    });
+    }) {
+        warn!("signals: SignalsUpdated broadcast had no subscribers for {key}: {err}");
+    }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/bae-core/src/signals/service/tests.rs
+++ b/bae-core/src/signals/service/tests.rs
@@ -3,11 +3,44 @@ use crate::identify::analyzer::ArtworkAnalyzer;
 use crate::identify::ArtworkAnalysis;
 use std::collections::HashMap;
 use std::fs;
+use std::io::{self, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use tempfile::TempDir;
+
+struct LogWriter {
+    bytes: Arc<StdMutex<Vec<u8>>>,
+}
+
+impl Write for LogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn capture_warn_logs(run: impl FnOnce()) -> String {
+    let bytes = Arc::new(StdMutex::new(Vec::new()));
+    let writer_bytes = bytes.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .with_writer(move || LogWriter {
+            bytes: writer_bytes.clone(),
+        })
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, run);
+
+    let bytes = bytes.lock().unwrap().clone();
+    String::from_utf8(bytes).unwrap()
+}
 
 /// Test analyzer: returns canned text lines keyed by filename (not full
 /// path, to stay portable across temp-dir paths). Optionally delays
@@ -323,6 +356,32 @@ async fn missing_folder_settles_gracefully() {
         signals[signals.len() - 1].text,
         TextSignal::Settled { .. }
     ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emit_signals_warns_when_broadcast_has_no_subscribers() {
+    let (handle, rx, _lib_tmp) = make_service().await;
+    drop(rx);
+
+    let logs = capture_warn_logs(|| {
+        emit_signals(
+            &handle.inner,
+            "cand-1",
+            Signals {
+                disc_id: DiscIdSignal::Absent { track_count: 0 },
+                barcode: BarcodeSignal::Absent,
+                text: TextSignal::Settled {
+                    catalogs: Vec::new(),
+                    free_text: Vec::new(),
+                },
+            },
+        );
+    });
+
+    assert!(
+        logs.contains("signals: SignalsUpdated broadcast had no subscribers"),
+        "expected no-subscriber warning, got {logs:?}",
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
`emit_signals` sent `SignalsUpdated` snapshots with `let _ =`, so a closed/no-subscriber broadcast path disappeared without any diagnostic. This now logs the broadcast send error through tracing, matching the identify state broadcast path.

The test installs a scoped tracing subscriber, drops the only receiver, and calls the real `emit_signals` unit so the warning path is covered directly.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core signals::service::tests::emit_signals_warns_when_broadcast_has_no_subscribers --features test-utils` (failed before fix, passes after)
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core signals::service::tests --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- Codex rules review: Spark quota blocked until Jul 6 11:00 PM; `gpt-5.5` local diff review returned zero findings after rerunning one hung slug.
- Pre-commit hook passed.