### PR TITLE
Align CUE unknown preview with commit

### DIFF
--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -24,6 +24,7 @@ use super::{album_artist_links, find_or_push_artist, ParsedAlbum, ParsedWorkGrap
 use crate::cue_flac::CueSheet;
 use crate::db::ReleaseMetadataSource;
 use crate::db::{DbAlbum, DbArtist, DbRelease, DbTrack, DbTrackArtist};
+use crate::import::folder_scanner::{AudioContent, CategorizedFiles};
 use crate::util::content_type::ContentType;
 use coven::Clock;
 use coven::IdProvider;
@@ -179,6 +180,35 @@ pub fn map_file_tags_to_db(
         clock,
         ids,
     ))
+}
+
+/// Map an Unknown import candidate to the metadata seed used by preview and
+/// commit. CUE-backed candidates take track layout and names from the parsed
+/// CUE; per-track-file candidates take them from embedded file tags.
+pub fn map_unknown_candidate_to_db(
+    categorized: &CategorizedFiles,
+    folder_name: Option<&str>,
+    clock: &dyn Clock,
+    ids: &dyn IdProvider,
+) -> Result<ParsedAlbum, String> {
+    match &categorized.audio {
+        AudioContent::CueFlacPairs { pairs, .. } => {
+            let mut sorted = pairs.iter().collect::<Vec<_>>();
+            sorted.sort_by(|a, b| {
+                natord::compare(&a.cue_file.relative_path, &b.cue_file.relative_path)
+            });
+            let sheets = sorted.iter().map(|p| &p.cue_sheet).collect::<Vec<_>>();
+            let audio = sorted
+                .iter()
+                .map(|p| p.audio_file.path.as_path())
+                .collect::<Vec<_>>();
+            map_cue_sheets_to_db(&sheets, &audio, folder_name, clock, ids)
+        }
+        AudioContent::TrackFiles { tracks, .. } => {
+            let audio_files = tracks.iter().map(|f| f.path.clone()).collect::<Vec<_>>();
+            map_file_tags_to_db(&audio_files, folder_name, clock, ids)
+        }
+    }
 }
 
 /// One track's source-agnostic seed. Produced from embedded file tags

