### PR TITLE
Add configurable release export images

### DIFF
--- a/bae-bridge/src/bridge_utils.rs
+++ b/bae-bridge/src/bridge_utils.rs
@@ -138,6 +138,9 @@ pub(crate) fn bridge_export_pregap_placement(
             BridgeExportPregapPlacement::AppendToPreviousIncludingHtoa
         }
         bae_core::config::ExportPregapPlacement::Exclude => BridgeExportPregapPlacement::Exclude,
+        bae_core::config::ExportPregapPlacement::SingleFileWithCue => {
+            BridgeExportPregapPlacement::SingleFileWithCue
+        }
     }
 }
 
@@ -152,6 +155,9 @@ pub(crate) fn core_export_pregap_placement(
             bae_core::config::ExportPregapPlacement::AppendToPreviousIncludingHtoa
         }
         BridgeExportPregapPlacement::Exclude => bae_core::config::ExportPregapPlacement::Exclude,
+        BridgeExportPregapPlacement::SingleFileWithCue => {
+            bae_core::config::ExportPregapPlacement::SingleFileWithCue
+        }
     }
 }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -2583,6 +2583,7 @@ pub enum BridgeExportPregapPlacement {
     AppendToPreviousExceptHtoa,
     AppendToPreviousIncludingHtoa,
     Exclude,
+    SingleFileWithCue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]

--- a/bae-core/src/config.rs
+++ b/bae-core/src/config.rs
@@ -322,6 +322,13 @@ impl ExportPresetCodec {
             Self::Aiff { .. } => "aiff",
         }
     }
