### PR TITLE
Reject playback info when album rows are missing

### DIFF
--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -1,3 +1,4 @@
+use super::track::playback_info_from_track_release;
 use super::*;
 use crate::config::Config;
 use crate::db::{
@@ -673,6 +674,39 @@ async fn delete_album_fails_before_rows_are_deleted_when_file_cleanup_lookup_fai
         .await
         .unwrap()
         .is_some());
+}
+
+#[tokio::test]
+async fn playback_info_from_track_release_rejects_missing_album() {
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let album = create_test_album();
+    let release = create_test_release(&album.id);
+    let track = crate::db::DbTrack::new_test(&release.id, "track-a", "Track Title", Some(1));
+    let track_artist = crate::db::DbTrackArtist::new(
+        &track.id,
+        "test-artist-id",
+        0,
+        Uuid::new_v4().to_string(),
+        Utc::now(),
+    );
+    manager.database.insert_album(&album).await.unwrap();
+    manager.database.insert_release(&release).await.unwrap();
+    manager.database.insert_track(&track).await.unwrap();
+    manager
+        .database
+        .insert_track_artist(&track_artist)
+        .await
+        .unwrap();
+
+    let mut broken_release = release.clone();
+    broken_release.album_id = "missing-album".to_string();
+
+    let error = playback_info_from_track_release(&manager.database, &track, &broken_release)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, LibraryError::TrackMapping(message) if message.contains("missing-album"))
+    );
 }
 
 #[tokio::test]

--- a/bae-core/src/library/manager/track.rs
+++ b/bae-core/src/library/manager/track.rs
@@ -166,11 +166,10 @@ pub(crate) async fn playback_info_from_track_release(
     let album_title = match database.find_album_by_id(&album_id).await? {
         Some(album) => album.title,
         None => {
-            warn!(
-                "Album not found for track {} (album_id {})",
+            return Err(LibraryError::TrackMapping(format!(
+                "album not found for track {} album {}",
                 track.id, album_id
-            );
-            String::new()
+            )));
         }
     };
 


### PR DESCRIPTION
Track playback metadata previously replaced a missing album row with an empty album title. That lets playback prep continue with malformed `PlaybackTrackInfo` when the release row points at an album that cannot be loaded.

This makes the mapping fail with `LibraryError::TrackMapping` instead, so the corrupt relationship is surfaced at the point where playback metadata is built. The regression test covers the production helper that created the substituted value; the manager-level path cannot seed this state through the test database because the album foreign key is enforced.

Test plan:
- `cargo fmt --check`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core library::manager::tests::playback_info_from_track_release_rejects_missing_album --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core library::manager::tests --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `git diff --check`

Rules review:
- Codex Spark attempted, quota-blocked until July 6, 2026 11:00 PM.
- `gpt-5.5` affected-rule rerun: four rules clean; `test-the-real-unit-not-a-reconstruction` repeated the known non-blocking finding and is classified FP because the tested unit is the production helper where the invalid empty title was produced, while the public DB path cannot create the broken FK state in this harness.