### PR TITLE
Reject unattributed Discogs releases

### DIFF
--- a/bae-core/src/discogs/mod.rs
+++ b/bae-core/src/discogs/mod.rs
@@ -7,11 +7,22 @@ pub use models::*;
 use std::fmt::Display;
 use tracing::debug;
 
-/// Split a Discogs "Artist - Album" title into its trimmed `(artist, album)`
-/// halves. Discogs packs both into one title field separated by " - ". Returns
-/// `None` when there's no separator; callers pick their own fallback.
-pub(crate) fn split_title(title: &str) -> Option<(&str, &str)> {
-    title.split_once(" - ").map(|(a, b)| (a.trim(), b.trim()))
+/// Split a Discogs "Artist - Album" title into trimmed `(artist, album)`
+/// parts. Discogs packs both into one title field separated by " - ". Returns
+/// `None` when there's no separator; an empty artist half is represented as
+/// `None`.
+pub(crate) fn split_title(title: &str) -> Option<(Option<&str>, &str)> {
+    title
+        .split_once(" - ")
+        .map(|(a, b)| (a.trim(), b.trim()))
+        .map(|(artist, album)| {
+            let artist = if artist.is_empty() {
+                None
+            } else {
+                Some(artist)
+            };
+            (artist, album)
+        })
 }
 
 pub(crate) fn remote_cover_from_urls<I>(

--- a/bae-core/src/import/discogs_mapper.rs
+++ b/bae-core/src/import/discogs_mapper.rs
@@ -102,7 +102,15 @@ pub fn map_discogs_to_db(
     let now = clock.now();
     let mut artists = Vec::new();
     if release.artists.is_empty() {
-        let artist_name = extract_artist_name(&release.title);
+        let artist_name = crate::discogs::split_title(&release.title)
+            .and_then(|(artist, _)| artist)
+            .ok_or_else(|| {
+                format!(
+                    "Discogs release {} has no release artist in artists list or title",
+                    release.id
+                )
+            })?
+            .to_string();
         let artist = DbArtist {
             id: ids.new_id(),
             name: artist_name.clone(),
@@ -478,16 +486,6 @@ pub fn parse_side_from_position(position: &str) -> i32 {
     1
 }
 
-/// Extract artist name from album title (fallback when artists array is empty).
-///
-/// Discogs album titles often follow "Artist - Album" format.
-/// Splits on " - " to extract the artist. Falls back to "Unknown Artist".
-fn extract_artist_name(title: &str) -> String {
-    crate::discogs::split_title(title)
-        .map(|(artist, _)| artist.to_string())
-        .unwrap_or_else(|| "Unknown Artist".to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -572,6 +570,36 @@ mod tests {
             extraartists: Some(vec![]),
             master_id: None,
         }
+    }
+
+    #[test]
+    fn release_without_artists_or_title_artist_returns_err() {
+        let mut release = make_release(vec![]);
+        release.artists = vec![];
+        release.title = "Album Title Without Artist".to_string();
+
+        let err = map(&release, Some(2024), None)
+            .expect_err("expected unattributed Discogs release to return an error");
+
+        assert!(
+            err.contains("has no release artist"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn release_without_artists_or_empty_title_artist_returns_err() {
+        let mut release = make_release(vec![]);
+        release.artists = vec![];
+        release.title = " - Album Title".to_string();
+
+        let err = map(&release, Some(2024), None)
+            .expect_err("expected unattributed Discogs release to return an error");
+
+        assert!(
+            err.contains("has no release artist"),
+            "unexpected error message: {err}"
+        );
     }
 
     #[test]

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -127,14 +127,7 @@ pub fn discogs_search_result_to_metadata(
     // Search titles use "Artist - Album"; split once. No separator means the
     // whole title is the album and the artist is unknown.
     let (artist, album) = match crate::discogs::split_title(&r.title) {
-        Some((artist, album)) => {
-            let artist = if artist.is_empty() {
-                None
-            } else {
-                Some(artist.to_string())
-            };
-            (artist, album.to_string())
-        }
+        Some((artist, album)) => (artist.map(str::to_string), album.to_string()),
         None => (None, r.title.clone()),
     };
     let year = r.year.as_ref().and_then(|y| y.parse::<i32>().ok());

--- a/bae-core/tests/alac_fixtures.rs
+++ b/bae-core/tests/alac_fixtures.rs
@@ -13,7 +13,7 @@ use crate::support::{
 use bae_core::audio_codec::{decode_audio, probe_audio_from_path};
 use bae_core::cue_flac::CueFlacProcessor;
 use bae_core::db::Database;
-use bae_core::discogs::models::{DiscogsRelease, DiscogsTrack};
+use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::import::discid::compute_discid_from_categorized;
 use bae_core::import::folder_scanner::{
     collect_release_candidate_files, scan_for_candidates_with_callback, AudioContent, ScanItem,
@@ -58,7 +58,10 @@ fn make_discogs_release(id: &str, title: &str, tracks: &[&str]) -> DiscogsReleas
         cover_image: None,
         thumb: None,
         catno: None,
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: tracks
             .iter()

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -11,7 +11,7 @@ use crate::support::{
     seed_discogs_test_release, test_config_and_keys, tracing_init, wait_for_import_complete,
 };
 use bae_core::db::Database;
-use bae_core::discogs::models::{DiscogsRelease, DiscogsTrack};
+use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::import::{
     IdentityChoice, ImportCommand, ImportService, MetadataRef, MetadataSource, StorageMode,
 };
@@ -66,7 +66,10 @@ fn create_test_discogs_release() -> DiscogsRelease {
         cover_image: None,
         thumb: None,
         catno: None,
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {
@@ -1470,7 +1473,10 @@ async fn assert_multi_disc_cue_ape_per_disc_mapping(storage_mode: StorageMode, p
         cover_image: None,
         thumb: None,
         catno: None,
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: (1..=2)
             .flat_map(|disc| {

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -13,7 +13,7 @@ use crate::support::{
     seed_discogs_test_release, test_config_and_keys, tracing_init, wait_for_import_complete,
 };
 use bae_core::db::Database;
-use bae_core::discogs::models::{DiscogsRelease, DiscogsTrack};
+use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::import::{
     IdentityChoice, ImportCommand, ImportService, MetadataRef, MetadataSource, StorageMode,
 };
@@ -685,7 +685,10 @@ fn create_test_discogs_release() -> DiscogsRelease {
         cover_image: None,
         thumb: None,
         catno: None,
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -233,7 +233,10 @@ fn discogs_release(title: &str, tracks: &[&str]) -> DiscogsRelease {
         cover_image: None,
         thumb: None,
         catno: None,
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: tracks
             .iter()
@@ -1175,7 +1178,10 @@ fn discogs_release_rich(title: &str, master_id: &str, tracks: &[&str]) -> Discog
         cover_image: None,
         thumb: None,
         catno: Some("CAT-001".to_string()),
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: tracks
             .iter()

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -8,7 +8,7 @@
 mod support;
 use crate::support::{seed_discogs_test_release, test_config_and_keys, wait_for_import_complete};
 use bae_core::db::{Database, LibraryImageType};
-use bae_core::discogs::models::{DiscogsRelease, DiscogsTrack};
+use bae_core::discogs::models::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
 use bae_core::import::{
     CoverSelection, IdentityChoice, ImportCommand, ImportProgress, ImportService, MetadataRef,
     MetadataSource, StorageMode,
@@ -537,7 +537,10 @@ fn create_test_discogs_release() -> DiscogsRelease {
         cover_image: None,
         thumb: None,
         catno: None,
-        artists: vec![],
+        artists: vec![DiscogsArtist {
+            id: "discogs-artist-1".to_string(),
+            name: "Artist Name".to_string(),
+        }],
         extraartists: Some(vec![]),
         tracklist: vec![
             DiscogsTrack {


### PR DESCRIPTION
Discogs sometimes omits the release artist list, and search results already represent unsplittable titles as unknown artist. The mapper was still inventing a persisted `Unknown Artist` row for a chosen Discogs release when neither the artist list nor the title supplied an artist. This now rejects that release shape instead of committing a placeholder artist, and the shared Discogs title parser represents an empty artist half as absent.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core release_without_artists_or_title_artist_returns_err --features test-utils` (failed before the fix, passed after)
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core import::discogs_mapper::tests --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core import::search::tests::discogs --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --test alac_fixtures --features test-utils -- --test-threads=1`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --test test_cue_ape --features test-utils -- --test-threads=1`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --test test_cue_flac --features test-utils -- --test-threads=1`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --test test_import_service --features test-utils -- --test-threads=1`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core --test test_storage --features test-utils -- --test-threads=1`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- pre-commit hook
- Codex rules review: full `gpt-5.5` pass found 4 true positives after fixture updates; affected-rule `gpt-5.5` pass after fixes found 0 findings. Spark quota-blocked until 2026-07-06 23:00.