### PR TITLE
Fail deletes when cleanup setup fails

### DIFF
--- a/bae-core/src/db/client/album.rs
+++ b/bae-core/src/db/client/album.rs
@@ -385,6 +385,28 @@ impl Database {
             .await
     }
 
+    pub async fn delete_album_with_cleanup(
+        &self,
+        album_id: &str,
+        cleanups: Vec<DeleteCleanupPlan>,
+    ) -> Result<(), DbError> {
+        let album_id = album_id.to_string();
+        self.call_sql(move |sql| {
+            let reg = sql.stamp();
+            let conn = sql.connection();
+            for cleanup in &cleanups {
+                apply_delete_cleanup_on(conn, cleanup, &reg)?;
+            }
+            conn.execute(
+                "UPDATE imports SET release_id = NULL WHERE release_id IN (SELECT id FROM releases WHERE album_id = ?)",
+                params![album_id],
+            )?;
+            conn.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
+            Ok(())
+        })
+        .await
+    }
+
     /// Update album's primary_release_id
     pub async fn set_album_primary_release(
         &self,

--- a/bae-core/src/db/client/blobs.rs
+++ b/bae-core/src/db/client/blobs.rs
@@ -285,21 +285,7 @@ impl Database {
         let cloud_key = cloud_key.to_string();
         self.call_sql(move |sql| {
             let created_at = sql.stamp();
-            let conn = sql.connection();
-            conn.execute(
-                "DELETE FROM cloud_outbox \
-                 WHERE operation IN ('upload', 'cancel') AND cloud_key = ?1",
-                [&cloud_key],
-            )
-            .map_err(DbError::from)?;
-            conn.execute(
-                "INSERT OR IGNORE INTO cloud_outbox \
-                 (operation, cloud_key, scope, created_at) \
-                 VALUES ('delete', ?1, NULL, ?2)",
-                (&cloud_key, &created_at),
-            )
-            .map(|_| ())
-            .map_err(DbError::from)
+            add_cloud_outbox_delete_on(sql.connection(), &cloud_key, &created_at)
         })
         .await
     }

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -64,6 +64,47 @@ fn clear_external_blob_on(conn: &Connection, blob_id: &str) -> Result<(), DbErro
         .map_err(DbError::from)
 }
 
+#[derive(Clone, Debug)]
+pub struct DeleteCleanupPlan {
+    pub cloud_delete_keys: Vec<String>,
+    pub external_blob_ids_to_clear: Vec<String>,
+}
+
+fn add_cloud_outbox_delete_on(
+    conn: &Connection,
+    cloud_key: &str,
+    created_at: &str,
+) -> Result<(), DbError> {
+    conn.execute(
+        "DELETE FROM cloud_outbox \
+         WHERE operation IN ('upload', 'cancel') AND cloud_key = ?1",
+        [cloud_key],
+    )
+    .map_err(DbError::from)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO cloud_outbox \
+         (operation, cloud_key, scope, created_at) \
+         VALUES ('delete', ?1, NULL, ?2)",
+        (cloud_key, created_at),
+    )
+    .map(|_| ())
+    .map_err(DbError::from)
+}
+
+fn apply_delete_cleanup_on(
+    conn: &Connection,
+    cleanup: &DeleteCleanupPlan,
+    created_at: &str,
+) -> Result<(), DbError> {
+    for cloud_key in &cleanup.cloud_delete_keys {
+        add_cloud_outbox_delete_on(conn, cloud_key, created_at)?;
+    }
+    for blob_id in &cleanup.external_blob_ids_to_clear {
+        clear_external_blob_on(conn, blob_id)?;
+    }
+    Ok(())
+}
+
 fn composer_summary_query(filter: Option<&str>, tail: Option<&str>) -> String {
     let release_unlinked = unlinked_release_composer_role_predicate("rar");
     let track_unlinked = unlinked_track_composer_role_predicate("tar");

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -669,6 +669,51 @@ impl Database {
         .await
     }
 
+    pub async fn delete_release_with_cleanup(
+        &self,
+        release_id: &str,
+        album_id: &str,
+        cleanup: DeleteCleanupPlan,
+    ) -> Result<bool, DbError> {
+        let release_id = release_id.to_string();
+        let album_id = album_id.to_string();
+        self.call_sql(move |sql| {
+            let reg = sql.stamp();
+            let conn = sql.connection();
+            apply_delete_cleanup_on(conn, &cleanup, &reg)?;
+            conn.execute(
+                "UPDATE imports SET release_id = NULL WHERE release_id = ?",
+                params![release_id],
+            )?;
+            conn.execute("DELETE FROM releases WHERE id = ?", params![release_id])?;
+
+            let remaining_release_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM releases WHERE album_id = ?",
+                params![album_id],
+                |row| row.get(0),
+            )?;
+            let album_deleted = remaining_release_count == 0;
+            if album_deleted {
+                conn.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
+            } else {
+                let primary_release_id: Option<String> = conn.query_row(
+                    "SELECT primary_release_id FROM albums WHERE id = ?",
+                    params![album_id],
+                    |row| row.get(0),
+                )?;
+                if primary_release_id.as_deref() == Some(&release_id) {
+                    conn.execute(
+                        "UPDATE albums SET primary_release_id = NULL, _updated_at = ? WHERE id = ?",
+                        params![reg, album_id],
+                    )?;
+                }
+            }
+
+            Ok(album_deleted)
+        })
+        .await
+    }
+
     /// Mark an import failed and remove the release it finalized in the same DB
     /// operation. Used when remote import upload setup fails after finalize: the
     /// release was never announced to the library, and its audio files are the

