### PR TITLE
Unify album cleanup after release removal

### DIFF
--- a/bae-core/src/db/client/album.rs
+++ b/bae-core/src/db/client/album.rs
@@ -378,28 +378,6 @@ impl Database {
         })
         .await
     }
-    /// Delete an album by ID
-    ///
-    /// This will cascade delete all related records:
-    /// - Releases (via FOREIGN KEY ON DELETE CASCADE)
-    /// - Album artists (via FOREIGN KEY ON DELETE CASCADE)
-    /// - Album discogs (via FOREIGN KEY ON DELETE CASCADE)
-    /// - All tracks, files, etc. from releases (via cascading)
-    /// - Import records referencing this album's releases (cleared before delete)
-    pub async fn delete_album(&self, album_id: &str) -> Result<(), DbError> {
-        let album_id = album_id.to_string();
-        self
-            .call(move |conn| {
-                let tx = conn;
-                tx.execute(
-                    "UPDATE imports SET release_id = NULL WHERE release_id IN (SELECT id FROM releases WHERE album_id = ?)",
-                    params![album_id],
-                )?;
-                tx.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
-                Ok(())
-            })
-            .await
-    }
 
     pub async fn delete_album_with_cleanup(
         &self,
@@ -436,24 +414,6 @@ impl Database {
             conn.execute(
                 "UPDATE albums SET primary_release_id = ?, _updated_at = ? WHERE id = ?",
                 params![primary_release_id, reg, album_id],
-            )
-            .map(|_| ())
-            .map_err(DbError::from)
-        })
-        .await
-    }
-
-    /// Clear an album's primary_release_id so summary queries fall back
-    /// to the first surviving release. Called after deleting the release
-    /// that primary_release_id pointed at.
-    pub async fn clear_album_primary_release(&self, album_id: &str) -> Result<(), DbError> {
-        let album_id = album_id.to_string();
-        self.call_sql(move |sql| {
-            let reg = sql.stamp();
-            let conn = sql.tx();
-            conn.execute(
-                "UPDATE albums SET primary_release_id = NULL, _updated_at = ? WHERE id = ?",
-                params![reg, album_id],
             )
             .map(|_| ())
             .map_err(DbError::from)

--- a/bae-core/src/db/client/identity.rs
+++ b/bae-core/src/db/client/identity.rs
@@ -233,8 +233,9 @@ impl Database {
     /// 3. UPDATE the release's `album_id` and metadata-source columns.
     /// 4. If the release vacated `current_album_id` (the source), check
     ///    inside the transaction whether any releases remain. None →
-    ///    delete the source album. Some → repair `primary_release_id`
-    ///    if it pointed at the moved release.
+    ///    delete the source album. Some → clear `primary_release_id`
+    ///    if it pointed at the moved release (read paths fall back to
+    ///    the first release).
     ///
     /// The post-move recheck on `current_album_id` closes a TOCTOU
     /// window: a separate writer could have inserted a release into the
@@ -360,61 +361,14 @@ impl Database {
             }
 
             // 5. Source-album cleanup. Only runs when the release actually
-            //    moved; same-album updates don't vacate anything.
-            let mut source_album_deleted = false;
-            if target_album_id != current_album_id {
-                // Recheck inside the transaction: how many releases does the
-                // source album hold now (after the UPDATE above)?
-                let remaining: i64 = tx.query_row(
-                    "SELECT COUNT(*) FROM releases WHERE album_id = ?",
-                    params![current_album_id],
-                    |row| row.get(0),
-                )?;
-
-                if remaining == 0 {
-                    // No releases left → delete the album. There can be no
-                    // imports to clear because the only way `releases` is
-                    // empty is if every prior release left the album, and
-                    // imports reference releases (not albums) — moving a
-                    // release elsewhere keeps the import row pointing at the
-                    // same release, just with a different `album_id`.
-                    tx.execute("DELETE FROM albums WHERE id = ?", params![current_album_id])?;
-                    source_album_deleted = true;
-                } else {
-                    // Album survives. If its `primary_release_id` pointed at
-                    // the moved release, repoint it at the oldest remaining
-                    // release (matching the "first release" fallback used
-                    // elsewhere in the read path).
-                    let dangling: Option<String> = tx
-                        .query_row(
-                            "SELECT primary_release_id FROM albums \
-                                 WHERE id = ? AND primary_release_id = ?",
-                            params![current_album_id, release_id],
-                            |row| row.get::<_, Option<String>>(0),
-                        )
-                        .optional()?
-                        .flatten();
-
-                    if dangling.is_some() {
-                        let new_primary: Option<String> = tx
-                            .query_row(
-                                "SELECT id FROM releases \
-                                     WHERE album_id = ? \
-                                     ORDER BY created_at ASC, id ASC \
-                                     LIMIT 1",
-                                params![current_album_id],
-                                |row| row.get::<_, String>(0),
-                            )
-                            .optional()?;
-
-                        tx.execute(
-                            "UPDATE albums SET primary_release_id = ?, _updated_at = ? \
-                                 WHERE id = ?",
-                            params![new_primary, reg, current_album_id],
-                        )?;
-                    }
-                }
-            }
+            //    moved; same-album updates don't vacate anything. Recheck
+            //    inside the transaction (TOCTOU: a writer may have added a
+            //    release to the source since the manager's pre-flight read).
+            let source_album_deleted = if target_album_id != current_album_id {
+                cleanup_album_after_release_removal_on(tx, &current_album_id, &release_id, &reg)?
+            } else {
+                false
+            };
 
             Ok(SetIdentityOutcome {
                 source_album_deleted,

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -181,6 +181,41 @@ fn apply_delete_cleanup_on(
     Ok(())
 }
 
+/// After `removed_release_id` has left `album_id` inside the current
+/// transaction (its row deleted, or its `album_id` repointed): delete the
+/// album when it has no releases left, otherwise clear a
+/// `primary_release_id` that pointed at the removed release.
+/// `primary_release_id` is the user's cover-release choice; when the chosen
+/// release leaves, the choice is gone (NULL) and read paths fall back to the
+/// album's first release. Does not touch `imports` — delete flows clear
+/// `imports.release_id` before the release row goes, and a moved release
+/// keeps its import row.
+/// Precondition: the release row must already be gone from / repointed away
+/// from `album_id` when this runs — it counts what remains.
+/// Returns true when the album row was deleted.
+fn cleanup_album_after_release_removal_on(
+    conn: &Connection,
+    album_id: &str,
+    removed_release_id: &str,
+    reg: &str,
+) -> Result<bool, DbError> {
+    let remaining: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM releases WHERE album_id = ?",
+        params![album_id],
+        |row| row.get(0),
+    )?;
+    if remaining == 0 {
+        conn.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
+        return Ok(true);
+    }
+    conn.execute(
+        "UPDATE albums SET primary_release_id = NULL, _updated_at = ? \
+         WHERE id = ? AND primary_release_id = ?",
+        params![reg, album_id, removed_release_id],
+    )?;
+    Ok(false)
+}
+
 fn composer_summary_query(filter: Option<&str>, tail: Option<&str>) -> String {
     let release_unlinked = unlinked_release_composer_role_predicate("rar");
     let track_unlinked = unlinked_track_composer_role_predicate("tar");

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -598,30 +598,12 @@ impl Database {
                             params![replacement.release_id],
                         )?;
 
-                        let remaining_release_count: i64 = tx.query_row(
-                            "SELECT COUNT(*) FROM releases WHERE album_id = ?",
-                            params![replacement.album_id],
-                            |row| row.get(0),
+                        let album_deleted = cleanup_album_after_release_removal_on(
+                            tx,
+                            &replacement.album_id,
+                            &replacement.release_id,
+                            &reg,
                         )?;
-                        let album_deleted = remaining_release_count == 0;
-                        if album_deleted {
-                            tx.execute(
-                                "DELETE FROM albums WHERE id = ?",
-                                params![replacement.album_id],
-                            )?;
-                        } else {
-                            let primary_release_id: Option<String> = tx.query_row(
-                                "SELECT primary_release_id FROM albums WHERE id = ?",
-                                params![replacement.album_id],
-                                |row| row.get(0),
-                            )?;
-                            if primary_release_id.as_deref() == Some(&replacement.release_id) {
-                                tx.execute(
-                                    "UPDATE albums SET primary_release_id = NULL, _updated_at = ? WHERE id = ?",
-                                    params![reg, replacement.album_id],
-                                )?;
-                            }
-                        }
                         replacement_outcomes_for_write
                             .lock()
                             .expect("replacement outcomes mutex not poisoned")
@@ -808,27 +790,6 @@ impl Database {
             .expect("replacement outcomes mutex not poisoned"))
     }
 
-    /// Delete a release by ID
-    ///
-    /// This will cascade delete all related records:
-    /// - Tracks (via FOREIGN KEY ON DELETE CASCADE)
-    /// - Files (via FOREIGN KEY ON DELETE CASCADE)
-    /// - Track artists, audio formats (via FOREIGN KEY ON DELETE CASCADE)
-    /// - Import records referencing this release (cleared before delete)
-    pub async fn delete_release(&self, release_id: &str) -> Result<(), DbError> {
-        let release_id = release_id.to_string();
-        self.call(move |conn| {
-            let tx = conn;
-            tx.execute(
-                "UPDATE imports SET release_id = NULL WHERE release_id = ?",
-                params![release_id],
-            )?;
-            tx.execute("DELETE FROM releases WHERE id = ?", params![release_id])?;
-            Ok(())
-        })
-        .await
-    }
-
     pub async fn delete_release_with_cleanup(
         &self,
         release_id: &str,
@@ -847,27 +808,8 @@ impl Database {
             )?;
             conn.execute("DELETE FROM releases WHERE id = ?", params![release_id])?;
 
-            let remaining_release_count: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM releases WHERE album_id = ?",
-                params![album_id],
-                |row| row.get(0),
-            )?;
-            let album_deleted = remaining_release_count == 0;
-            if album_deleted {
-                conn.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
-            } else {
-                let primary_release_id: Option<String> = conn.query_row(
-                    "SELECT primary_release_id FROM albums WHERE id = ?",
-                    params![album_id],
-                    |row| row.get(0),
-                )?;
-                if primary_release_id.as_deref() == Some(&release_id) {
-                    conn.execute(
-                        "UPDATE albums SET primary_release_id = NULL, _updated_at = ? WHERE id = ?",
-                        params![reg, album_id],
-                    )?;
-                }
-            }
+            let album_deleted =
+                cleanup_album_after_release_removal_on(conn, &album_id, &release_id, &reg)?;
 
             Ok(album_deleted)
         })
@@ -903,17 +845,6 @@ impl Database {
                 )
                 .optional()?
                 .ok_or_else(|| DbError(format!("release not found: {release_id}")))?;
-
-            let remaining_release_count: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM releases WHERE album_id = ? AND id != ?",
-                params![album_id, release_id],
-                |row| row.get(0),
-            )?;
-            let primary_release_id: Option<String> = conn.query_row(
-                "SELECT primary_release_id FROM albums WHERE id = ?",
-                params![album_id],
-                |row| row.get(0),
-            )?;
 
             // Every artist this release/album references, captured before the
             // cascade below removes those link rows. After the release (and its
@@ -1023,14 +954,7 @@ impl Database {
             )?;
             conn.execute("DELETE FROM releases WHERE id = ?", params![release_id])?;
 
-            if remaining_release_count == 0 {
-                conn.execute("DELETE FROM albums WHERE id = ?", params![album_id])?;
-            } else if primary_release_id.as_deref() == Some(&release_id) {
-                conn.execute(
-                    "UPDATE albums SET primary_release_id = NULL, _updated_at = ? WHERE id = ?",
-                    params![reg, album_id],
-                )?;
-            }
+            cleanup_album_after_release_removal_on(conn, &album_id, &release_id, &reg)?;
 
             // Delete the works this release owned, now that its track_works are
             // gone. A work still reachable from a surviving track — directly, or

--- a/bae-core/src/db/client/tests.rs
+++ b/bae-core/src/db/client/tests.rs
@@ -763,6 +763,139 @@ mod composer_mode_tests {
     use super::super::*;
     use coven::SystemClock;
 
+    /// A replacement with no blob/outbox cleanup — the released-in-place local
+    /// files these album-cleanup tests use carry no cloud state to tear down.
+    fn empty_cleanup_plan() -> DeleteCleanupPlan {
+        DeleteCleanupPlan {
+            cloud_delete_keys: Vec::new(),
+            in_flight_make_remote_blobs: Vec::new(),
+            external_blob_ids_to_clear: Vec::new(),
+            make_remote_release_ids_to_clear: Vec::new(),
+        }
+    }
+
+    /// Shared arrange for the two reimport-replacement tests. Seeds `album-old`
+    /// with `existing_release_ids` (its `primary_release_id` set to
+    /// `replaced_release_id`), then finalizes a reimport whose new release
+    /// `rel-new` lands in the fresh `album-new`, carrying an
+    /// `ImportReplacementDelete` for `replaced_release_id`. Returns the
+    /// finalize outcomes so each test asserts the album fate on its own.
+    async fn finalize_reimport_replacing_release(
+        db: &Database,
+        tmp: &tempfile::TempDir,
+        now: chrono::DateTime<chrono::Utc>,
+        existing_release_ids: &[&str],
+        replaced_release_id: &str,
+    ) -> Vec<ImportReplacementOutcome> {
+        let artist = DbArtist {
+            id: "artist-a".to_string(),
+            name: "Artist Name A".to_string(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: now,
+        };
+        db.insert_artist(&artist).await.unwrap();
+
+        let album_old = DbAlbum {
+            id: "album-old".to_string(),
+            title: "Album Title Old".to_string(),
+            artist_id: artist.id.clone(),
+            year: Some(2026),
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: now,
+        };
+        db.insert_album(&album_old).await.unwrap();
+        for id in existing_release_ids {
+            db.insert_release(&DbRelease::new_test(&album_old.id, id))
+                .await
+                .unwrap();
+        }
+        db.set_album_primary_release(&album_old.id, replaced_release_id)
+            .await
+            .unwrap();
+
+        // The reimport lands its new release in a fresh album.
+        db.insert_import(&DbImport::new(
+            "import-new",
+            "Album Title New",
+            "Artist Name A",
+            tmp.path().to_str().unwrap(),
+            now,
+        ))
+        .await
+        .unwrap();
+        let album_new = DbAlbum {
+            id: "album-new".to_string(),
+            title: "Album Title New".to_string(),
+            artist_id: artist.id.clone(),
+            year: Some(2026),
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: now,
+        };
+        let release_new = DbRelease::new_test(&album_new.id, "rel-new");
+        let track = DbTrack {
+            id: "track-new".to_string(),
+            release_id: release_new.id.clone(),
+            title: "Track Title New".to_string(),
+            side: 1,
+            track_number: Some(1),
+            duration_ms: Some(1000),
+            discogs_position: None,
+            created_at: now,
+        };
+        let file = DbFile::new(
+            &release_new.id,
+            "Track Title New.flac",
+            1024,
+            ContentType::Flac,
+            "file-new".to_string(),
+            now,
+        );
+        let track_files = vec![crate::import::TrackFile::Standalone {
+            db_track: track,
+            file_path: tmp.path().join("Track Title New.flac"),
+        }];
+
+        let replacement = ImportReplacementDelete {
+            release_id: replaced_release_id.to_string(),
+            album_id: album_old.id.clone(),
+            cleanup: empty_cleanup_plan(),
+        };
+        db.finalize_import_atomic(
+            Some(&album_new),
+            &release_new,
+            &track_files,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[file],
+            &[],
+            &[],
+            None,
+            &[],
+            None,
+            "import-new",
+            ImportOperationStatus::Complete,
+            &[],
+            tmp.path().to_str().unwrap(),
+            crate::config::HomeStorage::Opaque,
+            &[replacement],
+        )
+        .await
+        .unwrap()
+    }
+
     async fn seeded_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
@@ -1132,6 +1265,195 @@ mod composer_mode_tests {
             import.error_message.as_deref(),
             Some("remote upload failed")
         );
+    }
+
+    /// Reimport replacing one of several releases in an album: the prior
+    /// release leaves but the album survives, so a `primary_release_id`
+    /// pointing at the departed release is cleared to NULL (read paths fall
+    /// back to the first remaining release).
+    #[tokio::test]
+    async fn finalize_replacement_in_surviving_album_clears_dangling_primary() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        // album-old holds rel-one (primary) and rel-two; the reimport replaces
+        // rel-one, so the album survives on rel-two.
+        let outcomes =
+            finalize_reimport_replacing_release(&db, &tmp, now, &["rel-one", "rel-two"], "rel-one")
+                .await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].album_id, "album-old");
+        assert_eq!(outcomes[0].release_id, "rel-one");
+        assert!(!outcomes[0].album_deleted);
+
+        let surviving = db
+            .find_album_by_id("album-old")
+            .await
+            .unwrap()
+            .expect("album survives while rel-two remains");
+        assert_eq!(surviving.primary_release_id, None);
+        assert!(db.find_release_by_id("rel-one").await.unwrap().is_none());
+        assert!(db.find_release_by_id("rel-two").await.unwrap().is_some());
+    }
+
+    /// Reimport replacing the sole release of an album, landing in a new
+    /// album: the prior album empties and is deleted; the outcome reports it.
+    #[tokio::test]
+    async fn finalize_replacement_of_last_release_deletes_prior_album() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        // album-old holds only rel-old; replacing it empties and deletes it.
+        let outcomes =
+            finalize_reimport_replacing_release(&db, &tmp, now, &["rel-old"], "rel-old").await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].album_id, "album-old");
+        assert!(outcomes[0].album_deleted);
+
+        assert!(db.find_album_by_id("album-old").await.unwrap().is_none());
+        assert!(db.find_release_by_id("rel-old").await.unwrap().is_none());
+        assert!(db.find_album_by_id("album-new").await.unwrap().is_some());
+        assert!(db.find_release_by_id("rel-new").await.unwrap().is_some());
+    }
+
+    /// Failed-import rollback of one of several releases in an album: the
+    /// album survives, so a `primary_release_id` pointing at the failed
+    /// release is cleared to NULL and the sibling release is untouched.
+    #[tokio::test]
+    async fn fail_import_and_delete_release_in_surviving_album_clears_dangling_primary() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        db.insert_import(&DbImport::new(
+            "import-a",
+            "Album Title A",
+            "Artist Name A",
+            tmp.path().to_str().unwrap(),
+            now,
+        ))
+        .await
+        .unwrap();
+
+        let artist = DbArtist {
+            id: "artist-a".to_string(),
+            name: "Artist Name A".to_string(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: now,
+        };
+        db.insert_artist(&artist).await.unwrap();
+
+        let album = DbAlbum {
+            id: "album-a".to_string(),
+            title: "Album Title A".to_string(),
+            artist_id: artist.id.clone(),
+            year: Some(2026),
+            primary_release_id: None,
+            is_compilation: false,
+            created_at: now,
+        };
+        let release = DbRelease::new_test(&album.id, "rel-a");
+        let track = DbTrack {
+            id: "track-a".to_string(),
+            release_id: release.id.clone(),
+            title: "Track Title A".to_string(),
+            side: 1,
+            track_number: Some(1),
+            duration_ms: Some(1000),
+            discogs_position: None,
+            created_at: now,
+        };
+        let file = DbFile::new(
+            &release.id,
+            "Track Title A.flac",
+            1024,
+            ContentType::Flac,
+            "file-a".to_string(),
+            now,
+        );
+        let track_files = vec![crate::import::TrackFile::Standalone {
+            db_track: track,
+            file_path: tmp.path().join("Track Title A.flac"),
+        }];
+
+        // Finalize the import, pointing the album's primary at the release
+        // this import created.
+        db.finalize_import_atomic(
+            Some(&album),
+            &release,
+            &track_files,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[file],
+            &[],
+            &[],
+            None,
+            &[],
+            Some((&album.id, &release.id)),
+            "import-a",
+            ImportOperationStatus::Complete,
+            &[],
+            tmp.path().to_str().unwrap(),
+            crate::config::HomeStorage::Opaque,
+            &[],
+        )
+        .await
+        .unwrap();
+
+        // A sibling release in the same album keeps it alive through the
+        // rollback.
+        let sibling = DbRelease::new_test(&album.id, "rel-b");
+        db.insert_release(&sibling).await.unwrap();
+
+        db.fail_import_and_delete_release("import-a", "rel-a", "remote upload failed")
+            .await
+            .unwrap();
+
+        let surviving = db
+            .find_album_by_id("album-a")
+            .await
+            .unwrap()
+            .expect("album survives while sibling remains");
+        assert_eq!(surviving.primary_release_id, None);
+        assert!(db.find_release_by_id("rel-a").await.unwrap().is_none());
+        assert!(db.find_release_by_id("rel-b").await.unwrap().is_some());
+        let import = db
+            .find_import_by_id("import-a")
+            .await
+            .unwrap()
+            .expect("import remains visible as failed");
+        assert_eq!(import.status, ImportOperationStatus::Failed);
+        assert!(import.release_id.is_none());
     }
 
     /// A failed remote import's cover and artist-image blobs live only in

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -3921,21 +3921,19 @@ async fn set_identity_to_fresh_album_preserves_album_artists() {
 }
 
 #[tokio::test]
