### PR TITLE
Shared release IR and single assembler for import mappers

### DIFF
--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -731,77 +731,10 @@ impl DbAlbum {
             created_at: now,
         }
     }
-    /// Create a logical album from a Discogs release
-    /// Note: Artists should be created separately and linked via DbAlbumArtist
-    ///
-    /// master_year is the original release year (from the Discogs master release).
-    /// Falls back to the specific release year if master_year is unavailable.
-    pub fn from_discogs_release(
-        release: &crate::discogs::DiscogsRelease,
-        master_year: Option<u32>,
-        primary_artist_id: &str,
-        id: String,
-        now: DateTime<Utc>,
-    ) -> Self {
-        let is_compilation = release
-            .artists
-            .first()
-            .map(|a| is_various_artists(&a.name))
-            .unwrap_or(false);
-        let year = master_year
-            .map(|y| y as i32)
-            .or(release.year.map(|y| y as i32));
-        DbAlbum {
-            id,
-            title: release.title.clone(),
-            artist_id: primary_artist_id.to_string(),
-            year,
-            primary_release_id: None,
-            is_compilation,
-            created_at: now,
-        }
-    }
-    pub fn from_mb_response(
-        response: &crate::musicbrainz::MbReleaseResponse,
-        master_year: Option<u32>,
-        primary_artist_id: &str,
-        id: String,
-        now: DateTime<Utc>,
-    ) -> Self {
-        let first_release_date = response
-            .release_group
-            .as_ref()
-            .and_then(|rg| rg.first_release_date.clone())
-            .filter(|s| !s.is_empty());
-        let year = first_release_date
-            .as_ref()
-            .and_then(|d| d.split('-').next().and_then(|y| y.parse::<i32>().ok()))
-            .or_else(|| {
-                response
-                    .date
-                    .as_ref()
-                    .and_then(|d| d.split('-').next().and_then(|y| y.parse::<i32>().ok()))
-            })
-            .or(master_year.map(|y| y as i32));
-        let is_compilation = response
-            .artist_credit
-            .first()
-            .map(|ac| is_various_artists(&ac.name))
-            .unwrap_or(false);
-        DbAlbum {
-            id,
-            title: response.title.clone(),
-            artist_id: primary_artist_id.to_string(),
-            year,
-            primary_release_id: None,
-            is_compilation,
-            created_at: now,
-        }
-    }
 }
 
 /// Check if an artist name indicates a "Various Artists" compilation
-fn is_various_artists(name: &str) -> bool {
+pub(crate) fn is_various_artists(name: &str) -> bool {
     let lower = name.trim().to_lowercase();
     lower == "various" || lower == "various artists"
 }
@@ -826,90 +759,6 @@ impl DbRelease {
             created_at: now,
         }
     }
-    /// Create a release from a Discogs release
-    pub fn from_discogs_release(
-        album_id: &str,
-        release: &crate::discogs::DiscogsRelease,
-        id: String,
-        now: DateTime<Utc>,
-    ) -> Self {
-        let format = if release.format.is_empty() {
-            None
-        } else {
-            Some(release.format.join(", "))
-        };
-        DbRelease {
-            id,
-            album_id: album_id.to_string(),
-            release_name: None,
-            pressing: Pressing {
-                year: release.year.map(|y| y as i32),
-                format,
-                label: release.label.first().cloned(),
-                catalog_number: release.catno.clone(),
-                country: release.country.clone(),
-                barcode: None,
-            },
-            disc_id: None,
-            metadata_source: ReleaseMetadataSource::Discogs,
-            metadata_source_release_id: Some(release.id.clone()),
-            // Imports land local; the upload observer flips `remote` true
-            // once the release's audio is durably in the cloud.
-            remote: false,
-            source_folder_name: None,
-            content_hash: None,
-            album_loudness_lufs: None,
-            album_peak_linear: None,
-            created_at: now,
-        }
-    }
-    pub fn from_mb_response(
-        album_id: &str,
-        response: &crate::musicbrainz::MbReleaseResponse,
-        id: String,
-        now: DateTime<Utc>,
-    ) -> Self {
-        let year = response
-            .date
-            .as_ref()
-            .and_then(|d| d.split('-').next().and_then(|y| y.parse::<i32>().ok()));
-        let format = response.media.first().and_then(|m| m.format.clone());
-        let (label, catalog_number) = response
-            .label_info
-            .first()
-            .map(|li| {
-                (
-                    li.label.as_ref().and_then(|l| l.name.clone()),
-                    li.catalog_number.clone(),
-                )
-            })
-            .unwrap_or((None, None));
-        DbRelease {
-            id,
-            album_id: album_id.to_string(),
-            release_name: None,
-            pressing: Pressing {
-                year,
-                format,
-                label,
-                catalog_number,
-                country: response.country.clone(),
-                barcode: response.barcode.clone(),
-            },
-            disc_id: None,
-            metadata_source: ReleaseMetadataSource::MusicBrainz,
-            metadata_source_release_id: Some(response.id.clone()),
-            // Imports land local; the upload observer flips `remote` true
-            // once the release's audio is durably in the cloud.
-            remote: false,
-            source_folder_name: None,
-            content_hash: None,
-            album_loudness_lufs: None,
-            album_peak_linear: None,
-            created_at: now,
-        }
-    }
-
     /// Storage state — Local (local) or Remote (cloud) — from the shared
     /// `remote` fact. Pinned-ness is the orthogonal coven-cache property the
     /// caller carries separately; it is never part of this.
