### PR TITLE
Warn on MusicBrainz release-group fetch failures

### DIFF
--- a/bae-core/src/musicbrainz/mod.rs
+++ b/bae-core/src/musicbrainz/mod.rs
@@ -314,13 +314,11 @@ pub async fn lookup_release_by_id(
                     rg_id
                 );
 
-                if let Ok(rg_response) = fetch_release_group_with_relations(rg_id).await {
-                    extract_urls_from_relations(&rg_response.relations, &mut external_urls);
-
-                    if let Some(resource) = &external_urls.discogs_release_url {
-                        info!("Found Discogs release URL on release-group: {}", resource);
-                    }
-                }
+                merge_release_group_external_urls(
+                    rg_id,
+                    fetch_release_group_with_relations(rg_id).await,
+                    &mut external_urls,
+                );
             }
         }
     }
@@ -329,6 +327,25 @@ pub async fn lookup_release_by_id(
     RELEASE_CACHE.put(release_id, value.clone());
 
     Ok(value)
+}
+
+fn merge_release_group_external_urls(
+    rg_id: &str,
+    result: Result<ReleaseGroupResponse, MusicBrainzError>,
+    external_urls: &mut ExternalUrls,
+) {
+    match result {
+        Ok(rg_response) => {
+            extract_urls_from_relations(&rg_response.relations, external_urls);
+
+            if let Some(resource) = &external_urls.discogs_release_url {
+                info!("Found Discogs release URL on release-group: {}", resource);
+            }
+        }
+        Err(e) => {
+            warn!("Failed to fetch MusicBrainz release-group {rg_id}: {e}");
+        }
+    }
 }
 
 /// Fetch a release-group by ID, returning the raw JSON for metadata storage.

--- a/bae-core/src/musicbrainz/tests.rs
+++ b/bae-core/src/musicbrainz/tests.rs
@@ -260,6 +260,23 @@ fn empty_external_urls() -> ExternalUrls {
     }
 }
 
+#[test]
+fn release_group_fallback_error_is_logged_with_group_id() {
+    let mut urls = empty_external_urls();
+
+    let logs = crate::test_logs::capture_warn_logs(|| {
+        merge_release_group_external_urls(
+            "rg-error",
+            Err(MusicBrainzError::Other("transient fetch".to_string())),
+            &mut urls,
+        );
+    });
+
+    assert!(logs.contains("rg-error"));
+    assert!(logs.contains("transient fetch"));
+    assert!(urls.discogs_release_url.is_none());
+}
+
 #[tokio::test]
 async fn test_fetch_mb_xref_with_backlink_returns_response_and_metadata() {
     let discogs_id = "fetch-mb-xref-hit-1";


### PR DESCRIPTION
When a MusicBrainz release lacks inline release-group relations, `lookup_release_by_id` fetches the release-group relations separately so it can discover a Discogs release URL. That fallback fetch previously dropped errors through `if let Ok(...)`, so a transient provider or parse failure looked the same as a release group with no Discogs relation.

This keeps the successful merge behavior and logs the release-group id plus error on the failure branch. The regression covers the production result handler directly, avoiding a network-dependent test while exercising the exact branch that was masking the error.

Test plan:
- Confirmed failing before the fix: `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core musicbrainz::tests::release_group_fallback_error_is_logged_with_group_id --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core musicbrainz::tests::release_group_fallback_error_is_logged_with_group_id --features test-utils`
- `DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo test -p bae-core musicbrainz::tests --features test-utils`
- `CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= cargo check -p bae-core --features test-utils`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook: fmt, clippy lib/tests for bae-core, clippy bae-bridge, loc-gen

Rules review:
- Codex Spark attempted, quota-blocked until July 6, 2026 11:00 PM.
- `gpt-5.5` affected-rule rerun: zero findings.