-async fn set_identity_moves_primary_release_id_to_remaining_release() {
+async fn set_identity_clears_primary_when_it_pointed_at_moved_release() {
     let (manager, _temp_dir) = setup_test_manager().await;
+    let now = Utc::now();
+    let beta_track_id = "track-beta".to_string();
 
     // album_a carries two releases on g1 and points
-    // primary_release_id at release_alpha. Move release_alpha out
-    // and the pointer should be repaired to release_beta — anything
-    // less leaves the FK pointing at a release that no longer
-    // belongs to the album.
+    // primary_release_id at release_alpha. Move release_alpha out.
+    // The chosen release is gone, so primary_release_id becomes NULL
+    // and the read path falls back to the remaining release_beta.
     let album_a = create_test_album();
     manager.database.insert_album(&album_a).await.unwrap();
     let release_alpha = create_test_release(&album_a.id);
-    // Older `created_at` for beta so it wins the
-    // ORDER BY created_at ASC tiebreak.
-    let mut release_beta = create_test_release(&album_a.id);
-    release_beta.created_at = release_alpha.created_at - chrono::Duration::seconds(60);
+    let release_beta = create_test_release(&album_a.id);
 
     manager
         .database
@@ -3947,6 +3945,20 @@ async fn set_identity_moves_primary_release_id_to_remaining_release() {
         .insert_release(&release_beta)
         .await
         .unwrap();
+
+    // A track on release_beta so the read-path resolution below has an
+    // identifiable target: the fallback should surface beta's tracks.
+    let beta_track = crate::db::DbTrack {
+        id: beta_track_id.clone(),
+        release_id: release_beta.id.clone(),
+        title: "Track Title".to_string(),
+        side: 1,
+        track_number: Some(1),
+        duration_ms: Some(180_000),
+        discogs_position: None,
+        created_at: now,
+    };
+    manager.database.insert_track(&beta_track).await.unwrap();
 
     // Point album_a.primary_release_id at release_alpha — the
     // release we're about to move out.
@@ -3980,7 +3992,8 @@ async fn set_identity_moves_primary_release_id_to_remaining_release() {
         .await
         .unwrap();
 
-    // album_a survives, primary_release_id moved to release_beta.
+    // album_a survives; its primary_release_id is cleared to NULL now
+    // that the release it pointed at has left.
     let surviving_album = manager
         .database
         .find_album_by_id(&album_a.id)
@@ -3988,9 +4001,21 @@ async fn set_identity_moves_primary_release_id_to_remaining_release() {
         .unwrap()
         .expect("album should still exist with release_beta");
     assert_eq!(
-        surviving_album.primary_release_id.as_deref(),
-        Some(release_beta.id.as_str()),
-        "primary_release_id should repoint to the remaining release",
+        surviving_album.primary_release_id, None,
+        "primary_release_id should be cleared when its release moves out",
+    );
+
+    // Read path falls back to the first remaining release: album_a now
+    // resolves its primary to release_beta.
+    let resolved_track_ids = manager
+        .database
+        .get_primary_release_track_ids_for_album(&album_a.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        resolved_track_ids,
+        Some(vec![beta_track_id.clone()]),
+        "read path should resolve the cleared primary to release_beta",
     );
 }
 


### PR DESCRIPTION
The invariant "when a release leaves an album, delete the album if it was the last one, else repair a dangling primary_release_id" was hand-inlined in four transaction sites (finalize_import_atomic's replacement loop, delete_release_with_cleanup, fail_import_and_delete_release, set_identity_atomic) — and they had already diverged: three sites NULLed the dangling primary while set_identity_atomic repointed it to the oldest remaining release.

This PR centralizes the invariant into one helper, cleanup_album_after_release_removal_on, that all four sites call inside their existing transactions, and settles the policy: NULL + the read-path first-release default. NULL is the schema-documented state for "no user choice"; the read-side default already exists everywhere and can never be deleted (fresh albums are deliberately created with a NULL primary, and LWW sync merges can dangle a primary that only a read-side rule survives), so write-side repointing was a second mechanism for the same guarantee — it fabricated a user choice and is deleted.

Also deletes three zero-caller Database methods (delete_release, delete_album, clear_album_primary_release) — broken duplicates of the *_with_cleanup paths that skipped album cleanup, blob refs, and outbox tombstones, waiting for someone to call them.

## Test plan
- [x] Rewrote set_identity primary test to the NULL policy (fails on old code, passes on new), asserting both the stored NULL and the read-path resolution
- [x] New db-layer tests for the previously uncovered branches: finalize-replacement survivor + last-release, fail-import survivor
- [x] Full bae-core suite with --features test-utils: 1021 lib + all integration binaries green

🤖 Generated with [Claude Code](https://claude.com/claude-code)