### PR TITLE
Drive the Windows system media transport controls from playback

### DIFF
--- a/bae-windows.Tests/MediaControlStateTests.cs
+++ b/bae-windows.Tests/MediaControlStateTests.cs
@@ -1,0 +1,239 @@
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the decision logic in <see cref="MediaControlState"/> — the pure state
+/// machine that decides what the system transport controls show and whether a
+/// command acts on the library queue or a preview clip. The WinRT shell that
+/// applies these decisions is verified by compilation, not here.
+/// </summary>
+public sealed class MediaControlStateTests
+{
+    private const string TrackTitle = "Track Title";
+    private const string ArtistName = "Artist Name";
+    private const string AlbumTitle = "Album Title";
+    private const ulong DurationMs = 200_000;
+
+    private static MediaControlDisplay? Track(
+        MediaControlState state,
+        string? coverImageId = "img-1",
+        ulong durationMs = DurationMs,
+        MediaControlPlaybackStatus status = MediaControlPlaybackStatus.Playing) =>
+        state.UpdateForTrack(TrackTitle, ArtistName, AlbumTitle, coverImageId, durationMs, status);
+
+    // ── Track metadata and status ──────────────────────────────────────────────
+
+    // The status enum is internal, so it can't appear in a public [Theory]
+    // signature; drive the three cases from the body instead.
+    [Fact]
+    public void UpdateForTrack_PassesMetadataAndStatus()
+    {
+        AssertTrackStatus(MediaControlPlaybackStatus.Playing);
+        AssertTrackStatus(MediaControlPlaybackStatus.Paused);
+        AssertTrackStatus(MediaControlPlaybackStatus.Changing);
+    }
+
+    private static void AssertTrackStatus(MediaControlPlaybackStatus status)
+    {
+        var state = new MediaControlState();
+
+        var display = Track(state, status: status);
+
+        Assert.NotNull(display);
+        Assert.Equal(status, display!.Status);
+        Assert.Equal(TrackTitle, display.Title);
+        Assert.Equal(ArtistName, display.Artist);
+        Assert.Equal(AlbumTitle, display.AlbumTitle);
+    }
+
+    // ── Artwork: load / keep / clear ───────────────────────────────────────────
+
+    [Fact]
+    public void Artwork_LoadsNewIdKeepsSameIdClearsNull()
+    {
+        var state = new MediaControlState();
+
+        Assert.Equal("img-1", Assert.IsType<MediaControlArtwork.Load>(Track(state, "img-1")!.Artwork).ImageId);
+        Assert.IsType<MediaControlArtwork.Keep>(Track(state, "img-1")!.Artwork);
+        Assert.Equal("img-2", Assert.IsType<MediaControlArtwork.Load>(Track(state, "img-2")!.Artwork).ImageId);
+        Assert.IsType<MediaControlArtwork.Clear>(Track(state, null)!.Artwork);
+    }
+
+    [Fact]
+    public void Artwork_SameIdLoadsAgainAfterClear()
+    {
+        var state = new MediaControlState();
+
+        Assert.IsType<MediaControlArtwork.Load>(Track(state, "img-1")!.Artwork);
+        state.Clear();
+        Assert.IsType<MediaControlArtwork.Load>(Track(state, "img-1")!.Artwork);
+    }
+
+    // ── Stale-artwork guard ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ArtworkLoadFailed_SameIdLoadsAgainStaleFailureIgnored()
+    {
+        var state = new MediaControlState();
+
+        Assert.IsType<MediaControlArtwork.Load>(Track(state, "img-1")!.Artwork);
+        state.ArtworkLoadFailed("img-1");
+        Assert.IsType<MediaControlArtwork.Load>(Track(state, "img-1")!.Artwork);
+
+        Track(state, "img-2");
+        state.ArtworkLoadFailed("img-1");
+        Assert.True(state.ArtworkLoadIsCurrent("img-2"));
+        Assert.IsType<MediaControlArtwork.Keep>(Track(state, "img-2")!.Artwork);
+    }
+
+    [Fact]
+    public void ArtworkLoadIsCurrent_TrueForCurrentIdFalseAfterChange()
+    {
+        var state = new MediaControlState();
+
+        Track(state, "img-1");
+        Assert.True(state.ArtworkLoadIsCurrent("img-1"));
+
+        Track(state, "img-2");
+        Assert.False(state.ArtworkLoadIsCurrent("img-1"));
+        Assert.True(state.ArtworkLoadIsCurrent("img-2"));
+
+        state.Clear();
+        Assert.False(state.ArtworkLoadIsCurrent("img-2"));
+    }
+
+    // ── Position ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdatePosition_NullBeforeDisplayNonNullAfterTrack()
+    {
+        var state = new MediaControlState();
+
+        Assert.Null(state.UpdatePosition(1_000, DurationMs));
+
+        Track(state);
+        var timeline = state.UpdatePosition(1_000, DurationMs);
+
+        Assert.NotNull(timeline);
+        Assert.Equal(1_000ul, timeline!.PositionMs);
+        Assert.Equal(DurationMs, timeline.DurationMs);
+    }
+
+    [Fact]
+    public void UpdatePosition_RefreshesDurationUsedBySeek()
+    {
+        var state = new MediaControlState();
+
+        Track(state, durationMs: DurationMs);
+        state.UpdatePosition(10_000, 100_000);
+
+        // Seek reads the position event's duration, not the track's original one.
+        Assert.Equal(0.5, state.SeekRatio(50_000));
+    }
+
+    // ── Seek ratio ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SeekRatio_NullWithoutDuration()
+    {
+        var state = new MediaControlState();
+
+        Assert.Null(state.SeekRatio(1_000));
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0)]
+    [InlineData(100_000.0, 0.5)]
+    [InlineData(200_000.0, 1.0)]
+    [InlineData(300_000.0, 1.0)]  // above duration clamps to 1
+    [InlineData(-5_000.0, 0.0)]   // negative clamps to 0
+    public void SeekRatio_ClampsToUnitInterval(double requestedMs, double expected)
+    {
+        var state = new MediaControlState();
+
+        Track(state, durationMs: DurationMs);
+
+        Assert.Equal(expected, state.SeekRatio(requestedMs));
+    }
+
+    // ── Preview takeover ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Preview_SuppressesLibraryUpdates()
+    {
+        var state = new MediaControlState();
+
+        state.UpdateForPreview("C:\\clips\\preview-clip.flac", 120_000, isPlaying: true);
+
+        Assert.True(state.IsShowingPreview);
+        Assert.Null(Track(state));
+        Assert.Null(state.UpdatePosition(1_000, DurationMs));
+    }
+
+    [Fact]
+    public void Preview_TitleIsFileName()
+    {
+        var state = new MediaControlState();
+
+        var display = state.UpdateForPreview("C:\\clips\\preview-clip.flac", 120_000, isPlaying: false);
+
+        Assert.Equal(MediaControlPlaybackStatus.Paused, display.Status);
+        Assert.Equal("preview-clip.flac", display.Title);
+        Assert.Equal(string.Empty, display.Artist);
+        Assert.Equal(string.Empty, display.AlbumTitle);
+        Assert.IsType<MediaControlArtwork.Clear>(display.Artwork);
+    }
+
+    [Fact]
+    public void UpdatePreviewPosition_UsesPreviewDuration()
+    {
+        var state = new MediaControlState();
+
+        state.UpdateForPreview("C:\\clips\\preview-clip.flac", 120_000, isPlaying: true);
+        var timeline = state.UpdatePreviewPosition(30_000);
+
+        Assert.NotNull(timeline);
+        Assert.Equal(30_000ul, timeline!.PositionMs);
+        Assert.Equal(120_000ul, timeline.DurationMs);
+    }
+
+    [Fact]
+    public void UpdatePreviewPosition_NullWhenNotPreviewing()
+    {
+        var state = new MediaControlState();
+
+        Track(state);
+
+        Assert.Null(state.UpdatePreviewPosition(30_000));
+    }
+
+    // ── Leaving preview ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ClearPreview_RestoresLibraryUpdates()
+    {
+        var state = new MediaControlState();
+
+        state.UpdateForPreview("C:\\clips\\preview-clip.flac", 120_000, isPlaying: true);
+        state.ClearPreview();
+
+        Assert.False(state.IsShowingPreview);
+        Assert.NotNull(Track(state));
+    }
+
+    [Fact]
+    public void StopMidPreview_ClearsDisplayState()
+    {
+        var state = new MediaControlState();
+
+        state.UpdateForPreview("C:\\clips\\preview-clip.flac", 120_000, isPlaying: true);
+        state.Clear();
+
+        // The tracked duration is gone, so a scrub can't be honored and the
+        // preview timeline no longer has a duration to report.
+        Assert.Null(state.SeekRatio(30_000));
+        Assert.Null(state.UpdatePreviewPosition(30_000));
+    }
+}

