### PR TITLE
Warn on artist image lookup failures

### DIFF
--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -300,11 +300,16 @@ pub(crate) async fn fetch_artist_images(
         };
 
         // Check if artist already has an image in DB
-        if let Ok(Some(_)) = library_manager
+        match library_manager
             .get_library_image(actual_id, &crate::db::LibraryImageType::Artist)
             .await
         {
-            continue;
+            Ok(Some(_)) => continue,
+            Ok(None) => {}
+            Err(e) => {
+                warn!("failed to check existing artist image for artist {actual_id}: {e}");
+                continue;
+            }
         }
 
         crate::import::artist_image::fetch_and_save_artist_image(

--- a/bae-core/src/import/handle/tests.rs
+++ b/bae-core/src/import/handle/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::db::{Database, DbArtist};
+use crate::test_logs::capture_warn_logs_async;
 use chrono::Utc;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -104,6 +105,43 @@ async fn test_same_name_no_ids_reuses_existing() {
         .unwrap();
 
     assert_eq!(resolved[0], existing.id);
+}
+
+#[tokio::test]
+async fn fetch_artist_images_warns_and_skips_when_existing_image_check_fails() {
+    let (manager, _tmp) = setup_test_manager().await;
+    let database = manager.database_for_test();
+    database
+        .handle()
+        .sql(|sql| {
+            sql.connection().execute("DROP TABLE artist_images", [])?;
+            Ok::<(), coven::CovenError>(())
+        })
+        .await
+        .unwrap();
+
+    let parsed_artist = make_artist("Artist Name", Some("discogs-artist-1"), None);
+    let actual_artist_id = "artist-actual-1".to_string();
+    let artist_id_map = HashMap::from([(parsed_artist.id.clone(), actual_artist_id.clone())]);
+    let discogs_client = DiscogsClient::new("token".to_string());
+
+    let logs = capture_warn_logs_async(|| async {
+        fetch_artist_images(
+            &manager,
+            &discogs_client,
+            std::slice::from_ref(&parsed_artist),
+            &artist_id_map,
+        )
+        .await;
+    })
+    .await;
+
+    assert!(
+        logs.contains("failed to check existing artist image")
+            && logs.contains(&actual_artist_id)
+            && logs.contains("artist_images"),
+        "expected existing artist image check warning, got {logs:?}",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Artist image prefetch checked for an existing image with `if let Ok(Some(_))`, so a database read error fell through to the fetch path. The image fetch is best-effort, but a lookup fault should not cause a refetch or overwrite attempt. This matches the error arm explicitly, logs the failed check with the artist id, and skips that optional image fetch.

Test plan:
- DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core import::handle::tests::fetch_artist_images_warns_and_skips_when_existing_image_check_fails --features test-utils
- DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core import::handle::tests --features test-utils
- CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils
- cargo fmt --check
- code-rules-review affected slugs: Spark quota-blocked until July 6, 2026 11:00 PM; gpt-5.5 returned one no-self-heal finding classified FP because artist images are optional best-effort metadata and the fix prevents refetch/overwrite on DB lookup failure.