### PR TITLE
Reject bogus CUE pregap indexes

### DIFF
--- a/bae-core/src/cue_flac.rs
+++ b/bae-core/src/cue_flac.rs
@@ -454,14 +454,15 @@ impl CueFlacProcessor {
             )));
         }
 
-        // Some rippers (EAC v0.99pb4) write bogus INDEX 00 values that are
-        // before the previous track's INDEX 01. Clear these so audio_start_cue_frames()
-        // and pregap_duration_ms() don't use them downstream.
+        // Some rippers write bogus INDEX 00 values that are before the
+        // previous track's INDEX 01. Remove them so every downstream boundary
+        // reader sees the same corrected shape.
         for i in 1..tracks.len() {
             if let Some(pregap) = tracks[i].pregap_cue_frames {
                 if pregap <= tracks[i - 1].start_cue_frames {
                     tracks[i].pregap_cue_frames = None;
                     tracks[i].pregap = CuePregap::None;
+                    tracks[i].indexes.retain(|index| index.number != 0);
                 }
             }
         }

--- a/bae-core/src/cue_flac/tests.rs
+++ b/bae-core/src/cue_flac/tests.rs
@@ -792,6 +792,10 @@ FILE "test.ape" WAVE
         None,
         "Bogus pregap should be cleared, leaving no duration"
     );
+    assert!(
+        track3.index(0).is_none(),
+        "Bogus INDEX 00 should be removed from the raw index list"
+    );
 }
 
 #[test]

--- a/bae-core/src/import/service/format_prep.rs
+++ b/bae-core/src/import/service/format_prep.rs
@@ -473,6 +473,11 @@ pub(super) struct BuiltAudioFormats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audio_codec::ProbeResult;
+    use crate::import::types::{
+        CueAnalyzedAudioFile, CueAudioAnalysis, CueFlacAnalysis, TrackFile,
+    };
+    use std::sync::Arc;
 
     #[test]
     fn audio_codec_allowlist_is_the_intentional_import_surface() {
@@ -497,5 +502,98 @@ mod tests {
         assert!(!admitted_audio_content_type(&ContentType::Other(
             "audio/x-ms-wma".to_string()
         )));
+    }
+
+    #[test]
+    fn cue_backed_segments_ignore_rejected_index00_boundaries() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cue_path = temp.path().join("Album.cue");
+        let audio_path = temp.path().join("test.ape");
+        std::fs::write(
+            &cue_path,
+            r#"PERFORMER "Artist Name"
+TITLE "Album Title"
+FILE "test.ape" WAVE
+  TRACK 01 AUDIO
+    TITLE "Track One"
+    INDEX 00 00:00:00
+    INDEX 01 00:00:32
+  TRACK 02 AUDIO
+    TITLE "Track Two"
+    INDEX 01 05:05:00
+  TRACK 03 AUDIO
+    TITLE "Track Three"
+    INDEX 00 05:05:00
+    INDEX 01 08:31:20
+  TRACK 04 AUDIO
+    TITLE "Track Four"
+    INDEX 00 05:05:00
+    INDEX 01 11:01:30
+"#,
+        )
+        .expect("write cue");
+
+        let cue_sheet =
+            crate::cue_flac::CueFlacProcessor::parse_cue_sheet(&cue_path).expect("parse cue");
+        let cue_pair = Arc::new(CueFlacAnalysis {
+            cue_sheet,
+            audio_files: vec![CueAnalyzedAudioFile {
+                file_reference: "test.ape".to_string(),
+                path: audio_path.clone(),
+                analysis: CueAudioAnalysis {
+                    probe: ProbeResult {
+                        content_type: ContentType::Ape,
+                        duration: std::time::Duration::from_secs(12 * 60),
+                        sample_rate: 75,
+                        bits_per_sample: Some(16),
+                        channels: 2,
+                    },
+                },
+            }],
+        });
+
+        let tracks_to_files: Vec<_> = cue_pair
+            .cue_sheet
+            .playable_tracks()
+            .enumerate()
+            .map(|(index, track)| TrackFile::CueBacked {
+                db_track: crate::db::DbTrack::new_test(
+                    "release-id",
+                    &format!("track-{index}"),
+                    track.title.as_deref().unwrap_or("Track Title"),
+                    Some(track.number as i32),
+                ),
+                file_path: audio_path.clone(),
+                cue_pair: Arc::clone(&cue_pair),
+                cue_index: index,
+            })
+            .collect();
+        let file_ids = HashMap::from([(audio_path, "file-id".to_string())]);
+        let clock = coven::FixedClock(
+            chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        );
+        let ids = coven::SequentialIdProvider::new("audio");
+
+        let built = ImportService::build_audio_formats(&tracks_to_files, &file_ids, &clock, &ids)
+            .expect("build audio formats");
+        let main_segments: Vec<_> = built
+            .audio_segments
+            .iter()
+            .filter(|segment| segment.role == DbAudioSegmentRole::Main)
+            .collect();
+
+        assert_eq!(main_segments.len(), 4);
+        for segment in &main_segments {
+            assert!(
+                segment
+                    .end_sample
+                    .is_none_or(|end_sample| end_sample > segment.start_sample),
+                "main segment must have a positive sample window: {segment:?}",
+            );
+        }
+        assert_eq!(main_segments[1].end_sample, Some((8 * 60 + 31) * 75 + 20),);
+        assert_eq!(main_segments[2].end_sample, Some((11 * 60 + 1) * 75 + 30),);
     }
 }


### PR DESCRIPTION
Some CUE sheets contain an INDEX 00 pregap that points at or before the previous track start. The parser already rejected that pregap for display timing, but left the raw index in the parsed sheet, so import format preparation could still use it as the next segment boundary and persist an empty or inverted sample window.

This removes the rejected INDEX 00 from the parsed track indexes at the same point the pregap is rejected, so downstream readers see one corrected sheet shape. The new format-prep test drives build_audio_formats and checks the persisted main segment windows for that CUE shape.

Test plan:
- CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib cargo test -p bae-core cue_flac
- CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib cargo test -p bae-core format_prep
- CARGO_TARGET_DIR=target-iso RUSTC_WRAPPER= DYLD_LIBRARY_PATH=$PWD/bae-ffmpeg/dist/lib cargo test -p bae-core --lib
- pre-commit hook: fmt, bae-core clippy lib/tests, bae-bridge clippy, loc-gen check
- local rules-review: Codex 5.5, one FP under don-t-duplicate-existing-logic for test dependency setup