--- a/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows.Tests/bae-windows.Tests.csproj
@@ -1,16 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    Unit tests for bae-windows' locale-aware value formatters (Loc.Bytes /
-    Loc.Duration / Loc.Number) — the reimplementation of macOS's
-    ByteCountFormatter / DateComponentsFormatter, where parity matters.
+    Unit tests for bae-windows' pure logic that compiles without the Windows SDK
+    or the generated uniffi bindings, so it runs on any host including the macOS
+    dev machine:
 
-    These formatters are pure (System.Globalization only), so this is a plain
-    net8.0 xUnit project that runs on any host, including the macOS dev machine.
-    It compiles Loc.cs directly with BAE_PURE_FORMATTERS defined, which strips
-    the Windows-only catalog-resolution half of the file (WinUI ResourceLoader +
-    the MessageFormat parser). The WinUI build never defines that symbol, so its
-    view of Loc.cs is unchanged.
+    - The locale-aware value formatters (Loc.Bytes / Loc.Duration / Loc.Number) —
+      the reimplementation of macOS's ByteCountFormatter / DateComponentsFormatter,
+      where parity matters. Loc.cs is compiled with BAE_PURE_FORMATTERS defined,
+      which strips the Windows-only catalog-resolution half of the file (WinUI
+      ResourceLoader + the MessageFormat parser). The WinUI build never defines
+      that symbol, so its view of Loc.cs is unchanged.
+    - The media-control state layer (MediaControlState) — the decision logic
+      behind the system transport controls, expressed over plain BCL types with
+      no WinRT dependency (the WinRT shell that applies its decisions lives in
+      MediaControlService and is verified by compilation).
 
     The rest of bae-windows' pure logic (ReleaseCandidateChoice.Summary,
     ImportCandidate status/ToString, BridgeDisplay) depends on the generated
