### PR TITLE
Fail embedded cover reads on tag errors

### DIFF
--- a/bae-core/src/identify/discid.rs
+++ b/bae-core/src/identify/discid.rs
@@ -233,48 +233,9 @@ pub async fn lookup_and_resolve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::future::Future;
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex as StdMutex};
+    use crate::test_logs::capture_warn_logs_async;
+    use std::sync::Arc;
     use tempfile::TempDir;
-
-    struct LogWriter {
-        bytes: Arc<StdMutex<Vec<u8>>>,
-    }
-
-    impl Write for LogWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.bytes.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    async fn capture_warn_logs<F, Fut>(run: F) -> String
-    where
-        F: FnOnce() -> Fut,
-        Fut: Future<Output = ()>,
-    {
-        let bytes = Arc::new(StdMutex::new(Vec::new()));
-        let writer_bytes = bytes.clone();
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::WARN)
-            .with_ansi(false)
-            .with_writer(move || LogWriter {
-                bytes: writer_bytes.clone(),
-            })
-            .finish();
-
-        let guard = tracing::subscriber::set_default(subscriber);
-        run().await;
-        drop(guard);
-
-        let bytes = bytes.lock().unwrap().clone();
-        String::from_utf8(bytes).unwrap()
-    }
 
     /// Regression: one categorize yields both the disc ID (from the LOG here)
     /// and the real track count — the pair the service's folder identify reads.
