### PR TITLE
Reject decoder packet send failures

### DIFF
--- a/bae-core/src/audio_codec/decode.rs
+++ b/bae-core/src/audio_codec/decode.rs
@@ -591,7 +591,10 @@ unsafe fn decode_audio_avio(
         av_packet_unref(resources.packet);
 
         if ret < 0 {
-            continue;
+            return Err(format!(
+                "Failed to send packet to decoder: {}",
+                av_err_str(ret)
+            ));
         }
 
         while avcodec_receive_frame(resources.codec_ctx, resources.frame) >= 0 {
@@ -640,7 +643,10 @@ unsafe fn decode_audio_avio(
 
     // Flush decoder — only if we haven't reached end
     if !reached_end {
-        avcodec_send_packet(resources.codec_ctx, ptr::null());
+        let ret = avcodec_send_packet(resources.codec_ctx, ptr::null());
+        if ret < 0 {
+            return Err(format!("Failed to flush decoder: {}", av_err_str(ret)));
+        }
         while avcodec_receive_frame(resources.codec_ctx, resources.frame) >= 0 {
             let frame_samples_vec =
                 convert_frame_to_i32(resources.swr_ctx, resources.frame, channels as usize)?;
@@ -1156,7 +1162,10 @@ unsafe fn decode_audio_streaming_impl(
         av_packet_unref(resources.core().packet);
 
         if ret < 0 {
-            continue;
+            return Err(StreamingDecodeError::decode(format!(
+                "Failed to send packet to decoder: {}",
+                av_err_str(ret)
+            )));
         }
 
         while avcodec_receive_frame(resources.core().codec_ctx, resources.core().frame) >= 0 {
@@ -1223,7 +1232,13 @@ unsafe fn decode_audio_streaming_impl(
 
     // Flush decoder — only if we haven't reached stop_at
     if !reached_stop {
-        avcodec_send_packet(resources.core().codec_ctx, ptr::null());
+        let ret = avcodec_send_packet(resources.core().codec_ctx, ptr::null());
+        if ret < 0 {
+            return Err(StreamingDecodeError::decode(format!(
+                "Failed to flush decoder: {}",
+                av_err_str(ret)
+            )));
+        }
         while avcodec_receive_frame(resources.core().codec_ctx, resources.core().frame) >= 0 {
             if sink.is_cancelled() {
                 break;

--- a/bae-core/src/audio_codec/tests.rs
+++ b/bae-core/src/audio_codec/tests.rs
@@ -66,6 +66,16 @@ fn wav_extensible_pcm(
     wav
 }
 
+fn truncated_flac_packet_stream() -> Vec<u8> {
+    let original_samples: Vec<i32> = (0..44100)
+        .map(|i| ((i as f64 * 0.01).sin() * 0.5 * i32::MAX as f64) as i32)
+        .collect();
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+    let mut flac_data = encode_to_flac(&original_samples, 44100, 1, 16, &cancel).unwrap();
+    flac_data.truncate(flac_data.len() / 2);
+    flac_data
+}
+
 #[test]
 fn decode_audio_decodes_unsigned_8_bit_wav_as_full_range_pcm() {
     init();
@@ -378,6 +388,19 @@ fn test_decode_encode_roundtrip() {
 }
 
 #[test]
+fn decode_audio_rejects_truncated_flac_packet_stream() {
+    init();
+
+    let flac_data = truncated_flac_packet_stream();
+
+    let err = decode_audio(&flac_data, None, None).expect_err("truncated FLAC must fail");
+    assert!(
+        err.contains("Failed to send packet"),
+        "unexpected decode error: {err}"
+    );
+}
+
+#[test]
 fn test_encode_mp3() {
     init();
 
@@ -549,6 +572,35 @@ fn test_streaming_decode_treats_cancelled_input_as_normal_stop() {
     assert_eq!(result, Err(StreamingDecodeError::InputCancelled));
     assert!(!source.producer_finished());
     assert_eq!(source.samples_decoded(), 0);
+}
+
+#[test]
+fn streaming_decode_rejects_truncated_flac_packet_stream() {
+    use crate::playback::create_track_stream_pair_with_capacity;
+    use crate::playback::sparse_buffer::create_sparse_buffer;
+
+    init();
+
+    let flac_data = truncated_flac_packet_stream();
+
+    let buffer = create_sparse_buffer(flac_data.len() as u64);
+    buffer.append_at(0, &flac_data);
+    let (mut sink, source, _ready) = create_track_stream_pair_with_capacity(44100, 1, 100000);
+    let token = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let err = decode_audio_streaming(buffer, &mut sink, None, None, None, None, None, token)
+        .expect_err("truncated FLAC must fail");
+
+    match err {
+        StreamingDecodeError::Decode(message) => {
+            assert!(
+                message.contains("Failed to send packet"),
+                "unexpected decode error: {message}"
+            );
+        }
+        StreamingDecodeError::InputCancelled => panic!("truncation is not cancellation"),
+    }
+    assert!(!source.producer_finished());
 }
 
 /// Helper: test that seek_to via avformat_seek_file produces correct samples.


### PR DESCRIPTION
FFmpeg packet-send failures in both decode loops used to skip the packet and continue, so a truncated stream could return success with partial audio. The decoder now treats those failures, and decoder flush failures, as decode errors instead of producing incomplete output as a successful decode.

Test plan:
- failing before fix: `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core truncated_flac_packet_stream --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core truncated_flac_packet_stream --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core audio_codec::tests --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- pre-commit hook
- Codex rules review: `gpt-5.5`, 42 rules, 0 findings after rerunning the hung `many-fields-none-together-means-a-missing-type` rule