@@ -33,6 +37,7 @@
 
   <ItemGroup>
     <Compile Include="../bae-windows/Loc.cs" Link="Loc.cs" />
+    <Compile Include="../bae-windows/MediaControlState.cs" Link="MediaControlState.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -100,6 +100,11 @@ public sealed partial class MainWindow : Window
     // managed object rooted while Rust holds the callback handle.
     private NativeBae.UiEventSink? _eventCallback;
 
+    // Drives the system media transport controls (hardware media keys + the
+    // Windows media flyout) from playback events. One instance for the window's
+    // lifetime; library switches deactivate it rather than recreating it.
+    private readonly MediaControlService _mediaControls;
+
     // Latest queue snapshot from QueueUpdated; the queue dialog reads it on open.
     // The two lanes are kept separate so the dialog renders them as distinct
     // sections: the manual lane ("Up Next") and the context (the release being
@@ -169,6 +174,19 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
         Closed += OnClosed;
+
+        // The window's HWND exists at construction, so bind the transport controls
+        // to it now — before LoadLibrary starts the event stream that drives them.
+        _mediaControls = new MediaControlService(
+            WinRT.Interop.WindowNative.GetWindowHandle(this),
+            DispatcherQueue,
+            WithCurrentHandle,
+            imageId =>
+            {
+                byte[]? bytes = null;
+                WithCurrentHandle(handle => bytes = NativeBae.CoverImageBytes(handle, imageId));
+                return bytes;
+            });
 
         // Bind layout direction to the UI locale: ar/he (and any other RTL
         // culture) lay out right-to-left. The whole tree inherits from the root
@@ -546,6 +564,7 @@ public sealed partial class MainWindow : Window
         SearchBox.Text = string.Empty;
         StatusText.Text = string.Empty;
         NowPlayingBar.Visibility = Visibility.Collapsed;
+        _mediaControls.Deactivate();
         // The banners report the old library's sync / playback errors; clear them
         // so they don't describe state the next library (or none) doesn't have.
         Banner.IsOpen = false;
@@ -1845,6 +1864,8 @@ public sealed partial class MainWindow : Window
                 NpArtist.Text = playing.ArtistNames;
                 NpPlayPause.Content = "⏸";
                 NpCover.Source = CoverImage.LoadImage(CurrentHandleOrNull(), playing.CoverImageId);
+                _mediaControls.UpdateNowPlayingPlaying(
+                    playing.TrackTitle, playing.ArtistNames, playing.AlbumTitle, playing.CoverImageId, playing.DurationMs);
                 // Audio is flowing: drop the buffering spinner, restore the
                 // play/pause control.
                 NpLoading.IsActive = false;
@@ -1861,6 +1882,8 @@ public sealed partial class MainWindow : Window
                 NpArtist.Text = paused.ArtistNames;
                 NpPlayPause.Content = "▶";
                 NpCover.Source = CoverImage.LoadImage(CurrentHandleOrNull(), paused.CoverImageId);
+                _mediaControls.UpdateNowPlayingPaused(
+                    paused.TrackTitle, paused.ArtistNames, paused.AlbumTitle, paused.CoverImageId, paused.DurationMs);
                 NpLoading.IsActive = false;
                 NpLoading.Visibility = Visibility.Collapsed;
                 NpPlayPause.Visibility = Visibility.Visible;
@@ -1870,15 +1893,18 @@ public sealed partial class MainWindow : Window
                 NowPlayingBar.Visibility = Visibility.Collapsed;
                 _userSeeking = false;
                 _nowPlaying = null;
+                _mediaControls.UpdateNowPlayingStopped();
                 NpLoading.IsActive = false;
                 NpLoading.Visibility = Visibility.Collapsed;
                 NpPlayPause.Visibility = Visibility.Visible;
                 break;
             case BridgeUiEvent.PlaybackProgress progress:
                 RenderPlaybackProgress(progress.TrackId, progress.PositionMs, progress.DurationMs, progress.Progress);
+                _mediaControls.UpdatePosition(progress.PositionMs, progress.DurationMs);
                 break;
             case BridgeUiEvent.PlaybackSeeked seeked:
                 RenderPlaybackSeeked(seeked.TrackId, seeked.PositionMs, seeked.DurationMs, seeked.Progress);
+                _mediaControls.UpdatePosition(seeked.PositionMs, seeked.DurationMs);
                 break;
             case BridgeUiEvent.VolumeChanged volume:
                 _suppressVolume = true;
@@ -1904,14 +1930,17 @@ public sealed partial class MainWindow : Window
                         ? elapsed
                         : $"{elapsed} / {_previewDurationLabel}";
                 }