--- a/bae-core/src/db/mod.rs
+++ b/bae-core/src/db/mod.rs
@@ -1,6 +1,6 @@
 mod client;
 mod models;
 mod sort;
-pub use client::Database;
+pub use client::{Database, DeleteCleanupPlan};
 pub use models::*;
 pub use sort::sort_albums;

--- a/bae-core/src/library/manager/album.rs
+++ b/bae-core/src/library/manager/album.rs
@@ -105,16 +105,21 @@ impl LibraryManager {
 
         // Collect track IDs from all releases before deletion for playback cleanup
         let mut all_track_ids = Vec::new();
+        let mut db_cleanups = Vec::new();
+        let mut evict_blobs = Vec::new();
         for release in &releases {
-            if let Ok(tracks) = self.get_tracks(&release.id).await {
-                all_track_ids.extend(tracks.into_iter().map(|t| t.id));
-            }
-            self.queue_release_files_for_deletion(&release.id).await;
-            self.queue_release_cover_for_deletion(&release.id, release.remote)
-                .await;
+            let tracks = self.get_tracks(&release.id).await?;
+            all_track_ids.extend(tracks.into_iter().map(|t| t.id));
+            let delete_plan = self.release_delete_plan(release).await?;
+            db_cleanups.push(delete_plan.db_cleanup);
+            evict_blobs.extend(delete_plan.evict_blobs);
         }
 
-        self.database.delete_album(album_id).await?;
+        self.database
+            .delete_album_with_cleanup(album_id, db_cleanups)
+            .await?;
+        self.emit_outbox_changed().await;
+        self.evict_delete_blobs(evict_blobs).await;
 
         if !all_track_ids.is_empty() {
             self.emit(LibraryEvent::TracksDeleted {

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -41,8 +41,8 @@ use crate::config::CloudProvider;
 use crate::config::ConfigHandle;
 use crate::db::{
     Database, DbAlbum, DbAlbumArtist, DbArtist, DbAudioFormat, DbFile, DbImport, DbLibraryImage,
-    DbRelease, DbTrack, DbTrackArtist, ImportOperationStatus, LibraryImageType, Pressing,
-    SortDirection as DbSortDirection, StorageFilter as DbStorageFilter,
+    DbRelease, DbTrack, DbTrackArtist, DeleteCleanupPlan, ImportOperationStatus, LibraryImageType,
+    Pressing, SortDirection as DbSortDirection, StorageFilter as DbStorageFilter,
     StorageSortCriterion as DbStorageSortCriterion, StorageSortField as DbStorageSortField,
 };
 use crate::keys::BaeKeyServiceExt;
@@ -105,6 +105,11 @@ pub enum LibraryError {
     Encryption(#[from] coven::EncryptionError),
     #[error("Storage error: {0}")]
     Storage(String),
+}
+
+struct ReleaseDeletePlan {
+    db_cleanup: DeleteCleanupPlan,
+    evict_blobs: Vec<coven::BlobRef>,
 }
 
 /// All DB data needed to play or serve a track.
@@ -1235,95 +1240,69 @@ impl LibraryManager {
             .map_err(|e| LibraryError::Storage(format!("cloud key for cover {release_id}: {e}")))
     }
 
-    /// Queue files for a release for deletion (local + cloud).
-    ///
-    /// Skips local releases -- those are the user's original files. For
-    /// remote releases:
-    /// - Queues local file deletion if this device pins them
-    /// - Adds cloud outbox delete entries for each file
-    /// - Cancels any pending uploads for the same files
-    async fn queue_release_files_for_deletion(&self, release_id: &str) {
-        let release = match self.database.find_release_by_id(release_id).await {
-            Ok(Some(r)) => r,
-            _ => return,
-        };
-
-        let files = match self.get_files_for_release(release_id).await {
-            Ok(files) => files,
-            Err(e) => {
-                warn!("Failed to get files for release {}: {}", release_id, e);
-                return;
-            }
-        };
+    /// Build the database cleanup writes and cache blob refs for a release delete
+    /// without mutating durable state. The caller commits `db_cleanup` in the same
+    /// DB transaction as the row deletion, then evicts the cache blobs afterward.
+    async fn release_delete_plan(
+        &self,
+        release: &DbRelease,
+    ) -> Result<ReleaseDeletePlan, LibraryError> {
+        let release_id = &release.id;
+        let files = self.get_files_for_release(release_id).await?;
+        let mut evict_blobs = Vec::new();
+        let mut cloud_delete_keys = Vec::new();
+        let mut external_blob_ids_to_clear = Vec::new();
 
         if release.remote {
-            // Remote: tombstone the cloud blobs and drop coven's cache copies.
-            self.queue_storage_deletions(&files).await;
+            evict_blobs.extend(files.iter().map(Self::release_file_blob_ref));
+            cloud_delete_keys.extend(
+                files
+                    .iter()
+                    .map(|file| self.release_file_cloud_key(file))
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
         } else {
             // Local: the files are the user's own files in place — never delete
-            // them. Just clear coven's external refs so no orphan ref outlives the
-            // release row.
-            for file in &files {
-                if let Err(e) = self.database.clear_external_blob(&file.id).await {
-                    warn!(
-                        "Failed to clear external ref for {} on delete: {e}",
-                        file.id
-                    );
-                }
-            }
+            // them. Just clear coven's external refs in the delete transaction so
+            // no orphan ref outlives the release row.
+            external_blob_ids_to_clear.extend(files.iter().map(|file| file.id.clone()));
         }
-    }
 
-    /// Clean up a release's cover blob when the release is deleted. The `covers`
-    /// row itself is cascade-deleted with the release (its FK to `releases`), and
-    /// that DELETE changeset replicates the removal — and on peers coven's
-    /// apply-side cache drop removes their cover copy. This handles the owner's
-    /// blob bytes: a Remote release's cover is in the cloud + cache (tombstone the
-    /// cloud blob + drop the cache copy), a Local release's cover is in coven's
-    /// local store (drop it). Best-effort: each step logs and continues so a
-    /// cleanup hiccup never aborts the delete.
-    async fn queue_release_cover_for_deletion(&self, release_id: &str, was_remote: bool) {
-        let cover = match self
+        let cover = self
             .database
             .find_library_image(release_id, &LibraryImageType::Cover)
-            .await
-        {
-            Ok(Some(cover)) => cover,
-            // No cover: nothing to clean up.
-            Ok(None) => return,
-            Err(e) => {
-                warn!("Failed to look up cover for release {release_id}: {e}");
-                return;
-            }
-        };
+            .await?;
 
-        if was_remote {
-            // Remote: tombstone the cloud cover blob (its on-device cache copy is
-            // dropped below, alongside the Local case).
-            match self.cover_cloud_key(release_id, cover.cloud_path.as_deref()) {
-                Ok(cloud_key) => {
-                    if let Err(e) = self.database.add_cloud_outbox_delete(&cloud_key).await {
-                        warn!("Failed to enqueue cover blob delete for {release_id}: {e}");
-                    }
-                }
-                Err(e) => warn!("Failed to derive cover blob key for {release_id}: {e}"),
-            }
+        if let Some(cover) = cover.as_ref().filter(|_| release.remote) {
+            cloud_delete_keys.push(self.cover_cloud_key(release_id, cover.cloud_path.as_deref())?);
         }
-        // Drop every on-device copy of the cover blob — a Remote release's cache
-        // copy or a Local release's local-store copy (it lived in at most one).
-        if let Err(e) = self
-            .handle
-            .evict_blob(&Self::image_blob_ref(
+
+        if let Some(cover) = cover {
+            evict_blobs.push(Self::image_blob_ref(
                 crate::sync::COVERS_NAMESPACE,
                 release_id,
                 cover.cloud_path.clone(),
-            ))
-            .await
-        {
-            warn!("Failed to drop on-device cover copies for {release_id}: {e}");
+            ));
         }
 
-        self.emit_outbox_changed().await;
+        Ok(ReleaseDeletePlan {
+            db_cleanup: DeleteCleanupPlan {
+                cloud_delete_keys,
+                external_blob_ids_to_clear,
+            },
+            evict_blobs,
+        })
+    }
+
+    async fn evict_delete_blobs(&self, blobs: Vec<coven::BlobRef>) {
+        for blob in blobs {
+            if let Err(e) = self.handle.evict_blob(&blob).await {
+                warn!(
+                    "Failed to drop on-device copies during deletion for {}/{} ({:?}): {e}",
+                    blob.namespace, blob.id, blob.cloud_path
+                );
+            }
+        }
     }
 }
 

--- a/bae-core/src/library/manager/release.rs
+++ b/bae-core/src/library/manager/release.rs
@@ -731,21 +731,13 @@ impl LibraryManager {
             .map(|t| t.id)
             .collect();
 
-        // Queue files for deferred deletion before removing DB records
-        self.queue_release_files_for_deletion(release_id).await;
-        self.queue_release_cover_for_deletion(release_id, release.remote)
-            .await;
-
-        self.database.delete_release(release_id).await?;
-        let remaining_releases = self.get_releases_for_album(&album_id).await?;
-        let album_deleted = remaining_releases.is_empty();
-        if album_deleted {
-            self.database.delete_album(&album_id).await?;
-        } else if let Some(album) = self.database.find_album_by_id(&album_id).await? {
-            if album.primary_release_id.as_deref() == Some(release_id) {
-                self.database.clear_album_primary_release(&album_id).await?;
-            }
-        }
+        let delete_plan = self.release_delete_plan(&release).await?;
+        let album_deleted = self
+            .database
+            .delete_release_with_cleanup(release_id, &album_id, delete_plan.db_cleanup)
+            .await?;
+        self.emit_outbox_changed().await;
+        self.evict_delete_blobs(delete_plan.evict_blobs).await;
 
         if !track_ids.is_empty() {
             self.emit(LibraryEvent::TracksDeleted { track_ids });

--- a/bae-core/src/library/manager/storage.rs
+++ b/bae-core/src/library/manager/storage.rs
@@ -187,65 +187,6 @@ impl LibraryManager {
         let db_filter = to_db_storage_filter(filter);
         Ok(self.database.get_storage_count(db_filter).await?)
     }
-
-    /// Tombstone every file's cloud blob (cancelling any pending upload first) and
-    /// drop coven's local cache copies, for a Remote release that is being deleted.
-    ///
-    /// SAFETY: the cloud copies are the only ones, so this is only safe when the
-    /// release is genuinely being removed. Its sole caller is
-    /// `queue_release_files_for_deletion` (the delete path); make-Local
-    /// tombstoning is coven's (it enqueues the deletes inside `make_local`'s
-    /// atomic commit). `files` are precomputed by the caller, so the cloud keys are
-    /// correct.
-    pub(crate) async fn queue_storage_deletions(&self, files: &[DbFile]) {
-        // Queue cloud outbox deletes and cancel pending uploads. The delete key
-        // must match the key the blob was uploaded under, derived through coven
-        // for the home's scheme (the row's readable `cloud_path` on a browsable
-        // home, the hashed-by-id default on an opaque one).
-        for file in files {
-            let cloud_key = match self.release_file_cloud_key(file) {
-                Ok(key) => key,
-                Err(e) => {
-                    warn!("Failed to derive delete key for {}: {e}", file.id);
-                    continue;
-                }
-            };
-
-            // Cancel any pending upload for this file
-            if let Err(e) = self
-                .database
-                .remove_cloud_outbox_uploads_for_key(&cloud_key)
-                .await
-            {
-                warn!("Failed to cancel outbox upload for {}: {e}", cloud_key);
-            }
-
-            // Queue cloud delete
-            if let Err(e) = self.database.add_cloud_outbox_delete(&cloud_key).await {
-                warn!("Failed to add outbox delete for {}: {e}", cloud_key);
-            }
-        }
-
-        // Drop coven's local cache copies (both pinned and evictable folders) so a
-        // deleted release leaks nothing on disk. The release is Remote here, so its
-        // blobs are cache copies, not external refs. Dropping the on-device cache
-        // for a deleted blob is bae's delete-path responsibility. Best-effort: each
-        // drop logs and continues so a cleanup hiccup never aborts the delete.
-        for file in files {
-            if let Err(e) = self
-                .handle
-                .evict_blob(&Self::release_file_blob_ref(file))
-                .await
-            {
-                warn!(
-                    "Failed to drop on-device copies of {} during deletion: {e}",
-                    file.id
-                );
-            }
-        }
-
-        self.emit_outbox_changed().await;
-    }
 }
 
 /// Translate a UI-facing `StorageSort` to the DB-layer sort criterion.

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::config::Config;
-use crate::db::{DbAlbum, DbLibraryImage, DbRelease, DbTrackWork, DbWork, LibraryImageType};
+use crate::db::{
+    DbAlbum, DbFile, DbLibraryImage, DbRelease, DbTrackWork, DbWork, LibraryImageType,
+};
 use crate::import::MetadataSource;
 #[cfg(feature = "test-utils")]
 use crate::sync::CloudCipher;
@@ -59,6 +61,40 @@ async fn setup_test_manager_with_library_id(library_id: &str) -> (LibraryManager
         tokio::runtime::Handle::current(),
     );
     (manager, temp_dir)
+}
+
+async fn rename_table_for_test(manager: &LibraryManager, from: &str, to: &str) {
+    let statement = format!("ALTER TABLE {from} RENAME TO {to}");
+    manager
+        .database
+        .handle()
+        .sql(move |sql| {
+            sql.connection().execute(&statement, [])?;
+            Ok::<(), coven::CovenError>(())
+        })
+        .await
+        .unwrap();
+}
+
+async fn store_test_cover_image(manager: &LibraryManager, release_id: &str) {
+    manager
+        .store_library_image_blob(
+            &DbLibraryImage {
+                id: release_id.to_string(),
+                image_type: LibraryImageType::Cover,
+                content_type: crate::util::content_type::ContentType::Jpeg,
+                file_size: 5,
+                width: None,
+                height: None,
+                source: "local".to_string(),
+                source_url: None,
+                cloud_path: None,
+                created_at: manager.clock.now(),
+            },
+            b"image",
+        )
+        .await
+        .unwrap();
 }
 
 async fn setup_forget_library_manager(library_id: &str, home: &std::path::Path) -> LibraryManager {
@@ -499,10 +535,191 @@ async fn delete_release_tombstones_remote_cloud_blobs() {
     );
 }
 
+#[tokio::test]
+async fn delete_release_fails_before_rows_are_deleted_when_file_cleanup_lookup_fails() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+
+    let file = DbFile::new(
+        &release.id,
+        "track1.flac",
+        5,
+        crate::util::content_type::ContentType::Flac,
+        Uuid::new_v4().to_string(),
+        Utc::now(),
+    );
+    manager.add_file(&file).await.unwrap();
+
+    rename_table_for_test(&manager, "release_files", "release_files_unavailable").await;
+
+    let error = manager.delete_release(&release.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_release_by_id(&release.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn delete_release_fails_before_rows_are_deleted_when_file_tombstone_enqueue_fails() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+
+    let file = DbFile::new(
+        &release.id,
+        "track1.flac",
+        5,
+        crate::util::content_type::ContentType::Flac,
+        Uuid::new_v4().to_string(),
+        Utc::now(),
+    );
+    manager.add_file(&file).await.unwrap();
+
+    rename_table_for_test(&manager, "cloud_outbox", "cloud_outbox_unavailable").await;
+
+    let error = manager.delete_release(&release.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_release_by_id(&release.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn delete_release_fails_before_rows_are_deleted_when_local_external_ref_cleanup_fails() {
+    let (manager, temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+    manager
+        .database
+        .set_remote_for_test(&release.id, false)
+        .await
+        .unwrap();
+
+    let file = DbFile::new(
+        &release.id,
+        "track1.flac",
+        5,
+        crate::util::content_type::ContentType::Flac,
+        Uuid::new_v4().to_string(),
+        Utc::now(),
+    );
+    manager.add_file(&file).await.unwrap();
+    manager
+        .database
+        .register_release_external_refs_for_test(&release.id, temp_dir.path().to_str().unwrap())
+        .await
+        .unwrap();
+
+    rename_table_for_test(&manager, "local_blob_refs", "local_blob_refs_unavailable").await;
+
+    let error = manager.delete_release(&release.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_release_by_id(&release.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn delete_album_fails_before_rows_are_deleted_when_track_lookup_fails() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+
+    rename_table_for_test(&manager, "tracks", "tracks_unavailable").await;
+
+    let error = manager.delete_album(&album.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_album_by_id(&album.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn delete_album_fails_before_rows_are_deleted_when_file_cleanup_lookup_fails() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+
+    rename_table_for_test(&manager, "release_files", "release_files_unavailable").await;
+
+    let error = manager.delete_album(&album.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_album_by_id(&album.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn delete_release_fails_before_rows_are_deleted_when_cover_lookup_fails() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+    store_test_cover_image(&manager, &release.id).await;
+
+    rename_table_for_test(&manager, "covers", "covers_unavailable").await;
+
+    let error = manager.delete_release(&release.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_release_by_id(&release.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn delete_release_fails_before_rows_are_deleted_when_cover_tombstone_enqueue_fails() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+    store_test_cover_image(&manager, &release.id).await;
+
+    rename_table_for_test(&manager, "cloud_outbox", "cloud_outbox_unavailable").await;
+
+    let error = manager.delete_release(&release.id).await.unwrap_err();
+    assert!(matches!(error, LibraryError::Database(_)));
+    assert!(manager
+        .database
+        .find_release_by_id(&release.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
 /// Deleting a release cascade-deletes its `covers` row (the FK on `covers.id`
-/// to `releases`), and `queue_release_cover_for_deletion` cleans up the cover
-/// blob: a Remote release's cover is tombstoned in the cloud and dropped from
-/// the cache.
+/// to `releases`), and the delete path cleans up the cover blob: a Remote
+/// release's cover is tombstoned in the cloud and dropped from the cache.
 #[tokio::test]
 async fn delete_release_removes_its_cover_image() {
     let (mut manager, _temp_dir) = setup_test_manager().await;


### PR DESCRIPTION
Release and album deletion used to write cleanup state one step at a time before the database delete. A lookup or enqueue failure could be hidden, or a later delete failure could leave cleanup rows pointing at still-live releases.

This moves release-file, local-ref, and cover tombstone cleanup writes into the same database operation that removes the release or album rows. The manager now builds the cleanup plan first, commits it with the delete, and only evicts local cache copies after the durable state has committed.

Test plan:
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core library::manager::tests --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `cargo fmt --check`
- affected rules review with Codex `gpt-5.5` after Spark quota block