+
+    pub fn supports_single_file_cue(&self) -> bool {
+        match self {
+            Self::OpusOgg { .. } => false,
+            Self::Flac { .. } | Self::Mp3 { .. } | Self::Wav { .. } | Self::Aiff { .. } => true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -329,6 +336,7 @@ pub enum ExportPregapPlacement {
     AppendToPreviousExceptHtoa,
     AppendToPreviousIncludingHtoa,
     Exclude,
+    SingleFileWithCue,
 }
 
 fn default_export_pregap_placement() -> ExportPregapPlacement {
@@ -372,6 +380,22 @@ impl ExportPreset {
         if !self.applies_to_track && !self.applies_to_release {
             return Err(ConfigError::Config(format!(
                 "export preset {} does not apply to any export level",
+                self.id
+            )));
+        }
+        if self.pregap_placement == ExportPregapPlacement::SingleFileWithCue
+            && self.applies_to_track
+        {
+            return Err(ConfigError::Config(format!(
+                "export preset {} uses single-file CUE and cannot apply to track export",
+                self.id
+            )));
+        }
+        if self.pregap_placement == ExportPregapPlacement::SingleFileWithCue
+            && !self.codec.supports_single_file_cue()
+        {
+            return Err(ConfigError::Config(format!(
+                "export preset {} uses single-file CUE with an unsupported codec",
                 self.id
             )));
         }
@@ -1296,6 +1320,48 @@ mod tests {
             config.default_release_export_selection,
             default_export_selection()
         );
+    }
+
+    #[test]
+    fn single_file_cue_preset_is_release_only() {
+        let preset = ExportPreset {
+            id: "flac-image".to_string(),
+            name: "FLAC image".to_string(),
+            codec: ExportPresetCodec::Flac {
+                bit_depth: ExportBitDepth::Source,
+            },
+            filename_template: default_export_filename_template(),
+            metadata: default_export_metadata(),
+            pregap_placement: ExportPregapPlacement::SingleFileWithCue,
+            applies_to_track: true,
+            applies_to_release: true,
+        };
+
+        let err = preset
+            .validate()
+            .expect_err("single-file CUE cannot be a track export preset");
+        assert!(err.to_string().contains("cannot apply to track export"));
+
+        let release_only = ExportPreset {
+            applies_to_track: false,
+            ..preset
+        };
+        release_only.validate().unwrap();
+
+        let opus_image = ExportPreset {
+            id: "opus-image".to_string(),
+            name: "Opus image".to_string(),
+            codec: ExportPresetCodec::OpusOgg { bitrate_kbps: 192 },
+            filename_template: default_export_filename_template(),
+            metadata: default_export_metadata(),
+            pregap_placement: ExportPregapPlacement::SingleFileWithCue,
+            applies_to_track: false,
+            applies_to_release: true,
+        };
+        let err = opus_image
+            .validate()
+            .expect_err("single-file CUE requires a CUE-compatible codec");
+        assert!(err.to_string().contains("unsupported codec"));
     }
 
     #[test]

--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -2,8 +2,9 @@ use crate::library::manager::ExportTrackPlan;
 use crate::playback::{DecodedPcm, PlaybackError};
 use crate::util::content_type::ContentType;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Render a single-track export's suggested filename stem (no extension) from a
 /// template and the track's tag data. Supported tokens:
@@ -101,7 +102,7 @@ pub fn render_export_filename(
 /// space, trim leading/trailing spaces and dashes, then strip a leading '.' so
 /// the file isn't hidden. Replacing the separators is also what makes a `../`
 /// escape impossible.
-fn sanitize_filename_stem(input: &str) -> String {
+pub(crate) fn sanitize_filename_stem(input: &str) -> String {
     let replaced: String = input
         .chars()
         .map(|c| {
@@ -122,23 +123,55 @@ fn sanitize_filename_stem(input: &str) -> String {
 /// Export service for exporting individual tracks.
 pub struct ExportService;
 
+struct CancelOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+struct OutputPathsGuard {
+    paths: Vec<std::path::PathBuf>,
+    committed: bool,
+}
+
+impl OutputPathsGuard {
+    fn new(paths: Vec<std::path::PathBuf>) -> Self {
+        Self {
+            paths,
+            committed: false,
+        }
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for OutputPathsGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        for path in &self.paths {
+            if let Err(error) = std::fs::remove_file(path) {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    warn!(
+                        path = %path.display(),
+                        "failed to remove incomplete export output: {error}"
+                    );
+                }
+            }
+        }
+    }
+}
+
 impl ExportService {
     pub async fn export_original_track(
         mut plan: ExportTrackPlan,
         output_path: &Path,
     ) -> Result<(), String> {
-        struct OutputFileGuard {
-            path: std::path::PathBuf,
-            committed: bool,
-        }
-        impl Drop for OutputFileGuard {
-            fn drop(&mut self) {
-                if !self.committed {
-                    let _ = std::fs::remove_file(&self.path);
-                }
-            }
-        }
-
         let format = &plan.audio_meta.audio_format;
         let is_whole_source = format.start_sample == 0
             && format.end_sample.is_none()
@@ -148,13 +181,10 @@ impl ExportService {
         if is_whole_source {
             let audio_bytes = std::mem::take(&mut plan.audio_bytes);
             tokio::task::spawn_blocking(move || -> Result<(), String> {
-                let mut output_guard = OutputFileGuard {
-                    path: output_path_owned.clone(),
-                    committed: false,
-                };
+                let mut output_guard = OutputPathsGuard::new(vec![output_path_owned.clone()]);
                 std::fs::write(&output_path_owned, &audio_bytes)
                     .map_err(|e| format!("Failed to write original track file: {e}"))?;
-                output_guard.committed = true;
+                output_guard.commit();
                 Ok(())
             })
             .await
@@ -197,34 +227,204 @@ impl ExportService {
         Self::export_track_with_codec(plan, output_path, preset.codec, preset.metadata).await
     }
 
+    pub async fn export_release_image_with_cue(
+        mut plans: Vec<ExportTrackPlan>,
+        output_audio_path: &Path,
+        output_cue_path: &Path,
+        catalog: Option<String>,
+        preset: crate::config::ExportPreset,
+    ) -> Result<(), String> {
+        if plans.is_empty() {
+            return Err("release image export requires at least one track".to_string());
+        }
+        if plans.len() > 99 {
+            return Err("CUE sheets support at most 99 audio tracks".to_string());
+        }
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let _cancel_guard = CancelOnDrop(Arc::clone(&cancel));
+        let mut combined_samples = Vec::new();
+        let mut cue_tracks = Vec::with_capacity(plans.len());
+        let mut sample_rate = None;
+        let mut channels = None;
+        let source_bits_per_sample = plans[0].audio_meta.audio_format.bits_per_sample;
+        let release_title = plans[0].tags.album.clone();
+        let release_performer = plans[0].tags.artist.clone();
+        let cover_image_bytes = plans[0].cover_image_bytes.clone();
+        let is_digital = plans[0].is_digital;
+        let mut current_sample_frame = 0u64;
+
+        for (index, plan) in plans.iter_mut().enumerate() {
+            let pregap_sample_frames = plan
+                .audio_window
+                .leading_silence_samples
+                .checked_add(non_negative_samples(
+                    plan.audio_meta.audio_format.pregap_samples,
+                )?)
+                .ok_or_else(|| "CUE pregap sample count overflow".to_string())?;
+            let decoded_pcm = load_track_audio(plan).await.map_err(|e| e.to_string())?;
+            match (sample_rate, channels) {
+                (None, None) => {
+                    sample_rate = Some(decoded_pcm.sample_rate());
+                    channels = Some(decoded_pcm.channels());
+                }
+                (Some(rate), Some(channel_count))
+                    if rate == decoded_pcm.sample_rate()
+                        && channel_count == decoded_pcm.channels() => {}
+                _ => {
+                    return Err(format!(
+                        "release image export requires matching PCM shape; track {} is {}Hz/{}ch",
+                        plan.audio_meta.track.id,
+                        decoded_pcm.sample_rate(),
+                        decoded_pcm.channels()
+                    ));
+                }
+            }
+
+            let channel_count = usize::try_from(decoded_pcm.channels())
+                .map_err(|_| "channel count exceeds addressable memory".to_string())?;
+            if channel_count == 0 {
+                return Err("decoded audio has zero channels".to_string());
+            }
+            if decoded_pcm.raw_samples().len() % channel_count != 0 {
+                return Err(format!(
+                    "decoded sample count is not divisible by channel count for track {}",
+                    plan.audio_meta.track.id
+                ));
+            }
+            let segment_sample_frames =
+                u64::try_from(decoded_pcm.raw_samples().len() / channel_count)
+                    .map_err(|_| "decoded sample count exceeds CUE addressable range")?;
+            if pregap_sample_frames > segment_sample_frames {
+                return Err(format!(
+                    "track {} pregap exceeds decoded segment length",
+                    plan.audio_meta.track.id
+                ));
+            }
+
+            cue_tracks.push(CueTrack {
+                number: u8::try_from(index + 1)
+                    .map_err(|_| "CUE track number exceeds 99".to_string())?,
+                title: plan.tags.title.clone(),
+                performer: plan.tags.artist.clone(),
+                index_00_sample_frame: (pregap_sample_frames > 0).then_some(current_sample_frame),
+                index_01_sample_frame: current_sample_frame
+                    .checked_add(pregap_sample_frames)
+                    .ok_or_else(|| "CUE index sample count overflow".to_string())?,
+            });
+            current_sample_frame = current_sample_frame
+                .checked_add(segment_sample_frames)
+                .ok_or_else(|| "release image sample count overflow".to_string())?;
+            combined_samples.extend_from_slice(decoded_pcm.raw_samples());
+        }
+
+        let sample_rate =
+            sample_rate.ok_or_else(|| "release image export requires audio".to_string())?;
+        if sample_rate == 0 {
+            return Err("release image export requires a non-zero sample rate".to_string());
+        }
+        let channels = channels.ok_or_else(|| "release image export requires audio".to_string())?;
+        let audio_filename = output_audio_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                format!(
+                    "audio image path has no UTF-8 filename: {}",
+                    output_audio_path.display()
+                )
+            })?
+            .to_string();
+        let cue = render_cue_sheet(
+            &release_title,
+            &release_performer,
+            catalog
+                .as_deref()
+                .map(str::trim)
+                .filter(|catalog| !catalog.is_empty()),
+            plans[0].tags.year,
+            &audio_filename,
+            cue_file_type(&preset.codec)?,
+            sample_rate,
+            &cue_tracks,
+        );
+
+        let decoded_pcm = DecodedPcm::new(combined_samples, sample_rate, channels);
+        let output_audio_path_owned = output_audio_path.to_path_buf();
+        let output_cue_path_owned = output_cue_path.to_path_buf();
+        let cancel_for_blocking = Arc::clone(&cancel);
+        let codec = preset.codec;
+        let mut image_metadata = preset.metadata;
+        image_metadata.track_number = false;
+        image_metadata.disc_number = false;
+        let tags = crate::library::manager::ExportTags {
+            title: release_title.clone(),
+            artist: release_performer,
+            album: release_title,
+            year: plans[0].tags.year,
+            disc: None,
+        };
+        let total_tracks = plans.len() as u32;
+
+        tokio::task::spawn_blocking(move || -> Result<(), String> {
+            let mut output_guard = OutputPathsGuard::new(vec![
+                output_audio_path_owned.clone(),
+                output_cue_path_owned.clone(),
+            ]);
+            let (encoded_data, tag_type) = encode_pcm_with_codec(
+                &decoded_pcm,
+                &codec,
+                source_bits_per_sample,
+                &cancel_for_blocking,
+            )?;
+
+            if cancel_for_blocking.load(Ordering::Relaxed) {
+                return Err("export cancelled".to_string());
+            }
+
+            std::fs::write(&output_audio_path_owned, &encoded_data)
+                .map_err(|e| format!("Failed to write release image: {e}"))?;
+
+            if cancel_for_blocking.load(Ordering::Relaxed) {
+                return Err("export cancelled".to_string());
+            }
+
+            std::fs::write(&output_cue_path_owned, cue)
+                .map_err(|e| format!("Failed to write CUE sheet: {e}"))?;
+
+            if cancel_for_blocking.load(Ordering::Relaxed) {
+                return Err("export cancelled".to_string());
+            }
+
+            write_tags(
+                &output_audio_path_owned,
+                tag_type,
+                &tags,
+                None,
+                total_tracks,
+                is_digital,
+                cover_image_bytes.as_deref(),
+                &image_metadata,
+            )?;
+
+            if cancel_for_blocking.load(Ordering::Relaxed) {
+                return Err("export cancelled".to_string());
+            }
+
+            output_guard.commit();
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("encode task join error: {e}"))??;
+
+        Ok(())
+    }
+
     async fn export_track_with_codec(
         mut plan: ExportTrackPlan,
         output_path: &Path,
         codec: crate::config::ExportPresetCodec,
         metadata: crate::config::ExportMetadata,
     ) -> Result<(), String> {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
-
-        struct CancelOnDrop(Arc<AtomicBool>);
-        impl Drop for CancelOnDrop {
-            fn drop(&mut self) {
-                self.0.store(true, Ordering::Relaxed);
-            }
-        }
-
-        struct OutputFileGuard {
-            path: std::path::PathBuf,
-            committed: bool,
-        }
-        impl Drop for OutputFileGuard {
-            fn drop(&mut self) {
-                if !self.committed {
-                    let _ = std::fs::remove_file(&self.path);
-                }
-            }
-        }
-
         let track_id = plan.audio_meta.track.id.clone();
         info!("Exporting track {} to {}", track_id, output_path.display());
 
@@ -238,63 +438,14 @@ impl ExportService {
         let output_path_owned = output_path.to_path_buf();
         let cancel_for_blocking = Arc::clone(&cancel);
         let encoded_len = tokio::task::spawn_blocking(move || -> Result<usize, String> {
-            let mut output_guard = OutputFileGuard {
-                path: output_path_owned.clone(),
-                committed: false,
-            };
+            let mut output_guard = OutputPathsGuard::new(vec![output_path_owned.clone()]);
 
-            let encoded_data = match codec {
-                crate::config::ExportPresetCodec::Flac { bit_depth } => {
-                    crate::audio_codec::encode_to_flac(
-                        decoded_pcm.raw_samples(),
-                        decoded_pcm.sample_rate(),
-                        decoded_pcm.channels(),
-                        bit_depth.resolve(plan.audio_meta.audio_format.bits_per_sample),
-                        &cancel_for_blocking,
-                    )
-                    .map_err(|e| format!("Failed to encode FLAC: {e}"))?
-                }
-                crate::config::ExportPresetCodec::Mp3 { bitrate_kbps } => {
-                    crate::audio_codec::encode_to_mp3_with_bitrate(
-                        decoded_pcm.raw_samples(),
-                        decoded_pcm.sample_rate(),
-                        decoded_pcm.channels(),
-                        bitrate_kbps,
-                        &cancel_for_blocking,
-                    )
-                    .map_err(|e| format!("Failed to encode MP3: {e}"))?
-                }
-                crate::config::ExportPresetCodec::OpusOgg { bitrate_kbps } => {
-                    crate::audio_codec::encode_to_opus_ogg(
-                        decoded_pcm.raw_samples(),
-                        decoded_pcm.sample_rate(),
-                        decoded_pcm.channels(),
-                        bitrate_kbps,
-                        &cancel_for_blocking,
-                    )
-                    .map_err(|e| format!("Failed to encode Opus/Ogg: {e}"))?
-                }
-                crate::config::ExportPresetCodec::Wav { bit_depth } => {
-                    crate::audio_codec::encode_to_wav(
-                        decoded_pcm.raw_samples(),
-                        decoded_pcm.sample_rate(),
-                        decoded_pcm.channels(),
-                        bit_depth.resolve(plan.audio_meta.audio_format.bits_per_sample),
-                        &cancel_for_blocking,
-                    )
-                    .map_err(|e| format!("Failed to encode WAV: {e}"))?
-                }
-                crate::config::ExportPresetCodec::Aiff { bit_depth } => {
-                    crate::audio_codec::encode_to_aiff(
-                        decoded_pcm.raw_samples(),
-                        decoded_pcm.sample_rate(),
-                        decoded_pcm.channels(),
-                        bit_depth.resolve(plan.audio_meta.audio_format.bits_per_sample),
-                        &cancel_for_blocking,
-                    )
-                    .map_err(|e| format!("Failed to encode AIFF: {e}"))?
-                }
-            };
+            let (encoded_data, tag_type) = encode_pcm_with_codec(
+                &decoded_pcm,
+                &codec,
+                plan.audio_meta.audio_format.bits_per_sample,
+                &cancel_for_blocking,
+            )?;
 
             // Cancel check at every blocking boundary. Each fs::write /
             // write_tags call can run for a while on slow disks; checking
@@ -313,18 +464,6 @@ impl ExportService {
 
             let cover_data = plan.cover_image_bytes.as_deref();
 
-            let tag_type = match codec {
-                crate::config::ExportPresetCodec::Flac { .. } => {
-                    lofty::tag::TagType::VorbisComments
-                }
-                crate::config::ExportPresetCodec::Mp3 { .. } => lofty::tag::TagType::Id3v2,
-                crate::config::ExportPresetCodec::OpusOgg { .. } => {
-                    lofty::tag::TagType::VorbisComments
-                }
-                crate::config::ExportPresetCodec::Wav { .. } => lofty::tag::TagType::RiffInfo,
-                crate::config::ExportPresetCodec::Aiff { .. } => lofty::tag::TagType::AiffText,
-            };
-
             write_tags(
                 &output_path_owned,
                 tag_type,
@@ -340,7 +479,7 @@ impl ExportService {
                 return Err("export cancelled".to_string());
             }
 
-            output_guard.committed = true;
+            output_guard.commit();
             Ok(encoded_data.len())
         })
         .await
@@ -351,6 +490,171 @@ impl ExportService {
             track_id, encoded_len
         );
         Ok(())
+    }
+}
+
+fn encode_pcm_with_codec(
+    decoded_pcm: &DecodedPcm,
+    codec: &crate::config::ExportPresetCodec,
+    source_bits_per_sample: Option<i64>,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> Result<(Vec<u8>, lofty::tag::TagType), String> {
+    let encoded_data = match codec {
+        crate::config::ExportPresetCodec::Flac { bit_depth } => crate::audio_codec::encode_to_flac(
+            decoded_pcm.raw_samples(),
+            decoded_pcm.sample_rate(),
+            decoded_pcm.channels(),
+            bit_depth.resolve(source_bits_per_sample),
+            cancel,
+        )
+        .map_err(|e| format!("Failed to encode FLAC: {e}"))?,
+        crate::config::ExportPresetCodec::Mp3 { bitrate_kbps } => {
+            crate::audio_codec::encode_to_mp3_with_bitrate(
+                decoded_pcm.raw_samples(),
+                decoded_pcm.sample_rate(),
+                decoded_pcm.channels(),
+                *bitrate_kbps,
+                cancel,
+            )
+            .map_err(|e| format!("Failed to encode MP3: {e}"))?
+        }
+        crate::config::ExportPresetCodec::OpusOgg { bitrate_kbps } => {
+            crate::audio_codec::encode_to_opus_ogg(
+                decoded_pcm.raw_samples(),
+                decoded_pcm.sample_rate(),
+                decoded_pcm.channels(),
+                *bitrate_kbps,
+                cancel,
+            )
+            .map_err(|e| format!("Failed to encode Opus/Ogg: {e}"))?
+        }
+        crate::config::ExportPresetCodec::Wav { bit_depth } => crate::audio_codec::encode_to_wav(
+            decoded_pcm.raw_samples(),
+            decoded_pcm.sample_rate(),
+            decoded_pcm.channels(),
+            bit_depth.resolve(source_bits_per_sample),
+            cancel,
+        )
+        .map_err(|e| format!("Failed to encode WAV: {e}"))?,
+        crate::config::ExportPresetCodec::Aiff { bit_depth } => crate::audio_codec::encode_to_aiff(
+            decoded_pcm.raw_samples(),
+            decoded_pcm.sample_rate(),
+            decoded_pcm.channels(),
+            bit_depth.resolve(source_bits_per_sample),
+            cancel,
+        )
+        .map_err(|e| format!("Failed to encode AIFF: {e}"))?,
+    };
+
+    let tag_type = match codec {
+        crate::config::ExportPresetCodec::Flac { .. } => lofty::tag::TagType::VorbisComments,
+        crate::config::ExportPresetCodec::Mp3 { .. } => lofty::tag::TagType::Id3v2,
+        crate::config::ExportPresetCodec::OpusOgg { .. } => lofty::tag::TagType::VorbisComments,
+        crate::config::ExportPresetCodec::Wav { .. } => lofty::tag::TagType::RiffInfo,
+        crate::config::ExportPresetCodec::Aiff { .. } => lofty::tag::TagType::AiffText,
+    };
+
+    Ok((encoded_data, tag_type))
+}
+
+struct CueTrack {
+    number: u8,
+    title: String,
+    performer: String,
+    index_00_sample_frame: Option<u64>,
+    index_01_sample_frame: u64,
+}
+
+fn render_cue_sheet(
+    release_title: &str,
+    release_performer: &str,
+    catalog: Option<&str>,
+    year: Option<i32>,
+    audio_filename: &str,
+    cue_file_type: &'static str,
+    sample_rate: u32,
+    tracks: &[CueTrack],
+) -> String {
+    let mut cue = String::new();
+    if let Some(catalog) = catalog {
+        cue.push_str(&format!("CATALOG {}\n", catalog));
+    }
+    if let Some(year) = year {
+        cue.push_str(&format!("REM DATE {year}\n"));
+    }
+    cue.push_str(&format!(
+        "PERFORMER \"{}\"\n",
+        cue_string(release_performer)
+    ));
+    cue.push_str(&format!("TITLE \"{}\"\n", cue_string(release_title)));
+    cue.push_str(&format!(
+        "FILE \"{}\" {}\n",
+        cue_string(audio_filename),
+        cue_file_type
+    ));
+    for track in tracks {
+        cue.push_str(&format!("  TRACK {:02} AUDIO\n", track.number));
+        cue.push_str(&format!("    TITLE \"{}\"\n", cue_string(&track.title)));
+        cue.push_str(&format!(
+            "    PERFORMER \"{}\"\n",
+            cue_string(&track.performer)
+        ));
+        if let Some(index_00) = track.index_00_sample_frame {
+            cue.push_str(&format!(
+                "    INDEX 00 {}\n",
+                cue_time(index_00, sample_rate)
+            ));
+        }
+        cue.push_str(&format!(
+            "    INDEX 01 {}\n",
+            cue_time(track.index_01_sample_frame, sample_rate)
+        ));
+    }
+    cue
+}
+
+fn cue_file_type(codec: &crate::config::ExportPresetCodec) -> Result<&'static str, String> {
+    match codec {
+        crate::config::ExportPresetCodec::Mp3 { .. } => Ok("MP3"),
+        crate::config::ExportPresetCodec::Aiff { .. } => Ok("AIFF"),
+        crate::config::ExportPresetCodec::Flac { .. }
+        | crate::config::ExportPresetCodec::Wav { .. } => Ok("WAVE"),
+        crate::config::ExportPresetCodec::OpusOgg { .. } => Err(
+            "single-file CUE export does not support Opus/Ogg because CUE has no Opus/Ogg file type"
+                .to_string(),
+        ),
+    }
+}
+
+fn cue_time(sample_frame: u64, sample_rate: u32) -> String {
+    let cue_frames = sample_frame.saturating_mul(75) / u64::from(sample_rate);
+    let minutes = cue_frames / (75 * 60);
+    let seconds = (cue_frames / 75) % 60;
+    let frames = cue_frames % 75;
+    format!("{minutes:02}:{seconds:02}:{frames:02}")
+}
+
+fn cue_string(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_control() {
+                ' '
+            } else if c == '"' {
+                '\''
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+fn non_negative_samples(samples: Option<i64>) -> Result<u64, String> {
+    match samples {
+        Some(sample) => {
+            u64::try_from(sample).map_err(|_| "audio pregap sample count is negative".to_string())
+        }
+        None => Ok(0),
     }
 }
 
@@ -600,6 +904,66 @@ mod tests {
             render_export_filename("{track_number}", &r),
             "Fallback Title"
         );
+    }
+
+    #[test]
+    fn release_image_cue_places_indexes_from_track_windows() {
+        let cue = render_cue_sheet(
+            "Album Title",
+            "Artist Name",
+            None,
+            None,
+            "Album.flac",
+            "WAVE",
+            44_100,
+            &[
+                CueTrack {
+                    number: 1,
+                    title: "Opening".to_string(),
+                    performer: "Artist Name".to_string(),
+                    index_00_sample_frame: Some(0),
+                    index_01_sample_frame: 44_100 * 2,
+                },
+                CueTrack {
+                    number: 2,
+                    title: "Second".to_string(),
+                    performer: "Artist Name".to_string(),
+                    index_00_sample_frame: Some(44_100 * 10),
+                    index_01_sample_frame: 44_100 * 12,
+                },
+            ],
+        );
+
+        assert!(cue.contains("FILE \"Album.flac\" WAVE"));
+        assert!(cue.contains("  TRACK 01 AUDIO\n"));
+        assert!(cue.contains("    INDEX 00 00:00:00\n"));
+        assert!(cue.contains("    INDEX 01 00:02:00\n"));
+        assert!(cue.contains("  TRACK 02 AUDIO\n"));
+        assert!(cue.contains("    INDEX 00 00:10:00\n"));
+        assert!(cue.contains("    INDEX 01 00:12:00\n"));
+    }
+
+    #[test]
+    fn release_image_cue_writes_catalog_and_date() {
+        let cue = render_cue_sheet(
+            "Album Title",
+            "Artist Name",
+            Some("0123456789012"),
+            Some(2024),
+            "Album.flac",
+            "WAVE",
+            44_100,
+            &[CueTrack {
+                number: 1,
+                title: "Opening".to_string(),
+                performer: "Artist Name".to_string(),
+                index_00_sample_frame: None,
+                index_01_sample_frame: 0,
+            }],
+        );
+
+        assert!(cue.contains("CATALOG 0123456789012\n"));
+        assert!(cue.contains("REM DATE 2024\n"));
     }
 
     /// Exercises the real `write_tags` against an encoded FLAC: a selection that

--- a/bae-core/src/library/manager/config.rs
+++ b/bae-core/src/library/manager/config.rs
@@ -85,14 +85,20 @@ impl LibraryManager {
                 )));
             }
         }
-        let config = self.config_handle.config();
+        let (default_track_export_selection, default_release_export_selection) = {
+            let config = self.config_handle.config();
+            (
+                config.default_track_export_selection.clone(),
+                config.default_release_export_selection.clone(),
+            )
+        };
         Self::validate_export_selection_against_presets(
-            &config.default_track_export_selection,
+            &default_track_export_selection,
             &presets,
             true,
         )?;
         Self::validate_export_selection_against_presets(
-            &config.default_release_export_selection,
+            &default_release_export_selection,
             &presets,
             false,
         )?;

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -213,11 +213,16 @@ impl LibraryManager {
         )?;
 
         let files = self.database.get_files_for_release(release_id).await?;
+        let selection_kind = match &request.selection {
+            crate::config::ExportSelection::Original => "original",
+            crate::config::ExportSelection::Preset { .. } => "preset",
+        };
         info!(
             release_id,
             folder = folder.as_str(),
             file_count = files.len(),
-            "Exporting release files verbatim"
+            selection = selection_kind,
+            "Exporting release"
         );
 
         match request.selection {
@@ -226,8 +231,7 @@ impl LibraryManager {
                 for (index, file) in files.iter().enumerate() {
                     self.export_one_file(file, staging.path()).await?;
                     let percent = (((index + 1) * 100) / total.max(1)) as u8;
-                    self.export_queue.set_active_percent(release_id, percent);
-                    self.emit_export_queue_changed();
+                    self.set_export_progress(release_id, percent);
                 }
             }
             crate::config::ExportSelection::Preset { preset_id } => {
@@ -236,14 +240,7 @@ impl LibraryManager {
             }
         }
 
-        // Every file landed. Re-export replaces any prior copy: remove the existing
-        // final dir immediately before the rename. This leaves an unavoidable window
-        // where the final path is briefly absent, kept minimal by doing all the slow
-        // work (cloud reads, writes) into staging first so only the rename remains.
-        if final_dir.exists() {
-            std::fs::remove_dir_all(&final_dir)?;
-        }
-        std::fs::rename(staging.path(), &final_dir)?;
+        replace_export_dir(staging.path(), &final_dir, &folder, release_id)?;
         staging.disarm();
         Ok(())
     }
@@ -528,6 +525,12 @@ impl LibraryManager {
             })?;
         let tracks = self.database.get_tracks_for_release(release_id).await?;
         let total = tracks.len();
+        if preset.pregap_placement == crate::config::ExportPregapPlacement::SingleFileWithCue {
+            self.export_release_image_with_cue_to_dir(release_id, preset, &tracks, staging_dir)
+                .await?;
+            self.set_export_progress(release_id, 100);
+            return Ok(());
+        }
         let mut used_paths = std::collections::HashSet::new();
 
         for (index, track) in tracks.iter().enumerate() {
@@ -559,11 +562,64 @@ impl LibraryManager {
                 .await
                 .map_err(LibraryError::Import)?;
             let percent = (((index + 1) * 100) / total.max(1)) as u8;
-            self.export_queue.set_active_percent(release_id, percent);
-            self.emit_export_queue_changed();
+            self.set_export_progress(release_id, percent);
         }
 
         Ok(())
+    }
+
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    fn set_export_progress(&self, release_id: &str, percent: u8) {
+        if self.export_queue.contains(release_id) {
+            self.export_queue.set_active_percent(release_id, percent);
+            self.emit_export_queue_changed();
+        }
+    }
+
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    async fn export_release_image_with_cue_to_dir(
+        &self,
+        release_id: &str,
+        preset: crate::config::ExportPreset,
+        tracks: &[DbTrack],
+        staging_dir: &std::path::Path,
+    ) -> Result<(), LibraryError> {
+        let mut plans = Vec::with_capacity(tracks.len());
+        for track in tracks {
+            let mut plan = self.get_export_track_plan(&track.id).await?;
+            plan.metadata = preset.metadata;
+            plan.audio_window =
+                export_window_for_single_file_cue_audio_format(&plan.audio_meta.audio_format);
+            plans.push(plan);
+        }
+
+        let release = self
+            .get_release_by_id(release_id)
+            .await?
+            .ok_or_else(|| LibraryError::Import(format!("release not found: {release_id}")))?;
+        let folder = release.source_folder_name.ok_or_else(|| {
+            LibraryError::Import(format!(
+                "release {release_id} has no source folder name; cannot name its CUE image"
+            ))
+        })?;
+        let stem = crate::library::export::sanitize_filename_stem(&folder);
+        if stem.is_empty() {
+            return Err(LibraryError::Import(format!(
+                "release {release_id} source folder name has no usable filename characters"
+            )));
+        }
+        let output_audio_path = staging_dir.join(format!("{stem}.{}", preset.codec.extension()));
+        let output_cue_path = staging_dir.join(format!("{stem}.cue"));
+
+        ExportService::export_release_image_with_cue(
+            plans,
+            &output_audio_path,
+            &output_cue_path,
+            release.pressing.barcode,
+            preset,
+        )
+        .await
+        .map_err(LibraryError::Import)
     }
 }
 
@@ -636,6 +692,22 @@ fn export_window_for_track_file(
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
+fn export_window_for_single_file_cue_audio_format(
+    audio_format: &crate::db::DbAudioFormat,
+) -> super::ExportAudioWindow {
+    super::ExportAudioWindow {
+        source_start_sample: u64::try_from(audio_format.start_sample)
+            .expect("audio_format.start_sample is a non-negative sample position"),
+        source_end_sample: audio_format.end_sample.map(|sample| {
+            u64::try_from(sample)
+                .expect("audio_format.end_sample is a non-negative sample position")
+        }),
+        leading_silence_samples: non_negative_samples(audio_format.generated_pregap_samples),
+        trailing_silence_samples: 0,
+    }
+}
+
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn non_negative_samples(samples: Option<i64>) -> u64 {
     samples.map_or(0, |sample| {
         u64::try_from(sample).expect("audio_format pregap samples are non-negative")
@@ -678,6 +750,64 @@ fn unique_export_path(
             return path;
         }
         index += 1;
+    }
+}
+
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+fn replace_export_dir(
+    staging_dir: &std::path::Path,
+    final_dir: &std::path::Path,
+    folder: &str,
+    release_id: &str,
+) -> Result<(), LibraryError> {
+    let backup_dir = final_dir.with_file_name(format!(".{folder}.replace-{release_id}"));
+    if backup_dir.exists() {
+        return Err(LibraryError::Import(format!(
+            "export replacement backup already exists: {}",
+            backup_dir.display()
+        )));
+    }
+
+    let had_existing = final_dir.exists();
+    if had_existing {
+        std::fs::rename(final_dir, &backup_dir)?;
+    }
+
+    match std::fs::rename(staging_dir, final_dir) {
+        Ok(()) => {
+            if had_existing {
+                if let Err(cleanup_error) = std::fs::remove_dir_all(&backup_dir) {
+                    if let Err(move_new_error) = std::fs::rename(final_dir, staging_dir) {
+                        return Err(LibraryError::Import(format!(
+                            "failed to remove prior export backup {} ({cleanup_error}); also failed to move new export back to staging ({move_new_error})",
+                            backup_dir.display()
+                        )));
+                    }
+                    if let Err(restore_error) = std::fs::rename(&backup_dir, final_dir) {
+                        return Err(LibraryError::Import(format!(
+                            "failed to remove prior export backup {} ({cleanup_error}); moved new export back to staging but failed to restore prior export ({restore_error})",
+                            backup_dir.display()
+                        )));
+                    }
+                    return Err(LibraryError::Import(format!(
+                        "failed to remove prior export backup {}: {cleanup_error}",
+                        backup_dir.display()
+                    )));
+                }
+            }
+            Ok(())
+        }
+        Err(rename_error) => {
+            if had_existing {
+                if let Err(restore_error) = std::fs::rename(&backup_dir, final_dir) {
+                    return Err(LibraryError::Import(format!(
+                        "failed to move export into place ({rename_error}); also failed to restore prior export from {} ({restore_error})",
+                        backup_dir.display()
+                    )));
+                }
+            }
+            Err(rename_error.into())
+        }
     }
 }
 
@@ -731,5 +861,54 @@ impl Drop for StagingDir {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::DbAudioFormat;
+    use crate::util::content_type::ContentType;
+
+    #[test]
+    fn single_file_cue_window_includes_source_and_generated_pregap() {
+        let mut audio_format = DbAudioFormat::new(
+            "track-1",
+            ContentType::Flac,
+            44_100,
+            Some(16),
+            2,
+            10_000,
+            Some(30_000),
+            "audio-format-1".to_string(),
+            chrono::DateTime::from_timestamp(0, 0).expect("valid Unix epoch timestamp"),
+        );
+        audio_format.pregap_samples = Some(2_000);
+        audio_format.generated_pregap_samples = Some(3_000);
+
+        let window = export_window_for_single_file_cue_audio_format(&audio_format);
+
+        assert_eq!(window.source_start_sample, 10_000);
+        assert_eq!(window.source_end_sample, Some(30_000));
+        assert_eq!(window.leading_silence_samples, 3_000);
+        assert_eq!(window.trailing_silence_samples, 0);
+    }
+
+    #[test]
+    fn replace_export_dir_restores_prior_export_when_staging_rename_fails() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let final_dir = temp.path().join("album");
+        std::fs::create_dir(&final_dir).expect("create prior export dir");
+        std::fs::write(final_dir.join("prior.txt"), b"prior").expect("write prior export");
+
+        let missing_staging = temp.path().join("missing-staging");
+        replace_export_dir(&missing_staging, &final_dir, "album", "release-1")
+            .expect_err("missing staging fails");
+
+        assert_eq!(
+            std::fs::read(final_dir.join("prior.txt")).expect("read prior export"),
+            b"prior"
+        );
+        assert!(!temp.path().join(".album.replace-release-1").exists());
     }
 }

--- a/bae-core/tests/test_export.rs
+++ b/bae-core/tests/test_export.rs
@@ -7,7 +7,10 @@
 
 mod support;
 
-use bae_core::config::ExportSelection;
+use bae_core::config::{
+    ExportBitDepth, ExportMetadata, ExportPregapPlacement, ExportPreset, ExportPresetCodec,
+    ExportSelection,
+};
 use bae_core::db::Database;
 use bae_core::import::{IdentityChoice, ImportCommand, StorageMode};
 use bae_core::library::LibraryManager;
@@ -92,7 +95,7 @@ impl ExportFixture {
 /// originals deleted. This is the state export must handle: no local bytes,
 /// audio only in the cloud.
 async fn import_then_strand_in_cloud(f: &ExportFixture, album_dir: &Path) -> (String, Vec<u8>) {
-    let import_id = uuid::Uuid::new_v4().to_string();
+    let import_id = "import-then-strand-in-cloud".to_string();
     f.handle
         .send_command(ImportCommand {
             import_id: import_id.clone(),
@@ -135,6 +138,25 @@ async fn import_then_strand_in_cloud(f: &ExportFixture, album_dir: &Path) -> (St
     fs::remove_dir_all(album_dir).unwrap();
 
     (release_id, original_bytes)
+}
+
+async fn import_unknown_local(f: &ExportFixture, album_dir: &Path) -> String {
+    let import_id = "import-unknown-local".to_string();
+    f.handle
+        .send_command(ImportCommand {
+            import_id: import_id.clone(),
+            candidate_key: "test".to_string(),
+            folder: album_dir.to_path_buf(),
+            selected_cover: None,
+            storage_mode: StorageMode::Local,
+            pin: false,
+            identity_choice: IdentityChoice::Unknown,
+            user_edit: None,
+        })
+        .unwrap();
+    let mut progress_rx = f.handle.subscribe_import(import_id);
+    let (release_id, _album_id) = support::wait_for_import_complete(&mut progress_rx).await;
+    release_id
 }
 
 /// Exporting a single track of a cloud-only release downloads + decrypts the
@@ -198,6 +220,84 @@ async fn export_release_from_cloud_only_release() {
         .path();
     let written = fs::read(subdir.join("01.flac")).unwrap();
     assert_eq!(written, original_bytes);
+}
+
+#[tokio::test]
+async fn export_release_single_file_with_cue_writes_image_and_cue() {
+    support::tracing_init();
+    let f = ExportFixture::new().await;
+    let album_dir = f.temp_path().join("album");
+    fs::create_dir_all(&album_dir).unwrap();
+    let first_bytes = support::write_tagged_flac(&album_dir, "01.flac", "Track One");
+    let second_bytes = support::write_tagged_flac(&album_dir, "02.flac", "Track Two");
+    let release_id = import_unknown_local(&f, &album_dir).await;
+
+    let mut presets = f.mgr.export_presets();
+    presets.push(ExportPreset {
+        id: "flac-image".to_string(),
+        name: "FLAC image".to_string(),
+        codec: ExportPresetCodec::Flac {
+            bit_depth: ExportBitDepth::Source,
+        },
+        filename_template: "{track_number} - {title}".to_string(),
+        metadata: ExportMetadata {
+            title: true,
+            artist: true,
+            album: true,
+            year: true,
+            track_number: true,
+            disc_number: true,
+            cover_art: true,
+        },
+        pregap_placement: ExportPregapPlacement::SingleFileWithCue,
+        applies_to_track: false,
+        applies_to_release: true,
+    });
+    f.mgr.set_export_presets(presets).unwrap();
+
+    let target = f.temp_path().join("export-target");
+    fs::create_dir_all(&target).unwrap();
+    f.mgr
+        .export_release(
+            &release_id,
+            &target,
+            ExportSelection::Preset {
+                preset_id: "flac-image".to_string(),
+            },
+        )
+        .await
+        .expect("single-file CUE release export must succeed");
+
+    let subdir = fs::read_dir(&target)
+        .unwrap()
+        .next()
+        .expect("export wrote a release folder")
+        .unwrap()
+        .path();
+    let mut exported_files: Vec<_> = fs::read_dir(&subdir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    exported_files.sort();
+    assert_eq!(exported_files, vec!["album.cue", "album.flac"]);
+
+    let cue = fs::read_to_string(subdir.join("album.cue")).unwrap();
+    assert!(cue.contains("FILE \"album.flac\" WAVE"));
+    assert!(cue.contains("  TRACK 01 AUDIO"));
+    assert!(cue.contains("  TRACK 02 AUDIO"));
+
+    let image_pcm = bae_core::audio_codec::decode_audio(
+        &fs::read(subdir.join("album.flac")).unwrap(),
+        None,
+        None,
+    )
+    .unwrap();
+    let first_pcm = bae_core::audio_codec::decode_audio(&first_bytes, None, None).unwrap();
+    let second_pcm = bae_core::audio_codec::decode_audio(&second_bytes, None, None).unwrap();
+    assert_eq!(
+        image_pcm.samples.len(),
+        first_pcm.samples.len() + second_pcm.samples.len()
+    );
 }
 
 /// A cloud-only release whose blob is missing exports nothing and errors —

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -88251,6 +88251,196 @@
         }
       }
     },
+    "Single file + CUE": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Single file + CUE"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Single file + CUE"
+          }
+        }
+      }
+    },
     "Save presets": {
       "localizations": {
         "ar": {

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -18,13 +18,7 @@ private struct ExportSavePanel {
     let formatDelegate: ExportFormatDelegate
 }
 
-private struct ExportPanelChoice: Equatable {
-    let title: String
-    let extensionName: String
-    let selection: BridgeExportSelection
-}
-
-// MARK: - AlbumDetailView (smart wiring view)
+// MARK: - AlbumDetailView (wiring view)
 
 struct AlbumDetailView: View {
     let albumId: String
@@ -412,16 +406,21 @@ extension AlbumDetailView {
     /// queue and surfaces in the Storage Manager's Exporting pane.
     private func exportRelease(releaseId: String) {
         guard
-            let targetDir = ExportTarget.resolve(
-                configStore.config.exportLocation
+            let target = ExportTarget.resolveRelease(
+                configStore.config.exportLocation,
+                choices: ExportFormatChoice.releaseChoices(
+                    presets: configStore.config.exportPresets
+                ),
+                defaultSelection: configStore.config
+                    .defaultReleaseExportSelection
             )
         else {
             return
         }
         exports.enqueueExport(
             releaseId,
-            targetDir,
-            configStore.config.defaultReleaseExportSelection
+            target.targetDir,
+            target.selection
         )
     }
 
@@ -599,7 +598,11 @@ extension AlbumDetailView {
                 return
             }
             let choices = exportChoices(originalExtension: originalExtension)
-            let panel = makeExportSavePanel(stem: stem, choices: choices)
+            guard let panel = makeExportSavePanel(stem: stem, choices: choices)
+            else {
+                exportError = String(localized: "Default format")
+                return
+            }
             let formatPopup = panel.formatPopup
             let response = panel.savePanel.runModal()
             _ = panel.formatDelegate  // prevent deallocation during modal
@@ -628,10 +631,11 @@ extension AlbumDetailView {
         }
     }
 
-    private func exportChoices(originalExtension: String) -> [ExportPanelChoice]
+    private func exportChoices(originalExtension: String)
+        -> [ExportFormatChoice]
     {
         var choices = [
-            ExportPanelChoice(
+            ExportFormatChoice(
                 title: String(localized: "Original"),
                 extensionName: originalExtension,
                 selection: .original
@@ -641,7 +645,7 @@ extension AlbumDetailView {
             contentsOf: configStore.config.exportPresets
                 .filter(\.appliesToTrack)
                 .map {
-                    ExportPanelChoice(
+                    ExportFormatChoice(
                         title: $0.name,
                         extensionName: $0.extension,
                         selection: .preset(presetId: $0.id)
@@ -657,13 +661,20 @@ extension AlbumDetailView {
     /// the delegate must be retained for the modal's lifetime.
     private func makeExportSavePanel(
         stem: String,
-        choices: [ExportPanelChoice]
-    ) -> ExportSavePanel {
-        let selectedIndex =
-            choices.firstIndex {
+        choices: [ExportFormatChoice]
+    ) -> ExportSavePanel? {
+        guard
+            let selectedIndex = choices.firstIndex(where: {
                 $0.selection == configStore.config.defaultTrackExportSelection
-            } ?? 0
-        let defaultExt = choices[selectedIndex].extensionName
+            })
+        else {
+            return nil
+        }
+        guard let defaultExt = choices[selectedIndex].extensionName else {
+            preconditionFailure(
+                "track export choices must carry file extensions"
+            )
+        }
 
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "\(stem).\(defaultExt)"
@@ -1345,9 +1356,9 @@ struct ManageConfirmSheet: View {
 @MainActor
 private class ExportFormatDelegate: NSObject {
     weak var panel: NSSavePanel?
-    let choices: [ExportPanelChoice]
+    let choices: [ExportFormatChoice]
 
-    init(panel: NSSavePanel, choices: [ExportPanelChoice]) {
+    init(panel: NSSavePanel, choices: [ExportFormatChoice]) {
         self.panel = panel
         self.choices = choices
     }
@@ -1357,7 +1368,11 @@ private class ExportFormatDelegate: NSObject {
         guard let panel else {
             return
         }
-        let ext = choices[sender.indexOfSelectedItem].extensionName
+        guard let ext = choices[sender.indexOfSelectedItem].extensionName else {
+            preconditionFailure(
+                "track export choices must carry file extensions"
+            )
+        }
         let currentName = panel.nameFieldStringValue
         let stem = (currentName as NSString).deletingPathExtension
 

--- a/bae-macos/bae/bae/Views/ExportTarget.swift
+++ b/bae-macos/bae/bae/Views/ExportTarget.swift
@@ -1,26 +1,160 @@
 import AppKit
 import Foundation
 
+struct ExportFormatChoice {
+    let title: String
+    let extensionName: String?
+    let selection: BridgeExportSelection
+
+    @MainActor
+    static func releaseChoices(
+        presets: [BridgeExportPreset]
+    ) -> [ExportFormatChoice] {
+        var choices = [
+            ExportFormatChoice(
+                title: String(localized: "Original"),
+                extensionName: nil,
+                selection: .original
+            )
+        ]
+        choices.append(
+            contentsOf:
+                presets
+                .filter(\.appliesToRelease)
+                .map {
+                    ExportFormatChoice(
+                        title: $0.name,
+                        extensionName: $0.extension,
+                        selection: .preset(presetId: $0.id)
+                    )
+                }
+        )
+        return choices
+    }
+}
+
+struct ReleaseExportTarget {
+    let targetDir: String
+    let selection: BridgeExportSelection
+}
+
 /// Resolves the destination directory for a release export from the
 /// export-location setting: a fixed folder returns straight away; "ask each
 /// time" opens one `NSOpenPanel`. Returns `nil` when the user picks no folder,
 /// so the caller enqueues nothing. Shared by every export-trigger call site.
 enum ExportTarget {
     @MainActor
-    static func resolve(_ location: BridgeExportLocation) -> String? {
+    static func resolveRelease(
+        _ location: BridgeExportLocation,
+        choices: [ExportFormatChoice],
+        defaultSelection: BridgeExportSelection
+    ) -> ReleaseExportTarget? {
+        precondition(
+            !choices.isEmpty,
+            "release export choices must include Original"
+        )
+        guard
+            let selectedIndex = selectedFormatIndex(
+                choices: choices,
+                defaultSelection: defaultSelection
+            )
+        else {
+            showDefaultFormatUnavailableAlert()
+            return nil
+        }
+
         switch location {
         case .fixed(let dir):
-            return dir
+            guard
+                let selection = resolveReleaseSelection(
+                    choices: choices,
+                    selectedIndex: selectedIndex
+                )
+            else {
+                return nil
+            }
+            return ReleaseExportTarget(targetDir: dir, selection: selection)
         case .askEachTime:
             let panel = NSOpenPanel()
             panel.canChooseDirectories = true
             panel.canChooseFiles = false
             panel.canCreateDirectories = true
             panel.prompt = String(localized: "Export Here")
+            let popup = makeFormatPopup(
+                choices: choices,
+                selectedIndex: selectedIndex
+            )
+            panel.accessoryView = formatAccessoryView(popup: popup)
             guard panel.runModal() == .OK, let url = panel.url else {
                 return nil
             }
-            return url.path(percentEncoded: false)
+            return ReleaseExportTarget(
+                targetDir: url.path(percentEncoded: false),
+                selection: choices[popup.indexOfSelectedItem].selection
+            )
         }
+    }
+
+    @MainActor
+    private static func resolveReleaseSelection(
+        choices: [ExportFormatChoice],
+        selectedIndex: Int
+    ) -> BridgeExportSelection? {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Export")
+        alert.addButton(withTitle: String(localized: "Export"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        let popup = makeFormatPopup(
+            choices: choices,
+            selectedIndex: selectedIndex
+        )
+        alert.accessoryView = formatAccessoryView(popup: popup)
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return nil
+        }
+        return choices[popup.indexOfSelectedItem].selection
+    }
+
+    @MainActor
+    private static func selectedFormatIndex(
+        choices: [ExportFormatChoice],
+        defaultSelection: BridgeExportSelection
+    ) -> Int? {
+        choices.firstIndex { $0.selection == defaultSelection }
+    }
+
+    @MainActor
+    private static func showDefaultFormatUnavailableAlert() {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Export Failed")
+        alert.informativeText = String(localized: "Default format")
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
+    }
+
+    @MainActor
+    private static func makeFormatPopup(
+        choices: [ExportFormatChoice],
+        selectedIndex: Int
+    ) -> NSPopUpButton {
+        let popup = NSPopUpButton(
+            frame: NSRect(x: 54, y: 5, width: 190, height: 24),
+            pullsDown: false
+        )
+        popup.addItems(withTitles: choices.map(\.title))
+        popup.selectItem(at: selectedIndex)
+        return popup
+    }
+
+    @MainActor
+    private static func formatAccessoryView(popup: NSPopUpButton) -> NSView {
+        let accessoryContainer = NSView(
+            frame: NSRect(x: 0, y: 0, width: 250, height: 34)
+        )
+        let label = NSTextField(labelWithString: String(localized: "Format"))
+        label.frame = NSRect(x: 0, y: 7, width: 50, height: 20)
+        accessoryContainer.addSubview(label)
+        accessoryContainer.addSubview(popup)
+        return accessoryContainer
     }
 }

--- a/bae-macos/bae/bae/Views/Settings/ExportSettingsTab.swift
+++ b/bae-macos/bae/bae/Views/Settings/ExportSettingsTab.swift
@@ -87,50 +87,8 @@ struct ExportSettingsTab: View {
 
             Section("Presets") {
                 ForEach($presetDrafts, id: \.id) { $preset in
-                    VStack(alignment: .leading, spacing: 8) {
-                        TextField("Name", text: $preset.name)
-                        TextField(
-                            "Filename format",
-                            text: $preset.filenameTemplate
-                        )
-                        HStack {
-                            Text(preset.codec.label)
-                            Spacer()
-                            Toggle(
-                                "Track",
-                                isOn: $preset.appliesToTrack
-                            )
-                            Toggle(
-                                "Release",
-                                isOn: $preset.appliesToRelease
-                            )
-                        }
-                        PresetCodecEditor(preset: $preset)
-                        Picker(
-                            "Pregap",
-                            selection: $preset.pregapPlacement
-                        ) {
-                            Text("Append except HTOA")
-                                .tag(
-                                    BridgeExportPregapPlacement
-                                        .appendToPreviousExceptHtoa
-                                )
-                            Text("Append including HTOA")
-                                .tag(
-                                    BridgeExportPregapPlacement
-                                        .appendToPreviousIncludingHtoa
-                                )
-                            Text("Exclude")
-                                .tag(
-                                    BridgeExportPregapPlacement.exclude
-                                )
-                        }
-                        PresetMetadataEditor(preset: $preset)
-                        HStack {
-                            Button("Delete", role: .destructive) {
-                                presetDrafts.removeAll { $0.id == preset.id }
-                            }
-                        }
+                    ExportPresetRow(preset: $preset) {
+                        presetDrafts.removeAll { $0.id == preset.id }
                     }
                 }
                 Menu("Add preset") {
@@ -232,6 +190,98 @@ struct ExportSettingsTab: View {
         }
         catch {
             uiStore.showError(DisplayError(line: error.localizedDescription))
+        }
+    }
+}
+
+private struct ExportPresetRow: View {
+    @Binding
+    var preset: BridgeExportPreset
+    var delete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("Name", text: $preset.name)
+            TextField("Filename format", text: $preset.filenameTemplate)
+            HStack {
+                Text(preset.codec.label)
+                Spacer()
+                Toggle("Track", isOn: appliesToTrackBinding)
+                    .disabled(preset.pregapPlacement == .singleFileWithCue)
+                Toggle("Release", isOn: appliesToReleaseBinding)
+                    .disabled(preset.pregapPlacement == .singleFileWithCue)
+            }
+            PresetCodecEditor(preset: $preset)
+            Picker("Pregap", selection: pregapPlacementBinding) {
+                Text("Append except HTOA")
+                    .tag(
+                        BridgeExportPregapPlacement.appendToPreviousExceptHtoa
+                    )
+                Text("Append including HTOA")
+                    .tag(
+                        BridgeExportPregapPlacement
+                            .appendToPreviousIncludingHtoa
+                    )
+                Text("Exclude")
+                    .tag(BridgeExportPregapPlacement.exclude)
+                Text("Single file + CUE")
+                    .tag(BridgeExportPregapPlacement.singleFileWithCue)
+                    .disabled(!preset.codec.supportsSingleFileCue)
+            }
+            PresetMetadataEditor(preset: $preset)
+            HStack {
+                Button("Delete", role: .destructive, action: delete)
+            }
+        }
+    }
+
+    private var appliesToTrackBinding: Binding<Bool> {
+        Binding(
+            get: {
+                preset.pregapPlacement != .singleFileWithCue
+                    && preset.appliesToTrack
+            },
+            set: { enabled in
+                preset.appliesToTrack =
+                    enabled && preset.pregapPlacement != .singleFileWithCue
+            }
+        )
+    }
+
+    private var appliesToReleaseBinding: Binding<Bool> {
+        Binding(
+            get: {
+                preset.pregapPlacement == .singleFileWithCue
+                    || preset.appliesToRelease
+            },
+            set: { enabled in
+                preset.appliesToRelease =
+                    enabled || preset.pregapPlacement == .singleFileWithCue
+            }
+        )
+    }
+
+    private var pregapPlacementBinding: Binding<BridgeExportPregapPlacement> {
+        Binding(
+            get: { preset.pregapPlacement },
+            set: { placement in
+                preset.pregapPlacement = placement
+                if placement == .singleFileWithCue {
+                    preset.appliesToTrack = false
+                    preset.appliesToRelease = true
+                }
+            }
+        )
+    }
+}
+
+extension BridgeExportPresetCodec {
+    fileprivate var supportsSingleFileCue: Bool {
+        switch self {
+        case .opusOgg:
+            false
+        case .flac, .mp3, .wav, .aiff:
+            true
         }
     }
 }

--- a/bae-macos/bae/bae/Views/StorageActionRunner.swift
+++ b/bae-macos/bae/bae/Views/StorageActionRunner.swift
@@ -54,8 +54,13 @@ final class StorageActionRunner {
     /// via the Exporting pane.
     func export(releaseIds: [String]) {
         guard
-            let targetDir = ExportTarget.resolve(
-                configStore.config.exportLocation
+            let target = ExportTarget.resolveRelease(
+                configStore.config.exportLocation,
+                choices: ExportFormatChoice.releaseChoices(
+                    presets: configStore.config.exportPresets
+                ),
+                defaultSelection: configStore.config
+                    .defaultReleaseExportSelection
             )
         else {
             return
@@ -63,8 +68,8 @@ final class StorageActionRunner {
         for releaseId in releaseIds {
             exports.enqueueExport(
                 releaseId,
-                targetDir,
-                configStore.config.defaultReleaseExportSelection
+                target.targetDir,
+                target.selection
             )
         }
     }

--- a/bae-windows-ffi/src/lib.rs
+++ b/bae-windows-ffi/src/lib.rs
@@ -737,6 +737,45 @@ pub unsafe extern "C" fn bae_export_track(
     }
 }
 
+/// Export one release to `target_dir` using an export selection JSON. Returns
+/// null on success, or an error-message C string (free with [`bae_string_free`]).
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`bae_init`] and not yet freed;
+/// `release_id`, `target_dir`, and `selection_json` must be valid
+/// NUL-terminated UTF-8 C strings.
+#[no_mangle]
+pub unsafe extern "C" fn bae_export_release(
+    handle: *const BaeHandle,
+    release_id: *const c_char,
+    target_dir: *const c_char,
+    selection_json: *const c_char,
+) -> *mut c_char {
+    let Some(handle) = handle.as_ref() else {
+        return error_cstring("no app handle");
+    };
+    let (Some(release_id), Some(target_dir), Some(selection_json)) =
+        (cstr(release_id), cstr(target_dir), cstr(selection_json))
+    else {
+        return error_cstring("invalid release export argument");
+    };
+    let selection = match serde_json::from_str::<FfiExportSelection>(&selection_json) {
+        Ok(selection) => selection.into_core(),
+        Err(error) => return error_cstring(&format!("invalid export selection: {error}")),
+    };
+    let app = &handle.0;
+    match app
+        .runtime
+        .block_on(app.services.library_manager().export_release(
+            &release_id,
+            std::path::Path::new(&target_dir),
+            selection,
+        )) {
+        Ok(()) => std::ptr::null_mut(),
+        Err(e) => error_cstring(&e.to_string()),
+    }
+}
+
 /// The default filename stem (no extension) a single-track export suggests for
 /// `track_id`, rendered from the configured template. Returns the stem as a C
 /// string (free with [`bae_string_free`]), or null on error (logged).
@@ -4228,6 +4267,7 @@ enum FfiExportPregapPlacement {
     AppendToPreviousExceptHtoa,
     AppendToPreviousIncludingHtoa,
     Exclude,
+    SingleFileWithCue,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -4328,6 +4368,9 @@ fn ffi_export_pregap_placement(
             FfiExportPregapPlacement::AppendToPreviousIncludingHtoa
         }
         bae_core::config::ExportPregapPlacement::Exclude => FfiExportPregapPlacement::Exclude,
+        bae_core::config::ExportPregapPlacement::SingleFileWithCue => {
+            FfiExportPregapPlacement::SingleFileWithCue
+        }
     }
 }
 
@@ -4341,6 +4384,7 @@ impl FfiExportPregapPlacement {
                 bae_core::config::ExportPregapPlacement::AppendToPreviousIncludingHtoa
             }
             Self::Exclude => bae_core::config::ExportPregapPlacement::Exclude,
+            Self::SingleFileWithCue => bae_core::config::ExportPregapPlacement::SingleFileWithCue,
         }
     }
 }

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3673,6 +3673,7 @@ public sealed partial class MainWindow : Window
             StatusText.Text = error ?? Loc.Chrome("menu.set_primary_done");
         };
         var changeCoverItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.change_cover") };
+        var exportReleaseItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.export") };
         var deleteItem = new MenuFlyoutItem { Text = Loc.Chrome("menu.delete") };
         moreMenu.Items.Add(playNextItem);
         moreMenu.Items.Add(addQueueItem);
@@ -3680,6 +3681,7 @@ public sealed partial class MainWindow : Window
         {
             moreMenu.Items.Add(setPrimaryItem);
         }
+        moreMenu.Items.Add(exportReleaseItem);
         moreMenu.Items.Add(changeCoverItem);
         moreMenu.Items.Add(deleteItem);
         moreButton.Flyout = moreMenu;
@@ -3766,8 +3768,13 @@ public sealed partial class MainWindow : Window
                     exportStatus.Visibility = Visibility.Visible;
                     return;
                 }
-                var settings = JsonSerializer.Deserialize<Settings>(settingsJson, JsonOptions)
-                    ?? new Settings();
+                var settings = JsonSerializer.Deserialize<Settings>(settingsJson, JsonOptions);
+                if (settings is null)
+                {
+                    exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
+                    exportStatus.Visibility = Visibility.Visible;
+                    return;
+                }
                 var trackPresets = settings.ExportPresets
                     .Where(preset => preset.AppliesToTrack)
                     .ToList();
@@ -3789,10 +3796,54 @@ public sealed partial class MainWindow : Window
                     preset.TrackPickerLabel,
                     preset.FileExtension,
                     ExportSelection.Preset(preset.Id))));
-                foreach (var choice in choices)
+                var formatPicker = new ComboBox
                 {
-                    picker.FileTypeChoices.Add(choice.Label, new List<string> { choice.Extension });
+                    Header = Loc.Chrome("settings.export.default_track_format"),
+                    MinWidth = 260,
+                };
+                var defaultIndex = -1;
+                for (var index = 0; index < choices.Count; index++)
+                {
+                    var choice = choices[index];
+                    if (ExportSelectionsEqual(choice.Selection, settings.DefaultTrackExportSelection))
+                    {
+                        defaultIndex = index;
+                    }
+                    formatPicker.Items.Add(new ComboBoxItem
+                    {
+                        Content = choice.Label,
+                    });
                 }
+                if (defaultIndex < 0)
+                {
+                    exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
+                    exportStatus.Visibility = Visibility.Visible;
+                    return;
+                }
+                formatPicker.SelectedIndex = defaultIndex;
+                var formatDialog = new ContentDialog
+                {
+                    Title = Loc.Chrome("settings.export.label"),
+                    Content = formatPicker,
+                    PrimaryButtonText = Loc.Chrome("settings.export.label"),
+                    CloseButtonText = Loc.Chrome("action.cancel"),
+                    XamlRoot = Content.XamlRoot,
+                };
+                var formatResult = await formatDialog.ShowAsync();
+                if (formatResult != ContentDialogResult.Primary)
+                {
+                    return;
+                }
+                if (formatPicker.SelectedIndex < 0)
+                {
+                    exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
+                    exportStatus.Visibility = Visibility.Visible;
+                    return;
+                }
+                var selectedChoice = choices[formatPicker.SelectedIndex];
+                picker.FileTypeChoices.Add(
+                    selectedChoice.Label,
+                    new List<string> { selectedChoice.Extension });
                 // Seed the suggested name from the configured filename template,
                 // which the core renders and sanitizes from this track's metadata
                 // (falling back to the title, then a fixed stem, on its own). A
@@ -3823,11 +3874,7 @@ public sealed partial class MainWindow : Window
                     return;
                 }
 
-                var selection = choices
-                    .Where(choice => file.FileType.Equals(choice.Extension, StringComparison.OrdinalIgnoreCase))
-                    .Select(choice => choice.Selection)
-                    .FirstOrDefault() ?? ExportSelection.Original();
-                var selectionJson = JsonSerializer.Serialize(selection, JsonOptions);
+                var selectionJson = JsonSerializer.Serialize(selectedChoice.Selection, JsonOptions);
                 var path = file.Path;
                 var error = await System.Threading.Tasks.Task.Run(
                     () => NativeBae.ExportTrack(_handle, track.TrackId, path, selectionJson));
@@ -3904,9 +3951,15 @@ public sealed partial class MainWindow : Window
         // can't open over this one, so close it first and open the gallery after
         // ShowAsync returns (the gallery/edit/re-identify pattern).
         var changeCoverRequested = false;
+        var exportReleaseRequested = false;
         changeCoverItem.Click += (_, _) =>
         {
             changeCoverRequested = true;
+            dialog.Hide();
+        };
+        exportReleaseItem.Click += (_, _) =>
+        {
+            exportReleaseRequested = true;
             dialog.Hide();
         };
         deleteItem.Click += (_, _) =>
@@ -3934,6 +3987,10 @@ public sealed partial class MainWindow : Window
         else if (changeCoverRequested)
         {
             await ShowChangeCover(detail.Id, selectedRelease.ReleaseId);
+        }
+        else if (exportReleaseRequested && !string.IsNullOrEmpty(selectedRelease.ReleaseId))
+        {
+            await ShowExportRelease(selectedRelease.ReleaseId);
         }
         else if (deleteRequested)
         {
@@ -3990,6 +4047,96 @@ public sealed partial class MainWindow : Window
         storyboard.Children.Add(fade);
         storyboard.Begin();
     }
+
+    private async System.Threading.Tasks.Task ShowExportRelease(string releaseId)
+    {
+        var settingsJson = await System.Threading.Tasks.Task.Run(() => NativeBae.SettingsJson(_handle));
+        if (settingsJson is null)
+        {
+            StatusText.Text = Loc.Chrome("track.export.prepare_failed");
+            return;
+        }
+        var settings = JsonSerializer.Deserialize<Settings>(settingsJson, JsonOptions);
+        if (settings is null)
+        {
+            StatusText.Text = Loc.Chrome("track.export.prepare_failed");
+            return;
+        }
+        var choices = new List<(string Label, ExportSelection Selection)>
+        {
+            (Loc.Chrome("track.export.original"), ExportSelection.Original()),
+        };
+        choices.AddRange(settings.ExportPresets
+            .Where(preset => preset.AppliesToRelease)
+            .Select(preset => (preset.Name, ExportSelection.Preset(preset.Id))));
+
+        var formatPicker = new ComboBox
+        {
+            Header = Loc.Chrome("settings.export.default_release_format"),
+            MinWidth = 260,
+        };
+        var defaultIndex = -1;
+        for (var index = 0; index < choices.Count; index++)
+        {
+            var choice = choices[index];
+            if (ExportSelectionsEqual(choice.Selection, settings.DefaultReleaseExportSelection))
+            {
+                defaultIndex = index;
+            }
+            formatPicker.Items.Add(new ComboBoxItem
+            {
+                Content = choice.Label,
+                Tag = choice.Selection,
+            });
+        }
+        if (defaultIndex < 0)
+        {
+            StatusText.Text = Loc.Chrome("track.export.prepare_failed");
+            return;
+        }
+        formatPicker.SelectedIndex = defaultIndex;
+
+        var dialog = new ContentDialog
+        {
+            Title = Loc.Chrome("settings.export.label"),
+            Content = formatPicker,
+            PrimaryButtonText = Loc.Chrome("settings.export.label"),
+            CloseButtonText = Loc.Chrome("action.cancel"),
+            XamlRoot = Content.XamlRoot,
+        };
+        var result = await dialog.ShowAsync();
+        if (result != ContentDialogResult.Primary)
+        {
+            return;
+        }
+        if (formatPicker.SelectedItem is not ComboBoxItem selectedItem
+            || selectedItem.Tag is not ExportSelection selection)
+        {
+            StatusText.Text = Loc.Chrome("track.export.prepare_failed");
+            return;
+        }
+
+        var picker = new global::Windows.Storage.Pickers.FolderPicker();
+        picker.FileTypeFilter.Add("*");
+        WinRT.Interop.InitializeWithWindow.Initialize(
+            picker, WinRT.Interop.WindowNative.GetWindowHandle(this));
+        var folder = await picker.PickSingleFolderAsync();
+        if (folder is null)
+        {
+            return;
+        }
+
+        var selectionJson = JsonSerializer.Serialize(selection, JsonOptions);
+        var error = await System.Threading.Tasks.Task.Run(
+            () => NativeBae.ExportRelease(_handle, releaseId, folder.Path, selectionJson));
+        if (error is not null)
+        {
+            StatusText.Text = error;
+        }
+    }
+
+    private static bool ExportSelectionsEqual(ExportSelection a, ExportSelection b) =>
+        a.Kind == b.Kind && a.PresetId == b.PresetId;
 
     private async System.Threading.Tasks.Task ConfirmDeleteRelease(string releaseId)
     {
@@ -5536,6 +5683,11 @@ public sealed partial class MainWindow : Window
                     Header = Loc.Chrome("settings.export.preset_name"),
                     Text = preset.Name,
                 };
+                var filenameTemplate = new TextBox
+                {
+                    Header = Loc.Chrome("settings.export.filename_format"),
+                    Text = preset.FilenameTemplate,
+                };
                 var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
                 var codec = new TextBlock
                 {
@@ -5559,7 +5711,7 @@ public sealed partial class MainWindow : Window
                 var codecEditor = BuildPresetCodecEditor(preset);
 
                 var pregap = new ComboBox { Header = Loc.Chrome("settings.export.preset_pregap") };
-                foreach (var item in ExportPregapChoices())
+                foreach (var item in ExportPregapChoices(preset.Codec))
                 {
                     pregap.Items.Add(new ComboBoxItem
                     {
@@ -5568,11 +5720,27 @@ public sealed partial class MainWindow : Window
                         IsSelected = preset.PregapPlacement == item.Value,
                     });
                 }
+                void ApplyPregapApplicability()
+                {
+                    var singleFileCue = pregap.SelectedItem is ComboBoxItem selected
+                        && selected.Tag is string placement
+                        && placement == "single_file_with_cue";
+                    if (singleFileCue)
+                    {
+                        track.IsChecked = false;
+                        release.IsChecked = true;
+                    }
+                    track.IsEnabled = !singleFileCue;
+                    release.IsEnabled = !singleFileCue;
+                }
+                pregap.SelectionChanged += (_, _) => ApplyPregapApplicability();
+                ApplyPregapApplicability();
                 var metadataEditor = BuildPresetMetadataEditor(preset.Metadata);
                 var save = new Button { Content = Loc.Chrome("action.save") };
                 var remove = new Button { Content = Loc.Chrome("action.remove") };
                 var editor = new StackPanel { Spacing = 6 };
                 editor.Children.Add(name);
+                editor.Children.Add(filenameTemplate);
                 editor.Children.Add(row);
                 editor.Children.Add(codecEditor.View);
                 editor.Children.Add(pregap);
@@ -5586,6 +5754,12 @@ public sealed partial class MainWindow : Window
                 save.Click += async (_, _) =>
                 {
                     preset.Name = name.Text ?? string.Empty;
+                    if (filenameTemplate.Text is not string template)
+                    {
+                        ShowSettingsError(Loc.Chrome("settings.export.save_failed"));
+                        return;
+                    }
+                    preset.FilenameTemplate = template;
                     preset.AppliesToTrack = track.IsChecked == true;
                     preset.AppliesToRelease = release.IsChecked == true;
                     if (pregap.SelectedItem is ComboBoxItem selected && selected.Tag is string placement)
@@ -5726,12 +5900,34 @@ public sealed partial class MainWindow : Window
             };
         }
 
-        List<(string Label, string Value)> ExportPregapChoices() => new()
+        List<(string Label, string Value)> ExportPregapChoices(ExportPresetCodec codec)
         {
-            (Loc.Chrome("settings.export.pregap.append_except_htoa"), "append_to_previous_except_htoa"),
-            (Loc.Chrome("settings.export.pregap.append_including_htoa"), "append_to_previous_including_htoa"),
-            (Loc.Chrome("settings.export.pregap.exclude"), "exclude"),
-        };
+            var choices = new List<(string Label, string Value)>
+            {
+                (
+                    Loc.Chrome("settings.export.pregap.append_except_htoa"),
+                    "append_to_previous_except_htoa"
+                ),
+                (
+                    Loc.Chrome("settings.export.pregap.append_including_htoa"),
+                    "append_to_previous_including_htoa"
+                ),
+                (Loc.Chrome("settings.export.pregap.exclude"), "exclude"),
+            };
+
+            if (ExportCodecSupportsSingleFileCue(codec))
+            {
+                choices.Add((
+                    Loc.Chrome("settings.export.pregap.single_file_with_cue"),
+                    "single_file_with_cue"
+                ));
+            }
+
+            return choices;
+        }
+
+        static bool ExportCodecSupportsSingleFileCue(ExportPresetCodec codec) =>
+            codec.Kind != "opus_ogg";
 
         List<(string Label, string Value)> ExportBitDepthChoices() => new()
         {

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -386,6 +386,17 @@ internal static class NativeBae
     internal static string? ExportTrack(IntPtr handle, string trackId, string outputPath, string selectionJson) =>
         ResultMessage(ExportTrackPtr(handle, trackId, outputPath, selectionJson));
 
+    [DllImport(Dll, EntryPoint = "bae_export_release", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr ExportReleasePtr(
+        IntPtr handle,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string releaseId,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string targetDir,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string selectionJson);
+
+    /// <summary>Export one release into targetDir using an export selection JSON; null on success, else the error.</summary>
+    internal static string? ExportRelease(IntPtr handle, string releaseId, string targetDir, string selectionJson) =>
+        ResultMessage(ExportReleasePtr(handle, releaseId, targetDir, selectionJson));
+
     [DllImport(Dll, EntryPoint = "bae_export_track_suggested_name", CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr ExportTrackSuggestedNamePtr(
         IntPtr handle,

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ملف واحد + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>تعذر حفظ إعدادات التصدير</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Един файл + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Настройките за експортиране не можаха да бъдат запазени</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>একটি ফাইল + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>রপ্তানি সেটিংস সংরক্ষণ করা যায়নি</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Jeden soubor + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Nastavení exportu se nepodařilo uložit</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Einzeldatei + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Exporteinstellungen konnten nicht gespeichert werden</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -301,6 +301,7 @@
   <data name="settings.export.pregap.append_except_htoa" xml:space="preserve"><value>Append except HTOA</value></data>
   <data name="settings.export.pregap.append_including_htoa" xml:space="preserve"><value>Append including HTOA</value></data>
   <data name="settings.export.pregap.exclude" xml:space="preserve"><value>Exclude</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Single file + CUE</value></data>
   <data name="action.remove" xml:space="preserve"><value>Remove</value></data>
   <data name="settings.export.filename_format" xml:space="preserve"><value>Filename format</value></data>
   <data name="settings.export.tokens_help" xml:space="preserve"><value>Available tokens: {title} {artist} {album} {year} {track_number} {disc_number} {track_total}</value></data>
@@ -318,4 +319,5 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Export settings could not be saved</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Archivo único + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>No se pudieron guardar los ajustes de exportación</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Fichier unique + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Impossible d’enregistrer les réglages d’exportation</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>એક ફાઇલ + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>નિકાસ સેટિંગ્સ સાચવી શકાઈ નહીં</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>קובץ יחיד + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>לא ניתן היה לשמור את הגדרות הייצוא</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>एकल फ़ाइल + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>निर्यात सेटिंग्स सहेजी नहीं जा सकीं</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Jedna datoteka + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Postavke izvoza nije bilo moguće spremiti</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>File singolo + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Impossibile salvare le impostazioni di esportazione</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>単一ファイル + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>書き出し設定を保存できませんでした</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ಒಂದು ಫೈಲ್ + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>ರಫ್ತು ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಉಳಿಸಲಾಗಲಿಲ್ಲ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>단일 파일 + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>내보내기 설정을 저장할 수 없습니다</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ഒറ്റ ഫയൽ + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>കയറ്റുമതി ക്രമീകരണങ്ങൾ സംരക്ഷിക്കാനായില്ല</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>एकल फाइल + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>निर्यात सेटिंग्ज जतन करता आल्या नाहीत</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Enkel bestand + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Exportinstellingen konden niet worden opgeslagen</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ਇੱਕ ਫਾਈਲ + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>ਨਿਰਯਾਤ ਸੈਟਿੰਗਾਂ ਸੰਭਾਲੀਆਂ ਨਹੀਂ ਜਾ ਸਕੀਆਂ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Pojedynczy plik + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Nie można zapisać ustawień eksportu</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Arquivo único + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Não foi possível salvar as configurações de exportação</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ஒற்றை கோப்பு + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>ஏற்றுமதி அமைப்புகளைச் சேமிக்க முடியவில்லை</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ఒకే ఫైల్ + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>ఎగుమతి సెట్టింగ్‌లను సేవ్ చేయలేకపోయింది</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>ไฟล์เดียว + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>ไม่สามารถบันทึกการตั้งค่าการส่งออกได้</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Tek dosya + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Dışa aktarma ayarları kaydedilemedi</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Один файл + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Не вдалося зберегти налаштування експорту</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>واحد فائل + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>برآمد کی ترتیبات محفوظ نہیں ہو سکیں</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>Một tệp + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>Không thể lưu cài đặt xuất</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>单文件 + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>无法保存导出设置</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -250,4 +250,6 @@
   <data name="settings.export.bit_depth.bits32" xml:space="preserve"><value>32-bit</value></data>
   <data name="settings.export.bitrate" xml:space="preserve"><value>Bitrate</value></data>
   <data name="settings.export.metadata_label" xml:space="preserve"><value>Metadata</value></data>
+  <data name="settings.export.pregap.single_file_with_cue" xml:space="preserve"><value>單一檔案 + CUE</value></data>
+  <data name="settings.export.save_failed" xml:space="preserve"><value>無法儲存匯出設定</value></data>
 </root>

--- a/plans/export-single-file-cue.md
+++ b/plans/export-single-file-cue.md
@@ -1,0 +1,85 @@
+# Release Export Presets And Single-File CUE
+
+## Goal
+
+Release and track export use configured presets instead of hard-coded format
+choices. A library starts with MP3 and FLAC presets, Original is always
+available, and users can configure release-applicable and track-applicable
+presets in settings.
+
+For release export, presets can choose how pregaps are written. Single-file CUE
+mode writes one encoded release image plus a `.cue` sheet whose track indexes
+match the exported audio. External playback follows the CUE layout: pregaps are
+audible where the CUE layout places them.
+
+## Core Model
+
+- Add `ExportPregapPlacement::SingleFileWithCue`.
+- Keep `Original` outside presets and default-selected for track and release
+  exports.
+- Validate presets in core:
+  - a preset must apply to track export, release export, or both;
+  - single-file CUE applies only to release export;
+  - single-file CUE is allowed only for formats with a CUE `FILE` type that we
+    can write correctly.
+- Release exports use the release export queue.
+- Make preset writes fail before committing config when a default selection would
+  reference a removed preset.
+
+## Single-File CUE Export
+
+- Build each release track from the same export plan shape used by track export.
+- For each track, decode the selected source window, including the source pregap
+  region when the track has one.
+- Add generated leading silence when the CUE layout requires hidden track-one
+  audio or inter-track pregap placement.
+- Concatenate decoded PCM into one release image.
+- Reject mixed sample rates or channel layouts before writing output.
+- Encode the image using the selected preset codec.
+- Write a `.cue` sheet next to the image:
+  - `FILE` references only the image filename;
+  - CUE file type is derived from the encoded container;
+  - `INDEX 01` points to the start of each track's program audio;
+  - `INDEX 00` points to pregap start when the track has a pregap;
+  - titles, performers, album title, album artist, catalog, and year are written
+    when present.
+- Use one output guard for both files so cancellation or an encode/write error
+  removes partial output.
+
+## CUE Scope
+
+- Support single-file image plus CUE export.
+- CUE-backed import and playback behavior is unchanged.
+- Multi-file CUE export is not supported.
+- Lossy packet-copy "Original" slicing is not supported without a
+  codec/container-specific path with explicit packet-boundary and timestamp
+  behavior.
+
+## macOS
+
+- Settings > Export shows preset configuration for track and release export.
+- The pregap picker shows "Single file + CUE" disabled when the selected codec
+  cannot write a CUE file type.
+- Selecting "Single file + CUE" forces release-applicable on and
+  track-applicable off.
+- Saving presets sends the edited values to core; invalid combinations fail
+  through config validation.
+- Track export keeps the save-panel format picker, fed by track-applicable
+  presets.
+- Release export shows a format picker for both album-detail export and Storage
+  Manager batch export:
+  - fixed export directory: ask for format, then enqueue;
+  - ask-each-time directory: ask for folder and format in one panel, then
+    enqueue.
+
+## Windows
+
+- Settings > Export shows the same preset fields and pregap choices as macOS.
+- The pregap picker includes "Single file + CUE" only for supported codecs.
+- Selecting "Single file + CUE" forces release-applicable on and
+  track-applicable off.
+- Windows FFI exposes release export with a selected `ExportSelection`.
+- Album-detail release export asks for format and target folder, then calls core
+  release export.
+- Track export keeps its format selection and uses track-applicable
+  presets.


### PR DESCRIPTION
Release and track export now use configured presets instead of hard-coded output choices, with Original still available by default. This adds release-level format selection on macOS and Windows, exposes release export through the Windows FFI, and adds a release-only single-file CUE export mode that writes one encoded image plus a CUE sheet while preserving CUE playback behavior.\n\nThe core export path validates preset applicability, builds CUE image exports from the same track export plans, writes catalog/date metadata into the CUE sheet, and replaces release export folders through a staging/rollback path. macOS and Windows settings now expose preset editing for track/release applicability, codec options, filename templates, metadata, and pregap placement.\n\nVerification:\n- cargo fmt --all --check\n- cargo test -p bae-core --features bae-core/test-utils config::tests::single_file_cue_preset_is_release_only -- --nocapture\n- cargo test -p bae-core --features bae-core/test-utils release_image_cue -- --nocapture\n- cargo test -p bae-core --features bae-core/test-utils single_file_cue_window_includes_source_and_generated_pregap -- --nocapture\n- cargo test -p bae-core --features bae-core/test-utils replace_export_dir_restores_prior_export_when_staging_rename_fails -- --nocapture\n- cargo test -p bae-core --features bae-core/test-utils --test test_export -- --nocapture\n- cargo clippy -p bae-core --features bae-core/test-utils --all-targets -- -D warnings\n- cargo clippy -p bae-bridge --all-targets -- -D warnings\n- cargo clippy -p bae-windows-ffi --all-targets -- -D warnings\n- xcrun swift-format lint -s on changed macOS Swift files\n- python3 scripts/loc-chrome-orphans.py\n- ./bae-bridge/build-macos.sh && xcodegen && xcodebuild ... CODE_SIGNING_ALLOWED=NO build\n\nWindows C# compilation was not run locally because dotnet/msbuild/csc are not installed in this environment.