@@ -406,7 +367,7 @@ mod tests {
             .await
             .unwrap();
 
-        let logs = capture_warn_logs(|| async {
+        let logs = capture_warn_logs_async(|| async {
             let (paths, cover_staging) = resolve_release_artwork_paths(&manager, &release.id)
                 .await
                 .unwrap();

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -443,17 +443,33 @@ fn probe_content_type(path: &Path) -> Option<ContentType> {
 /// only feeds the cover pipeline when neither an explicit selection nor a
 /// folder image provides one (the caller enforces that ordering). Prefers
 /// a `PictureType::CoverFront` picture; falls back to the first embedded
-/// picture of any type. Returns `None` when no file carries a picture or
-/// the picture's MIME isn't a supported image type (e.g. lofty's `Tiff`,
-/// which the library doesn't store as a cover) — a missing or unsupported
-/// embedded picture simply means there's nothing to seed.
-pub fn read_embedded_cover(audio_files: &[PathBuf]) -> Option<(Vec<u8>, ContentType)> {
+/// picture of any type. Returns `Ok(None)` when no file carries a picture
+/// or the picture's MIME isn't a supported image type (e.g. lofty's
+/// `Tiff`, which the library doesn't store as a cover) — a missing or
+/// unsupported embedded picture simply means there's nothing to seed.
+/// Returns `Err` when an audio file can't be opened or its tags can't be
+/// read.
+pub fn read_embedded_cover(
+    audio_files: &[PathBuf],
+) -> Result<Option<(Vec<u8>, ContentType)>, String> {
     for path in audio_files {
-        let Ok(probe) = Probe::open(path) else {
-            continue;
+        let probe = match Probe::open(path) {
+            Ok(probe) => probe,
+            Err(e) => {
+                return Err(format!(
+                    "failed to open {} for embedded cover read: {e}",
+                    path.display()
+                ));
+            }
         };
-        let Ok(tagged) = probe.read() else {
-            continue;
+        let tagged = match probe.read() {
+            Ok(tagged) => tagged,
+            Err(e) => {
+                return Err(format!(
+                    "failed to read embedded cover tags from {}: {e}",
+                    path.display()
+                ));
+            }
         };
         let Some(tag) = tagged.primary_tag().or_else(|| tagged.first_tag()) else {
             continue;
@@ -469,13 +485,13 @@ pub fn read_embedded_cover(audio_files: &[PathBuf]) -> Option<(Vec<u8>, ContentT
         };
 
         match picture.mime_type().and_then(image_content_type) {
-            Some(content_type) => return Some((picture.data().to_vec(), content_type)),
+            Some(content_type) => return Ok(Some((picture.data().to_vec(), content_type))),
             // A picture in a MIME type the library can't store as a cover
             // (e.g. TIFF) — skip this file and try the next.
             None => continue,
         }
     }
-    None
+    Ok(None)
 }
 
 /// Map a lofty picture MIME to the library's [`ContentType`], for the
@@ -1328,7 +1344,7 @@ mod tests {
             lofty::picture::MimeType::Jpeg,
             JPEG_BYTES,
         );
-        let (bytes, content_type) = read_embedded_cover(&[f]).expect("cover present");
+        let (bytes, content_type) = read_embedded_cover(&[f]).unwrap().expect("cover present");
         assert_eq!(bytes, JPEG_BYTES);
         assert_eq!(content_type, ContentType::Jpeg);
     }
@@ -1340,7 +1356,7 @@ mod tests {
         let src = fixtures_dir().join("flac").join("01 Test Track 1.flac");
         let dest = temp.path().join("01.flac");
         fs::copy(&src, &dest).unwrap();
-        assert!(read_embedded_cover(&[dest]).is_none());
+        assert!(read_embedded_cover(&[dest]).unwrap().is_none());
     }
 
     /// When a file carries both a back and a front cover, the front cover
@@ -1373,7 +1389,9 @@ mod tests {
         tagged.insert_tag(tag);
         tagged.save_to_path(&dest, WriteOptions::default()).unwrap();
 
-        let (bytes, content_type) = read_embedded_cover(&[dest]).expect("cover present");
+        let (bytes, content_type) = read_embedded_cover(&[dest])
+            .unwrap()
+            .expect("cover present");
         assert_eq!(bytes, JPEG_BYTES, "front cover wins over back");
         assert_eq!(content_type, ContentType::Jpeg);
     }
@@ -1390,7 +1408,38 @@ mod tests {
             lofty::picture::MimeType::Tiff,
             &[0x49, 0x49, 0x2A, 0x00],
         );
-        assert!(read_embedded_cover(&[f]).is_none());
+        assert!(read_embedded_cover(&[f]).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_embedded_cover_returns_err_when_audio_file_cannot_open() {
+        let temp = TempDir::new().unwrap();
+        let missing = temp.path().join("missing.flac");
+
+        let err = read_embedded_cover(std::slice::from_ref(&missing)).unwrap_err();
+
+        assert!(
+            err.contains("failed to open")
+                && err.contains("for embedded cover read")
+                && err.contains(&missing.display().to_string()),
+            "expected embedded-cover open error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn read_embedded_cover_returns_err_when_audio_tags_cannot_be_read() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("test-fixtures")
+            .join("audio-format")
+            .join("placeholder-dsd.dsf");
+
+        let err = read_embedded_cover(std::slice::from_ref(&path)).unwrap_err();
+
+        assert!(
+            err.contains("failed to read embedded cover tags")
+                && err.contains(&path.display().to_string()),
+            "expected embedded-cover tag-read error, got {err:?}"
+        );
     }
 
     #[test]

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -681,7 +681,7 @@ impl ImportService {
                 crate::import::file_tag_mapper::read_embedded_cover(&audio_paths)
             })
             .await
-            .map_err(|e| format!("embedded-cover read task failed: {e}"))?
+            .map_err(|e| format!("embedded-cover read task failed: {e}"))??
         } else {
             None
         };

--- a/bae-core/src/lib.rs
+++ b/bae-core/src/lib.rs
@@ -32,6 +32,8 @@ mod serde_helpers;
 pub mod signals;
 pub mod storage;
 pub mod sync;
+#[cfg(test)]
+pub(crate) mod test_logs;
 pub mod text_encoding;
 pub mod ui;
 pub mod util;

--- a/bae-core/src/signals/service/tests.rs
+++ b/bae-core/src/signals/service/tests.rs
@@ -1,46 +1,14 @@
 use super::*;
 use crate::identify::analyzer::ArtworkAnalyzer;
 use crate::identify::ArtworkAnalysis;
+use crate::test_logs::capture_warn_logs;
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use tempfile::TempDir;
-
-struct LogWriter {
-    bytes: Arc<StdMutex<Vec<u8>>>,
-}
-
-impl Write for LogWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.bytes.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-fn capture_warn_logs(run: impl FnOnce()) -> String {
-    let bytes = Arc::new(StdMutex::new(Vec::new()));
-    let writer_bytes = bytes.clone();
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::WARN)
-        .with_ansi(false)
-        .with_writer(move || LogWriter {
-            bytes: writer_bytes.clone(),
-        })
-        .finish();
-
-    tracing::subscriber::with_default(subscriber, run);
-
-    let bytes = bytes.lock().unwrap().clone();
-    String::from_utf8(bytes).unwrap()
-}
 
 /// Test analyzer: returns canned text lines keyed by filename (not full
 /// path, to stay portable across temp-dir paths). Optionally delays

--- a/bae-core/src/test_logs.rs
+++ b/bae-core/src/test_logs.rs
@@ -1,0 +1,57 @@
+use std::future::Future;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+struct LogWriter {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for LogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn warn_subscriber(bytes: Arc<Mutex<Vec<u8>>>) -> impl tracing::Subscriber + Send + Sync + 'static {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .with_writer(move || LogWriter {
+            bytes: bytes.clone(),
+        })
+        .finish()
+}
+
+fn logs_from(bytes: Arc<Mutex<Vec<u8>>>) -> String {
+    let bytes = bytes.lock().unwrap().clone();
+    String::from_utf8(bytes).unwrap()
+}
+
+pub(crate) fn capture_warn_logs(run: impl FnOnce()) -> String {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = warn_subscriber(bytes.clone());
+
+    tracing::subscriber::with_default(subscriber, run);
+
+    logs_from(bytes)
+}
+
+pub(crate) async fn capture_warn_logs_async<F, Fut>(run: F) -> String
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = warn_subscriber(bytes.clone());
+
+    let guard = tracing::subscriber::set_default(subscriber);
+    run().await;
+    drop(guard);
+
+    logs_from(bytes)
+}


### PR DESCRIPTION
Embedded cover import treated tag probe failures the same as “no embedded picture,” so an Unknown import could continue after failing to inspect an already-selected audio file. This changes embedded cover extraction to return an error for open/read failures while keeping missing pictures and unsupported image MIME types as absence. The warning-log test helper is shared by the remaining tests that still inspect tracing output.

Test plan:
- DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core import::file_tag_mapper::tests --features test-utils
- DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core signals::service::tests::emit_signals_warns_when_broadcast_has_no_subscribers --features test-utils
- DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core identify::discid::tests::resolve_release_artwork_paths_warns_on_missing_registered_image_file --features test-utils
- CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils
- cargo fmt --check
- code-rules-review affected slugs: Spark quota-blocked until July 6, 2026 11:00 PM; gpt-5.5 returned errors=0 findings=0