--- a/bae-core/src/import/handle/import.rs
+++ b/bae-core/src/import/handle/import.rs
@@ -1,16 +1,17 @@
 use super::*;
 
 impl ImportServiceHandle {
-    /// Project the embedded tags of a folder's audio files into a
+    /// Project an Unknown import candidate into a
     /// `ReleaseUserEdit` shape so the edit-metadata form can seed itself
-    /// from what's on disk. Used by the "Add as Unknown" affordance:
-    /// the user clicks the link, the UI calls this to preview, then
-    /// shows the editor for verification before commit.
+    /// from what's on disk. CUE-backed candidates use the parsed CUE track
+    /// layout; per-track-file candidates use embedded tags. Used by the
+    /// "Add as Unknown" affordance: the user clicks the link, the UI calls this
+    /// to preview, then shows the editor for verification before commit.
     ///
-    /// The commit-side worker re-reads tags from the same files at
-    /// commit time, so the user's edits — applied via the
-    /// `user_edit` overlay on the import command — are the source of
-    /// truth for fields they touched. This preview is the seed only.
+    /// The commit-side worker re-scans the same folder and runs the same
+    /// Unknown mapper at commit time, so the user's edits — applied via the
+    /// `user_edit` overlay on the import command — are the source of truth for
+    /// fields they touched. This preview is the seed only.
     pub async fn preview_file_tags_for_folder(
         &self,
         folder: std::path::PathBuf,
@@ -28,16 +29,11 @@ impl ImportServiceHandle {
         .await
         .map_err(|e| format!("folder scan task failed: {e}"))??;
 
-        let audio_paths = categorized_audio_paths(&categorized);
-        if audio_paths.is_empty() {
-            return Err("folder contains no audio files".to_string());
-        }
-
         let clock = self.library_manager.clock().clone();
         let ids = self.library_manager.ids().clone();
         tokio::task::spawn_blocking(move || {
-            let parsed = crate::import::file_tag_mapper::map_file_tags_to_db(
-                &audio_paths,
+            let parsed = crate::import::file_tag_mapper::map_unknown_candidate_to_db(
+                &categorized,
                 folder_name.as_deref(),
                 clock.as_ref(),
                 ids.as_ref(),
@@ -45,16 +41,17 @@ impl ImportServiceHandle {
             Ok(parsed_album_to_user_edit(&parsed))
         })
         .await
-        .map_err(|e| format!("file-tag projection task failed: {e}"))?
+        .map_err(|e| format!("unknown preview projection task failed: {e}"))?
     }
 
     /// Build an import command and enqueue it. For Exact / Approximate
     /// the worker calls `prepare_release` itself to fetch and map the
     /// release — reading from the same LRU caches the UI's prefetch
-    /// warmed up. For Unknown the worker reads embedded tags from the
-    /// candidate's audio files instead. Remote cover bytes are not
-    /// threaded through the command; `download_cover_art_bytes`
-    /// consults the URL cache when the worker writes the cover.
+    /// warmed up. For Unknown the worker reads the candidate's local evidence:
+    /// CUE sheets for CUE-backed candidates, embedded tags for per-track-file
+    /// candidates. Remote cover bytes are not threaded through the command;
+    /// `download_cover_art_bytes` consults the URL cache when the worker writes
+    /// the cover.
     ///
     /// `identity_choice` carries both the user's claim shape and the
     /// release reference (when applicable): Exact preserves the

--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -324,7 +324,7 @@ pub(crate) async fn fetch_artist_images(
 
 /// Project a parsed album (mapper output) into the editor's
 /// `ReleaseUserEdit` shape. Used by the Unknown preview path so the
-/// edit-metadata form can seed itself from the file-tag projection
+/// edit-metadata form can seed itself from the local-evidence projection
 /// without going through a wire-shape `ImportSearchReleaseDetail` that
 /// would require a synthetic release id. Also used by the reset-to-source
 /// path to project cached source data back into the editor.
@@ -484,7 +484,8 @@ pub fn shape_user_edit_from_search_detail(
 /// audio file from each pair (the CUE itself carries no embedded
 /// tags); per-track releases yield each track in scan order.
 ///
-/// Used by the Unknown import path to feed `map_file_tags_to_db`.
+/// Used by the Unknown import path to read embedded cover art from the backing
+/// audio files.
 pub fn categorized_audio_paths(
     categorized: &crate::import::folder_scanner::CategorizedFiles,
 ) -> Vec<std::path::PathBuf> {

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -438,11 +438,11 @@ impl ImportService {
     /// For Exact / Approximate calls `prepare_release` to fetch and map
     /// the release — this hits the network LRU caches that the UI's
     /// prefetch warmed, so the normal case is a cache hit. For Unknown
-    /// reads embedded tags via `map_file_tags_to_db` from the
-    /// candidate's audio files instead. Either way: walks the folder
-    /// to discover files, then runs track mapping, storage, and the
-    /// atomic DB transaction. Remote cover bytes are pulled through
-    /// `download_cover_art_bytes`, which has its own LRU cache.
+    /// reads the candidate's local evidence through
+    /// `map_unknown_candidate_to_db`. Either way: walks the folder to discover
+    /// files, then runs track mapping, storage, and the atomic DB transaction.
+    /// Remote cover bytes are pulled through `download_cover_art_bytes`, which
+    /// has its own LRU cache.
     async fn prepare_and_run_folder_import(
         &self,
         import_id: String,
@@ -491,9 +491,9 @@ impl ImportService {
         );
 
         // Source the parsed album. Exact / Approximate fetch from
-        // MB / Discogs; Unknown reads embedded tags. The UI's prefetch
-        // warmed the network LRU cache for the source-release path,
-        // so that case is a cache-hit; cold cache costs one round-trip.
+        // MB / Discogs; Unknown maps local evidence from the scan. The UI's
+        // prefetch warmed the network LRU cache for the source-release path, so
+        // that case is a cache-hit; cold cache costs one round-trip.
         let (parsed, metadata_pairs) = match &identity_choice {
             crate::import::IdentityChoice::Exact { release_ref }
             | crate::import::IdentityChoice::Approximate { release_ref } => {
@@ -507,56 +507,17 @@ impl ImportService {
                     .map(|s| s.to_string());
                 let clock = library_manager.clock().clone();
                 let ids = library_manager.ids().clone();
-                // Track structure for a CUE image comes from the CUE, not the
-                // single audio file: one DbTrack per CUE TRACK, titles from the
-                // sheet. Per-track rips seed one DbTrack per file. Both feed the
-                // same assembly in file_tag_mapper.
-                let parsed = match &categorized.audio {
-                    crate::import::folder_scanner::AudioContent::CueFlacPairs { pairs, .. } => {
-                        // Sort pairs the same way `map_tracks_to_files` slices
-                        // them so seed order lines up, then hand the parsed
-                        // sheets + audio paths to the blocking task.
-                        let mut sorted: Vec<&crate::import::folder_scanner::ScannedCueFlacPair> =
-                            pairs.iter().collect();
-                        sorted.sort_by(|a, b| {
-                            natord::compare(&a.cue_file.relative_path, &b.cue_file.relative_path)
-                        });
-                        let mut owned: Vec<(crate::cue_flac::CueSheet, PathBuf)> =
-                            Vec::with_capacity(sorted.len());
-                        for p in sorted {
-                            owned.push((p.cue_sheet.clone(), p.audio_file.path.clone()));
-                        }
-                        tokio::task::spawn_blocking(move || {
-                            let sheets: Vec<&crate::cue_flac::CueSheet> =
-                                owned.iter().map(|(s, _)| s).collect();
-                            let audio: Vec<&Path> =
-                                owned.iter().map(|(_, p)| p.as_path()).collect();
-                            crate::import::file_tag_mapper::map_cue_sheets_to_db(
-                                &sheets,
-                                &audio,
-                                folder_name.as_deref(),
-                                clock.as_ref(),
-                                ids.as_ref(),
-                            )
-                        })
-                        .await
-                        .map_err(|e| format!("cue-seed mapping task failed: {e}"))??
-                    }
-                    crate::import::folder_scanner::AudioContent::TrackFiles { .. } => {
-                        let audio_paths =
-                            crate::import::handle::categorized_audio_paths(&categorized);
-                        tokio::task::spawn_blocking(move || {
-                            crate::import::file_tag_mapper::map_file_tags_to_db(
-                                &audio_paths,
-                                folder_name.as_deref(),
-                                clock.as_ref(),
-                                ids.as_ref(),
-                            )
-                        })
-                        .await
-                        .map_err(|e| format!("file-tag mapping task failed: {e}"))??
-                    }
-                };
+                let categorized_for_seed = categorized.clone();
+                let parsed = tokio::task::spawn_blocking(move || {
+                    crate::import::file_tag_mapper::map_unknown_candidate_to_db(
+                        &categorized_for_seed,
+                        folder_name.as_deref(),
+                        clock.as_ref(),
+                        ids.as_ref(),
+                    )
+                })
+                .await
+                .map_err(|e| format!("unknown-seed mapping task failed: {e}"))??;
                 (parsed, Vec::new())
             }
         };

--- a/bae-core/src/import/service/reconcile.rs
+++ b/bae-core/src/import/service/reconcile.rs
@@ -22,7 +22,7 @@ impl ImportService {
     /// Input is the already-mapped `ParsedAlbum` plus the raw metadata
     /// pairs (empty for Unknown). The caller chooses the mapper based
     /// on identity choice — `prepare_release` for Exact / Approximate,
-    /// `map_file_tags_to_db` for Unknown. This function does pure DB
+    /// `map_unknown_candidate_to_db` for Unknown. This function does pure DB
     /// work and string remapping, no network.
     ///
     /// Applies the user's `identity_choice` post-process on top of the
@@ -48,7 +48,7 @@ impl ImportService {
     /// `metadata_source_release_id` are kept pointing at the picked
     /// release — the release records which source release seeded it
     /// regardless of identity claim. For Unknown those columns
-    /// already arrive set by `map_file_tags_to_db`.
+    /// already arrive set by the Unknown mapper.
     ///
     /// `user_edit` is an optional overlay from the confirmation-page
     /// editor. Applied after the choice transformation so the user's

--- a/bae-core/src/import/types.rs
+++ b/bae-core/src/import/types.rs
@@ -632,8 +632,8 @@ pub struct DiscoveredFile {
 ///
 /// `identity_choice` carries both the user's claim shape and the
 /// release reference (when applicable). For Unknown, the worker
-/// sources the release shape by reading embedded tags from the
-/// candidate's audio files via `map_file_tags_to_db`.
+/// sources the release shape from the scanned candidate: CUE sheets for
+/// CUE-backed candidates, embedded tags for per-track-file candidates.
 ///
 /// `user_edit` is an optional overlay from the confirmation-page
 /// editor. When present, fields override the seeded metadata after the

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -85,6 +85,13 @@ fn generate_album_files(dir: &Path, filenames: &[&str]) {
     }
 }
 
+fn copy_cue_flac_fixture(dir: &Path) {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cue_flac");
+    for name in ["Test Album.cue", "Test Album.flac"] {
+        fs::copy(fixture.join(name), dir.join(name)).expect("copy CUE fixture");
+    }
+}
+
 /// Per-track tag values for `generate_tagged_album_files` — covers the
 /// fields the file-tag projection reads at import time. `track_artist`
 /// empty rolls up to the album artist in the editor's convention.
@@ -1817,6 +1824,103 @@ async fn unknown_import_seeds_from_file_tags_and_writes_no_identity() {
     assert_eq!(tracks.len(), 2);
     assert_eq!(tracks[0].title, "Track One");
     assert_eq!(tracks[1].title, "Track Two");
+}
+
+#[tokio::test]
+#[serial]
+async fn unknown_preview_for_cue_matches_unknown_commit_layout() {
+    support::tracing_init();
+
+    let f = ImportFixture::new().await;
+    let album_dir = f.temp_path().join("cue-album");
+    fs::create_dir_all(&album_dir).unwrap();
+    copy_cue_flac_fixture(&album_dir);
+
+    let preview = f
+        .handle
+        .preview_file_tags_for_folder(album_dir.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(preview.album_title, "Test Album");
+    assert_eq!(preview.album_artist_names, vec!["Test Artist".to_string()]);
+    assert_eq!(preview.pressing.year, None);
+    assert_eq!(preview.pressing.format.as_deref(), Some("FLAC"));
+
+    let preview_tracks: Vec<(String, Vec<String>)> = preview
+        .tracks
+        .iter()
+        .map(|t| (t.title.clone(), t.artist_names.clone()))
+        .collect();
+    assert_eq!(
+        preview_tracks,
+        vec![
+            (
+                "Track One (Silence)".to_string(),
+                vec!["Test Artist".to_string()],
+            ),
+            (
+                "Track Two (White Noise)".to_string(),
+                vec!["Test Artist".to_string()],
+            ),
+            (
+                "Track Three (Brown Noise)".to_string(),
+                vec!["Test Artist".to_string()],
+            ),
+        ],
+    );
+
+    let import_id = uuid::Uuid::new_v4().to_string();
+    f.handle
+        .send_command(ImportCommand {
+            import_id: import_id.clone(),
+            candidate_key: "cue".to_string(),
+            folder: album_dir,
+            selected_cover: None,
+            storage_mode: StorageMode::Local,
+            pin: false,
+            identity_choice: IdentityChoice::Unknown,
+            user_edit: None,
+        })
+        .unwrap();
+
+    let mut progress_rx = f.handle.subscribe_import(import_id);
+    let (release_id, album_id) = support::wait_for_import_complete(&mut progress_rx).await;
+    let album = f.db.find_album_by_id(&album_id).await.unwrap().unwrap();
+    assert_eq!(preview.album_title, album.title);
+
+    let release = f.db.find_release_by_id(&release_id).await.unwrap().unwrap();
+    assert_eq!(preview.pressing.year, release.pressing.year);
+    assert_eq!(preview.pressing.format, release.pressing.format);
+
+    let album_detail =
+        f.db.find_album_detail(&album_id)
+            .await
+            .unwrap()
+            .expect("album detail");
+    let committed_album_artist_names: Vec<String> = album_detail
+        .artists
+        .iter()
+        .map(|a| a.name.clone())
+        .collect();
+    assert_eq!(preview.album_artist_names, committed_album_artist_names);
+
+    let release_detail =
+        f.db.find_release_detail(&release_id)
+            .await
+            .unwrap()
+            .expect("release detail");
+    let committed_tracks: Vec<(String, Vec<String>)> = release_detail
+        .tracks
+        .iter()
+        .map(|track| {
+            (
+                track.track.title.clone(),
+                track.artists.iter().map(|a| a.name.clone()).collect(),
+            )
+        })
+        .collect();
+    assert_eq!(preview_tracks, committed_tracks);
 }
 
 /// A tagged rip whose only artwork is embedded in the audio (no folder


### PR DESCRIPTION
Unknown import preview and commit were reading different local evidence for CUE-backed folders: preview projected the embedded tags from the single audio image, while commit used the parsed CUE sheet. This PR gives both paths the same Unknown candidate mapper, so the edit preview shows the same track layout and titles that commit seeds.

Fixes #282

Test plan:
- cargo test -p bae-core --features bae-core/test-utils --test test_import_service unknown_preview_for_cue_matches_unknown_commit_layout -- --nocapture
- cargo test -p bae-core --features bae-core/test-utils --test test_import_service
- cargo test -p bae-core --features bae-core/test-utils import::file_tag_mapper
- cargo fmt --all --check
- cargo clippy -p bae-core --lib -- -D warnings -A unexpected_cfgs -A deprecated
- cargo clippy -p bae-core --tests --features bae-core/test-utils -- -D warnings -A unexpected_cfgs -A deprecated
- cargo clippy -p bae-bridge -- -D warnings -A unexpected_cfgs -A deprecated
- cargo run -q -p bae-loc --bin loc-gen -- check

Note: `cargo test -p bae-core` currently fails at `audio_codec::tests::test_encode_opus_ogg` because the bundled FFmpeg build lacks the `libopus` encoder; the focused import tests above pass.