+                _mediaControls.UpdatePreviewPosition(previewProgress.PositionMs);
                 break;
             case BridgeUiEvent.PreviewPlaying preview:
                 // Total duration arrives once when preview starts; the next
                 // PreviewProgress tick renders it alongside the elapsed position.
                 _previewDurationLabel = DurationLabel(preview.DurationMs);
+                _mediaControls.UpdateNowPlayingForPreview(preview.Path, preview.DurationMs, isPlaying: true);
                 break;
             case BridgeUiEvent.PreviewPaused preview:
                 _previewDurationLabel = DurationLabel(preview.DurationMs);
+                _mediaControls.UpdateNowPlayingForPreview(preview.Path, preview.DurationMs, isPlaying: false);
                 break;
             case BridgeUiEvent.PreviewIdle:
                 _previewDurationLabel = null;
@@ -1919,6 +1948,7 @@ public sealed partial class MainWindow : Window
                 {
                     _previewElapsed.Text = string.Empty;
                 }
+                _mediaControls.UpdatePreviewIdle();
                 break;
             case BridgeUiEvent.Invalidated invalidated:
                 HandleInvalidation(invalidated.Invalidation);
@@ -1956,12 +1986,21 @@ public sealed partial class MainWindow : Window
                 NpPlayPause.Visibility = Visibility.Collapsed;
                 NpLoading.IsActive = true;
                 NpLoading.Visibility = Visibility.Visible;
+                // A bare loading event carries no metadata; leave the transport
+                // controls showing the prior track until the target resolves.
+                if (loading.Track is { } loadingTrack)
+                {
+                    _mediaControls.UpdateNowPlayingLoading(
+                        loadingTrack.TrackTitle, loadingTrack.ArtistNames, loadingTrack.AlbumTitle,
+                        loadingTrack.CoverImageId, loadingTrack.DurationMs);
+                }
                 break;
             case BridgeUiEvent.QueueUpdated queue:
                 _queueManual = queue.Snapshot.Manual.ToList();
                 _queueContext = queue.Snapshot.Context;
                 NpPrev.IsEnabled = queue.Snapshot.HasPrevious;
                 NpNext.IsEnabled = queue.Snapshot.HasNext;
+                _mediaControls.UpdateCommandAvailability(queue.Snapshot.HasNext, queue.Snapshot.HasPrevious);
                 break;
             case BridgeUiEvent.QueueItemsAdded added:
                 if (added.Count > 0)