@@ -935,27 +784,6 @@ impl DbTrack {
             track_number,
             duration_ms: None,
             discogs_position: None,
-
-            created_at: now,
-        }
-    }
-    pub fn from_discogs_track(
-        title: &str,
-        release_id: &str,
-        track_number: i32,
-        side: i32,
-        discogs_position: Option<String>,
-        id: String,
-        now: DateTime<Utc>,
-    ) -> Self {
-        DbTrack {
-            id,
-            release_id: release_id.to_string(),
-            title: title.to_string(),
-            side,
-            track_number: Some(track_number),
-            duration_ms: None,
-            discogs_position,
 
             created_at: now,
         }

--- a/bae-core/src/import/assemble.rs
+++ b/bae-core/src/import/assemble.rs
@@ -1,0 +1,623 @@
+//! Shared release intermediate representation and the single assembler.
+//!
+//! All three import mappers (file tags, MusicBrainz, Discogs) parse their
+//! source into a [`ReleaseIr`] — an ordered, pre-id, pre-dedup description of
+//! what the source said — and hand it to [`assemble_parsed_album`], which owns
+//! artist-pool dedup, per-side numbering, junction-row emission, and DB-row
+//! construction. The IR draws the boundary between "what the source claims" and
+//! "which rows we mint": every [`ArtistRef`] is an unresolved reference, and the
+//! assembler resolves each one against a single artist pool.
+//!
+//! Per-track events are ordered because that order is observable output:
+//! [`ParsedAlbum::artists`] insertion order, junction-row order, and id-mint
+//! order all follow the event stream. The mappers preserve each source's exact
+//! discovery order when they build the IR.
+
+use crate::db::{
+    DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbReleaseArtistRole, DbTrack, DbTrackArtist,
+    DbTrackArtistRole, DbTrackWork, DbWork, DbWorkArtist, DbWorkPart, Pressing,
+    ReleaseMetadataSource,
+};
+use crate::import::types::{MetadataSource, ReleaseIdentity};
+use crate::import::{ParsedAlbum, ParsedWorkGraph};
+use chrono::{DateTime, Utc};
+use coven::{Clock, IdProvider};
+use std::collections::HashSet;
+use tracing::debug;
+
+/// A reference to an artist as a source credits it, before any DB id exists.
+pub(crate) struct ArtistRef {
+    pub name: String,
+    pub sort_name: Option<String>,
+    pub musicbrainz_artist_id: Option<String>,
+    pub discogs_artist_id: Option<String>,
+}
+
+/// How a track's number is determined.
+pub(crate) enum TrackNumber {
+    /// 1-based position within the track's side, assigned by the assembler via
+    /// [`per_side_positions`] (MusicBrainz, Discogs, CUE, fully-untagged tag
+    /// sides).
+    PerSide,
+    /// The source supplied (or withheld) the number; written verbatim (file
+    /// tags: TRACKNUMBER, or `None` for the user to fill in).
+    Explicit(Option<i32>),
+}
+
+pub(crate) enum PartDirection {
+    Forward,
+    Backward,
+}
+
+/// A work and its sub-graph, validated: every event carries its payload. The
+/// source→IR mapper drops malformed relations (and logs them), so the assembler
+/// never has to.
+pub(crate) struct WorkNode {
+    /// Source work id; used verbatim as `DbWork.id`.
+    pub id: String,
+    pub title: String,
+    pub disambiguation: Option<String>,
+    pub work_type: Option<String>,
+    /// Composer credits and part relations, in source relation order.
+    pub events: Vec<WorkEvent>,
+}
+
+pub(crate) enum WorkEvent {
+    Composer(ArtistRef),
+    /// "parts" relation: `Forward` names a child of this work, `Backward` names
+    /// its parent.
+    Part {
+        direction: PartDirection,
+        work: WorkGraphRef,
+    },
+}
+
+/// A reference to a work, from a track performance or a parent work. Each work
+/// is reachable from many places; the first reference in a release carries the
+/// expanded sub-graph (`Expanded`), and every later reference to the same work
+/// carries only its id (`AlreadyExpanded`). The distinction is explicit so a
+/// relation-less work (an `Expanded` node with no events) is never confused with
+/// a repeat reference.
+pub(crate) enum WorkGraphRef {
+    Expanded(WorkNode),
+    AlreadyExpanded { id: String },
+}
+
+/// One track-scoped event, in source order. Order determines artist-pool
+/// insertion order, junction-row order, and id-mint order.
+pub(crate) enum TrackEvent {
+    /// Display credit → `track_artists` row at `position`.
+    Credit { position: i32, artist: ArtistRef },
+    /// Role credit → `track_artist_roles` row.
+    Role {
+        position: i32,
+        artist: ArtistRef,
+        source: MetadataSource,
+        source_credit: Option<String>,
+    },
+    /// Work performance → work graph rows + a `track_works` row (deduped per
+    /// track on work id).
+    Work {
+        position: i32,
+        source: MetadataSource,
+        work: WorkGraphRef,
+    },
+}
+
+pub(crate) struct TrackIr {
+    pub title: String,
+    pub side: i32,
+    pub number: TrackNumber,
+    /// Raw source position ("A1", "1-2", MusicBrainz track number); lands in
+    /// `DbTrack.discogs_position`.
+    pub source_position: Option<String>,
+    pub events: Vec<TrackEvent>,
+}
+
+/// Release-level role credit (Discogs extraartists composers).
+pub(crate) struct ReleaseRole {
+    pub position: i32,
+    pub artist: ArtistRef,
+    pub source: MetadataSource,
+    pub source_credit: Option<String>,
+}
+
+/// Which artists get `album_artists` junction rows (beyond the primary).
+pub(crate) enum AlbumArtistScope {
+    /// Only the release's own positional credits (MusicBrainz / Discogs).
+    ReleaseCredits,
+    /// Every artist in the final pool — a divergent per-track artist also
+    /// becomes an album artist (file-tag / CUE seeds).
+    FullPool,
+}
+
+pub(crate) struct ReleaseIr {
+    pub album_title: String,
+    /// The album's primary artist (`ParsedAlbum.artists[0]`, `DbAlbum.artist_id`).
+    pub primary_artist: ArtistRef,
+    /// Remaining release-level credits in order; pushed to the pool without
+    /// dedup, positions 1.. in `album_artists`.
+    pub additional_artists: Vec<ArtistRef>,
+    pub album_year: Option<i32>,
+    pub is_compilation: bool,
+    pub pressing: Pressing,
+    pub metadata_source: ReleaseMetadataSource,
+    pub metadata_source_release_id: Option<String>,
+    pub album_artist_scope: AlbumArtistScope,
+    pub release_roles: Vec<ReleaseRole>,
+    pub tracks: Vec<TrackIr>,
+    pub identities: Vec<ReleaseIdentity>,
+}
+
+/// 1-based position of each element within its side, counting every element in
+/// input order (sides may interleave; the counter is per distinct side value).
+/// The single per-side numbering implementation, shared by the assembler and
+/// `shape_user_edit_from_search_detail` so the commit plane and the editor-seed
+/// plane compute numbers with identical code over the same side sequences.
+pub(crate) fn per_side_positions<S: Copy + Eq + std::hash::Hash>(
+    sides: impl IntoIterator<Item = S>,
+) -> Vec<i32> {
+    let mut counts: std::collections::HashMap<S, i32> = std::collections::HashMap::new();
+    sides
+        .into_iter()
+        .map(|side| {
+            let count = counts.entry(side).or_insert(0);
+            *count += 1;
+            *count
+        })
+        .collect()
+}
+
+/// Mint a `DbArtist` from an [`ArtistRef`] and append it to the pool, returning
+/// its new id. No dedup — the caller decides whether to look first.
+fn push_artist(
+    artists: &mut Vec<DbArtist>,
+    artist_ref: &ArtistRef,
+    ids: &dyn IdProvider,
+    now: DateTime<Utc>,
+) -> String {
+    let artist = DbArtist {
+        id: ids.new_id(),
+        name: artist_ref.name.clone(),
+        sort_name: artist_ref.sort_name.clone(),
+        discogs_artist_id: artist_ref.discogs_artist_id.clone(),
+        musicbrainz_artist_id: artist_ref.musicbrainz_artist_id.clone(),
+        created_at: now,
+    };
+    let id = artist.id.clone();
+    artists.push(artist);
+    id
+}
+
+/// Resolve an [`ArtistRef`] against the pool, minting a new artist on a miss.
+///
+/// Match rule, in order:
+///   - ref has a musicbrainz id → an existing artist with the same musicbrainz
+///     id;
+///   - else ref has a discogs id → an existing artist with the same discogs id;
+///   - else (no source ids) → a case-insensitive name match. For
+///     `ReleaseMetadataSource::MusicBrainz` the match is restricted to existing
+///     artists that also lack a musicbrainz id (an id-less credit never merges
+///     into an id-bearing artist); Discogs / FileTags match any artist by name.
+fn find_or_push_artist(
+    artists: &mut Vec<DbArtist>,
+    artist_ref: &ArtistRef,
+    source: ReleaseMetadataSource,
+    ids: &dyn IdProvider,
+    now: DateTime<Utc>,
+) -> String {
+    let existing = artists.iter().find(|artist| {
+        if let Some(mb_id) = artist_ref.musicbrainz_artist_id.as_ref() {
+            artist.musicbrainz_artist_id.as_ref() == Some(mb_id)
+        } else if let Some(discogs_id) = artist_ref.discogs_artist_id.as_ref() {
+            artist.discogs_artist_id.as_ref() == Some(discogs_id)
+        } else {
+            let name_matches = artist.name.eq_ignore_ascii_case(&artist_ref.name);
+            match source {
+                // An id-less MusicBrainz credit only merges into an artist that
+                // also lacks a musicbrainz id.
+                ReleaseMetadataSource::MusicBrainz => {
+                    name_matches && artist.musicbrainz_artist_id.is_none()
+                }
+                ReleaseMetadataSource::Discogs | ReleaseMetadataSource::FileTags => name_matches,
+            }
+        }
+    });
+
+    if let Some(existing) = existing {
+        return existing.id.clone();
+    }
+    push_artist(artists, artist_ref, ids, now)
+}
+
+pub(crate) fn album_artist_links(
+    album_id: &str,
+    artists: &[DbArtist],
+    ids: &dyn IdProvider,
+    now: DateTime<Utc>,
+) -> Vec<DbAlbumArtist> {
+    artists
+        .iter()
+        .enumerate()
+        .skip(1)
+        .map(|(position, artist)| {
+            DbAlbumArtist::new(album_id, &artist.id, position as i32, ids.new_id(), now)
+        })
+        .collect()
+}
+
+/// Pools the assembler threads through the work-graph walk.
+struct WorkPools<'a> {
+    artists: &'a mut Vec<DbArtist>,
+    works: &'a mut Vec<DbWork>,
+    work_artists: &'a mut Vec<DbWorkArtist>,
+    work_parts: &'a mut Vec<DbWorkPart>,
+    seen_works: &'a mut HashSet<String>,
+    expanded_works: &'a mut HashSet<String>,
+}
+
+/// Fold a validated [`WorkNode`] into the work graph: mint the work row once,
+/// link it to `parent` if given, then expand its events once. `seen_works` /
+/// `expanded_works` are release-global; `work_artists` / `work_parts` positions
+/// are the running pool lengths.
+fn push_work_graph(
+    node: &WorkNode,
+    parent: Option<&str>,
+    source: MetadataSource,
+    pools: &mut WorkPools,
+    ids: &dyn IdProvider,
+    now: DateTime<Utc>,
+) {
+    if pools.seen_works.insert(node.id.clone()) {
+        pools.works.push(DbWork::new(
+            &node.id,
+            &node.title,
+            node.disambiguation.clone(),
+            node.work_type.clone(),
+            now,
+        ));
+    }
+
+    if let Some(parent_work_id) = parent {
+        if !pools
+            .work_parts
+            .iter()
+            .any(|part| part.parent_work_id == parent_work_id && part.child_work_id == node.id)
+        {
+            pools.work_parts.push(DbWorkPart::new(
+                parent_work_id,
+                &node.id,
+                pools.work_parts.len() as i32,
+                source,
+                ids.new_id(),
+                now,
+            ));
+        }
+    }
+
+    if node.events.is_empty() || !pools.expanded_works.insert(node.id.clone()) {
+        return;
+    }
+
+    for event in &node.events {
+        match event {
+            WorkEvent::Composer(artist_ref) => {
+                let artist_id = find_or_push_artist(
+                    pools.artists,
+                    artist_ref,
+                    ReleaseMetadataSource::MusicBrainz,
+                    ids,
+                    now,
+                );
+                if !pools.work_artists.iter().any(|link| {
+                    link.work_id == node.id && link.artist_id == artist_id && link.source == source
+                }) {
+                    pools.work_artists.push(DbWorkArtist::new(
+                        &node.id,
+                        &artist_id,
+                        pools.work_artists.len() as i32,
+                        source,
+                        ids.new_id(),
+                        now,
+                    ));
+                }
+            }
+            WorkEvent::Part { direction, work } => match direction {
+                PartDirection::Backward => {
+                    // `work` is this node's parent.
+                    let parent_id = push_work_ref(work, None, source, pools, ids, now);
+                    if !pools.work_parts.iter().any(|part| {
+                        part.parent_work_id == parent_id && part.child_work_id == node.id
+                    }) {
+                        pools.work_parts.push(DbWorkPart::new(
+                            &parent_id,
+                            &node.id,
+                            pools.work_parts.len() as i32,
+                            source,
+                            ids.new_id(),
+                            now,
+                        ));
+                    }
+                }
+                PartDirection::Forward => {
+                    // `work` is a child of this node; `push_work_ref` creates the
+                    // parent link.
+                    push_work_ref(work, Some(&node.id), source, pools, ids, now);
+                }
+            },
+        }
+    }
+}
+
+/// Resolve a [`WorkGraphRef`] into the graph, returning the referenced work id.
+/// `Expanded` walks the sub-graph (minting the work row and, if `parent` is
+/// given, the parent→child link). `AlreadyExpanded` names a work whose row and
+/// sub-graph a prior reference already emitted; only its `parent` link, if any,
+/// still needs creating.
+fn push_work_ref(
+    work: &WorkGraphRef,
+    parent: Option<&str>,
+    source: MetadataSource,
+    pools: &mut WorkPools,
+    ids: &dyn IdProvider,
+    now: DateTime<Utc>,
+) -> String {
+    match work {
+        WorkGraphRef::Expanded(node) => {
+            push_work_graph(node, parent, source, pools, ids, now);
+            node.id.clone()
+        }
+        WorkGraphRef::AlreadyExpanded { id } => {
+            if let Some(parent_work_id) = parent {
+                if !pools
+                    .work_parts
+                    .iter()
+                    .any(|part| part.parent_work_id == parent_work_id && part.child_work_id == *id)
+                {
+                    pools.work_parts.push(DbWorkPart::new(
+                        parent_work_id,
+                        id,
+                        pools.work_parts.len() as i32,
+                        source,
+                        ids.new_id(),
+                        now,
+                    ));
+                }
+            }
+            id.clone()
+        }
+    }
+}
+
+/// The single place a [`ParsedAlbum`] is built. Owns artist dedup, per-side
+/// numbering, junction emission, and row construction. Infallible — all source
+/// validation happens in the source→IR mappers.
+pub(crate) fn assemble_parsed_album(
+    ir: ReleaseIr,
+    clock: &dyn Clock,
+    ids: &dyn IdProvider,
+) -> ParsedAlbum {
+    let now = clock.now();
+
+    // Release-level artists: primary then additional, minted in order, no
+    // dedup (matches every mapper's release-credit loop).
+    let mut artists: Vec<DbArtist> = Vec::new();
+    push_artist(&mut artists, &ir.primary_artist, ids, now);
+    for artist_ref in &ir.additional_artists {
+        push_artist(&mut artists, artist_ref, ids, now);
+    }
+    let release_artist_count = artists.len();
+
+    let album = DbAlbum {
+        id: ids.new_id(),
+        title: ir.album_title,
+        artist_id: artists[0].id.clone(),
+        year: ir.album_year,
+        primary_release_id: None,
+        is_compilation: ir.is_compilation,
+        created_at: now,
+    };
+
+    let release = DbRelease {
+        id: ids.new_id(),
+        album_id: album.id.clone(),
+        release_name: None,
+        pressing: ir.pressing,
+        disc_id: None,
+        metadata_source: ir.metadata_source,
+        metadata_source_release_id: ir.metadata_source_release_id,
+        // Imports land local; the upload observer flips `remote` true once the
+        // release's audio is durably in the cloud.
+        remote: false,
+        source_folder_name: None,
+        content_hash: None,
+        // Album loudness is measured in `build_audio_formats` and written to the
+        // release row in the finalize transaction, not here.
+        album_loudness_lufs: None,
+        album_peak_linear: None,
+        created_at: now,
+    };
+
+    let mut release_artist_roles: Vec<DbReleaseArtistRole> = Vec::new();
+    for role in &ir.release_roles {
+        let artist_id =
+            find_or_push_artist(&mut artists, &role.artist, ir.metadata_source, ids, now);
+        release_artist_roles.push(DbReleaseArtistRole::new(
+            &release.id,
+            &artist_id,
+            role.position,
+            role.source,
+            role.source_credit.clone(),
+            ids.new_id(),
+            now,
+        ));
+    }
+
+    let positions = per_side_positions(ir.tracks.iter().map(|t| t.side));
+
+    let mut tracks: Vec<DbTrack> = Vec::with_capacity(ir.tracks.len());
+    let mut track_artists: Vec<DbTrackArtist> = Vec::new();
+    let mut track_artist_roles: Vec<DbTrackArtistRole> = Vec::new();
+    let mut works: Vec<DbWork> = Vec::new();
+    let mut work_artists: Vec<DbWorkArtist> = Vec::new();
+    let mut work_parts: Vec<DbWorkPart> = Vec::new();
+    let mut track_works: Vec<DbTrackWork> = Vec::new();
+    let mut seen_works: HashSet<String> = HashSet::new();
+    let mut expanded_works: HashSet<String> = HashSet::new();
+
+    for (index, track_ir) in ir.tracks.iter().enumerate() {
+        let track_number = match track_ir.number {
+            TrackNumber::PerSide => Some(positions[index]),
+            TrackNumber::Explicit(n) => n,
+        };
+
+        let db_track = DbTrack {
+            id: ids.new_id(),
+            release_id: release.id.clone(),
+            title: track_ir.title.clone(),
+            side: track_ir.side,
+            track_number,
+            duration_ms: None,
+            discogs_position: track_ir.source_position.clone(),
+            created_at: now,
+        };
+
+        // A recording can carry more than one performance relation to the same
+        // work; track_works is uniquely keyed on (track_id, work_id), so link
+        // each work to this track at most once.
+        let mut track_work_ids: HashSet<String> = HashSet::new();
+
+        for event in &track_ir.events {
+            match event {
+                TrackEvent::Credit { position, artist } => {
+                    let artist_id =
+                        find_or_push_artist(&mut artists, artist, ir.metadata_source, ids, now);
+                    track_artists.push(DbTrackArtist::new(
+                        &db_track.id,
+                        &artist_id,
+                        *position,
+                        ids.new_id(),
+                        now,
+                    ));
+                }
+                TrackEvent::Role {
+                    position,
+                    artist,
+                    source,
+                    source_credit,
+                } => {
+                    let artist_id =
+                        find_or_push_artist(&mut artists, artist, ir.metadata_source, ids, now);
+                    track_artist_roles.push(DbTrackArtistRole::new(
+                        &db_track.id,
+                        &artist_id,
+                        *position,
+                        *source,
+                        source_credit.clone(),
+                        ids.new_id(),
+                        now,
+                    ));
+                }
+                TrackEvent::Work {
+                    position,
+                    source,
+                    work,
+                } => {
+                    let work_id = {
+                        let mut pools = WorkPools {
+                            artists: &mut artists,
+                            works: &mut works,
+                            work_artists: &mut work_artists,
+                            work_parts: &mut work_parts,
+                            seen_works: &mut seen_works,
+                            expanded_works: &mut expanded_works,
+                        };
+                        push_work_ref(work, None, *source, &mut pools, ids, now)
+                    };
+                    if !track_work_ids.insert(work_id.clone()) {
+                        debug!(
+                            track_id = %db_track.id,
+                            work_id = %work_id,
+                            "Skipping duplicate MusicBrainz recording performance relation to the same work"
+                        );
+                        continue;
+                    }
+                    track_works.push(DbTrackWork::new(
+                        &db_track.id,
+                        &work_id,
+                        *position,
+                        *source,
+                        ids.new_id(),
+                        now,
+                    ));
+                }
+            }
+        }
+
+        tracks.push(db_track);
+    }
+
+    let album_artist_slice = match ir.album_artist_scope {
+        AlbumArtistScope::ReleaseCredits => &artists[..release_artist_count],
+        AlbumArtistScope::FullPool => &artists[..],
+    };
+    let album_artists = album_artist_links(&album.id, album_artist_slice, ids, now);
+
+    ParsedAlbum {
+        album,
+        release,
+        tracks,
+        artists,
+        album_artists,
+        track_artists,
+        work_graph: ParsedWorkGraph {
+            works,
+            work_artists,
+            work_parts,
+            track_works,
+        },
+        release_artist_roles,
+        track_artist_roles,
+        identities: ir.identities,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_side_positions_numbers_sequential_sides() {
+        // Two tracks on side 1, one on side 2.
+        assert_eq!(per_side_positions([1, 1, 2]), vec![1, 2, 1]);
+    }
+
+    #[test]
+    fn per_side_positions_resumes_counting_interleaved_sides() {
+        // Sides interleave; each side's counter resumes where it left off.
+        assert_eq!(per_side_positions([1, 2, 1, 2]), vec![1, 1, 2, 2]);
+    }
+
+    #[test]
+    fn per_side_positions_single_side() {
+        assert_eq!(per_side_positions([7, 7, 7]), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn per_side_positions_empty() {
+        assert_eq!(
+            per_side_positions(std::iter::empty::<i32>()),
+            Vec::<i32>::new()
+        );
+    }
+
+    #[test]
+    fn per_side_positions_works_over_u32_keys() {
+        // The editor-seed plane passes `u32` sides; the commit plane passes
+        // `i32`. Both must number identically.
+        let as_i32 = per_side_positions([1i32, 1, 2, 2, 1]);
+        let as_u32 = per_side_positions([1u32, 1, 2, 2, 1]);
+        assert_eq!(as_i32, as_u32);
+        assert_eq!(as_i32, vec![1, 2, 1, 2, 3]);
+    }
+}

--- a/bae-core/src/import/discogs_mapper.rs
+++ b/bae-core/src/import/discogs_mapper.rs
@@ -1,13 +1,16 @@
-use super::{album_artist_links, find_or_push_artist, ParsedAlbum, ParsedWorkGraph};
-use crate::db::{
-    DbAlbum, DbArtist, DbRelease, DbReleaseArtistRole, DbTrack, DbTrackArtist, DbTrackArtistRole,
+use super::assemble::{
+    assemble_parsed_album, AlbumArtistScope, ArtistRef, ReleaseIr, ReleaseRole, TrackEvent,
+    TrackIr, TrackNumber,
 };
+use super::ParsedAlbum;
+use crate::db::{is_various_artists, Pressing, ReleaseMetadataSource};
 use crate::discogs::{DiscogsArtist, DiscogsRelease, DiscogsRoleArtist};
 use crate::import::types::ReleaseIdentity;
 use crate::import::MetadataSource;
 use crate::musicbrainz::MbReleaseResponse;
 use coven::Clock;
 use coven::IdProvider;
+use std::collections::HashSet;
 use tracing::{debug, warn};
 
 fn discogs_role_is_composer(role: &str) -> bool {
@@ -23,60 +26,38 @@ fn discogs_role_is_composer(role: &str) -> bool {
         || compact.contains("composer")
 }
 
-fn find_or_push_discogs_role_artist(
-    artists: &mut Vec<DbArtist>,
-    credit: &DiscogsRoleArtist,
-    ids: &dyn IdProvider,
-    now: chrono::DateTime<chrono::Utc>,
-) -> String {
-    find_or_push_artist(
-        artists,
-        |artist| {
-            if let Some(source_id) = credit.id.as_ref() {
-                artist.discogs_artist_id.as_ref() == Some(source_id)
-            } else {
-                artist.name.eq_ignore_ascii_case(&credit.name)
-            }
-        },
-        || {
-            let name = match credit.credited_name.clone() {
-                Some(name) => name,
-                None => {
-                    warn!(
-                        discogs_artist_id = ?credit.id,
-                        artist_name = %credit.name,
-                        "Discogs role artist has no credited name; using canonical name"
-                    );
-                    credit.name.clone()
-                }
-            };
-            (name.clone(), Some(name), credit.id.clone(), None)
-        },
-        ids,
-        now,
-    )
+/// An [`ArtistRef`] for a Discogs artist: the display name doubles as its own
+/// sort name, and the Discogs artist id (when present) is what dedups the pool.
+/// Discogs artists carry no MusicBrainz id.
+fn discogs_artist_ref(name: String, discogs_artist_id: Option<String>) -> ArtistRef {
+    ArtistRef {
+        name: name.clone(),
+        sort_name: Some(name),
+        musicbrainz_artist_id: None,
+        discogs_artist_id,
+    }
 }
 
-fn find_or_push_discogs_track_artist(
-    artists: &mut Vec<DbArtist>,
-    credit: &DiscogsArtist,
-    ids: &dyn IdProvider,
-    now: chrono::DateTime<chrono::Utc>,
-) -> String {
-    find_or_push_artist(
-        artists,
-        |artist| artist.discogs_artist_id.as_ref() == Some(&credit.id),
-        || {
-            (
-                credit.name.clone(),
-                Some(credit.name.clone()),
-                Some(credit.id.clone()),
-                None,
-            )
-        },
-        ids,
-        now,
-    )
+/// An [`ArtistRef`] for a Discogs role credit. The display name is the
+/// `credited_name`, falling back to the canonical name (logged) when absent.
+fn discogs_role_artist_ref(credit: &DiscogsRoleArtist) -> ArtistRef {
+    let name = match credit.credited_name.clone() {
+        Some(name) => name,
+        None => {
+            warn!(
+                discogs_artist_id = ?credit.id,
+                artist_name = %credit.name,
+                "Discogs role artist has no credited name; using canonical name"
+            );
+            credit.name.clone()
+        }
+    };
+    discogs_artist_ref(name, credit.id.clone())
+}
+
+/// An [`ArtistRef`] for a Discogs display credit, keyed on its canonical name.
+fn discogs_track_artist_ref(credit: &DiscogsArtist) -> ArtistRef {
+    discogs_artist_ref(credit.name.clone(), Some(credit.id.clone()))
 }
 
 /// Map Discogs release metadata into database models including artist information.
@@ -99,9 +80,9 @@ pub fn map_discogs_to_db(
     clock: &dyn Clock,
     ids: &dyn IdProvider,
 ) -> Result<ParsedAlbum, String> {
-    let now = clock.now();
-    let mut artists = Vec::new();
-    if release.artists.is_empty() {
+    // Release artists → the artist pool. With no artists list, fall back to
+    // the artist half of the "Artist - Album" title split.
+    let mut release_refs: Vec<ArtistRef> = if release.artists.is_empty() {
         let artist_name = crate::discogs::split_title(&release.title)
             .and_then(|(artist, _)| artist)
             .ok_or_else(|| {
@@ -111,56 +92,55 @@ pub fn map_discogs_to_db(
                 )
             })?
             .to_string();
-        let artist = DbArtist {
-            id: ids.new_id(),
+        vec![ArtistRef {
             name: artist_name.clone(),
             sort_name: Some(artist_name),
-            discogs_artist_id: None,
             musicbrainz_artist_id: None,
-            created_at: now,
-        };
-        artists.push(artist);
+            discogs_artist_id: None,
+        }]
     } else {
-        for discogs_artist in &release.artists {
-            let artist = DbArtist {
-                id: ids.new_id(),
-                name: discogs_artist.name.clone(),
-                sort_name: Some(discogs_artist.name.clone()),
-                discogs_artist_id: Some(discogs_artist.id.clone()),
-                musicbrainz_artist_id: None,
-                created_at: now,
-            };
-            artists.push(artist);
-        }
-    }
+        release
+            .artists
+            .iter()
+            .map(discogs_track_artist_ref)
+            .collect()
+    };
+    let primary_artist = release_refs.remove(0);
 
-    let primary_artist_id = &artists[0].id;
-    let album =
-        DbAlbum::from_discogs_release(release, master_year, primary_artist_id, ids.new_id(), now);
-    let db_release = DbRelease::from_discogs_release(&album.id, release, ids.new_id(), now);
+    let album_year = master_year
+        .map(|y| y as i32)
+        .or(release.year.map(|y| y as i32));
+    let is_compilation = release
+        .artists
+        .first()
+        .map(|a| is_various_artists(&a.name))
+        .unwrap_or(false);
+    let format = if release.format.is_empty() {
+        None
+    } else {
+        Some(release.format.join(", "))
+    };
+    let pressing = Pressing {
+        year: release.year.map(|y| y as i32),
+        format,
+        label: release.label.first().cloned(),
+        catalog_number: release.catno.clone(),
+        country: release.country.clone(),
+        barcode: None,
+    };
 
-    let album_artists = album_artist_links(&album.id, &artists, ids, now);
-
-    let processed = process_tracklist(&release.tracklist);
-
-    let mut tracks = Vec::new();
-    let mut track_artists = Vec::new();
-    let mut release_artist_roles = Vec::new();
-    let mut track_artist_roles = Vec::new();
-
+    // Release-level composer role credits, positions from the source order
+    // (non-composer roles are skipped, so positions keep holes).
+    let mut release_roles: Vec<ReleaseRole> = Vec::new();
     if let Some(extraartists) = release.extraartists.as_ref() {
         for (position, credit) in extraartists.iter().enumerate() {
             if discogs_role_is_composer(&credit.role) {
-                let artist_id = find_or_push_discogs_role_artist(&mut artists, credit, ids, now);
-                release_artist_roles.push(DbReleaseArtistRole::new(
-                    &db_release.id,
-                    &artist_id,
-                    position as i32,
-                    MetadataSource::Discogs,
-                    Some(credit.role.clone()),
-                    ids.new_id(),
-                    now,
-                ));
+                release_roles.push(ReleaseRole {
+                    position: position as i32,
+                    artist: discogs_role_artist_ref(credit),
+                    source: MetadataSource::Discogs,
+                    source_credit: Some(credit.role.clone()),
+                });
             } else {
                 debug!(
                     discogs_release_id = %release.id,
@@ -172,80 +152,11 @@ pub fn map_discogs_to_db(
         }
     }
 
-    for pt in &processed {
-        let track = DbTrack::from_discogs_track(
-            &pt.title,
-            &db_release.id,
-            pt.track_number,
-            pt.side,
-            Some(pt.position.clone()),
-            ids.new_id(),
-            now,
-        );
-
-        let mut track_artist_position = 0i32;
-        for source_track_index in &pt.source_track_indices {
-            let discogs_track = &release.tracklist[*source_track_index];
-            match discogs_track.extraartists.as_ref() {
-                Some(extraartists) => {
-                    for (role_position, credit) in extraartists.iter().enumerate() {
-                        if discogs_role_is_composer(&credit.role) {
-                            let artist_id =
-                                find_or_push_discogs_role_artist(&mut artists, credit, ids, now);
-                            track_artist_roles.push(DbTrackArtistRole::new(
-                                &track.id,
-                                &artist_id,
-                                role_position as i32,
-                                MetadataSource::Discogs,
-                                Some(credit.role.clone()),
-                                ids.new_id(),
-                                now,
-                            ));
-                        } else {
-                            debug!(
-                                discogs_release_id = %release.id,
-                                discogs_track_position = %discogs_track.position,
-                                track_title = %discogs_track.title,
-                                artist_name = %credit.name,
-                                role = %credit.role,
-                                "Skipping Discogs track-level extraartist with non-composer role"
-                            );
-                        }
-                    }
-                }
-                None => {
-                    debug!(
-                        discogs_release_id = %release.id,
-                        discogs_track_position = %discogs_track.position,
-                        track_title = %discogs_track.title,
-                        "Discogs track has no extraartists field; skipping per-track role credits"
-                    );
-                }
-            }
-
-            for discogs_artist in &discogs_track.artists {
-                let artist_id =
-                    find_or_push_discogs_track_artist(&mut artists, discogs_artist, ids, now);
-
-                // Avoid duplicate track-artist links for the same artist on this track
-                let already_linked = track_artists
-                    .iter()
-                    .any(|ta: &DbTrackArtist| ta.track_id == track.id && ta.artist_id == artist_id);
-                if !already_linked {
-                    track_artists.push(DbTrackArtist::new(
-                        &track.id,
-                        &artist_id,
-                        track_artist_position,
-                        ids.new_id(),
-                        now,
-                    ));
-                    track_artist_position += 1;
-                }
-            }
-        }
-
-        tracks.push(track);
-    }
+    let processed = process_tracklist(&release.tracklist);
+    let tracks: Vec<TrackIr> = processed
+        .iter()
+        .map(|pt| discogs_track_ir(release, pt))
+        .collect();
 
     // Identity rows. Discogs's `master_id` is what we group on; absence
     // means the release stands on its own (no group identity to speak
@@ -279,26 +190,92 @@ pub fn map_discogs_to_db(
         });
     }
 
-    Ok(ParsedAlbum {
-        album,
-        release: db_release,
+    let ir = ReleaseIr {
+        album_title: release.title.clone(),
+        primary_artist,
+        additional_artists: release_refs,
+        album_year,
+        is_compilation,
+        pressing,
+        metadata_source: ReleaseMetadataSource::Discogs,
+        metadata_source_release_id: Some(release.id.clone()),
+        album_artist_scope: AlbumArtistScope::ReleaseCredits,
+        release_roles,
         tracks,
-        artists,
-        album_artists,
-        track_artists,
-        work_graph: ParsedWorkGraph {
-            works: Vec::new(),
-            work_artists: Vec::new(),
-            work_parts: Vec::new(),
-            track_works: Vec::new(),
-        },
-        release_artist_roles,
-        track_artist_roles,
         identities,
-    })
+    };
+
+    Ok(assemble_parsed_album(ir, clock, ids))
 }
 
-/// A processed track ready for DB insertion.
+/// Build one track's IR from a processed Discogs track. Role credits precede
+/// display credits per source row (preserving the artist-pool discovery order);
+/// display credits are deduped across a collapsed track's source rows by Discogs
+/// artist id, first occurrence wins, with positions compacted `0..n`.
+fn discogs_track_ir(release: &DiscogsRelease, pt: &ProcessedTrack) -> TrackIr {
+    let mut events: Vec<TrackEvent> = Vec::new();
+    let mut seen_credit_ids: HashSet<String> = HashSet::new();
+    let mut credit_position = 0i32;
+
+    for source_track_index in &pt.source_track_indices {
+        let discogs_track = &release.tracklist[*source_track_index];
+        match discogs_track.extraartists.as_ref() {
+            Some(extraartists) => {
+                for (role_position, credit) in extraartists.iter().enumerate() {
+                    if discogs_role_is_composer(&credit.role) {
+                        events.push(TrackEvent::Role {
+                            position: role_position as i32,
+                            artist: discogs_role_artist_ref(credit),
+                            source: MetadataSource::Discogs,
+                            source_credit: Some(credit.role.clone()),
+                        });
+                    } else {
+                        debug!(
+                            discogs_release_id = %release.id,
+                            discogs_track_position = %discogs_track.position,
+                            track_title = %discogs_track.title,
+                            artist_name = %credit.name,
+                            role = %credit.role,
+                            "Skipping Discogs track-level extraartist with non-composer role"
+                        );
+                    }
+                }
+            }
+            None => {
+                debug!(
+                    discogs_release_id = %release.id,
+                    discogs_track_position = %discogs_track.position,
+                    track_title = %discogs_track.title,
+                    "Discogs track has no extraartists field; skipping per-track role credits"
+                );
+            }
+        }
+
+        for discogs_artist in &discogs_track.artists {
+            // One display-credit row per distinct Discogs artist across the
+            // collapsed track; positions compact over the rows actually emitted.
+            if seen_credit_ids.insert(discogs_artist.id.clone()) {
+                events.push(TrackEvent::Credit {
+                    position: credit_position,
+                    artist: discogs_track_artist_ref(discogs_artist),
+                });
+                credit_position += 1;
+            }
+        }
+    }
+
+    TrackIr {
+        title: pt.title.clone(),
+        side: pt.side,
+        number: TrackNumber::PerSide,
+        source_position: Some(pt.position.clone()),
+        events,
+    }
+}
+
+/// A processed track: heading/sub-track collapsing and index filtering applied,
+/// with its side derived from the position. Per-side track numbers are assigned
+/// downstream by the assembler's single numbering pass.
 pub(crate) struct ProcessedTrack {
     pub title: String,
     pub position: String,
@@ -306,11 +283,10 @@ pub(crate) struct ProcessedTrack {
     /// sub-track entries; for regular tracks, this contains the one source row.
     pub source_track_indices: Vec<usize>,
     pub side: i32,
-    pub track_number: i32,
 }
 
-/// Process a Discogs tracklist: filter index entries, collapse headings with sub-tracks,
-/// assign sides from position format, and compute sequential track numbers per side.
+/// Process a Discogs tracklist: filter index entries, collapse headings with
+/// sub-tracks, and assign sides from the position format.
 pub(crate) fn process_tracklist(tracklist: &[crate::discogs::DiscogsTrack]) -> Vec<ProcessedTrack> {
     use crate::discogs::DiscogsTrack;
 
@@ -413,24 +389,19 @@ pub(crate) fn process_tracklist(tracklist: &[crate::discogs::DiscogsTrack]) -> V
         &mut heading_position,
     );
 
-    // Phase 3: Assign sides and compute track numbers
-    let mut result = Vec::new();
-    let mut per_side_count: std::collections::HashMap<i32, i32> = std::collections::HashMap::new();
-
-    for ct in collapsed {
-        let side = parse_side_from_position(&ct.position);
-        let count = per_side_count.entry(side).or_insert(0);
-        *count += 1;
-        result.push(ProcessedTrack {
-            title: ct.title,
-            position: ct.position,
-            source_track_indices: ct.source_track_indices,
-            side,
-            track_number: *count,
-        });
-    }
-
-    result
+    // Phase 3: Assign sides from the position format.
+    collapsed
+        .into_iter()
+        .map(|ct| {
+            let side = parse_side_from_position(&ct.position);
+            ProcessedTrack {
+                title: ct.title,
+                position: ct.position,
+                source_track_indices: ct.source_track_indices,
+                side,
+            }
+        })
+        .collect()
 }
 
 /// Check if a position string indicates a sub-track (e.g., "B1i", "B1ii", "B1iii").
@@ -1108,6 +1079,91 @@ mod tests {
         assert!(
             logs.contains("has no credited name"),
             "expected a fallback warning, got: {logs}"
+        );
+    }
+
+    /// An id-less composer role credit whose name case-insensitively matches
+    /// the release artist (which carries a Discogs id) reuses that artist
+    /// rather than minting a duplicate: the Discogs role-artist matcher falls
+    /// back to a name match when the credit has no id, and that match is
+    /// unrestricted by whether the existing artist bears a source id.
+    #[test]
+    fn id_less_role_credit_reuses_release_artist_by_name() {
+        let mut release = make_release(vec![make_track("1", "Track 1")]);
+        // Release artist: name "Artist Name A", discogs id "artist-1".
+        release.extraartists = Some(vec![DiscogsRoleArtist {
+            id: None,
+            name: "ARTIST NAME A".to_string(),
+            role: "Composed By".to_string(),
+            credited_name: None,
+        }]);
+
+        let parsed = map(&release, Some(2024), None).unwrap();
+
+        let matching: Vec<_> = parsed
+            .artists
+            .iter()
+            .filter(|a| a.name.eq_ignore_ascii_case("Artist Name A"))
+            .collect();
+        assert_eq!(
+            matching.len(),
+            1,
+            "id-less role credit must reuse the release artist by name, not duplicate it"
+        );
+        let role = parsed
+            .release_artist_roles
+            .first()
+            .expect("composer role imported");
+        assert_eq!(role.artist_id, parsed.album.artist_id);
+    }
+
+    /// An id-less Discogs role credit dedups on its *credited* name — the name
+    /// actually stored on the artist row. Two id-less composer credits sharing a
+    /// credited name but with different canonical names collapse into one
+    /// artist: the dedup key and the stored name are the same field.
+    #[test]
+    fn id_less_role_credits_dedup_on_credited_name() {
+        let mut release = make_release(vec![make_track("1", "Track 1")]);
+        release.extraartists = Some(vec![
+            DiscogsRoleArtist {
+                id: None,
+                name: "Canonical One".to_string(),
+                role: "Composed By".to_string(),
+                credited_name: Some("Shared Credited Name".to_string()),
+            },
+            DiscogsRoleArtist {
+                id: None,
+                name: "Canonical Two".to_string(),
+                role: "Written-By".to_string(),
+                credited_name: Some("Shared Credited Name".to_string()),
+            },
+        ]);
+
+        let parsed = map(&release, Some(2024), None).unwrap();
+
+        let matching: Vec<_> = parsed
+            .artists
+            .iter()
+            .filter(|a| a.name == "Shared Credited Name")
+            .collect();
+        assert_eq!(
+            matching.len(),
+            1,
+            "id-less role credits with the same credited name dedup into one artist"
+        );
+        // The stored name is the credited name; neither canonical name lands.
+        assert!(!parsed
+            .artists
+            .iter()
+            .any(|a| a.name == "Canonical One" || a.name == "Canonical Two"));
+        // Both release roles point at the single deduped artist.
+        assert_eq!(
+            parsed
+                .release_artist_roles
+                .iter()
+                .filter(|r| r.artist_id == matching[0].id)
+                .count(),
+            2
         );
     }
 }

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -20,10 +20,12 @@
 //! from any tag carrying a date. Both stay `None` if not determinable
 //! rather than being defaulted.
 
-use super::{album_artist_links, find_or_push_artist, ParsedAlbum, ParsedWorkGraph};
+use super::assemble::{
+    assemble_parsed_album, AlbumArtistScope, ArtistRef, ReleaseIr, TrackEvent, TrackIr, TrackNumber,
+};
+use super::ParsedAlbum;
 use crate::cue_flac::CueSheet;
-use crate::db::ReleaseMetadataSource;
-use crate::db::{DbAlbum, DbArtist, DbRelease, DbTrack, DbTrackArtist};
+use crate::db::{Pressing, ReleaseMetadataSource};
 use crate::import::folder_scanner::{AudioContent, CategorizedFiles};
 use crate::util::content_type::ContentType;
 use coven::Clock;
@@ -134,8 +136,7 @@ pub fn map_file_tags_to_db(
         *entry = *entry || t.track_number.is_some();
     }
 
-    let mut per_side_count: std::collections::HashMap<i32, i32> = std::collections::HashMap::new();
-    let tracks: Vec<TrackSeed> = extracted
+    let tracks: Vec<TrackIr> = extracted
         .iter()
         .map(|t| {
             // The folder scanner only admits files with a recognised audio
@@ -152,40 +153,93 @@ pub fn map_file_tags_to_db(
             });
 
             let side = side_of(t);
-            let count = per_side_count.entry(side).or_insert(0);
-            *count += 1;
-            let side_partially_tagged = side_has_tagged_track.get(&side).copied().unwrap_or(false);
-            let track_number = match t.track_number {
-                Some(0) => None,
-                Some(n) if n > i32::MAX as u32 => None,
-                Some(n) => Some(n as i32),
+            let side_has_tagged = side_has_tagged_track.get(&side).copied().unwrap_or(false);
+            let number = match t.track_number {
+                Some(0) => TrackNumber::Explicit(None),
+                Some(n) if n > i32::MAX as u32 => TrackNumber::Explicit(None),
+                Some(n) => TrackNumber::Explicit(Some(n as i32)),
                 // Untagged file on a side that has tagged siblings — leave it
                 // for the user rather than backfill a colliding position.
-                None if side_partially_tagged => None,
-                // Fully-untagged side — positional by file order.
-                None => Some(*count),
+                None if side_has_tagged => TrackNumber::Explicit(None),
+                // Fully-untagged side — positional by file order, numbered by
+                // the assembler's per-side pass.
+                None => TrackNumber::PerSide,
             };
 
-            TrackSeed {
+            TrackIr {
                 title,
-                artist: t.track_artist.clone(),
                 side,
-                track_number,
+                number,
+                source_position: None,
+                events: file_tag_credit_events(t.track_artist.as_deref()),
             }
         })
         .collect();
 
     Ok(assemble_parsed_album(
-        AlbumSeed {
-            album_title,
-            album_artist_name,
-            year,
-            format,
-            tracks,
-        },
+        file_tag_release_ir(album_title, &album_artist_name, year, format, tracks),
         clock,
         ids,
     ))
+}
+
+/// An [`ArtistRef`] for a file-tag ARTIST/PERFORMER value: the name doubles as
+/// its own sort name, and the file tags carry no source artist ids.
+fn file_tag_artist_ref(name: &str) -> ArtistRef {
+    ArtistRef {
+        name: name.to_string(),
+        sort_name: Some(name.to_string()),
+        musicbrainz_artist_id: None,
+        discogs_artist_id: None,
+    }
+}
+
+/// The track's credit events: a single display credit at position 0 when the
+/// source carries an ARTIST/PERFORMER, else none. The junction row is emitted
+/// whenever a name is present, regardless of whether it matches the album
+/// artist — the junction is the source of truth for per-track credits.
+fn file_tag_credit_events(artist: Option<&str>) -> Vec<TrackEvent> {
+    match artist {
+        Some(name) => vec![TrackEvent::Credit {
+            position: 0,
+            artist: file_tag_artist_ref(name),
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// The [`ReleaseIr`] shared by the file-tag and CUE-sheet seeders. `identities`
+/// is always empty (Unknown makes no identity claim); `metadata_source` is
+/// `FileTags`; `album_artist_scope` is `FullPool` so a divergent per-track
+/// artist also becomes an album artist.
+fn file_tag_release_ir(
+    album_title: String,
+    album_artist_name: &str,
+    year: Option<i32>,
+    format: Option<String>,
+    tracks: Vec<TrackIr>,
+) -> ReleaseIr {
+    ReleaseIr {
+        album_title,
+        primary_artist: file_tag_artist_ref(album_artist_name),
+        additional_artists: Vec::new(),
+        album_year: year,
+        is_compilation: false,
+        pressing: Pressing {
+            year,
+            format,
+            label: None,
+            catalog_number: None,
+            country: None,
+            barcode: None,
+        },
+        metadata_source: ReleaseMetadataSource::FileTags,
+        metadata_source_release_id: None,
+        album_artist_scope: AlbumArtistScope::FullPool,
+        release_roles: Vec::new(),
+        tracks,
+        identities: Vec::new(),
+    }
 }
 
 /// Map an Unknown import candidate to the metadata seed used by preview and
@@ -214,157 +268,6 @@ pub fn map_unknown_candidate_to_db(
             let audio_files = tracks.iter().map(|f| f.path.clone()).collect::<Vec<_>>();
             map_file_tags_to_db(&audio_files, folder_name, clock, ids)
         }
-    }
-}
-
-/// One track's source-agnostic seed. Produced from embedded file tags
-/// (per-track rips, [`map_file_tags_to_db`]) or a CUE sheet (single-image
-/// rips, [`map_cue_sheets_to_db`]); both feed [`assemble_parsed_album`].
-struct TrackSeed {
-    title: String,
-    /// Track ARTIST/PERFORMER when the source carries one, else `None`. A
-    /// `Some` emits a track-artists junction row, deduped against the album
-    /// artist by name.
-    artist: Option<String>,
-    side: i32,
-    track_number: Option<i32>,
-}
-
-/// Album-level seed plus per-track seeds, source-agnostic.
-struct AlbumSeed {
-    album_title: String,
-    album_artist_name: String,
-    year: Option<i32>,
-    format: Option<String>,
-    tracks: Vec<TrackSeed>,
-}
-
-/// Assemble a [`ParsedAlbum`] from source-agnostic seeds — the single place
-/// the Unknown path builds album / artist / release / track rows, shared by
-/// the file-tag and CUE-sheet seeders. `identities` is always empty (Unknown
-/// makes no identity claim) and `metadata_source` is `FileTags`.
-fn assemble_parsed_album(seed: AlbumSeed, clock: &dyn Clock, ids: &dyn IdProvider) -> ParsedAlbum {
-    let now = clock.now();
-
-    // ── Album / artists / album-artist junction ────────────────────────
-    let primary_artist = DbArtist {
-        id: ids.new_id(),
-        name: seed.album_artist_name.clone(),
-        sort_name: Some(seed.album_artist_name.clone()),
-        discogs_artist_id: None,
-        musicbrainz_artist_id: None,
-        created_at: now,
-    };
-
-    let mut artists: Vec<DbArtist> = vec![primary_artist];
-
-    let album = DbAlbum {
-        id: ids.new_id(),
-        title: seed.album_title,
-        artist_id: artists[0].id.clone(),
-        year: seed.year,
-        primary_release_id: None,
-        is_compilation: false,
-        created_at: now,
-    };
-
-    let release = DbRelease {
-        id: ids.new_id(),
-        album_id: album.id.clone(),
-        release_name: None,
-        pressing: crate::db::Pressing {
-            year: seed.year,
-            format: seed.format,
-            label: None,
-            catalog_number: None,
-            country: None,
-            barcode: None,
-        },
-        disc_id: None,
-        metadata_source: ReleaseMetadataSource::FileTags,
-        metadata_source_release_id: None,
-        // Imports land local; the upload observer flips `remote` true once
-        // the release's audio is durably in the cloud.
-        remote: false,
-        source_folder_name: None,
-        content_hash: None,
-        // Album loudness is measured in `build_audio_formats` and written to the
-        // release row in the finalize transaction, not here.
-        album_loudness_lufs: None,
-        album_peak_linear: None,
-        created_at: now,
-    };
-
-    let mut tracks: Vec<DbTrack> = Vec::with_capacity(seed.tracks.len());
-    let mut track_artists: Vec<DbTrackArtist> = Vec::new();
-
-    for seed_track in seed.tracks {
-        let db_track = DbTrack {
-            id: ids.new_id(),
-            release_id: release.id.clone(),
-            title: seed_track.title,
-            side: seed_track.side,
-            track_number: seed_track.track_number,
-            duration_ms: None,
-            discogs_position: None,
-            created_at: now,
-        };
-
-        // Per-track artist: emit a track_artists junction row whenever the
-        // source carries an ARTIST/PERFORMER, regardless of whether it matches
-        // the album artist. Mirrors map_mb_response_to_db / map_discogs_to_db,
-        // which emit a row for every track-artist credit unconditionally — the
-        // junction is the source of truth for per-track credits, not a
-        // divergence-only annotation.
-        if let Some(track_artist_name) = seed_track.artist.as_ref() {
-            let artist_id = find_or_push_artist(
-                &mut artists,
-                |artist| artist.name.eq_ignore_ascii_case(track_artist_name),
-                || {
-                    (
-                        track_artist_name.to_string(),
-                        Some(track_artist_name.to_string()),
-                        None,
-                        None,
-                    )
-                },
-                ids,
-                now,
-            );
-
-            track_artists.push(DbTrackArtist::new(
-                &db_track.id,
-                &artist_id,
-                0,
-                ids.new_id(),
-                now,
-            ));
-        }
-
-        tracks.push(db_track);
-    }
-
-    // Additional artists (beyond the primary) go in the album-artists
-    // junction. Seeds don't carry positional album artists the way MB does;
-    // the junction stays empty unless a per-track artist introduced one.
-    let album_artists = album_artist_links(&album.id, &artists, ids, now);
-
-    ParsedAlbum {
-        album,
-        release,
-        tracks,
-        artists,
-        album_artists,
-        track_artists,
-        work_graph: ParsedWorkGraph {
-            works: Vec::new(),
-            work_artists: Vec::new(),
-            work_parts: Vec::new(),
-            track_works: Vec::new(),
-        },
-        release_artist_roles: Vec::new(),
-        track_artist_roles: Vec::new(),
-        identities: Vec::new(),
     }
 }
 
@@ -412,30 +315,27 @@ pub fn map_cue_sheets_to_db(
         .and_then(|p| probe_content_type(p))
         .map(|content_type| content_type.display_name().to_string());
 
-    let mut tracks: Vec<TrackSeed> = Vec::new();
+    // Each sheet is one side and its playable tracks are already in order, so
+    // per-side numbering by the assembler reproduces `position + 1` exactly.
+    let mut tracks: Vec<TrackIr> = Vec::new();
     for (disc_index, sheet) in sheets.iter().enumerate() {
         let side = disc_index as i32 + 1;
-        for (position, track) in sheet.playable_tracks().enumerate() {
+        for track in sheet.playable_tracks() {
             // A CUE track without a TITLE is rare; seed a blank for the user
             // rather than fabricate a placeholder.
             let title = non_empty(track.title.clone()).unwrap_or_default();
-            tracks.push(TrackSeed {
+            tracks.push(TrackIr {
                 title,
-                artist: non_empty(track.performer.clone()),
                 side,
-                track_number: Some(position as i32 + 1),
+                number: TrackNumber::PerSide,
+                source_position: None,
+                events: file_tag_credit_events(non_empty(track.performer.clone()).as_deref()),
             });
         }
     }
 
     Ok(assemble_parsed_album(
-        AlbumSeed {
-            album_title,
-            album_artist_name,
-            year,
-            format,
-            tracks,
-        },
+        file_tag_release_ir(album_title, &album_artist_name, year, format, tracks),
         clock,
         ids,
     ))
@@ -1073,6 +973,13 @@ mod tests {
         assert_eq!(parsed.track_artists[0].artist_id, parsed.artists[0].id);
         assert_eq!(parsed.track_artists[1].track_id, parsed.tracks[1].id);
         assert_eq!(parsed.track_artists[1].artist_id, parsed.artists[1].id);
+
+        // The divergent per-track artist joins the album-artists junction: the
+        // file-tag path scopes album artists to the whole pool, so any artist
+        // introduced by a per-track credit also becomes an album artist.
+        assert_eq!(parsed.album_artists.len(), 1);
+        assert_eq!(parsed.album_artists[0].artist_id, parsed.artists[1].id);
+        assert_eq!(parsed.album_artists[0].position, 1);
     }
 
     /// Missing optional tags (no year, no DISCNUMBER) → year is None,

--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -765,29 +765,28 @@ pub fn shape_user_edit_from_search_detail(
         }
     };
 
-    // Number tracks per side, matching the per-side numbering the commit-side
-    // mappers assign (musicbrainz_mapper / discogs_mapper reset their count at
-    // each side, so A1,A2,B1,B2 -> 1,2,1,2). `detail.tracks` carries each
-    // track's already-resolved `side` in the same order the seed was built, so
-    // a counter keyed on side reproduces those numbers exactly. A release-global
-    // `i + 1` index would diverge and, since `apply_user_edit_to_seed` writes
-    // `track_number` verbatim onto the seed, corrupt the per-side numbers of any
-    // multi-side vinyl/cassette/multi-disc release.
-    let mut per_side_count: std::collections::HashMap<u32, i32> = std::collections::HashMap::new();
+    // Number tracks per side with the same function the commit-side assembler
+    // uses (`per_side_positions`). Both planes run identical code over side
+    // sequences produced by the same side-derivation (`medium_sides` for MB,
+    // `process_tracklist` for Discogs), so the editor seed and the committed
+    // rows can never disagree on numbering. A release-global `i + 1` index would
+    // diverge and, since `apply_user_edit_to_seed` writes `track_number`
+    // verbatim onto the seed, corrupt the per-side numbers of any multi-side
+    // vinyl/cassette/multi-disc release.
+    let numbers = crate::import::assemble::per_side_positions(detail.tracks.iter().map(|t| t.side));
     let tracks = detail
         .tracks
         .iter()
-        .map(|t| {
+        .zip(numbers)
+        .map(|(t, number)| {
             let artist_names = match t.artist.as_deref() {
                 Some(a) if !a.is_empty() && a != primary_album_artist => vec![a.to_string()],
                 _ => Vec::new(),
             };
-            let count = per_side_count.entry(t.side).or_insert(0);
-            *count += 1;
             super::TrackUserEdit {
                 title: t.title.clone(),
                 side: t.side as i32,
-                track_number: Some(*count),
+                track_number: Some(number),
                 artist_names,
             }
         })

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -1,4 +1,5 @@
 pub mod artist_image;
+mod assemble;
 pub mod commit;
 pub mod cover_art;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
@@ -34,47 +35,13 @@ use crate::db::{
     DbAlbum, DbAlbumArtist, DbArtist, DbRelease, DbReleaseArtistRole, DbTrack, DbTrackArtist,
     DbTrackArtistRole, DbTrackWork, DbWork, DbWorkArtist, DbWorkPart,
 };
-use coven::IdProvider;
 
-pub(crate) fn find_or_push_artist(
-    artists: &mut Vec<DbArtist>,
-    matches: impl Fn(&DbArtist) -> bool,
-    seed: impl FnOnce() -> (String, Option<String>, Option<String>, Option<String>),
-    ids: &dyn IdProvider,
-    now: chrono::DateTime<chrono::Utc>,
-) -> String {
-    if let Some(existing) = artists.iter().find(|artist| matches(artist)) {
-        return existing.id.clone();
-    }
-
-    let (name, sort_name, discogs_artist_id, musicbrainz_artist_id) = seed();
-    let artist = DbArtist {
-        id: ids.new_id(),
-        name,
-        sort_name,
-        discogs_artist_id,
-        musicbrainz_artist_id,
-        created_at: now,
-    };
-    let id = artist.id.clone();
-    artists.push(artist);
-    id
-}
-
-pub(crate) fn album_artist_links(
-    album_id: &str,
-    artists: &[DbArtist],
-    ids: &dyn IdProvider,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Vec<DbAlbumArtist> {
-    artists
-        .iter()
-        .enumerate()
-        .skip(1)
-        .map(|(position, artist)| {
-            DbAlbumArtist::new(album_id, &artist.id, position as i32, ids.new_id(), now)
-        })
-        .collect()
+/// The four-digit year at the head of a metadata date string (`"1998"`,
+/// `"1998-05-01"`), or `None` when the value is absent or has no leading year.
+/// The single date→year parser shared by the source mappers and the search
+/// detail builder.
+pub(crate) fn parse_year(date: Option<&str>) -> Option<i32> {
+    date?.split('-').next()?.parse().ok()
 }
 
 #[derive(Debug, Clone)]

--- a/bae-core/src/import/musicbrainz_mapper.rs
+++ b/bae-core/src/import/musicbrainz_mapper.rs
@@ -14,11 +14,12 @@
 //! produce only a Discogs identity row at first; the reverse cross-link
 //! is resolved via MB's URL endpoint.
 
-use super::{album_artist_links, ParsedAlbum, ParsedWorkGraph};
-use crate::db::{
-    DbAlbum, DbArtist, DbRelease, DbTrack, DbTrackArtist, DbTrackArtistRole, DbTrackWork, DbWork,
-    DbWorkArtist, DbWorkPart,
+use super::assemble::{
+    assemble_parsed_album, AlbumArtistScope, ArtistRef, PartDirection, ReleaseIr, TrackEvent,
+    TrackIr, TrackNumber, WorkEvent, WorkGraphRef, WorkNode,
 };
+use super::ParsedAlbum;
+use crate::db::{is_various_artists, Pressing, ReleaseMetadataSource};
 use crate::import::types::ReleaseIdentity;
 use crate::import::MetadataSource;
 use crate::musicbrainz::{
@@ -57,86 +58,38 @@ fn mb_artist_name(artist: &MbArtistRef, credit: Option<&str>) -> Option<String> 
         .or_else(|| artist.name.clone())
 }
 
-fn find_or_push_mb_artist(
-    artists: &mut Vec<DbArtist>,
-    artist_ref: &MbArtistRef,
-    credit: Option<&str>,
-    ids: &(impl IdProvider + ?Sized),
-    now: chrono::DateTime<chrono::Utc>,
-) -> Option<String> {
-    let artist_name = mb_artist_name(artist_ref, credit)?;
-    let mb_artist_id = artist_ref.id.clone();
-    if let Some(existing) =
-        artists.iter().find(
-            |artist| match (&artist.musicbrainz_artist_id, &mb_artist_id) {
-                (Some(existing_id), Some(new_id)) => existing_id == new_id,
-                (None, None) => artist.name.eq_ignore_ascii_case(&artist_name),
-                _ => false,
-            },
-        )
-    {
-        return Some(existing.id.clone());
-    }
-
-    let artist = DbArtist {
-        id: ids.new_id(),
-        name: artist_name.clone(),
-        sort_name: artist_ref.sort_name.clone(),
-        discogs_artist_id: None,
-        musicbrainz_artist_id: mb_artist_id,
-        created_at: now,
-    };
-    let id = artist.id.clone();
-    artists.push(artist);
-    Some(id)
-}
-
 fn mb_relation_is_composer(relation: &MbRelation) -> bool {
     relation.relation_type.as_deref() == Some("composer")
 }
 
-fn push_work_graph(
-    work: &MbWork,
-    parent: Option<&str>,
-    artists: &mut Vec<DbArtist>,
-    works: &mut Vec<DbWork>,
-    work_artists: &mut Vec<DbWorkArtist>,
-    work_parts: &mut Vec<DbWorkPart>,
-    seen_works: &mut HashSet<String>,
-    expanded_works: &mut HashSet<String>,
-    ids: &(impl IdProvider + ?Sized),
-    now: chrono::DateTime<chrono::Utc>,
-) {
-    if seen_works.insert(work.id.clone()) {
-        works.push(DbWork::new(
-            &work.id,
-            &work.title,
-            work.disambiguation.clone(),
-            work.work_type.clone(),
-            now,
-        ));
+/// An [`ArtistRef`] for a MusicBrainz artist: `name` is the resolved credit
+/// name; sort name and MB id come from the artist payload; MB artists carry no
+/// Discogs id here (release-level cross-ref enrichment is handled inline).
+fn mb_artist_ref(name: String, artist: &MbArtistRef) -> ArtistRef {
+    ArtistRef {
+        name,
+        sort_name: artist.sort_name.clone(),
+        musicbrainz_artist_id: artist.id.clone(),
+        discogs_artist_id: None,
+    }
+}
+
+/// Resolve an `MbWork` into a [`WorkGraphRef`], validating relations (malformed
+/// ones are dropped and logged here, at the source→IR boundary, so the
+/// assembler's walk never meets one).
+///
+/// `converted` is release-scoped: the first reference to a work id returns an
+/// `Expanded` node carrying its walked sub-graph; every later reference returns
+/// `AlreadyExpanded`, so each work's relations are walked and logged exactly
+/// once per release and the assembler emits its row and sub-graph once.
+fn mb_work_ref(work: &MbWork, converted: &mut HashSet<String>) -> WorkGraphRef {
+    if !converted.insert(work.id.clone()) {
+        return WorkGraphRef::AlreadyExpanded {
+            id: work.id.clone(),
+        };
     }
 
-    if let Some(parent_work_id) = parent {
-        if !work_parts
-            .iter()
-            .any(|part| part.parent_work_id == parent_work_id && part.child_work_id == work.id)
-        {
-            work_parts.push(DbWorkPart::new(
-                parent_work_id,
-                &work.id,
-                work_parts.len() as i32,
-                MetadataSource::MusicBrainz,
-                ids.new_id(),
-                now,
-            ));
-        }
-    }
-
-    if work.relations.is_empty() || !expanded_works.insert(work.id.clone()) {
-        return;
-    }
-
+    let mut events = Vec::new();
     for relation in &work.relations {
         if relation.target_type.as_deref() == Some("artist") {
             if mb_relation_is_composer(relation) {
@@ -148,13 +101,8 @@ fn push_work_graph(
                     );
                     continue;
                 };
-                let Some(artist_id) = find_or_push_mb_artist(
-                    artists,
-                    artist_ref,
-                    relation.target_credit.as_deref(),
-                    ids,
-                    now,
-                ) else {
+                let Some(name) = mb_artist_name(artist_ref, relation.target_credit.as_deref())
+                else {
                     warn!(
                         work_id = %work.id,
                         musicbrainz_artist_id = ?artist_ref.id,
@@ -162,20 +110,7 @@ fn push_work_graph(
                     );
                     continue;
                 };
-                if !work_artists.iter().any(|link| {
-                    link.work_id == work.id
-                        && link.artist_id == artist_id
-                        && link.source == MetadataSource::MusicBrainz
-                }) {
-                    work_artists.push(DbWorkArtist::new(
-                        &work.id,
-                        &artist_id,
-                        work_artists.len() as i32,
-                        MetadataSource::MusicBrainz,
-                        ids.new_id(),
-                        now,
-                    ));
-                }
+                events.push(WorkEvent::Composer(mb_artist_ref(name, artist_ref)));
             } else {
                 debug!(
                     work_id = %work.id,
@@ -194,48 +129,24 @@ fn push_work_graph(
                 );
                 continue;
             };
-            match relation.direction.as_deref() {
-                Some("backward") => {
-                    push_work_graph(
-                        child_or_parent,
-                        None,
-                        artists,
-                        works,
-                        work_artists,
-                        work_parts,
-                        seen_works,
-                        expanded_works,
-                        ids,
-                        now,
-                    );
-                    if !work_parts.iter().any(|part| {
-                        part.parent_work_id == child_or_parent.id && part.child_work_id == work.id
-                    }) {
-                        work_parts.push(DbWorkPart::new(
-                            &child_or_parent.id,
-                            &work.id,
-                            work_parts.len() as i32,
-                            MetadataSource::MusicBrainz,
-                            ids.new_id(),
-                            now,
-                        ));
-                    }
-                }
-                _ => push_work_graph(
-                    child_or_parent,
-                    Some(&work.id),
-                    artists,
-                    works,
-                    work_artists,
-                    work_parts,
-                    seen_works,
-                    expanded_works,
-                    ids,
-                    now,
-                ),
-            }
+            let direction = match relation.direction.as_deref() {
+                Some("backward") => PartDirection::Backward,
+                _ => PartDirection::Forward,
+            };
+            events.push(WorkEvent::Part {
+                direction,
+                work: mb_work_ref(child_or_parent, converted),
+            });
         }
     }
+
+    WorkGraphRef::Expanded(WorkNode {
+        id: work.id.clone(),
+        title: work.title.clone(),
+        disambiguation: work.disambiguation.clone(),
+        work_type: work.work_type.clone(),
+        events,
+    })
 }
 
 /// Fetch a MusicBrainz release. Pure MB: no Discogs client, no cross-ref.
@@ -366,9 +277,10 @@ pub fn map_mb_response_to_db(
     clock: &dyn Clock,
     ids: &dyn IdProvider,
 ) -> Result<ParsedAlbum, String> {
-    let now = clock.now();
-    let mut artists = Vec::new();
-
+    // Release-level artist credits → `ArtistRef`s, keeping the credit-name
+    // preference and the Discogs cross-ref `discogs_artist_id` name-match
+    // enrichment.
+    let mut release_refs: Vec<ArtistRef> = Vec::new();
     for credit in &response.artist_credit {
         if let Some(artist_obj) = &credit.artist {
             let artist_name = mb_artist_name(artist_obj, Some(&credit.name)).ok_or_else(|| {
@@ -377,51 +289,34 @@ pub fn map_mb_response_to_db(
                     response.id, artist_obj.id
                 )
             })?;
-
-            let mb_artist_id = artist_obj.id.clone();
-
             let discogs_artist_id = discogs_release.as_ref().and_then(|dr| {
                 dr.artists
                     .iter()
                     .find(|da| da.name.eq_ignore_ascii_case(&artist_name))
                     .map(|da| da.id.clone())
             });
-
-            let artist = DbArtist {
-                id: ids.new_id(),
+            release_refs.push(ArtistRef {
                 name: artist_name,
                 sort_name: artist_obj.sort_name.clone(),
+                musicbrainz_artist_id: artist_obj.id.clone(),
                 discogs_artist_id,
-                musicbrainz_artist_id: mb_artist_id,
-                created_at: now,
-            };
-            artists.push(artist);
+            });
         }
     }
-
-    if artists.is_empty() {
+    if release_refs.is_empty() {
         let artist_name = response
             .artist_credit
             .first()
             .ok_or_else(|| format!("MusicBrainz release {} has no artist credits", response.id))?
             .name
             .clone();
-        let artist = DbArtist {
-            id: ids.new_id(),
-            name: artist_name.clone(),
+        release_refs.push(ArtistRef {
+            name: artist_name,
             sort_name: None,
-            discogs_artist_id: None,
             musicbrainz_artist_id: None,
-            created_at: now,
-        };
-        artists.push(artist);
+            discogs_artist_id: None,
+        });
     }
-
-    let primary_artist_id = &artists[0].id;
-
-    let album =
-        DbAlbum::from_mb_response(response, master_year, primary_artist_id, ids.new_id(), now);
-    let db_release = DbRelease::from_mb_response(&album.id, response, ids.new_id(), now);
 
     // Identity rows. Always one for MB (every MB release belongs to a
     // release group; absence is a structural bug in the response, not a
@@ -449,27 +344,54 @@ pub fn map_mb_response_to_db(
         }
     }
 
-    let album_artists = album_artist_links(&album.id, &artists, ids, now);
+    // Album year: release-group first-release-date, then the release date,
+    // then the Discogs master year.
+    let album_year = super::parse_year(
+        response
+            .release_group
+            .as_ref()
+            .and_then(|rg| rg.first_release_date.as_deref()),
+    )
+    .or_else(|| super::parse_year(response.date.as_deref()))
+    .or(master_year.map(|y| y as i32));
+    let is_compilation = response
+        .artist_credit
+        .first()
+        .map(|ac| is_various_artists(&ac.name))
+        .unwrap_or(false);
 
-    let mut tracks = Vec::new();
-    let mut track_artists = Vec::new();
-    let mut works = Vec::new();
-    let mut work_artists = Vec::new();
-    let mut work_parts = Vec::new();
-    let mut track_works = Vec::new();
-    let mut track_artist_roles = Vec::new();
-    let mut seen_works = HashSet::new();
-    let mut expanded_works = HashSet::new();
+    // Pressing: this release's own date year, first medium format, first label.
+    let pressing_year = super::parse_year(response.date.as_deref());
+    let format = response.media.first().and_then(|m| m.format.clone());
+    let (label, catalog_number) = response
+        .label_info
+        .first()
+        .map(|li| {
+            (
+                li.label.as_ref().and_then(|l| l.name.clone()),
+                li.catalog_number.clone(),
+            )
+        })
+        .unwrap_or((None, None));
+    let pressing = Pressing {
+        year: pressing_year,
+        format,
+        label,
+        catalog_number,
+        country: response.country.clone(),
+        barcode: response.barcode.clone(),
+    };
 
-    // Compute side base: each medium contributes 1 or 2 sides depending on format.
+    // Each medium contributes 1 or 2 sides; `side_base` advances so side values
+    // never repeat across media, and every track's number is its position within
+    // its final side value, assigned by the assembler's single per-side pass.
+    let mut tracks: Vec<TrackIr> = Vec::new();
     let mut side_base = 0i32;
-
+    // Release-scoped: each work's relations are converted (and its skip lines
+    // logged) at most once, no matter how many tracks reference it.
+    let mut converted_works: HashSet<String> = HashSet::new();
     for medium in &response.media {
         let sides = medium_sides(&response.id, medium)?;
-
-        // Running 1-based position within each side of this medium.
-        let mut per_side_count: std::collections::HashMap<i32, i32> =
-            std::collections::HashMap::new();
 
         for (track, &side_offset) in medium.tracks.iter().zip(&sides.offsets) {
             let title = track
@@ -486,171 +408,116 @@ pub fn map_mb_response_to_db(
                 })?
                 .to_string();
 
-            let side_offset = side_offset as i32;
-            let track_number = {
-                let count = per_side_count.entry(side_offset).or_insert(0);
-                *count += 1;
-                *count
-            };
+            let side = side_base + side_offset as i32 + 1;
 
-            let side = side_base + side_offset + 1;
-
-            let db_track = DbTrack {
-                id: ids.new_id(),
-                release_id: db_release.id.clone(),
-                title,
-                side,
-                track_number: Some(track_number),
-                duration_ms: None,
-                discogs_position: track.number.clone(),
-                created_at: now,
-            };
+            let mut events: Vec<TrackEvent> = Vec::new();
 
             for (credit_pos, credit) in track.artist_credit.iter().enumerate() {
                 if let Some(artist_obj) = &credit.artist {
                     // A track credit with no resolvable name (empty credit and no
                     // artist payload name) is malformed sub-data; skip it and keep
-                    // the track, mirroring how the composer relations above handle
-                    // an unresolvable artist rather than aborting the whole import.
-                    let Some(artist_id) = find_or_push_mb_artist(
-                        &mut artists,
-                        artist_obj,
-                        Some(credit.name.as_str()),
-                        ids,
-                        now,
-                    ) else {
+                    // the track, mirroring how the composer relations handle an
+                    // unresolvable artist rather than aborting the whole import.
+                    let Some(name) = mb_artist_name(artist_obj, Some(credit.name.as_str())) else {
                         warn!(
-                            track_id = %db_track.id,
                             musicbrainz_artist_id = ?artist_obj.id,
                             track_number = ?track.number,
+                            track_title = %title,
                             "Skipping MusicBrainz track artist credit with unresolvable artist name"
                         );
                         continue;
                     };
-
-                    track_artists.push(DbTrackArtist::new(
-                        &db_track.id,
-                        &artist_id,
-                        credit_pos as i32,
-                        ids.new_id(),
-                        now,
-                    ));
+                    events.push(TrackEvent::Credit {
+                        position: credit_pos as i32,
+                        artist: mb_artist_ref(name, artist_obj),
+                    });
                 }
             }
 
-            // A recording can carry more than one performance relation to the
-            // same work; track_works is uniquely keyed on (track_id, work_id),
-            // so link each work to this track at most once.
-            let mut track_work_ids = HashSet::new();
             if let Some(recording) = track.recording.as_ref() {
                 for (relation_pos, relation) in recording.relations.iter().enumerate() {
                     if mb_relation_is(relation, "work", "performance") {
                         let Some(work) = relation.work.as_ref() else {
                             warn!(
-                                track_id = %db_track.id,
+                                track_title = %title,
                                 relation_type = ?relation.relation_type,
                                 "Skipping MusicBrainz recording work relation without work payload"
                             );
                             continue;
                         };
-                        push_work_graph(
-                            work,
-                            None,
-                            &mut artists,
-                            &mut works,
-                            &mut work_artists,
-                            &mut work_parts,
-                            &mut seen_works,
-                            &mut expanded_works,
-                            ids,
-                            now,
-                        );
-                        if !track_work_ids.insert(work.id.clone()) {
-                            debug!(
-                                track_id = %db_track.id,
-                                work_id = %work.id,
-                                "Skipping duplicate MusicBrainz recording performance relation to the same work"
-                            );
-                            continue;
-                        }
-                        track_works.push(DbTrackWork::new(
-                            &db_track.id,
-                            &work.id,
-                            relation_pos as i32,
-                            MetadataSource::MusicBrainz,
-                            ids.new_id(),
-                            now,
-                        ));
+                        events.push(TrackEvent::Work {
+                            position: relation_pos as i32,
+                            source: MetadataSource::MusicBrainz,
+                            work: mb_work_ref(work, &mut converted_works),
+                        });
                     } else if relation.target_type.as_deref() == Some("artist") {
                         if mb_relation_is_composer(relation) {
                             let Some(artist_ref) = relation.artist.as_ref() else {
                                 warn!(
-                                    track_id = %db_track.id,
+                                    track_title = %title,
                                     relation_type = ?relation.relation_type,
                                     "Skipping MusicBrainz recording artist relation without artist payload"
                                 );
                                 continue;
                             };
-                            let Some(artist_id) = find_or_push_mb_artist(
-                                &mut artists,
-                                artist_ref,
-                                relation.target_credit.as_deref(),
-                                ids,
-                                now,
-                            ) else {
+                            let Some(name) =
+                                mb_artist_name(artist_ref, relation.target_credit.as_deref())
+                            else {
                                 warn!(
-                                    track_id = %db_track.id,
+                                    track_title = %title,
                                     musicbrainz_artist_id = ?artist_ref.id,
                                     "Skipping MusicBrainz recording artist relation with unresolved artist"
                                 );
                                 continue;
                             };
-                            track_artist_roles.push(DbTrackArtistRole::new(
-                                &db_track.id,
-                                &artist_id,
-                                relation_pos as i32,
-                                MetadataSource::MusicBrainz,
-                                relation.relation_type.clone(),
-                                ids.new_id(),
-                                now,
-                            ));
+                            events.push(TrackEvent::Role {
+                                position: relation_pos as i32,
+                                artist: mb_artist_ref(name, artist_ref),
+                                source: MetadataSource::MusicBrainz,
+                                source_credit: relation.relation_type.clone(),
+                            });
                         } else {
                             debug!(
-                                track_id = %db_track.id,
+                                track_title = %title,
                                 relation_type = ?relation.relation_type,
                                 target_type = ?relation.target_type,
                                 target_credit = ?relation.target_credit,
                                 "Skipping MusicBrainz recording artist relation with non-composer relation type"
                             );
-                        };
+                        }
                     }
                 }
             }
 
-            tracks.push(db_track);
+            tracks.push(TrackIr {
+                title,
+                side,
+                number: TrackNumber::PerSide,
+                source_position: track.number.clone(),
+                events,
+            });
         }
 
-        // Advance side_base for the next medium.
         side_base += sides.side_span as i32;
     }
 
-    Ok(ParsedAlbum {
-        album,
-        release: db_release,
+    let primary_artist = release_refs.remove(0);
+    let ir = ReleaseIr {
+        album_title: response.title.clone(),
+        primary_artist,
+        additional_artists: release_refs,
+        album_year,
+        is_compilation,
+        pressing,
+        metadata_source: ReleaseMetadataSource::MusicBrainz,
+        metadata_source_release_id: Some(response.id.clone()),
+        album_artist_scope: AlbumArtistScope::ReleaseCredits,
+        release_roles: Vec::new(),
         tracks,
-        artists,
-        album_artists,
-        track_artists,
-        work_graph: ParsedWorkGraph {
-            works,
-            work_artists,
-            work_parts,
-            track_works,
-        },
-        release_artist_roles: Vec::new(),
-        track_artist_roles,
         identities,
-    })
+    };
+
+    Ok(assemble_parsed_album(ir, clock, ids))
 }
 
 #[cfg(test)]
@@ -1488,6 +1355,48 @@ mod tests {
             .any(|role| role.artist_id == composer.id));
     }
 
+    /// An id-less track credit sharing the release artist's name creates a
+    /// *separate* artist rather than merging into the id-bearing release
+    /// artist. The MB matcher's `(None, None)` name arm only fires when the
+    /// existing artist also lacks an MB id, so an id-bearing artist is never a
+    /// merge target for an id-less credit. (The mirror of
+    /// `known_mb_artist_id_does_not_merge_into_same_name_artist_without_id`,
+    /// which withholds the id on the existing side rather than the new side.)
+    #[test]
+    fn id_less_track_credit_does_not_merge_into_id_bearing_release_artist() {
+        // Release artist "Artist Name A" carries MB id "artist-1".
+        let mut track = make_mb_track("1", "Track 1");
+        track.artist_credit = vec![MbArtistCredit {
+            name: "Artist Name A".to_string(),
+            artist: Some(MbArtistRef {
+                id: None,
+                name: Some("Artist Name A".to_string()),
+                sort_name: None,
+            }),
+        }];
+        let response = make_response(vec![MbMedium {
+            format: Some("CD".to_string()),
+            tracks: vec![track],
+        }]);
+
+        let parsed = map(&response, Some(2024), None).unwrap();
+
+        let matching: Vec<_> = parsed
+            .artists
+            .iter()
+            .filter(|a| a.name == "Artist Name A")
+            .collect();
+        assert_eq!(
+            matching.len(),
+            2,
+            "an id-less credit must not merge into the id-bearing release artist"
+        );
+        assert!(matching
+            .iter()
+            .any(|a| a.musicbrainz_artist_id.as_deref() == Some("artist-1")));
+        assert!(matching.iter().any(|a| a.musicbrainz_artist_id.is_none()));
+    }
+
     #[test]
     fn known_mb_artist_ids_keep_same_name_artists_separate() {
         let mut track = make_mb_track("1", "Track 1");
@@ -1663,6 +1572,65 @@ mod tests {
         assert!(
             logs.contains("work artist relation without artist payload"),
             "expected a skip warning, got: {logs}"
+        );
+    }
+
+    /// A work reached from two tracks is converted once per release: its
+    /// malformed composer relation is logged a single time, and its sub-graph is
+    /// walked once, no matter how many tracks reference it. (Locks `mb_work_ref`'s
+    /// per-release memoization.)
+    #[test]
+    fn work_referenced_by_two_tracks_logs_skip_once() {
+        let work = MbWork {
+            id: "mb-work-a".to_string(),
+            title: "Work Title".to_string(),
+            disambiguation: None,
+            work_type: Some("work".to_string()),
+            relations: vec![MbRelation {
+                target_type: Some("artist".to_string()),
+                relation_type: Some("composer".to_string()),
+                artist: None,
+                ..MbRelation::default()
+            }],
+        };
+        let performance = |work: MbWork| MbRelation {
+            target_type: Some("work".to_string()),
+            relation_type: Some("performance".to_string()),
+            work: Some(work),
+            ..MbRelation::default()
+        };
+        let mut track_one = make_mb_track("1", "Track 1");
+        track_one.recording.as_mut().unwrap().relations = vec![performance(work.clone())];
+        let mut track_two = make_mb_track("2", "Track 2");
+        track_two.recording.as_mut().unwrap().relations = vec![performance(work)];
+        let response = make_response(vec![MbMedium {
+            format: Some("CD".to_string()),
+            tracks: vec![track_one, track_two],
+        }]);
+
+        let mut parsed = None;
+        let logs = crate::test_logs::capture_warn_logs(|| {
+            parsed = Some(map(&response, Some(2024), None).unwrap());
+        });
+        let parsed = parsed.unwrap();
+
+        // The work row lands once and both tracks link it.
+        assert!(parsed.work_graph.works.iter().any(|w| w.id == "mb-work-a"));
+        assert_eq!(
+            parsed
+                .work_graph
+                .track_works
+                .iter()
+                .filter(|l| l.work_id == "mb-work-a")
+                .count(),
+            2
+        );
+        // The skip line is logged exactly once, not once per referencing track.
+        assert_eq!(
+            logs.matches("work artist relation without artist payload")
+                .count(),
+            1,
+            "expected the work's skip to log once per release, got: {logs}"
         );
     }
 

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -9,6 +9,7 @@
 
 use crate::discogs::client::{DiscogsClient, DiscogsError, DiscogsSearchParams};
 use crate::import::cover_art::{CoverArtArchiveClient, RemoteCover};
+use crate::import::parse_year;
 use crate::import::types::MetadataSource;
 use crate::musicbrainz::{self, MbReleaseResponse, ReleaseSearchParams, SearchRelease};
 use crate::retry::retry_with_backoff;
@@ -147,10 +148,6 @@ pub fn discogs_search_result_to_metadata(
         cover_art,
         source_group_id,
     }
-}
-
-fn parse_year(date: Option<&str>) -> Option<i32> {
-    date?.split('-').next()?.parse().ok()
 }
 
 fn mb_release_to_metadata(r: MbReleaseResponse, cover_art: Option<RemoteCover>) -> MetadataResult {
@@ -555,9 +552,20 @@ pub async fn commit_discogs_release(
 mod tests {
     use super::*;
     use crate::discogs::client::DiscogsSearchResult;
+    use crate::discogs::{DiscogsArtist, DiscogsRelease, DiscogsTrack};
+    use crate::import::{IdentityChoice, MetadataRef};
     use crate::musicbrainz::{
         MbArtistCredit, MbMedium, MbRecording, MbReleaseGroupRef, MbReleaseResponse, MbTrack,
     };
+    use coven::{FixedClock, SequentialIdProvider};
+
+    fn test_clock() -> FixedClock {
+        FixedClock(
+            chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        )
+    }
 
     fn make_mb_track(number: &str, title: &str) -> MbTrack {
         MbTrack {
@@ -737,5 +745,122 @@ mod tests {
         let err = build_mb_detail("mb-release-1", &response, vec![])
             .expect_err("expected error for vinyl track without side letter");
         assert!(err.contains("no side letter"), "unexpected error: {}", err);
+    }
+
+    /// Assert the commit plane and the editor-seed plane assign identical
+    /// `(side, track_number)` to every track: the commit rows from
+    /// `map_*_to_db` and the editor seed from a detail →
+    /// `shape_user_edit_from_search_detail(Exact)` line up position for
+    /// position.
+    fn assert_planes_agree_on_numbering(
+        parsed: &crate::import::ParsedAlbum,
+        detail: &ImportSearchReleaseDetail,
+        release_ref: MetadataRef,
+    ) {
+        let user_edit = crate::import::shape_user_edit_from_search_detail(
+            detail,
+            &IdentityChoice::Exact { release_ref },
+        );
+        let commit: Vec<(i32, Option<i32>)> = parsed
+            .tracks
+            .iter()
+            .map(|t| (t.side, t.track_number))
+            .collect();
+        let seed: Vec<(i32, Option<i32>)> = user_edit
+            .tracks
+            .iter()
+            .map(|t| (t.side, t.track_number))
+            .collect();
+        assert_eq!(commit, seed);
+    }
+
+    /// The commit plane (`map_mb_response_to_db`) and the editor-seed plane
+    /// (`build_mb_detail` → `shape_user_edit_from_search_detail`) agree on
+    /// `(side, track_number)` for every track of a multi-side vinyl release:
+    /// both number through `per_side_positions` over side values from the same
+    /// `medium_sides` derivation.
+    #[test]
+    fn mb_commit_and_editor_seed_agree_on_side_and_number() {
+        let response = response_with_media(vec![
+            MbMedium {
+                format: Some("12\" Vinyl".to_string()),
+                tracks: vec![
+                    make_mb_track("A1", "Track A1"),
+                    make_mb_track("A2", "Track A2"),
+                    make_mb_track("B1", "Track B1"),
+                ],
+            },
+            MbMedium {
+                format: Some("12\" Vinyl".to_string()),
+                tracks: vec![
+                    make_mb_track("C1", "Track C1"),
+                    make_mb_track("D1", "Track D1"),
+                ],
+            },
+        ]);
+        let clock = test_clock();
+        let ids = SequentialIdProvider::new("mb");
+        let parsed = crate::import::musicbrainz_mapper::map_mb_response_to_db(
+            &response, None, None, &clock, &ids,
+        )
+        .unwrap();
+        let detail = build_mb_detail("mb-release-1", &response, vec![]).unwrap();
+
+        assert_planes_agree_on_numbering(
+            &parsed,
+            &detail,
+            MetadataRef::new("mb-release-1", MetadataSource::MusicBrainz),
+        );
+    }
+
+    /// The same numbering agreement over a multi-disc Discogs release, whose
+    /// sides come from `process_tracklist`.
+    #[test]
+    fn discogs_commit_and_editor_seed_agree_on_side_and_number() {
+        let make_track = |position: &str, title: &str| DiscogsTrack {
+            position: position.to_string(),
+            title: title.to_string(),
+            duration: None,
+            artists: vec![],
+            type_: "track".to_string(),
+            extraartists: None,
+        };
+        let release = DiscogsRelease {
+            id: "discogs-release-1".to_string(),
+            title: "Album Title".to_string(),
+            year: Some(2024),
+            genre: vec![],
+            style: vec![],
+            format: vec![],
+            country: None,
+            label: vec![],
+            cover_image: None,
+            thumb: None,
+            catno: None,
+            artists: vec![DiscogsArtist {
+                id: "artist-1".to_string(),
+                name: "Artist Name".to_string(),
+            }],
+            extraartists: Some(vec![]),
+            tracklist: vec![
+                make_track("1-1", "Disc 1 Track 1"),
+                make_track("1-2", "Disc 1 Track 2"),
+                make_track("2-1", "Disc 2 Track 1"),
+                make_track("2-2", "Disc 2 Track 2"),
+            ],
+            master_id: None,
+        };
+        let clock = test_clock();
+        let ids = SequentialIdProvider::new("d");
+        let parsed =
+            crate::import::discogs_mapper::map_discogs_to_db(&release, None, None, &clock, &ids)
+                .unwrap();
+        let detail = build_discogs_detail(&release);
+
+        assert_planes_agree_on_numbering(
+            &parsed,
+            &detail,
+            MetadataRef::new("discogs-release-1", MetadataSource::Discogs),
+        );
     }
 }


### PR DESCRIPTION
The three import mappers (file tags, MusicBrainz, Discogs) each hand-assembled the same ParsedAlbum shape — artist pool, per-side track numbering, junction rows — with almost no shared code. Per-side numbering existed in four verbatim copies, the fourth in the import editor's seed builder with a comment admitting it would corrupt multi-side releases if it drifted from the mappers. Artist dedup existed as three hand-rolled matchers with subtly different rules.

This PR introduces a normalized intermediate representation (ReleaseIr: album-level fields plus an ordered per-track event stream of credits, roles, and work references) and one assembler that owns artist dedup, numbering, and row emission. The mappers become pure source→IR builders; the editor seed calls the same numbering function the assembler uses, making the commit-plane/editor-plane agreement structural instead of comment-enforced. Mapper output is byte-identical, locked by characterization tests written before the refactor plus new cross-plane consistency tests; the one ratified semantic change is that id-less Discogs role credits now dedup on the name that is actually stored (the credited name) instead of matching one name while storing another.

The five DbAlbum/DbRelease/DbTrack from_* constructors that existed only for the mappers are deleted along with the per-mapper matchers and the half-built AlbumSeed types.

## Test plan
- [x] Characterization tests for the three artist-dedup matcher arms, landed green on unmodified code first
- [x] Cross-plane consistency tests: mapper output vs editor seed agree on (side, track_number) for multi-side MB and multi-disc Discogs fixtures
- [x] per_side_positions unit tests (interleaved sides, i32/u32 keys)
- [x] Full bae-core suite with --features test-utils: 1029 lib + all integration binaries green; cargo check -p bae-bridge clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)