### PR TITLE
Android: real back stack for the library

### DIFF
--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryBrowser.kt
@@ -1,13 +1,13 @@
 package fm.bae.app.ui
 
 import android.content.Context
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -48,45 +47,56 @@ private val DEFAULT_ALBUM_SORT =
 private val DEFAULT_COMPOSER_SORT =
     BridgeComposerSortCriterion(BridgeComposerSortField.NAME, BridgeSortDirection.ASCENDING)
 
+/**
+ * Browser chrome state, owned above the stack in [LibraryScreen] so tab, sort,
+ * search, and grid scroll survive while a pushed destination hides the browser.
+ */
+internal class LibraryBrowserState {
+    var searchOpen by mutableStateOf(false)
+    var searchQuery by mutableStateOf("")
+    var mode by mutableStateOf(LibraryBrowserMode.ALBUMS)
+    var sortCriterion by mutableStateOf(DEFAULT_ALBUM_SORT)
+    var composerSortCriterion by mutableStateOf(DEFAULT_COMPOSER_SORT)
+    val gridState = LazyGridState()
+
+    fun closeSearch() {
+        searchOpen = false
+        searchQuery = ""
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun LibraryBrowser(
     session: OpenLibrary,
+    state: LibraryBrowserState,
     onSelectAlbum: (String) -> Unit,
     onSelectComposer: (String) -> Unit,
     onSelectWork: (String) -> Unit,
     onSettings: () -> Unit,
 ) {
-    var searchQuery by remember { mutableStateOf("") }
-    var searchOpen by remember { mutableStateOf(false) }
-    var mode by remember { mutableStateOf(LibraryBrowserMode.ALBUMS) }
-    var sortCriterion by remember { mutableStateOf(DEFAULT_ALBUM_SORT) }
-    var composerSortCriterion by remember { mutableStateOf(DEFAULT_COMPOSER_SORT) }
     val generation by session.libraryStore.generation.collectAsState()
     val composerGeneration by session.libraryStore.composerGeneration.collectAsState()
     val syncing by session.configStore.syncing.collectAsState()
     val syncError by session.configStore.syncError.collectAsState()
     val appError by session.configStore.error.collectAsState()
-    val gridState = rememberLazyGridState()
     val appContext = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
+    BackHandler(enabled = state.searchOpen) { state.closeSearch() }
     Column(modifier = Modifier.fillMaxSize()) {
         LibraryBrowserChrome(
-            searchOpen = searchOpen,
-            searchQuery = searchQuery,
-            onSearchQueryChange = { searchQuery = it },
-            onOpenSearch = { searchOpen = true },
-            onCloseSearch = {
-                searchOpen = false
-                searchQuery = ""
-            },
-            mode = mode,
-            onModeChange = { mode = it },
-            sortCriterion = sortCriterion,
-            onSortChange = { sortCriterion = it },
-            composerSortCriterion = composerSortCriterion,
-            onComposerSortChange = { composerSortCriterion = it },
+            searchOpen = state.searchOpen,
+            searchQuery = state.searchQuery,
+            onSearchQueryChange = { state.searchQuery = it },
+            onOpenSearch = { state.searchOpen = true },
+            onCloseSearch = state::closeSearch,
+            mode = state.mode,
+            onModeChange = { state.mode = it },
+            sortCriterion = state.sortCriterion,
+            onSortChange = { state.sortCriterion = it },
+            composerSortCriterion = state.composerSortCriterion,
+            onComposerSortChange = { state.composerSortCriterion = it },
             syncing = syncing,
             onShuffleLibrary = { session.playLibraryShuffledOrReport(appContext, coroutineScope) },
             onSettings = onSettings,
@@ -95,15 +105,15 @@ internal fun LibraryBrowser(
         LibraryBrowserContent(
             modifier = Modifier.fillMaxWidth().weight(1f),
             session = session,
-            searchQuery = searchQuery,
-            mode = mode,
+            searchQuery = state.searchQuery,
+            mode = state.mode,
             generation = generation,
             composerGeneration = composerGeneration,
-            sortCriterion = sortCriterion,
-            composerSortCriterion = composerSortCriterion,
+            sortCriterion = state.sortCriterion,
+            composerSortCriterion = state.composerSortCriterion,
             appError = appError,
             syncError = syncError,
-            gridState = gridState,
+            gridState = state.gridState,
             onSelectAlbum = onSelectAlbum,
             onSelectComposer = onSelectComposer,
             onSelectWork = onSelectWork,

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryNavigator.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryNavigator.kt
@@ -1,0 +1,121 @@
+package fm.bae.app.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import fm.bae.app.OpenLibrary
+
+internal data class AlbumTarget(
+    val albumId: String,
+    val initialReleaseId: String? = null,
+)
+
+internal sealed interface LibraryDestination {
+    data class Album(
+        val target: AlbumTarget,
+    ) : LibraryDestination
+
+    data class Work(
+        val workId: String,
+    ) : LibraryDestination
+
+    data class Composer(
+        val artistId: String,
+    ) : LibraryDestination
+
+    data object Members : LibraryDestination
+
+    data object Settings : LibraryDestination
+}
+
+/**
+ * One pushed level of the library navigation stack. [key] is unique per push
+ * for the composition lifetime and keys the entry's saved UI state (scroll
+ * positions) in the [androidx.compose.runtime.saveable.SaveableStateHolder],
+ * so revisiting the same destination twice never resurrects stale state.
+ */
+internal data class LibraryStackEntry(
+    val key: Long,
+    val destination: LibraryDestination,
+)
+
+/**
+ * In-memory back stack over the library browser. An empty stack shows the
+ * browser; pushing shows the new top; popping returns to the previous level.
+ * Backed by snapshot state so composition reacts to changes. The stack lives
+ * only as long as the open-library composition, like all other UI state here.
+ */
+internal class LibraryNavigator {
+    private var nextKey = 0L
+    val entries = mutableStateListOf<LibraryStackEntry>()
+    val top: LibraryStackEntry? get() = entries.lastOrNull()
+
+    fun push(destination: LibraryDestination) {
+        entries.add(LibraryStackEntry(nextKey++, destination))
+    }
+
+    /**
+     * Removes and returns the top entry, or null when the stack is already
+     * empty. Empty is a designed-for input: a back event can be dispatched in
+     * the same frame the stack emptied, before the BackHandler's enabled flag
+     * catches up; the next press then gets the system default.
+     */
+    fun pop(): LibraryStackEntry? = entries.removeLastOrNull()
+}
+
+@Composable
+internal fun LibraryDestinationScreen(
+    session: OpenLibrary,
+    destination: LibraryDestination,
+    onBack: () -> Unit,
+    onPush: (LibraryDestination) -> Unit,
+    onLeaveLibrary: () -> Unit,
+) {
+    val pushWork: (String) -> Unit = { onPush(LibraryDestination.Work(it)) }
+    val pushAlbum: (String, String) -> Unit = { albumId, releaseId ->
+        onPush(LibraryDestination.Album(AlbumTarget(albumId, releaseId)))
+    }
+    when (destination) {
+        is LibraryDestination.Album -> {
+            val target = destination.target
+            AlbumDetailScreen(
+                session = session,
+                albumId = target.albumId,
+                initialReleaseId = target.initialReleaseId,
+                onBack = onBack,
+            )
+        }
+
+        is LibraryDestination.Work -> {
+            WorkDetailScreen(
+                session = session,
+                workId = destination.workId,
+                onBack = onBack,
+                onSelectWork = pushWork,
+                onSelectAlbum = pushAlbum,
+            )
+        }
+
+        is LibraryDestination.Composer -> {
+            ComposerDetailScreen(
+                session = session,
+                artistId = destination.artistId,
+                onBack = onBack,
+                onSelectWork = pushWork,
+                onSelectAlbum = pushAlbum,
+            )
+        }
+
+        LibraryDestination.Members -> {
+            MembersScreen(session = session, onBack = onBack)
+        }
+
+        LibraryDestination.Settings -> {
+            SettingsScreen(
+                session = session,
+                onBack = onBack,
+                onManageDevices = { onPush(LibraryDestination.Members) },
+                onLeaveLibrary = onLeaveLibrary,
+            )
+        }
+    }
+}

--- a/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/ui/LibraryScreen.kt
@@ -1,6 +1,7 @@
 package fm.bae.app.ui
 
 import android.content.Context
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -50,6 +51,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -89,29 +91,6 @@ internal class PageError(
 internal enum class LibraryBrowserMode {
     ALBUMS,
     COMPOSERS,
-}
-
-private data class AlbumTarget(
-    val albumId: String,
-    val initialReleaseId: String? = null,
-)
-
-private sealed interface LibraryDestination {
-    data class Album(
-        val target: AlbumTarget,
-    ) : LibraryDestination
-
-    data class Work(
-        val workId: String,
-    ) : LibraryDestination
-
-    data class Composer(
-        val artistId: String,
-    ) : LibraryDestination
-
-    data object Members : LibraryDestination
-
-    data object Settings : LibraryDestination
 }
 
 /**
@@ -220,63 +199,35 @@ fun LibraryScreen(
     session: OpenLibrary,
     onLeaveLibrary: () -> Unit,
 ) {
-    var destination by remember { mutableStateOf<LibraryDestination?>(null) }
-    when (val activeDestination = destination) {
-        is LibraryDestination.Album -> {
-            val selected = activeDestination.target
-            AlbumDetailScreen(
-                session = session,
-                albumId = selected.albumId,
-                initialReleaseId = selected.initialReleaseId,
-                onBack = { destination = null },
-            )
-        }
-
-        is LibraryDestination.Work -> {
-            WorkDetailScreen(
-                session = session,
-                workId = activeDestination.workId,
-                onBack = { destination = null },
-                onSelectWork = { destination = LibraryDestination.Work(it) },
-                onSelectAlbum = { albumId, releaseId ->
-                    destination = LibraryDestination.Album(AlbumTarget(albumId, releaseId))
-                },
-            )
-        }
-
-        is LibraryDestination.Composer -> {
-            ComposerDetailScreen(
-                session = session,
-                artistId = activeDestination.artistId,
-                onBack = { destination = null },
-                onSelectWork = { destination = LibraryDestination.Work(it) },
-                onSelectAlbum = { albumId, releaseId ->
-                    destination = LibraryDestination.Album(AlbumTarget(albumId, releaseId))
-                },
-            )
-        }
-
-        LibraryDestination.Members -> {
-            MembersScreen(session = session, onBack = { destination = null })
-        }
-
-        LibraryDestination.Settings -> {
-            SettingsScreen(
-                session = session,
-                onBack = { destination = null },
-                onManageDevices = { destination = LibraryDestination.Members },
-                onLeaveLibrary = onLeaveLibrary,
-            )
-        }
-
+    val navigator = remember { LibraryNavigator() }
+    val browserState = remember { LibraryBrowserState() }
+    val stateHolder = rememberSaveableStateHolder()
+    val popEntry: () -> Unit = {
+        navigator.pop()?.let { stateHolder.removeState(it.key) }
+    }
+    BackHandler(enabled = navigator.entries.isNotEmpty()) { popEntry() }
+    when (val entry = navigator.top) {
         null -> {
             LibraryBrowser(
                 session = session,
-                onSelectAlbum = { destination = LibraryDestination.Album(AlbumTarget(it)) },
-                onSelectComposer = { destination = LibraryDestination.Composer(it) },
-                onSelectWork = { destination = LibraryDestination.Work(it) },
-                onSettings = { destination = LibraryDestination.Settings },
+                state = browserState,
+                onSelectAlbum = { navigator.push(LibraryDestination.Album(AlbumTarget(it))) },
+                onSelectComposer = { navigator.push(LibraryDestination.Composer(it)) },
+                onSelectWork = { navigator.push(LibraryDestination.Work(it)) },
+                onSettings = { navigator.push(LibraryDestination.Settings) },
             )
+        }
+
+        else -> {
+            stateHolder.SaveableStateProvider(entry.key) {
+                LibraryDestinationScreen(
+                    session = session,
+                    destination = entry.destination,
+                    onBack = popEntry,
+                    onPush = navigator::push,
+                    onLeaveLibrary = onLeaveLibrary,
+                )
+            }
         }
     }
 }

--- a/bae-android/app/src/test/java/fm/bae/app/ui/LibraryNavigatorTest.kt
+++ b/bae-android/app/src/test/java/fm/bae/app/ui/LibraryNavigatorTest.kt
@@ -1,0 +1,73 @@
+package fm.bae.app.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The navigator is an ordered in-memory back stack: pushing shows the new top,
+ * popping returns to the previous level, an empty stack pops to null, and every
+ * push gets a fresh key so revisiting the same destination never shares saved
+ * UI state with a prior visit.
+ */
+class LibraryNavigatorTest {
+    @Test
+    fun pushShowsNewTopInOrder() {
+        val navigator = LibraryNavigator()
+        navigator.push(LibraryDestination.Composer("artist-1"))
+        navigator.push(LibraryDestination.Work("work-1"))
+        navigator.push(LibraryDestination.Album(AlbumTarget("album-1")))
+
+        assertEquals(LibraryDestination.Album(AlbumTarget("album-1")), navigator.top?.destination)
+        assertEquals(
+            listOf(
+                LibraryDestination.Composer("artist-1"),
+                LibraryDestination.Work("work-1"),
+                LibraryDestination.Album(AlbumTarget("album-1")),
+            ),
+            navigator.entries.map { it.destination },
+        )
+    }
+
+    @Test
+    fun popReturnsToPreviousLevel() {
+        val navigator = LibraryNavigator()
+        navigator.push(LibraryDestination.Composer("artist-1"))
+        navigator.push(LibraryDestination.Work("work-1"))
+        navigator.push(LibraryDestination.Album(AlbumTarget("album-1")))
+
+        assertEquals(LibraryDestination.Album(AlbumTarget("album-1")), navigator.pop()?.destination)
+        assertEquals(LibraryDestination.Work("work-1"), navigator.top?.destination)
+        assertEquals(LibraryDestination.Work("work-1"), navigator.pop()?.destination)
+        assertEquals(LibraryDestination.Composer("artist-1"), navigator.top?.destination)
+    }
+
+    @Test
+    fun popOnEmptyReturnsNull() {
+        val navigator = LibraryNavigator()
+        assertNull(navigator.pop())
+        assertTrue(navigator.entries.isEmpty())
+    }
+
+    @Test
+    fun keysAreUniqueAcrossRepushOfSameDestination() {
+        val navigator = LibraryNavigator()
+        navigator.push(LibraryDestination.Work("work-1"))
+        val firstKey = navigator.pop()?.key
+        navigator.push(LibraryDestination.Work("work-1"))
+        val secondKey = navigator.top?.key
+
+        assertTrue(firstKey != secondKey)
+    }
+
+    @Test
+    fun settingsThenMembersStacksBothLevels() {
+        val navigator = LibraryNavigator()
+        navigator.push(LibraryDestination.Settings)
+        navigator.push(LibraryDestination.Members)
+
+        assertEquals(LibraryDestination.Members, navigator.pop()?.destination)
+        assertEquals(LibraryDestination.Settings, navigator.top?.destination)
+    }
+}


### PR DESCRIPTION
The Android app modeled navigation as a single destination variable: opening an album from a work opened from a composer, then pressing back, collapsed straight to the library browser, and Settings → Manage devices replaced Settings instead of layering on it. Worse, nothing in the app handled the system back gesture at all — back always backgrounded the activity, even three levels deep. Browser chrome (tab, sort, search text, grid scroll) also lived inside the browser composable, so it reset every time a detail screen covered it.

Navigation is now a snapshot-backed stack (the same shape as iOS's routePath): pushed levels unwind one at a time, a BackHandler wires the system gesture to the stack (and a second one closes search first, matching the on-screen X), and per-entry SaveableStateProvider keys preserve each level's scroll state across pushes without ever resurrecting a previous visit's state. Browser chrome state is hoisted above the stack so it survives navigation. Hand-rolled rather than navigation-compose: the app already dispatches on sealed types over snapshot state, has no ViewModels or kotlinx-serialization, and needs none of navigation-compose's deep-link/multi-graph machinery.

## Test plan

- [x] LibraryNavigatorTest: push order, pop return value, empty-pop null, key uniqueness across re-push of the same destination, Settings→Members stacking
- [x] ./gradlew testFullDebugUnitTest, lintFullDebug, assembleFullDebug
- [x] ktlint, detekt
- [ ] Device: composer → work → album back-unwind, search-close via gesture, sheet/dialog back precedence, rotation mid-stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tK3JoFW9Nsdb2Tc139iLH