@@ -6878,6 +6917,9 @@ public sealed partial class MainWindow : Window
 
     private async void OnClosed(object sender, WindowEventArgs args)
     {
+        // Clear the transport controls first so no ghost entry lingers during
+        // shutdown; OnClosed doesn't go through TearDownLibrary. Idempotent.
+        _mediaControls.Deactivate();
         if (CurrentHandleOrNull() != null)
         {
             // Persist the queue / current track / position before freeing the

--- a/bae-windows/MediaControlService.cs
+++ b/bae-windows/MediaControlService.cs
@@ -1,0 +1,310 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Windows.Media;
+using Windows.Storage.Streams;
+using uniffi.bae_bridge;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// Owns the window's <see cref="SystemMediaTransportControls"/> and applies the
+/// decisions of <see cref="MediaControlState"/>: metadata and status pushes,
+/// timeline updates, the async artwork fetch, and the button / seek callbacks
+/// (marshalled onto the UI thread). All decision logic lives in the state; this
+/// shell only translates it into WinRT calls.
+/// </summary>
+internal sealed class MediaControlService
+{
+    private readonly SystemMediaTransportControls _smtc;
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly Func<Action<AppHandle>, bool> _withCurrentHandle;
+    private readonly Func<string, byte[]?> _fetchCoverBytes;
+    private readonly MediaControlState _state = new();
+
+    // Kept alive while the display updater references it as the current thumbnail.
+    private InMemoryRandomAccessStream? _thumbnailStream;
+
+    internal MediaControlService(
+        IntPtr windowHandle,
+        DispatcherQueue dispatcherQueue,
+        Func<Action<AppHandle>, bool> withCurrentHandle,
+        Func<string, byte[]?> fetchCoverBytes)
+    {
+        _dispatcherQueue = dispatcherQueue;
+        _withCurrentHandle = withCurrentHandle;
+        _fetchCoverBytes = fetchCoverBytes;
+
+        _smtc = SystemMediaTransportControlsInterop.GetForWindow(windowHandle);
+        // Play/pause stay armed for the whole session; next/previous track the
+        // queue's has-next/has-previous. The session is inert until something
+        // plays, at which point Apply enables it.
+        _smtc.IsEnabled = false;
+        _smtc.IsPlayEnabled = true;
+        _smtc.IsPauseEnabled = true;
+        _smtc.IsNextEnabled = false;
+        _smtc.IsPreviousEnabled = false;
+        _smtc.ButtonPressed += OnButtonPressed;
+        // Registering this handler arms the system seek bar; the timeline pushes
+        // tell it the track's extent.
+        _smtc.PlaybackPositionChangeRequested += OnPlaybackPositionChangeRequested;
+    }
+
+    internal void UpdateNowPlayingPlaying(
+        string trackTitle, string artistNames, string albumTitle, string? coverImageId, ulong durationMs) =>
+        Apply(_state.UpdateForTrack(
+            trackTitle, artistNames, albumTitle, coverImageId, durationMs, MediaControlPlaybackStatus.Playing));
+
+    internal void UpdateNowPlayingPaused(
+        string trackTitle, string artistNames, string albumTitle, string? coverImageId, ulong durationMs) =>
+        Apply(_state.UpdateForTrack(
+            trackTitle, artistNames, albumTitle, coverImageId, durationMs, MediaControlPlaybackStatus.Paused));
+
+    internal void UpdateNowPlayingLoading(
+        string trackTitle, string artistNames, string albumTitle, string? coverImageId, ulong durationMs) =>
+        Apply(_state.UpdateForTrack(
+            trackTitle, artistNames, albumTitle, coverImageId, durationMs, MediaControlPlaybackStatus.Changing));
+
+    internal void UpdateNowPlayingStopped()
+    {
+        _state.Clear();
+        ClearSystemDisplay();
+    }
+
+    internal void UpdatePosition(ulong positionMs, ulong durationMs)
+    {
+        var timeline = _state.UpdatePosition(positionMs, durationMs);
+        if (timeline is not null)
+        {
+            PushTimeline(timeline);
+        }
+    }
+
+    internal void UpdateCommandAvailability(bool hasNext, bool hasPrevious)
+    {
+        _smtc.IsNextEnabled = hasNext;
+        _smtc.IsPreviousEnabled = hasPrevious;
+    }
+
+    internal void UpdateNowPlayingForPreview(string path, ulong durationMs, bool isPlaying) =>
+        Apply(_state.UpdateForPreview(path, durationMs, isPlaying));
+
+    internal void UpdatePreviewIdle()
+    {
+        _state.ClearPreview();
+        ClearSystemDisplay();
+    }
+
+    internal void UpdatePreviewPosition(ulong positionMs)
+    {
+        var timeline = _state.UpdatePreviewPosition(positionMs);
+        if (timeline is not null)
+        {
+            PushTimeline(timeline);
+        }
+    }
+
+    // Called on library teardown and window close. Idempotent, so a close after a
+    // library close is fine.
+    internal void Deactivate()
+    {
+        _state.Clear();
+        ClearSystemDisplay();
+    }
+
+    // Pushes a display's metadata, artwork action, and status to the system, and
+    // marks the session live. Null while a preview suppresses library updates.
+    private void Apply(MediaControlDisplay? display)
+    {
+        if (display is null)
+        {
+            return;
+        }
+
+        var updater = _smtc.DisplayUpdater;
+        updater.Type = MediaPlaybackType.Music;
+        updater.MusicProperties.Title = display.Title;
+        updater.MusicProperties.Artist = display.Artist;
+        updater.MusicProperties.AlbumTitle = display.AlbumTitle;
+        switch (display.Artwork)
+        {
+            case MediaControlArtwork.Keep:
+                break;
+            case MediaControlArtwork.Clear:
+                updater.Thumbnail = null;
+                _thumbnailStream?.Dispose();
+                _thumbnailStream = null;
+                break;
+            case MediaControlArtwork.Load load:
+                updater.Thumbnail = null;
+                StartArtworkLoad(load.ImageId);
+                break;
+        }
+        updater.Update();
+        _smtc.PlaybackStatus = ToPlaybackStatus(display.Status);
+        _smtc.IsEnabled = true;
+    }
+
+    private void ClearSystemDisplay()
+    {
+        _smtc.DisplayUpdater.ClearAll();
+        _smtc.PlaybackStatus = MediaPlaybackStatus.Closed;
+        _smtc.IsEnabled = false;
+        _smtc.IsNextEnabled = false;
+        _smtc.IsPreviousEnabled = false;
+        _thumbnailStream?.Dispose();
+        _thumbnailStream = null;
+    }
+
+    private void PushTimeline(MediaControlTimeline timeline) =>
+        _smtc.UpdateTimelineProperties(new SystemMediaTransportControlsTimelineProperties
+        {
+            StartTime = TimeSpan.Zero,
+            MinSeekTime = TimeSpan.Zero,
+            Position = TimeSpan.FromMilliseconds(timeline.PositionMs),
+            MaxSeekTime = TimeSpan.FromMilliseconds(timeline.DurationMs),
+            EndTime = TimeSpan.FromMilliseconds(timeline.DurationMs),
+        });
+
+    private static MediaPlaybackStatus ToPlaybackStatus(MediaControlPlaybackStatus status) =>
+        status switch
+        {
+            MediaControlPlaybackStatus.Playing => MediaPlaybackStatus.Playing,
+            MediaControlPlaybackStatus.Paused => MediaPlaybackStatus.Paused,
+            MediaControlPlaybackStatus.Changing => MediaPlaybackStatus.Changing,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown media control status"),
+        };
+
+    private void OnButtonPressed(
+        SystemMediaTransportControls sender, SystemMediaTransportControlsButtonPressedEventArgs args)
+    {
+        var button = args.Button;
+        _dispatcherQueue.TryEnqueue(() => HandleButton(button));
+    }
+
+    // Routes a system button to the same core commands the on-screen transport
+    // uses, splitting on whether a preview clip is showing.
+    private void HandleButton(SystemMediaTransportControlsButton button)
+    {
+        var previewing = _state.IsShowingPreview;
+        var dispatched = button switch
+        {
+            SystemMediaTransportControlsButton.Play when previewing => _withCurrentHandle(NativeBae.PreviewTogglePause),
+            SystemMediaTransportControlsButton.Pause when previewing => _withCurrentHandle(NativeBae.PreviewTogglePause),
+            SystemMediaTransportControlsButton.Play => _withCurrentHandle(NativeBae.Resume),
+            SystemMediaTransportControlsButton.Pause => _withCurrentHandle(NativeBae.Pause),
+            SystemMediaTransportControlsButton.Next when previewing => _withCurrentHandle(NativeBae.PreviewStop),
+            SystemMediaTransportControlsButton.Previous when previewing => _withCurrentHandle(NativeBae.PreviewStop),
+            SystemMediaTransportControlsButton.Next => _withCurrentHandle(NativeBae.Next),
+            SystemMediaTransportControlsButton.Previous => _withCurrentHandle(NativeBae.Previous),
+            // Buttons this service never enables (stop, FF, rewind, shuffle,
+            // repeat) — nothing to dispatch.
+            _ => true,
+        };
+        if (!dispatched)
+        {
+            // A button can race library teardown: the session was cleared between
+            // the press and this dispatch. Dropping the command is correct.
+            BaeDiagnostics.Logger.Debug($"Dropped system media button {button}: no open library handle.");
+        }
+    }
+
+    private void OnPlaybackPositionChangeRequested(
+        SystemMediaTransportControls sender, PlaybackPositionChangeRequestedEventArgs args)
+    {
+        var requestedMs = args.RequestedPlaybackPosition.TotalMilliseconds;
+        _dispatcherQueue.TryEnqueue(() => HandleSeek(requestedMs));
+    }
+
+    private void HandleSeek(double requestedMs)
+    {
+        if (_state.SeekRatio(requestedMs) is not { } ratio)
+        {
+            BaeDiagnostics.Logger.Warning("Ignoring system seek request: no current duration tracked.");
+            return;
+        }
+
+        bool dispatched;
+        if (_state.IsShowingPreview)
+        {
+            dispatched = _withCurrentHandle(handle => NativeBae.PreviewSeekByRatio(handle, ratio));
+        }
+        else
+        {
+            // Move the system timeline to the seek target now; the PlaybackSeeked
+            // event that follows corrects it. Duration is known whenever a ratio is.
+            if (_state.CurrentDurationMs is { } durationMs)
+            {
+                var timeline = _state.UpdatePosition((ulong)(ratio * durationMs), durationMs);
+                if (timeline is not null)
+                {
+                    PushTimeline(timeline);
+                }
+            }
+            dispatched = _withCurrentHandle(handle => NativeBae.SeekByRatio(handle, ratio));
+        }
+        if (!dispatched)
+        {
+            // A seek can race library teardown, same as the buttons.
+            BaeDiagnostics.Logger.Debug("Dropped system seek request: no open library handle.");
+        }
+    }
+
+    private void StartArtworkLoad(string imageId)
+    {
+        _ = Task.Run(() => _fetchCoverBytes(imageId)).ContinueWith(task =>
+        {
+            var bytes = task.Status == TaskStatus.RanToCompletion ? task.Result : null;
+            if (task.Exception is not null)
+            {
+                BaeDiagnostics.Logger.Warning("Failed to read system media thumbnail.", task.Exception);
+            }
+            _dispatcherQueue.TryEnqueue(() => ApplyArtwork(imageId, bytes));
+        }, TaskScheduler.Default);
+    }
+
+    // Writes the fetched cover into the display's thumbnail, unless the track
+    // changed while the fetch was in flight (stale load) or the fetch produced
+    // nothing.
+    private async void ApplyArtwork(string imageId, byte[]? bytes)
+    {
+        if (!_state.ArtworkLoadIsCurrent(imageId))
+        {
+            // A newer track's load owns the thumbnail slot now.
+            BaeDiagnostics.Logger.Debug("Skipping stale system media thumbnail load.");
+            return;
+        }
+        if (bytes is null)
+        {
+            // The fetch threw (logged at the fetch site) or the library handle
+            // closed mid-fetch. Forget the id so the next update for this cover
+            // retries the load instead of keeping a thumbnail that never arrived.
+            BaeDiagnostics.Logger.Debug("System media thumbnail fetch produced no bytes; will retry on the next update.");
+            _state.ArtworkLoadFailed(imageId);
+            return;
+        }
+
+        var stream = new InMemoryRandomAccessStream();
+        using (var writer = new DataWriter(stream))
+        {
+            writer.WriteBytes(bytes);
+            await writer.StoreAsync();
+            writer.DetachStream();
+        }
+        stream.Seek(0);
+
+        // The write yielded the UI thread; re-check the load is still current so a
+        // track change during it doesn't leave a stale thumbnail.
+        if (!_state.ArtworkLoadIsCurrent(imageId))
+        {
+            BaeDiagnostics.Logger.Debug("Skipping stale system media thumbnail load.");
+            stream.Dispose();
+            return;
+        }
+
+        _thumbnailStream?.Dispose();
+        _thumbnailStream = stream;
+        _smtc.DisplayUpdater.Thumbnail = RandomAccessStreamReference.CreateFromStream(stream);
+        _smtc.DisplayUpdater.Update();
+    }
+}

--- a/bae-windows/MediaControlState.cs
+++ b/bae-windows/MediaControlState.cs
@@ -1,0 +1,190 @@
+﻿using System;
+
+namespace Bae.Windows;
+
+/// <summary>How the current session's state renders on the system transport
+/// controls. Mirrors WinRT's MediaPlaybackStatus, mirrored here so this layer
+/// compiles without the Windows SDK projection. Closed has no counterpart: a
+/// cleared display never goes through a <see cref="MediaControlDisplay"/> —
+/// the shell clears the system session directly.</summary>
+internal enum MediaControlPlaybackStatus { Changing, Paused, Playing }
+
+/// <summary>What the artwork slot should do after a metadata update: keep the
+/// current thumbnail (same image), clear it (no cover), or load a new image id.</summary>
+internal abstract record MediaControlArtwork
+{
+    internal sealed record Keep : MediaControlArtwork;
+    internal sealed record Clear : MediaControlArtwork;
+    internal sealed record Load(string ImageId) : MediaControlArtwork;
+}
+
+/// <summary>One push to the system display: status, the metadata fields, and
+/// the artwork action. Artist and album are empty for preview clips.</summary>
+internal sealed record MediaControlDisplay(
+    MediaControlPlaybackStatus Status,
+    string Title,
+    string Artist,
+    string AlbumTitle,
+    MediaControlArtwork Artwork);
+
+/// <summary>A timeline push: elapsed and total, in milliseconds.</summary>
+internal sealed record MediaControlTimeline(ulong PositionMs, ulong DurationMs);
+
+/// <summary>Decides what the system media transport controls should show and
+/// whether commands act on the library queue or a preview clip. Pure state
+/// machine over the bridge's playback events; the WinRT calls live in
+/// MediaControlService.</summary>
+internal sealed class MediaControlState
+{
+    private bool _isShowingPreview;
+    private bool _hasDisplay;          // something has been pushed since the last Clear
+    private ulong? _currentDurationMs;
+    private string? _artworkImageId;   // image id currently loaded/loading into the thumbnail
+
+    /// <summary>Whether a preview clip is showing, so button/seek commands route
+    /// to the preview instead of the library queue.</summary>
+    internal bool IsShowingPreview => _isShowingPreview;
+
+    /// <summary>The duration the current display tracks, or null when nothing is
+    /// shown. The seek handler projects the optimistic timeline against it.</summary>
+    internal ulong? CurrentDurationMs => _currentDurationMs;
+
+    /// <summary>The display for a library track, or null while a preview is
+    /// showing (a preview clip takes over the now-playing slot). The caller only
+    /// invokes this for a playing or paused track, or a loading target whose
+    /// metadata core has resolved; a bare loading event keeps the existing
+    /// display untouched.</summary>
+    internal MediaControlDisplay? UpdateForTrack(
+        string trackTitle,
+        string artistNames,
+        string albumTitle,
+        string? coverImageId,
+        ulong durationMs,
+        MediaControlPlaybackStatus status)
+    {
+        if (_isShowingPreview)
+        {
+            return null;
+        }
+
+        _currentDurationMs = durationMs;
+        _hasDisplay = true;
+        return new MediaControlDisplay(status, trackTitle, artistNames, albumTitle, ArtworkFor(coverImageId));
+    }
+
+    /// <summary>Resets every tracked field. The shell clears the system display
+    /// unconditionally, so this returns nothing.</summary>
+    internal void Clear()
+    {
+        _hasDisplay = false;
+        _currentDurationMs = null;
+        _artworkImageId = null;
+    }
+
+    /// <summary>A timeline push for the current library track, or null while a
+    /// preview is showing or before anything has been displayed. Refreshes the
+    /// duration used by <see cref="SeekRatio"/> from the event, which carries the
+    /// pregap-adjusted value.</summary>
+    internal MediaControlTimeline? UpdatePosition(ulong positionMs, ulong durationMs)
+    {
+        if (_isShowingPreview || !_hasDisplay)
+        {
+            return null;
+        }
+
+        _currentDurationMs = durationMs;
+        return new MediaControlTimeline(positionMs, durationMs);
+    }
+
+    /// <summary>Enters preview mode and returns its display: the title is the
+    /// clip's file name, artist and album are empty, and the artwork slot is
+    /// cleared.</summary>
+    internal MediaControlDisplay UpdateForPreview(string path, ulong durationMs, bool isPlaying)
+    {
+        _isShowingPreview = true;
+        _hasDisplay = true;
+        _currentDurationMs = durationMs;
+        _artworkImageId = null;
+        var status = isPlaying ? MediaControlPlaybackStatus.Playing : MediaControlPlaybackStatus.Paused;
+        return new MediaControlDisplay(status, FileName(path), string.Empty, string.Empty, new MediaControlArtwork.Clear());
+    }
+
+    /// <summary>Leaves preview mode and resets every tracked field, like
+    /// <see cref="Clear"/>.</summary>
+    internal void ClearPreview()
+    {
+        _isShowingPreview = false;
+        Clear();
+    }
+
+    /// <summary>A timeline push for the current preview clip, or null when nothing
+    /// is previewing. The duration is the clip's stored duration.</summary>
+    internal MediaControlTimeline? UpdatePreviewPosition(ulong positionMs)
+    {
+        if (!_isShowingPreview || _currentDurationMs is not { } durationMs)
+        {
+            return null;
+        }
+
+        return new MediaControlTimeline(positionMs, durationMs);
+    }
+
+    /// <summary>The seek ratio in [0, 1] for a requested position, or null when no
+    /// duration is known — the command can't be honored without one.</summary>
+    internal double? SeekRatio(double requestedPositionMs)
+    {
+        if (_currentDurationMs is not { } durationMs || durationMs == 0)
+        {
+            return null;
+        }
+
+        var ratio = requestedPositionMs / durationMs;
+        return Math.Clamp(ratio, 0.0, 1.0);
+    }
+
+    /// <summary>Whether a completed artwork load for <paramref name="imageId"/> is
+    /// still the current image — false once the track changed mid-load. Guards the
+    /// async fetch from writing a stale thumbnail.</summary>
+    internal bool ArtworkLoadIsCurrent(string imageId) => imageId == _artworkImageId;
+
+    /// <summary>Records that the load for <paramref name="imageId"/> produced no
+    /// thumbnail. Forgetting the id means the next update for the same cover
+    /// issues a fresh <see cref="MediaControlArtwork.Load"/> instead of keeping a
+    /// thumbnail that never arrived. A stale failure (the track already moved on)
+    /// leaves the current load's tracking untouched.</summary>
+    internal void ArtworkLoadFailed(string imageId)
+    {
+        if (imageId == _artworkImageId)
+        {
+            _artworkImageId = null;
+        }
+    }
+
+    /// <summary>The artwork action for a track's cover: clear when it has none,
+    /// keep when the id is unchanged (the thumbnail is already loaded), otherwise
+    /// load the new id.</summary>
+    private MediaControlArtwork ArtworkFor(string? coverImageId)
+    {
+        if (coverImageId is null)
+        {
+            _artworkImageId = null;
+            return new MediaControlArtwork.Clear();
+        }
+
+        if (coverImageId == _artworkImageId)
+        {
+            return new MediaControlArtwork.Keep();
+        }
+
+        _artworkImageId = coverImageId;
+        return new MediaControlArtwork.Load(coverImageId);
+    }
+
+    /// <summary>The last path segment, splitting on both separators so a Windows
+    /// path resolves the same regardless of the host running this logic.</summary>
+    private static string FileName(string path)
+    {
+        var separator = path.LastIndexOfAny(new[] { '/', '\\' });
+        return separator < 0 ? path : path[(separator + 1)..];
+    }
+}

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -617,7 +617,13 @@ internal static class NativeBae
 
     internal static void PlayPause(AppHandle handle) => handle.TogglePlayPause();
 
+    internal static void Pause(AppHandle handle) => handle.Pause();
+
+    internal static void Resume(AppHandle handle) => handle.Resume();
+
     internal static void SeekByRatio(AppHandle handle, double ratio) => handle.SeekByRatio(ratio);
+
+    internal static void PreviewSeekByRatio(AppHandle handle, double ratio) => handle.PreviewSeekByRatio(ratio);
 
     internal static void SetVolume(AppHandle handle, float volume) => handle.SetVolume(volume);
 


### PR DESCRIPTION
On Windows, hardware media keys and the volume-flyout now-playing panel did nothing: the app never registered with SystemMediaTransportControls, so the OS had no session to show or send commands to. macOS has had the full MPRemoteCommandCenter/MPNowPlayingInfoCenter integration; this brings Windows to parity.

The decision logic (what the system display shows, preview-clip takeover, artwork keep/clear/load with a stale-load guard, seek-ratio derivation, failed-artwork retry) lives in a WinRT-free MediaControlState so it compiles into bae-windows.Tests and runs on any host; MediaControlService is a thin shell that owns the SMTC instance obtained via SystemMediaTransportControlsInterop.GetForWindow (the unpackaged-app path — CommandManager was rejected since the Rust core owns audio output), translates state decisions into WinRT calls, and marshals button/seek callbacks onto the UI thread. MainWindow feeds it from the existing HandleEvent cases, so session-generation gating is inherited. Buttons and scrubbing route through the same NativeBae calls the on-screen transport uses, with next/prev enablement tracking the queue's has-next/has-previous and preview clips taking over the session like they do on macOS.

## Test plan

- [x] 56 tests in bae-windows.Tests incl. 16 new MediaControlState cases (status mapping, artwork keep/clear/load/retry-after-failure, stale-load guard, seek clamping, preview takeover/restore)
- [x] dotnet test locally on macOS host
- [ ] Windows CI: WinUI compile of both binding variants, dotnet format, style gates
- [ ] Manual on Windows: media keys, volume-flyout metadata + artwork, scrubbing, preview takeover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tK3JoFW9Nsdb2Tc139iLH