### PR TITLE
Model the current playback track as an explicit slot state machine

### DIFF
--- a/bae-core/src/playback/audio_output.rs
+++ b/bae-core/src/playback/audio_output.rs
@@ -388,9 +388,6 @@ pub trait AudioOutput: Send + 'static {
 
     fn set_state(&self, state: AudioState);
     fn get_state(&self) -> AudioState;
-    fn is_paused(&self) -> bool {
-        self.get_state() == AudioState::Paused
-    }
     fn set_volume(&self, volume: f32);
     fn get_volume(&self) -> f32;
 }

--- a/bae-core/src/playback/service/advance.rs
+++ b/bae-core/src/playback/service/advance.rs
@@ -23,7 +23,8 @@ impl PlaybackService {
 
             // Advance to next track if queue has one, otherwise stay stopped
             if let Some(next_id) = self.playback_queue.advance_to_front() {
-                self.play_track(&next_id, TrackStart::Direct, false).await;
+                self.play_track(&next_id, TrackStart::Direct, PlayTarget::Playing)
+                    .await;
             }
         } else {
             // Current track is fine, but check preloaded next track
@@ -92,18 +93,18 @@ impl PlaybackService {
         // Otherwise hold it for the rebuild path (format change, no live
         // stream yet, or repeat-track mode where the current track replays
         // instead) which the completion → AutoAdvance flow handles.
-        let stage_target = match (&self.current_prepared, &self.current_playback_source) {
-            (Some(current), Some(gapless))
-                if current.sample_rate == prepared.sample_rate
-                    && current.channels == prepared.channels
+        let stage_source: Option<Arc<Mutex<source::PlaybackSource>>> = match &self.slot {
+            PlaybackSlot::Active(cur)
+                if cur.prepared.sample_rate == prepared.sample_rate
+                    && cur.prepared.channels == prepared.channels
                     && self.playback_queue.repeat_mode() != RepeatMode::Track
-                    && !self.should_hold_for_side_pause(current, &prepared) =>
+                    && !self.should_hold_for_side_pause(&cur.prepared, &prepared) =>
             {
-                Some(gapless)
+                Some(cur.source.clone())
             }
             _ => None,
         };
-        if let Some(gapless) = stage_target {
+        if let Some(gapless) = stage_source {
             info!(
                 "Preload: staged next track into gapless chain: {}",
                 track_id
@@ -139,11 +140,10 @@ impl PlaybackService {
             return Ok(None);
         }
 
-        let Some(current) = self
-            .current_prepared
-            .as_ref()
-            .map(|prepared| prepared.track_info.clone())
-        else {
+        let Some(current) = (match &self.slot {
+            PlaybackSlot::Active(cur) => Some(cur.prepared.track_info.clone()),
+            _ => None,
+        }) else {
             error!("side-pause decision requested without current track metadata");
             return Err(());
         };
@@ -219,51 +219,72 @@ impl PlaybackService {
     }
 
     pub(super) fn pause_for_side_end(&mut self, decision: SidePauseDecision) {
-        self.pending_side_pause = Some(decision.clone());
-        self.audio_output
-            .set_state(crate::playback::audio_output::AudioState::Paused);
-        emit_progress(
-            &self.progress_tx,
-            PlaybackProgress::StateChanged {
-                state: self.make_paused_state(PlaybackPauseReason::SideEnded(decision.prompt)),
-            },
-        );
+        // The current track drained (phase Completed); fold the side-pause into
+        // the phase, carrying the track it resumes into.
+        if let PlaybackSlot::Active(cur) = &mut self.slot {
+            cur.phase = TrackPhase::Paused(PausePhase::SideEnded(decision));
+        }
+        self.sync_audio_state();
+        self.emit_state();
         self.emit_queue_update();
     }
 
     pub(super) async fn resume_from_side_pause(&mut self) {
-        let Some(pending) = self.pending_side_pause.clone() else {
+        let Some(pending_track_id) = self.side_pause_resume_track_id() else {
             warn!("side-pause resume requested without pending side-pause state");
             return;
         };
-        let pending_track_id = pending.track_id;
 
         if self.next_track_id() == Some(pending_track_id.as_str()) {
-            self.advance_and_play_preloaded(&pending_track_id, true, false)
+            self.advance_and_play_preloaded(&pending_track_id, true, PlayTarget::Playing)
                 .await;
-            self.pending_side_pause = None;
             return;
         }
 
         let Some(front) = self.playback_queue.front().map(str::to_string) else {
             error!("side-pause resume expected {pending_track_id}, but the queue is empty");
-            self.pending_side_pause = None;
+            self.demote_side_pause_to_manual();
             return;
         };
         if front != pending_track_id {
             error!("side-pause resume expected {pending_track_id}, but queue front is {front}");
-            self.pending_side_pause = None;
+            self.demote_side_pause_to_manual();
             return;
         }
         match self.playback_queue.next_entry() {
             NextEntry::Play(track_id) => {
-                self.pending_side_pause = None;
                 self.emit_queue_update();
-                self.play_track(&track_id, TrackStart::Natural, false).await;
+                self.play_track(&track_id, TrackStart::Natural, PlayTarget::Playing)
+                    .await;
             }
             other => {
                 error!("side-pause resume expected Play for {pending_track_id}, got {other:?}");
-                self.pending_side_pause = None;
+                self.demote_side_pause_to_manual();
+            }
+        }
+    }
+
+    /// The track a side-pause resumes into, if the current phase is a side-pause.
+    fn side_pause_resume_track_id(&self) -> Option<String> {
+        match &self.slot {
+            PlaybackSlot::Active(cur) => match &cur.phase {
+                TrackPhase::Paused(PausePhase::SideEnded(decision)) => {
+                    Some(decision.track_id.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Demote a side-pause to a plain manual pause without emitting. Used when a
+    /// queue mutation invalidates the pending next side, or on a side-pause
+    /// resume that can no longer find its target — the UI keeps showing the last
+    /// emitted state (still paused) while the machine forgets the side-pause.
+    pub(super) fn demote_side_pause_to_manual(&mut self) {
+        if let PlaybackSlot::Active(cur) = &mut self.slot {
+            if matches!(cur.phase, TrackPhase::Paused(PausePhase::SideEnded(_))) {
+                cur.phase = TrackPhase::Paused(PausePhase::Manual);
             }
         }
     }
@@ -288,11 +309,19 @@ impl PlaybackService {
         }
     }
 
+    /// The current track's playback source, if a track is active.
+    pub(super) fn current_source(&self) -> Option<&Arc<Mutex<source::PlaybackSource>>> {
+        match &self.slot {
+            PlaybackSlot::Active(cur) => Some(&cur.source),
+            _ => None,
+        }
+    }
+
     pub(super) fn clear_next_track_state(&mut self) {
-        clear_preloaded_next(
-            &mut self.preloaded_next,
-            self.current_playback_source.as_ref(),
-        );
+        // Clone the Arc so the borrow of the slot ends before we mutate
+        // `preloaded_next` (both are fields of self).
+        let current_source = self.current_source().cloned();
+        clear_preloaded_next(&mut self.preloaded_next, current_source.as_ref());
     }
 
     /// Whether a preloaded next-track source is available.
@@ -303,8 +332,7 @@ impl PlaybackService {
         match &preloaded.source {
             PreloadedNextSource::Held(_) => true,
             PreloadedNextSource::Staged => self
-                .current_playback_source
-                .as_ref()
+                .current_source()
                 .is_some_and(|gapless| gapless.lock().unwrap().has_next()),
         }
     }
@@ -352,16 +380,25 @@ impl PlaybackService {
         let track_id = crossing.incoming_fmt.track_id.clone();
         info!("Gapless boundary: now playing {}", track_id);
 
-        // The previous track's decoder has finished; the next track's decoder
-        // becomes the current one.
-        self.current_decoder_handle = Some(decoder_handle);
-
+        // The `PlaybackSource` already advanced within the same stream; swap the
+        // finishing track's prepared + decoder for the incoming one in place. The
+        // phase stays Playing — a crossing only fires while samples are pulling.
+        let Some(cur) = (match &mut self.slot {
+            PlaybackSlot::Active(cur) => Some(cur),
+            _ => None,
+        }) else {
+            warn!(
+                track_id = %crossing.incoming_fmt.track_id,
+                "Gapless boundary fired with no active track; ignoring"
+            );
+            return;
+        };
         // Release the previous track's buffer (unless shared with the new one).
-        if let Some(prev) = self.current_prepared.take() {
-            prev.release_buffers_not_used_by(&next_prepared, &mut self.shared_file_buffers);
-        }
+        cur.prepared
+            .release_buffers_not_used_by(&next_prepared, &mut self.shared_file_buffers);
+        cur.prepared = next_prepared;
+        cur.decoder_handle = decoder_handle;
 
-        self.current_prepared = Some(next_prepared);
         // The crossed-into track is now playing: hand its reader fetch priority
         // over the track preloaded below.
         self.mark_current_foreground();
@@ -373,7 +410,8 @@ impl PlaybackService {
         *self.current_position_shared.lock().unwrap() = Some(std::time::Duration::ZERO);
 
         // Tell the UI which track is now playing (StateChanged covers the transition).
-        self.emit_current_state();
+        self.sync_audio_state();
+        self.emit_state();
 
         self.preload_queue_front().await;
 
@@ -401,12 +439,12 @@ impl PlaybackService {
         &mut self,
         preloaded_track_id: &str,
         natural: bool,
-        preserve_paused: bool,
+        target: PlayTarget,
     ) {
         if self.has_preloaded_next() {
             info!("Using preloaded track: {}", preloaded_track_id);
             self.advance_to_preloaded();
-            self.play_preloaded_track(natural, preserve_paused).await;
+            self.play_preloaded_track(natural, target).await;
         } else {
             // Preload started but the streaming source isn't ready yet.
             self.advance_to_preloaded();
@@ -414,7 +452,7 @@ impl PlaybackService {
             self.play_track(
                 preloaded_track_id,
                 TrackStart::from_natural_transition(natural),
-                preserve_paused,
+                target,
             )
             .await;
         }
@@ -428,7 +466,7 @@ impl PlaybackService {
     pub(super) async fn play_preloaded_track(
         &mut self,
         is_natural_transition: bool,
-        preserve_paused: bool,
+        target: PlayTarget,
     ) {
         let preloaded = match self.preloaded_next.take() {
             Some(preloaded) => preloaded,
@@ -452,15 +490,13 @@ impl PlaybackService {
         if !is_natural_transition && pregap_ms.is_some_and(|p| p > 0) {
             info!("Pregap skip needed for preloaded track - falling back to play_track");
             next_prepared.cancel_unshared_buffers();
-            if let Some(source) =
-                detach_preloaded_source(self.current_playback_source.as_ref(), preloaded_source)
-            {
+            if let Some(source) = detach_preloaded_source(self.current_source(), preloaded_source) {
                 source.cancel();
             }
             self.play_track(
                 &track_id,
                 TrackStart::from_natural_transition(is_natural_transition),
-                preserve_paused,
+                target,
             )
             .await;
             return;
@@ -468,49 +504,51 @@ impl PlaybackService {
 
         // Recover the preloaded next source (staged in the gapless chain or held
         // for the rebuild path) BEFORE tearing down the current stream.
-        let source =
-            detach_preloaded_source(self.current_playback_source.as_ref(), preloaded_source)
-                .expect("Preloaded track has no streaming source");
+        let source = detach_preloaded_source(self.current_source(), preloaded_source)
+            .expect("Preloaded track has no streaming source");
 
-        // Cancel current streaming state
-        if let Some(gapless) = self.current_playback_source.take() {
-            if let Ok(guard) = gapless.lock() {
+        // Tear down the current track. Cancel its source so the callback goes
+        // silent, then release its buffers (unless shared with the incoming
+        // track). The preloaded track's already-running decoder becomes current.
+        if let PlaybackSlot::Active(cur) = std::mem::replace(&mut self.slot, PlaybackSlot::Stopped)
+        {
+            if let Ok(guard) = cur.source.lock() {
                 guard.cancel();
             }
+            cur.prepared
+                .release_buffers_not_used_by(&next_prepared, &mut self.shared_file_buffers);
+            // Dropping `cur` drops the old stream/events and detaches its decoder.
         }
-        if let Some(prepared) = &self.current_prepared {
-            prepared.release_buffers_not_used_by(&next_prepared, &mut self.shared_file_buffers);
-        }
-
-        // Swap next to current. The preloaded track's decoder becomes the current
-        // one; the previous track's decoder was cancelled above via the source.
-        self.current_decoder_handle = Some(decoder_handle);
-        self.current_prepared = Some(next_prepared);
-        // The preloaded track is now the playing one: hand its reader fetch
-        // priority over whatever gets preloaded next.
-        self.mark_current_foreground();
 
         // Natural transition: start at position 0 (INDEX 00, pregap plays).
-        let fmt = self
-            .current_prepared
-            .as_ref()
-            .expect("current_prepared just set above")
-            .track_fmt(std::time::Duration::ZERO);
+        let fmt = next_prepared.track_fmt(std::time::Duration::ZERO);
 
-        // Initialize streaming with the preloaded source
-        if !self.init_streaming(source, fmt).await {
-            self.stop().await;
-            return;
-        }
+        // Initialize streaming with the preloaded source. On failure the caller
+        // owns the failure path: surface a PlaybackError, then stop() to resolve
+        // the transition to Stopped (as play_track does when audio can't start).
+        let parts = match self.init_streaming(source, fmt).await {
+            Ok(parts) => parts,
+            Err(_) => {
+                emit_progress(
+                    &self.progress_tx,
+                    PlaybackProgress::PlaybackError {
+                        reason: crate::ui::PlaybackErrorReason::internal(
+                            "Couldn't start audio output for the next track.",
+                        ),
+                    },
+                );
+                self.stop().await;
+                return;
+            }
+        };
 
-        // Set audio state: always Playing unless preserving paused state
-        if !preserve_paused {
-            self.audio_output
-                .set_state(crate::playback::audio_output::AudioState::Playing);
-        }
-
-        // Send state notification
-        self.emit_current_state();
+        // The preloaded track's already-running decoder becomes current.
+        let started = StartedStream {
+            parts,
+            decoder_handle,
+        };
+        self.install_active_track(next_prepared, started, target.into_track_phase());
+        self.emit_state();
 
         self.preload_queue_front().await;
 

--- a/bae-core/src/playback/service/mod.rs
+++ b/bae-core/src/playback/service/mod.rs
@@ -59,7 +59,13 @@ mod pipeline;
 mod preview;
 mod queue_commands;
 mod seek;
+mod slot;
 mod state;
+
+use pipeline::StartedStream;
+use slot::{
+    CurrentTrack, LoadGeneration, PausePhase, PlayIntent, PlayTarget, PlaybackSlot, TrackPhase,
+};
 
 #[cfg(test)]
 mod tests;
@@ -113,6 +119,17 @@ pub struct LoadingTrack {
     pub duration_ms: u64,
 }
 
+impl LoadingTrack {
+    /// The metadata a `Loading` state carries for a resolved track: its info plus
+    /// the pregap-adjusted duration `Playing`/`Paused` also report.
+    fn from_prepared(prepared: &PlaybackPreparedTrack) -> Self {
+        Self {
+            track_info: prepared.track_info.clone(),
+            duration_ms: pregap_adjusted_duration(prepared),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaybackSidePausePrompt {
     pub id: String,
@@ -132,15 +149,15 @@ pub enum PlaybackPauseReason {
     SideEnded(PlaybackSidePausePrompt),
 }
 
-#[derive(Clone)]
-struct SidePauseDecision {
+#[derive(Debug, Clone)]
+pub(super) struct SidePauseDecision {
     track_id: String,
     prompt: PlaybackSidePausePrompt,
 }
 
 /// Playback commands sent to the service
 #[derive(Debug)]
-pub enum PlaybackCommand {
+pub(crate) enum PlaybackCommand {
     Play(String),
     PlayRelease {
         release_id: String,
@@ -157,18 +174,18 @@ pub enum PlaybackCommand {
     Next,
     /// Auto-advance from track completion (play pregap)
     AutoAdvance,
-    /// Internal: the in-core decoder for `track_id` filled its ring buffer to
-    /// the play threshold (or reached EOF). Sent from a watcher task awaiting
-    /// the decoder's ready signal; the handler emits Playing/Paused only if this
-    /// is still the live load. Identity is the prepared track's `cancel_token`
-    /// Arc, not the track id: RepeatCurrent / RestartCurrent / re-Play replay the
-    /// SAME id through a fresh load, so an id match would accept a ready signal
-    /// from the abandoned load. A new load mints a new token, so comparing the
-    /// Arc by pointer against `current_prepared` rejects the stale signal. The
-    /// id is carried only to name the dropped track in the debug log.
+    /// Internal: the in-core decoder for a load filled its ring buffer to the
+    /// play threshold (or reached EOF). Sent from a watcher task awaiting the
+    /// decoder's ready signal; the handler resolves the current track's phase to
+    /// its target (Playing/Paused) only if this is still the live load. Identity
+    /// is the load `generation`, not the track id: RepeatCurrent / RestartCurrent
+    /// / re-Play replay the SAME id through a fresh load, so an id match would
+    /// accept a ready signal from the abandoned load. A new load mints a new
+    /// generation, so a stale signal no longer matches. The id is carried only to
+    /// name the dropped track in the debug log.
     TrackReady {
         track_id: String,
-        cancel_token: Arc<std::sync::atomic::AtomicBool>,
+        generation: LoadGeneration,
     },
     /// Internal: a mid-flight read failure (cloud or local) emitted a
     /// `PlaybackProgress::PlaybackError`. Sent from the progress self-subscription
@@ -816,17 +833,14 @@ pub struct PlaybackService {
     playback_queue: PlaybackQueue,
     current_position_shared: Arc<std::sync::Mutex<Option<std::time::Duration>>>,
     audio_output: Box<dyn AudioOutput>,
-    stream: Option<Box<dyn AudioStream>>,
-    /// Current track prepared data and streaming state
-    current_prepared: Option<PlaybackPreparedTrack>,
-    /// Current playing source. A `PlaybackSource` wraps the current track and an
-    /// optional pre-staged next track so the audio callback can advance across a
-    /// track boundary without rebuilding the stream.
-    current_playback_source: Option<Arc<Mutex<source::PlaybackSource>>>,
-    /// JoinHandle for the current decoder thread (needed for seek cancellation)
-    current_decoder_handle: Option<std::thread::JoinHandle<()>>,
-    /// Receiver for events emitted by the current stream's audio callback.
-    current_audio_events: Option<AudioEventReceiver>,
+    /// The single authority for what is current and in what phase. Owns the
+    /// stream, source, decoder handle, audio-events receiver, and prepared track
+    /// as one consistent whole; the `AudioState` atomic is written as a
+    /// projection of it via `sync_audio_state`.
+    slot: PlaybackSlot,
+    /// Mints a fresh `LoadGeneration` per decoder load so a `TrackReady` from an
+    /// abandoned load can be told from the live one.
+    load_generation_counter: u64,
     /// Preloaded next track state, either staged into the current gapless source
     /// or held for a stream rebuild.
     preloaded_next: Option<PreloadedNext>,
@@ -846,7 +860,6 @@ pub struct PlaybackService {
     /// Shared with PlaybackHandle. Written on every position tick and by
     /// `emit_position_display`; read by late-mounting views.
     last_position_display: Arc<std::sync::Mutex<Option<f64>>>,
-    pending_side_pause: Option<SidePauseDecision>,
     /// Prioritizes byte fetches across tracks: the current track's reader fetches
     /// immediately, a next-track preload's reader yields to it. Shared into every
     /// reader; the current track is designated foreground via
@@ -859,9 +872,67 @@ impl PlaybackService {
     /// priority, so its reader fetches immediately and a next-track preload's
     /// reader yields to it. Called wherever a track becomes the current one.
     fn mark_current_foreground(&self) {
-        if let Some(prepared) = &self.current_prepared {
-            if let Some(segment) = prepared.segments.first() {
+        if let PlaybackSlot::Active(cur) = &self.slot {
+            if let Some(segment) = cur.prepared.segments.first() {
                 self.fetch_arbiter.set_foreground(segment.buffer.id());
+            }
+        }
+    }
+
+    /// Mint a fresh load generation. Each fresh play or seek gets its own so a
+    /// `TrackReady` from an abandoned load can be told from the live one.
+    fn next_load_generation(&mut self) -> LoadGeneration {
+        let generation = LoadGeneration(self.load_generation_counter);
+        self.load_generation_counter += 1;
+        generation
+    }
+
+    /// Drive playback down to Stopped after a mid-flight read/decode failure
+    /// surfaced a `PlaybackError`. The self-handled failure paths in `play_track`
+    /// emit `PlaybackError` AND call `stop()` synchronously before returning to
+    /// the loop, so by the time this dequeues the slot is already Stopped and a
+    /// second `stop()` would emit a duplicate Stopped — no-op there. A genuine
+    /// mid-flight failure leaves the slot Active, so the teardown fires. The
+    /// serial loop can't interleave a new load between `stop()` finishing and
+    /// this running, so the guard is race-free. `stop()` emits no `PlaybackError`,
+    /// so this can't feed back into the self-subscription that dispatched it.
+    async fn halt_on_error(&mut self) {
+        if matches!(self.slot, PlaybackSlot::Stopped) {
+            debug!("HaltOnError: playback already stopped, nothing to halt");
+        } else {
+            self.stop().await;
+        }
+    }
+
+    /// Manual skip to the next track (skip pregap). A side-pause forces the next
+    /// side to start playing; any other state carries the outgoing track's
+    /// play/pause intent forward (a naturally-completed track carries Playing, so
+    /// the skip resumes audibly rather than inheriting the Stopped atomic).
+    async fn handle_next(&mut self) {
+        let target = if self.is_side_paused() {
+            PlayTarget::Playing
+        } else {
+            self.current_play_target()
+        };
+        info!("Next command received");
+        // If we have a preloaded track, use it directly.
+        if let Some(preloaded_track_id) = self.next_track_id().map(|s| s.to_string()) {
+            self.advance_and_play_preloaded(&preloaded_track_id, false, target)
+                .await;
+        } else {
+            // No preloaded track, use PlaybackQueue decision logic.
+            match self.playback_queue.next_entry() {
+                NextEntry::Play(next_track) => {
+                    info!("No preloaded track, playing from queue: {}", next_track);
+                    self.emit_queue_update();
+                    self.play_track(&next_track, TrackStart::Direct, target)
+                        .await;
+                }
+                _ => {
+                    info!("No next track available, stopping");
+                    self.emit_queue_update();
+                    self.stop().await;
+                }
             }
         }
     }
@@ -910,7 +981,15 @@ impl PlaybackService {
                 samples_decoded,
             },
         );
-        self.current_audio_events = None;
+        // The track drained: mark the phase Completed. The stream/source/decoder
+        // stay in the slot because AutoAdvance and the side-pause decision still
+        // read them; the audio-events receiver is retained but no longer polled
+        // (the drain tick's guard skips a Completed slot). The audio callback
+        // already flipped the atomic to Stopped, which `sync_audio_state` confirms.
+        if let PlaybackSlot::Active(cur) = &mut self.slot {
+            cur.phase = TrackPhase::Completed;
+        }
+        self.sync_audio_state();
     }
 
     fn log_audio_diagnostic(&self, event: AudioEvent) {
@@ -977,16 +1056,16 @@ impl PlaybackService {
 
     async fn drain_current_audio_events(&mut self) {
         while let Some(event) = self
-            .current_audio_events
-            .as_mut()
+            .slot
+            .pollable_audio_events()
             .and_then(AudioEventReceiver::pop)
         {
             self.handle_audio_event(event).await;
         }
 
         let dropped_required = self
-            .current_audio_events
-            .as_ref()
+            .slot
+            .pollable_audio_events_ref()
             .map(AudioEventReceiver::take_dropped_required_count)
             .unwrap_or(0);
         if dropped_required > 0 {
@@ -1006,7 +1085,7 @@ impl PlaybackService {
             return;
         }
 
-        if let Some(events) = &self.current_audio_events {
+        if let Some(events) = self.slot.pollable_audio_events_ref() {
             let dropped = events.take_dropped_count();
             if dropped > 0 {
                 warn!(dropped, "audio callback event queue dropped events");
@@ -1299,11 +1378,8 @@ impl PlaybackService {
                     playback_queue: PlaybackQueue::new(queue_ids),
                     current_position_shared: Arc::new(std::sync::Mutex::new(None)),
                     audio_output,
-                    stream: None,
-                    current_prepared: None,
-                    current_playback_source: None,
-                    current_decoder_handle: None,
-                    current_audio_events: None,
+                    slot: PlaybackSlot::Stopped,
+                    load_generation_counter: 0,
                     preloaded_next: None,
                     preview,
                     main_was_playing_before_preview: false,
@@ -1312,7 +1388,6 @@ impl PlaybackService {
                     position_update_interval_ms,
                     shared_file_buffers: HashMap::new(),
                     last_position_display,
-                    pending_side_pause: None,
                     fetch_arbiter: FetchArbiter::new(),
                 };
                 match service.library_manager.load_playback_state().await {
@@ -1358,7 +1433,7 @@ impl PlaybackService {
         audio_event_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
-                _ = audio_event_tick.tick(), if self.current_audio_events.is_some() => {
+                _ = audio_event_tick.tick(), if self.slot.has_pollable_audio_events() => {
                     self.drain_current_audio_events().await;
                 }
                 Some(command) = self.command_rx.recv() => {
@@ -1382,9 +1457,8 @@ impl PlaybackService {
                             self.playback_queue.play_single(track_id.clone());
                         }
                     }
-                    self.pending_side_pause = None;
                     self.emit_queue_update();
-                    self.play_track(&track_id, TrackStart::Direct, false).await;
+                    self.play_track(&track_id, TrackStart::Direct, PlayTarget::Playing).await;
                 }
                 PlaybackCommand::PlayRelease { release_id, start_track_index, shuffle } => {
                     let track_ids = match self.library_manager.get_track_ids(&release_id).await {
@@ -1429,9 +1503,8 @@ impl PlaybackService {
                         track_ids,
                         start,
                     );
-                    self.pending_side_pause = None;
                     self.emit_queue_update();
-                    self.play_track(&first_track, TrackStart::Direct, false).await;
+                    self.play_track(&first_track, TrackStart::Direct, PlayTarget::Playing).await;
                 }
                 PlaybackCommand::PlayLibraryShuffled => {
                     let track_ids = match self.fetch_source_tracks(&ContextSource::Library).await {
@@ -1455,9 +1528,8 @@ impl PlaybackService {
                             seed: rand::random(),
                         },
                     );
-                    self.pending_side_pause = None;
                     self.emit_queue_update();
-                    self.play_track(&first_track, TrackStart::Direct, false).await;
+                    self.play_track(&first_track, TrackStart::Direct, PlayTarget::Playing).await;
                 }
                 PlaybackCommand::Pause => {
                     self.pause().await;
@@ -1469,37 +1541,7 @@ impl PlaybackService {
                     self.stop().await;
                 }
                 PlaybackCommand::Next => {
-                    let was_side_paused = self.pending_side_pause.is_some();
-                    if was_side_paused {
-                        self.pending_side_pause = None;
-                    }
-                    info!("Next command received");
-                    // If we have a preloaded track, use it directly
-                    if let Some(preloaded_track_id) = self.next_track_id().map(|s| s.to_string()) {
-                        // skip pregap, preserve paused
-                        self.advance_and_play_preloaded(
-                            &preloaded_track_id,
-                            false,
-                            !was_side_paused,
-                        )
-                            .await;
-                    } else {
-                        // No preloaded track, use PlaybackQueue decision logic
-                        match self.playback_queue.next_entry() {
-                            NextEntry::Play(next_track) => {
-                                info!("No preloaded track, playing from queue: {}", next_track);
-                                self.emit_queue_update();
-                                self.play_track(&next_track, TrackStart::Direct, !was_side_paused)
-                                    .await;
-                                // preserve paused
-                            }
-                            _ => {
-                                info!("No next track available, stopping");
-                                self.emit_queue_update();
-                                self.stop().await;
-                            }
-                        }
-                    }
+                    self.handle_next().await;
                 }
                 PlaybackCommand::AutoAdvance => {
                     info!("AutoAdvance command received (natural transition)");
@@ -1522,7 +1564,7 @@ impl PlaybackService {
                             self.next_track_id().map(|s| s.to_string())
                         {
                             // natural transition, start playing
-                            self.advance_and_play_preloaded(&preloaded_track_id, true, false)
+                            self.advance_and_play_preloaded(&preloaded_track_id, true, PlayTarget::Playing)
                                 .await;
                             continue;
                         }
@@ -1532,12 +1574,12 @@ impl PlaybackService {
                     match self.playback_queue.next_entry() {
                         NextEntry::RepeatCurrent(track_id) => {
                             info!("Repeat mode: track, replaying {}", track_id);
-                            self.play_track(&track_id, TrackStart::Natural, false).await;
+                            self.play_track(&track_id, TrackStart::Natural, PlayTarget::Playing).await;
                         }
                         NextEntry::Play(next_track) => {
                             info!("Playing from queue: {}", next_track);
                             self.emit_queue_update();
-                            self.play_track(&next_track, TrackStart::Natural, false).await;
+                            self.play_track(&next_track, TrackStart::Natural, PlayTarget::Playing).await;
                         }
                         NextEntry::Stop => {
                             info!("No next track available, stopping");
@@ -1548,54 +1590,25 @@ impl PlaybackService {
                 }
                 PlaybackCommand::TrackReady {
                     track_id,
-                    cancel_token,
+                    generation,
                 } => {
-                    // Emit Playing/Paused now that audio is actually flowing. A
-                    // signal from an abandoned load (the user switched tracks, or
-                    // replayed the same track via RepeatCurrent / RestartCurrent /
-                    // re-Play) carries the old load's token; only the live load's
-                    // token is the current prepared track's. Comparing the id
-                    // alone would accept a same-id replay's stale signal, so match
-                    // the token Arc by pointer and drop anything that isn't it.
-                    let is_live = self
-                        .current_prepared
-                        .as_ref()
-                        .is_some_and(|p| Arc::ptr_eq(&p.cancel_token, &cancel_token));
-                    if is_live {
-                        self.emit_current_state();
-                    } else {
-                        debug!(
-                            track_id,
-                            "ignoring stale TrackReady from an abandoned load"
-                        );
-                    }
+                    // Resolve the current track's phase to its target now that
+                    // audio is actually flowing. A signal from an abandoned load
+                    // (the user switched tracks, or replayed the same track via
+                    // RepeatCurrent / RestartCurrent / re-Play, or a pause/preview
+                    // collapsed the Loading phase) carries a generation that no
+                    // longer matches the current load; drop it.
+                    self.resolve_track_ready(track_id, generation);
                 }
                 PlaybackCommand::HaltOnError => {
-                    // The self-handled failure paths in play_track (prepare
-                    // failure, init_streaming failure) emit PlaybackError AND call
-                    // stop() synchronously before returning to this loop. The
-                    // command loop is serial: stop() has fully run by the time the
-                    // HaltOnError it triggered is dequeued, so playback is already
-                    // Stopped and a second stop() would emit a duplicate Stopped.
-                    // No-op when nothing is prepared and the output is stopped —
-                    // race-free because the serial loop can't interleave a new
-                    // load between stop() finishing and this command running.
-                    // A genuine mid-flight reader/decoder failure leaves a track
-                    // prepared and Playing, so the no-op doesn't fire there.
-                    let already_stopped = self.current_prepared.is_none()
-                        && self.audio_output.get_state()
-                            == crate::playback::audio_output::AudioState::Stopped;
-                    if already_stopped {
-                        debug!("HaltOnError: playback already stopped, nothing to halt");
-                    } else {
-                        // stop() does not emit PlaybackError, so this can't feed
-                        // back into the self-subscription that dispatched it.
-                        self.stop().await;
-                    }
+                    self.halt_on_error().await;
                 }
                 PlaybackCommand::Previous => {
-                    self.pending_side_pause = None;
                     if let Some(current_track_id) = self.current_track_id().map(|s| s.to_string()) {
+                        // Carry the outgoing track's play/pause intent to the
+                        // track we land on (a side-pause collapses to a plain
+                        // manual pause across the track change).
+                        let target = self.current_play_target();
                         let current_position = self
                             .current_position_shared
                             .lock()
@@ -1609,12 +1622,12 @@ impl PlaybackService {
                                 // previous_action already stepped the context cursor
                                 // back and made this track current; just play it.
                                 self.emit_queue_update();
-                                self.play_track(&previous_track_id, TrackStart::Direct, true)
+                                self.play_track(&previous_track_id, TrackStart::Direct, target)
                                     .await;
                             }
                             PreviousAction::RestartCurrent => {
                                 info!("Restarting current track from beginning");
-                                self.play_track(&current_track_id, TrackStart::Direct, true).await;
+                                self.play_track(&current_track_id, TrackStart::Direct, target).await;
                             }
                         }
                     }
@@ -1623,12 +1636,16 @@ impl PlaybackService {
                     self.seek(position).await;
                 }
                 PlaybackCommand::SeekByRatio(ratio) => {
-                    if let Some(prepared) = &self.current_prepared {
+                    let position_ms = if let PlaybackSlot::Active(cur) = &self.slot {
+                        let prepared = &cur.prepared;
                         let pregap_ms = prepared.pregap_ms.unwrap_or(0).max(0) as u64;
                         let duration_ms = prepared.duration.as_millis() as u64;
                         let track_duration = duration_ms.saturating_sub(pregap_ms);
-                        let position_ms =
-                            pregap_ms + (ratio.clamp(0.0, 1.0) * track_duration as f64) as u64;
+                        Some(pregap_ms + (ratio.clamp(0.0, 1.0) * track_duration as f64) as u64)
+                    } else {
+                        None
+                    };
+                    if let Some(position_ms) = position_ms {
                         self.seek(std::time::Duration::from_millis(position_ms))
                             .await;
                     }
@@ -1775,9 +1792,8 @@ impl PlaybackService {
                             entry.id.0, entry.track_id
                         );
 
-                        self.pending_side_pause = None;
                         self.emit_queue_update();
-                        self.play_track(&entry.track_id, TrackStart::Direct, false).await;
+                        self.play_track(&entry.track_id, TrackStart::Direct, PlayTarget::Playing).await;
                     }
                 }
                 PlaybackCommand::PreviewPlay(path) => {
@@ -1796,11 +1812,17 @@ impl PlaybackService {
                     self.preview_completed();
                 }
                 PlaybackCommand::TogglePlayPause => {
-                    use crate::playback::audio_output::AudioState;
-                    match self.audio_output.get_state() {
-                        AudioState::Playing => self.pause().await,
-                        AudioState::Paused => self.resume().await,
-                        AudioState::Stopped => {}
+                    // Dispatch on the slot's play intent, not the atomic. A load
+                    // still filling counts as its target intent; Completed and a
+                    // stopped/loading slot are no-ops (there is nothing to toggle).
+                    let intent = match &self.slot {
+                        PlaybackSlot::Active(cur) => Some(cur.phase.intent()),
+                        _ => None,
+                    };
+                    match intent {
+                        Some(PlayIntent::Playing) => self.pause().await,
+                        Some(PlayIntent::Paused) => self.resume().await,
+                        Some(PlayIntent::Stopped) | None => {}
                     }
                 }
                 PlaybackCommand::GetVolume(reply) => {

--- a/bae-core/src/playback/service/pipeline.rs
+++ b/bae-core/src/playback/service/pipeline.rs
@@ -1,126 +1,133 @@
 use super::*;
 
+/// A built, playing cpal (or test) stream over a decoded `TrackStream`: the
+/// `StreamSetup` (stream + its audio-events receiver) plus the wrapped source.
+/// `start_decoder_and_watch` pairs this with the decoder handle it spawned; the
+/// preload-advance paths pair it with the already-running preloaded decoder.
+pub(super) struct StreamParts {
+    pub(super) setup: StreamSetup,
+    pub(super) source: Arc<Mutex<source::PlaybackSource>>,
+}
+
+/// Everything a fresh decoder load assembles: the stream parts plus the decoder
+/// thread the caller stores in the `CurrentTrack`. Returned by
+/// `start_decoder_and_watch` so the caller assigns the slot as one whole value.
+pub(super) struct StartedStream {
+    pub(super) parts: StreamParts,
+    pub(super) decoder_handle: std::thread::JoinHandle<()>,
+}
+
 impl PlaybackService {
-    // Helper accessors for current/next track state
-    pub(super) fn current_track_id(&self) -> Option<&str> {
-        self.current_prepared
-            .as_ref()
-            .map(|p| p.track_info.track_id.as_str())
-    }
-
-    /// Drop current audio callback events when the stream is no longer live.
-    pub(super) fn abort_current_listeners(&mut self) {
-        self.current_audio_events = None;
-    }
-
-    /// Tear down the outgoing track before a manual switch (Play / SkipTo /
-    /// Previous / Next-without-preload). Mirrors `stop()`'s current-track
-    /// teardown — cancel the playback source so the callback goes silent, signal
-    /// the decoder cancel token and cancel the buffer (so the decoder thread
-    /// exits its park loop instead of filling a ring nobody pulls, and the
-    /// data reader's fill loop stops fetching), and abort listeners — but leaves
-    /// the audio state and the shared-buffer cache alone so the incoming track
-    /// owns the transition. The buffer is spared when it's shared (the
-    /// same-source reuse path appends into it via `uncancel`); a shared buffer
-    /// is dropped wholesale by `stop()` instead.
+    /// Tear down the current track, whatever phase it is in, leaving the slot
+    /// Stopped. Cancels the playback source so the callback goes silent, signals
+    /// the decoder cancel token and cancels its unshared buffers (so the decoder
+    /// thread exits its park loop and the data reader stops fetching), and drops
+    /// the stream, audio-events receiver, and (detaching) the decoder handle.
     ///
-    /// The decoder thread is not joined here: joining would block the command
-    /// loop, and the cancel token plus buffer cancel already make it exit
-    /// promptly. `play_track` overwrites `current_decoder_handle` with the new
-    /// thread's handle right after.
+    /// A shared buffer is spared (the same-source reuse path appends into it via
+    /// `uncancel`); `stop()` drops the shared-buffer cache wholesale instead. The
+    /// decoder thread is not joined — joining would block the command loop, and
+    /// the cancel token plus buffer cancel already make it exit promptly; a fresh
+    /// load's decoder replaces it.
     pub(super) fn teardown_current_track(&mut self) {
-        self.stream = None;
-        if let Some(source) = self.current_playback_source.take() {
-            match source.lock() {
+        if let PlaybackSlot::Active(cur) = std::mem::replace(&mut self.slot, PlaybackSlot::Stopped)
+        {
+            match cur.source.lock() {
                 Ok(guard) => guard.cancel(),
                 // A poisoned lock means the cpal callback thread panicked while
                 // holding it. The source is being dropped here anyway, so the
                 // cancel it would have requested is moot — log and move on.
                 Err(_) => warn!("playback source lock poisoned during teardown; skipping cancel"),
             }
-        }
-        if let Some(prepared) = &self.current_prepared {
-            prepared
+            cur.prepared
                 .cancel_token
                 .store(true, std::sync::atomic::Ordering::Release);
-            prepared.cancel_unshared_buffers();
+            cur.prepared.cancel_unshared_buffers();
+            // Dropping `cur` drops the stream and audio-events receiver and
+            // detaches the decoder thread.
         }
-        self.abort_current_listeners();
-        self.current_prepared = None;
-        self.current_decoder_handle = None;
     }
 
-    /// Initialize streaming infrastructure without changing audio state.
-    ///
-    /// Sets up the cpal stream and attaches its event receiver to the service loop.
-    /// The audio output state remains unchanged - caller must explicitly
-    /// call `audio_output.set_state(Playing)` to start audio output.
-    ///
-    /// Returns true if initialization succeeded, false on error.
-    pub(super) async fn init_streaming(&mut self, source: TrackStream, fmt: TrackFmt) -> bool {
-        // Drop old stream first
-        self.stream = None;
+    /// Install a freshly built stream as the current track, in `phase`, and
+    /// project its intent onto the audio-state atomic. Also hands this track's
+    /// reader fetch priority. Does not emit a `StateChanged` — the caller decides
+    /// whether the transition surfaces one now (skip, gapless advance) or waits
+    /// for the ready-watcher's `TrackReady` (fresh play, seek).
+    pub(super) fn install_active_track(
+        &mut self,
+        prepared: PlaybackPreparedTrack,
+        started: StartedStream,
+        phase: TrackPhase,
+    ) {
+        self.slot = PlaybackSlot::Active(CurrentTrack {
+            prepared,
+            stream: started.parts.setup.stream,
+            source: started.parts.source,
+            decoder_handle: started.decoder_handle,
+            audio_events: started.parts.setup.audio_events,
+            phase,
+        });
+        self.mark_current_foreground();
+        self.sync_audio_state();
+    }
 
-        // fmt is the per-stream formatting envelope; the caller built it from
-        // its prepared track (see `PlaybackPreparedTrack::track_fmt`). The
-        // audio callback tags every position/completion emit with it; at a
-        // gapless boundary the callback swaps to the staged next track's fmt.
+    /// Build the cpal (or test) stream over a decoded `TrackStream`, start it,
+    /// and return the parts. Sets the shared position to the stream's start
+    /// offset. Does not touch the slot or the audio-state atomic — the caller
+    /// assembles the slot and calls `sync_audio_state`.
+    pub(super) async fn init_streaming(
+        &mut self,
+        source: TrackStream,
+        fmt: TrackFmt,
+    ) -> Result<StreamParts, PlaybackError> {
+        // fmt is the per-stream formatting envelope; the caller built it from its
+        // prepared track (see `PlaybackPreparedTrack::track_fmt`). The audio
+        // callback tags every position/completion emit with it; at a gapless
+        // boundary the callback swaps to the staged next track's fmt.
         let position_offset = fmt.position_offset;
 
         // Wrap the track source in a PlaybackSource so the audio callback can
         // advance to a pre-staged next track without rebuilding the stream.
         let gapless = Arc::new(Mutex::new(source::PlaybackSource::new(source, fmt)));
 
-        let setup = match setup_audio_stream(
+        let setup = setup_audio_stream(
             &mut *self.audio_output,
             gapless.clone(),
             self.position_update_interval_ms,
         )
-        .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                error!("Failed to create streaming audio stream: {:?}", e);
-                return false;
-            }
-        };
+        .await?;
 
         if let Err(e) = setup.stream.play() {
-            error!("Failed to start streaming playback: {:?}", e);
-            return false;
+            return Err(PlaybackError::task(format!(
+                "Failed to start streaming playback: {e:?}"
+            )));
         }
 
-        // Update state
-        self.stream = Some(setup.stream);
-        self.current_playback_source = Some(gapless);
-        self.current_audio_events = Some(setup.audio_events);
         *self.current_position_shared.lock().unwrap() = Some(position_offset);
 
-        true
+        Ok(StreamParts {
+            setup,
+            source: gapless,
+        })
     }
 
-    /// Spawn the in-core decoder for the current prepared track, build the audio
-    /// stream, and arm the ready-watcher — the shared tail of the play and seek
-    /// paths. Reads the buffer and cancel token from `current_prepared` (the
-    /// caller stages it first), so the watcher's `TrackReady` carries the live
-    /// load's token and the handler ignores a stale signal.
+    /// Spawn the in-core decoder for `prepared`, build the audio stream, and arm
+    /// the ready-watcher — the shared tail of the play and seek paths. The
+    /// decoder reads `prepared`'s buffer and cancel token, so the watcher's
+    /// `TrackReady` carries this load's `generation` and the handler ignores a
+    /// stale signal. Audio doesn't flow until the ring fills, so the caller may
+    /// set the phase target after this returns without racing the watcher.
     ///
-    /// Returns whether `init_streaming` succeeded; the caller owns the
-    /// failure path (its cleanup differs) and any audio-state change.
-    /// Audio doesn't flow until the ring fills, so the caller may set the
-    /// audio state after this returns without racing the watcher.
+    /// On stream-build failure the just-spawned decoder is cancelled (it would
+    /// otherwise fill a ring nobody pulls) and the error is returned; the caller
+    /// owns the rest of the failure path.
     pub(super) async fn start_decoder_and_watch(
         &mut self,
+        prepared: &PlaybackPreparedTrack,
         decode: StreamDecodeParams,
         fmt: TrackFmt,
-        sample_rate: u32,
-        channels: u32,
-        track_id: String,
-    ) -> bool {
-        let prepared = self
-            .current_prepared
-            .as_ref()
-            .expect("start_decoder_and_watch requires a staged current_prepared");
+        generation: LoadGeneration,
+    ) -> Result<StartedStream, PlaybackError> {
         let decoder_buffer = prepared
             .segments
             .first()
@@ -128,6 +135,9 @@ impl PlaybackService {
             .buffer
             .clone();
         let cancel_token = prepared.cancel_token.clone();
+        let sample_rate = prepared.sample_rate;
+        let channels = prepared.channels;
+        let track_id = prepared.track_info.track_id.clone();
 
         // Create decoder sink/source with the track's sample rate and spawn the
         // in-core FFmpeg decoder thread that fills the sink's ring buffer.
@@ -156,31 +166,42 @@ impl PlaybackService {
                 }
             })
         };
-        self.current_decoder_handle = Some(decoder_handle);
 
-        if !self.init_streaming(source, fmt).await {
-            return false;
-        }
+        let parts = match self.init_streaming(source, fmt).await {
+            Ok(parts) => parts,
+            Err(e) => {
+                error!("Failed to create streaming audio stream: {:?}", e);
+                // The decoder is spawned but no stream will pull from it. Cancel
+                // it so it exits instead of parking on a ring nobody reads, then
+                // detach — joining would block the command loop.
+                cancel_token.store(true, std::sync::atomic::Ordering::Release);
+                prepared.cancel_unshared_buffers();
+                for segment in &prepared.segments {
+                    segment.buffer.wake_readers();
+                }
+                drop(decoder_handle);
+                return Err(e);
+            }
+        };
 
-        // Hold Playing until audio is actually flowing. The in-core decoder
-        // signals `ready_rx` when the ring buffer fills to the play threshold
-        // (or hits EOF for a short track); a watcher task turns that into a
-        // `TrackReady` command so the command loop stays responsive to
-        // Stop/Pause during a slow cloud load. Awaiting inline would wedge the
-        // loop.
+        // Hold the phase in Loading until audio is actually flowing. The in-core
+        // decoder signals `ready_rx` when the ring buffer fills to the play
+        // threshold (or hits EOF for a short track); a watcher task turns that
+        // into a `TrackReady` command so the command loop stays responsive to
+        // Stop/Pause during a slow cloud load. Awaiting inline would wedge the loop.
         let command_tx = self.command_tx.clone();
         tokio::spawn(async move {
             // Err means the decoder dropped its sink before signalling ready (it
             // died or was cancelled). The decode-failure path drives playback to
-            // Stopped, and a cancelled load is no longer current so TrackReady
-            // would be ignored anyway — the error path owns recovery, so just
-            // record the dropped watcher.
+            // Stopped, and a cancelled load's generation no longer matches so
+            // TrackReady would be ignored anyway — the error path owns recovery,
+            // so just record the dropped watcher.
             match ready_rx.await {
                 Ok(()) => dispatch_command(
                     &command_tx,
                     PlaybackCommand::TrackReady {
                         track_id,
-                        cancel_token,
+                        generation,
                     },
                 ),
                 Err(_) => {
@@ -189,39 +210,41 @@ impl PlaybackService {
             }
         });
 
-        true
+        Ok(StartedStream {
+            parts,
+            decoder_handle,
+        })
     }
 
     /// Play a track.
     /// - `start`: selects direct starts, natural transitions, or a restored raw position
-    /// - `preserve_paused`: if true, inherits current paused state; if false, always starts playing
+    /// - `target`: where the load lands once audio is ready (Playing, or Paused
+    ///   with a reason). Computed absolutely by the caller.
     pub(super) async fn play_track(
         &mut self,
         track_id: &str,
         start: TrackStart,
-        preserve_paused: bool,
+        target: PlayTarget,
     ) {
         info!(
-            "Playing track: {} (start: {:?}, preserve_paused: {})",
-            track_id, start, preserve_paused
+            "Playing track: {} (start: {:?}, target: {:?})",
+            track_id, start, target
         );
 
         // Tear down the outgoing track up front so a manual switch silences the
         // old audio immediately and frees the old decoder + reader, instead of
-        // leaving them running until this method overwrites the current state at
-        // the end. Spares a shared source buffer the incoming track reuses.
+        // leaving them running until this method assembles the new track at the
+        // end. Spares a shared source buffer the incoming track reuses.
         self.teardown_current_track();
         self.clear_next_track_state();
 
-        emit_progress(
-            &self.progress_tx,
-            PlaybackProgress::StateChanged {
-                state: PlaybackState::Loading {
-                    track_id: track_id.to_string(),
-                    resolved: None,
-                },
-            },
-        );
+        // First Loading emission: bare, before the metadata lookup.
+        self.slot = PlaybackSlot::Loading {
+            track_id: track_id.to_string(),
+            resolved: None,
+        };
+        self.sync_audio_state();
+        self.emit_state();
 
         // Prepare track: fetch metadata, create buffer, start reading
         let prepared = prepare_track_for_playback(
@@ -247,22 +270,13 @@ impl PlaybackService {
             }
         };
 
-        // Metadata is resolved now: re-emit Loading carrying the target track's
-        // info so the bar switches from the prior track to the target while the
-        // first audio bytes are still downloading.
-        let loading_duration_ms = pregap_adjusted_duration(&prepared);
-        emit_progress(
-            &self.progress_tx,
-            PlaybackProgress::StateChanged {
-                state: PlaybackState::Loading {
-                    track_id: track_id.to_string(),
-                    resolved: Some(LoadingTrack {
-                        track_info: prepared.track_info.clone(),
-                        duration_ms: loading_duration_ms,
-                    }),
-                },
-            },
-        );
+        // Second Loading emission: carries the target track's metadata so the bar
+        // switches from the prior track to the target while audio still downloads.
+        self.slot = PlaybackSlot::Loading {
+            track_id: track_id.to_string(),
+            resolved: Some(LoadingTrack::from_prepared(&prepared)),
+        };
+        self.emit_state();
 
         let start_position = start.position(prepared.total_pregap_ms());
         let include_pregap = start.includes_pregap();
@@ -272,39 +286,38 @@ impl PlaybackService {
             0
         };
         let decode = prepared.decode_params(start_sample_offset, include_pregap);
-
-        let sample_rate = prepared.sample_rate;
-        let channels = prepared.channels;
         let fmt = prepared.track_fmt(start_position);
+        let generation = self.next_load_generation();
 
-        // Store prepared track state so the shared tail reads this load's buffer
-        // and cancel token.
-        self.current_prepared = Some(prepared);
-        // This track is now the one the user is waiting to hear: its reader
-        // fetches with priority, the next-track preload below yields to it.
-        self.mark_current_foreground();
-        if !self
-            .start_decoder_and_watch(decode, fmt, sample_rate, channels, track_id.to_string())
+        let started = match self
+            .start_decoder_and_watch(&prepared, decode, fmt, generation)
             .await
         {
-            emit_progress(
-                &self.progress_tx,
-                PlaybackProgress::PlaybackError {
-                    reason: crate::ui::PlaybackErrorReason::internal(
-                        "Couldn't start audio output for the track.",
-                    ),
-                },
-            );
-            self.stop().await;
-            return;
-        }
+            Ok(started) => started,
+            Err(_) => {
+                emit_progress(
+                    &self.progress_tx,
+                    PlaybackProgress::PlaybackError {
+                        reason: crate::ui::PlaybackErrorReason::internal(
+                            "Couldn't start audio output for the track.",
+                        ),
+                    },
+                );
+                self.stop().await;
+                return;
+            }
+        };
 
-        // Set audio state: always Playing unless preserving paused state. Audio
-        // doesn't flow until the ring fills, so this doesn't race the watcher.
-        if !preserve_paused {
-            self.audio_output
-                .set_state(crate::playback::audio_output::AudioState::Playing);
-        }
+        // Assemble the current track. The phase stays Loading (with this load's
+        // generation and target) until the ready-watcher's TrackReady resolves it
+        // — no StateChanged is emitted here; the second Loading above is the last
+        // emission until audio flows. `install_active_track` projects the target
+        // onto the atomic so the callback outputs samples/silence as intended.
+        self.install_active_track(
+            prepared,
+            started,
+            TrackPhase::Loading { generation, target },
+        );
 
         info!("Streaming playback started for track: {}", track_id);
 
@@ -315,7 +328,6 @@ impl PlaybackService {
     }
 
     pub(super) async fn stop(&mut self) {
-        self.pending_side_pause = None;
         // Stop any active preview first (without resuming main, since we're stopping)
         self.stop_preview_for_main_playback();
 
@@ -328,14 +340,9 @@ impl PlaybackService {
         // Drop shared buffer cache — stop means we're done with this album
         self.shared_file_buffers.clear();
         *self.current_position_shared.lock().unwrap() = None;
-        self.audio_output
-            .set_state(crate::playback::audio_output::AudioState::Stopped);
-        emit_progress(
-            &self.progress_tx,
-            PlaybackProgress::StateChanged {
-                state: PlaybackState::Stopped,
-            },
-        );
+        // The slot is Stopped; project that onto the atomic and emit Stopped.
+        self.sync_audio_state();
+        self.emit_state();
         // Audio is now Stopped, so this clears the durable row — covering every
         // stop path (natural end, halt-on-error, the current track removed),
         // not just the explicit Stop command.

--- a/bae-core/src/playback/service/preview.rs
+++ b/bae-core/src/playback/service/preview.rs
@@ -8,19 +8,21 @@ impl PlaybackService {
     /// Pause main player for preview. Called after a preview successfully starts
     /// so that a failed preview start doesn't leave the main player paused.
     pub(super) fn pause_main_for_preview(&mut self) {
-        if self.audio_output.get_state() == crate::playback::audio_output::AudioState::Playing {
-            self.main_was_playing_before_preview = true;
-            self.audio_output
-                .set_state(crate::playback::audio_output::AudioState::Paused);
-
-            if self.current_prepared.is_some() {
-                emit_progress(
-                    &self.progress_tx,
-                    PlaybackProgress::StateChanged {
-                        state: self.make_paused_state(PlaybackPauseReason::Manual),
-                    },
-                );
+        // Pause the main player only if it is actually playing (a load still
+        // filling counts as playing intent). A paused/stopped main player is left
+        // alone, and the resume marker stays clear so preview stop doesn't
+        // spuriously resume it.
+        let paused = match &mut self.slot {
+            PlaybackSlot::Active(cur) if cur.phase.intent() == PlayIntent::Playing => {
+                cur.phase = TrackPhase::Paused(PausePhase::Manual);
+                true
             }
+            _ => false,
+        };
+        if paused {
+            self.main_was_playing_before_preview = true;
+            self.sync_audio_state();
+            self.emit_state();
         }
     }
 
@@ -30,16 +32,16 @@ impl PlaybackService {
             return;
         }
         self.main_was_playing_before_preview = false;
-        self.audio_output
-            .set_state(crate::playback::audio_output::AudioState::Playing);
-
-        if self.current_prepared.is_some() {
-            emit_progress(
-                &self.progress_tx,
-                PlaybackProgress::StateChanged {
-                    state: self.make_playing_state(),
-                },
-            );
+        let resumed = match &mut self.slot {
+            PlaybackSlot::Active(cur) => {
+                cur.phase = TrackPhase::Playing;
+                true
+            }
+            _ => false,
+        };
+        if resumed {
+            self.sync_audio_state();
+            self.emit_state();
         }
     }
 

--- a/bae-core/src/playback/service/queue_commands.rs
+++ b/bae-core/src/playback/service/queue_commands.rs
@@ -3,7 +3,10 @@ use super::*;
 impl PlaybackService {
     /// Emit queue update to all subscribers
     pub(super) async fn on_queue_mutated(&mut self) {
-        self.pending_side_pause = None;
+        // A queue change can invalidate which track a side-pause resumes into, so
+        // forget the side-pause (demote to a plain manual pause) without emitting
+        // — the UI keeps showing the paused state it last saw.
+        self.demote_side_pause_to_manual();
         self.refresh_preload_for_queue_front().await;
         self.emit_queue_update();
         self.persist_playback_state().await;

--- a/bae-core/src/playback/service/seek.rs
+++ b/bae-core/src/playback/service/seek.rs
@@ -2,23 +2,28 @@ use super::*;
 
 impl PlaybackService {
     pub(super) async fn seek(&mut self, position: std::time::Duration) {
-        // Verify streaming state is available
-        if self.current_playback_source.is_none() {
-            error!("Cannot seek: no streaming source active");
-            return;
-        }
+        // Drain first so a pending gapless crossing is applied before we read the
+        // current track — a seek arriving right at a boundary then rebuilds the
+        // track the callback already advanced into, not the finishing one.
         self.drain_current_audio_events().await;
 
-        let current_prepared = match self.current_prepared.as_mut() {
-            Some(prepared) => prepared,
-            None => {
-                error!("Cannot seek: no current_prepared");
+        // Seek only operates on an active track. Take it out to tear down its
+        // decoder and rebuild; a Stopped or still-resolving (Loading) slot has no
+        // stream to rebuild and is put back untouched. While the slot is Stopped
+        // here nothing observes it: no emission, and the serial loop can't
+        // interleave a command until seek returns.
+        let cur = match std::mem::replace(&mut self.slot, PlaybackSlot::Stopped) {
+            PlaybackSlot::Active(cur) => cur,
+            other => {
+                self.slot = other;
+                error!("Cannot seek: no active track");
                 return;
             }
         };
-        let track_id = current_prepared.track_info.track_id.clone();
+        let track_id = cur.prepared.track_info.track_id.clone();
 
-        // Check for same-position seek (difference < 100ms)
+        // Same-position seek (difference < 100ms): put the track back, refresh the
+        // display, no rebuild.
         let current_position = self
             .current_position_shared
             .lock()
@@ -30,112 +35,130 @@ impl PlaybackService {
                 "Seek: Skipping seek to same position (difference: {:?} < 100ms)",
                 position_diff
             );
+            self.slot = PlaybackSlot::Active(cur);
             self.emit_position_display(position.as_millis() as u64, track_id);
             return;
         }
 
-        let old_buffers: Vec<_> = current_prepared
+        let generation = self.next_load_generation();
+        let CurrentTrack {
+            mut prepared,
+            stream,
+            source,
+            decoder_handle,
+            audio_events,
+            phase,
+        } = cur;
+
+        // Where the rebuilt load should land: seek preserves the current
+        // play/pause intent. A completed track resumes audibly at the seek
+        // target (rather than staying silently frozen with a Stopped atomic).
+        let target = match phase {
+            TrackPhase::Playing | TrackPhase::Completed => PlayTarget::Playing,
+            TrackPhase::Paused(pause) => PlayTarget::Paused(pause),
+            TrackPhase::Loading { target, .. } => target,
+        };
+
+        // Drop the old stream and its event receiver — the rebuild replaces them.
+        drop(stream);
+        drop(audio_events);
+
+        let old_cancel_token = prepared.cancel_token.clone();
+        let old_buffers: Vec<_> = prepared
             .segments
             .iter()
             .map(|segment| segment.buffer.clone())
             .collect();
-        let old_cancel_token = current_prepared.cancel_token.clone();
-        let prepared = current_prepared.clone();
-        // Mint a fresh cancel token for the seek's decoder so the ready-watcher's
-        // TrackReady is tied to this seek, and a later seek/switch supersedes it.
-        let new_cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        current_prepared.cancel_token = new_cancel_token;
+        // Mint a fresh cancel token for the seek's decoder so cancelling the old
+        // decoder below doesn't cancel the new one; staleness is decided by
+        // generation, not by this token.
+        prepared.cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        // Abort old listeners immediately to prevent stale position ticks
-        self.abort_current_listeners();
+        // Preserve any staged gapless next track across the rebuild so playback
+        // stays gapless after the seek. Removing it from the old chain keeps the
+        // teardown below from cancelling its (still-running) decoder; its source +
+        // fmt are re-staged into the new stream once it's built.
+        let staged_next: Option<(TrackStream, TrackFmt)> = source
+            .lock()
+            .unwrap()
+            .take_next()
+            .map(|(s, fmt)| (s, (*fmt).clone()));
 
-        // Preserve any staged gapless next track across the stream rebuild so
-        // playback stays gapless after a seek. Removing it from the old chain
-        // keeps the teardown below from cancelling its (still-running) decoder;
-        // its source + fmt are re-staged into the new stream once it's built.
-        let staged_next = if let Some(gapless) = &self.current_playback_source {
-            gapless.lock().unwrap().take_next()
-        } else {
-            None
-        };
-        let staged_next: Option<(TrackStream, TrackFmt)> =
-            staged_next.map(|(s, fmt)| (s, (*fmt).clone()));
-
+        let mut source_opt = Some(source);
+        let mut decoder_opt = Some(decoder_handle);
         teardown_decoder_for_seek(
-            &mut self.current_playback_source,
+            &mut source_opt,
             &old_buffers,
             &old_cancel_token,
-            &mut self.current_decoder_handle,
+            &mut decoder_opt,
         )
         .await;
 
-        // Show buffering at the target immediately (the same Loading→Playing arc
-        // the play path uses): the bar jumps to the seek position via Seeked
-        // below, Loading covers the wait for the demanded window, and the
-        // ready-watcher confirms Playing once audio flows. The decoder reads
-        // immediately and the demand-driven fill fetches the seek target first,
-        // so there's no fixed wait and no frozen-but-Playing bar.
+        // Show buffering at the target immediately (the same Loading→ready arc the
+        // play path uses): the bar jumps to the seek position via Seeked below,
+        // Loading covers the wait for the demanded window, and the ready-watcher
+        // confirms the target once audio flows. The decoder reads immediately and
+        // the demand-driven fill fetches the seek target first, so there's no
+        // fixed wait and no frozen-but-playing bar.
+        self.slot = PlaybackSlot::Loading {
+            track_id: track_id.clone(),
+            resolved: Some(LoadingTrack::from_prepared(&prepared)),
+        };
+        self.sync_audio_state();
+        self.emit_state();
+
         let position_samples = (position.as_secs_f64() * prepared.sample_rate as f64) as u64;
         let decode = prepared.decode_params(position_samples, true);
-        info!("Seek: position {:?}", position);
-        emit_progress(
-            &self.progress_tx,
-            PlaybackProgress::StateChanged {
-                state: PlaybackState::Loading {
-                    track_id: track_id.clone(),
-                    resolved: Some(LoadingTrack {
-                        track_info: prepared.track_info.clone(),
-                        duration_ms: pregap_adjusted_duration(&prepared),
-                    }),
-                },
-            },
-        );
-
         let fmt = prepared.track_fmt(position);
-        if !self
-            .start_decoder_and_watch(
-                decode,
-                fmt,
-                prepared.sample_rate,
-                prepared.channels,
-                track_id.clone(),
-            )
+        info!("Seek: position {:?}", position);
+
+        let started = match self
+            .start_decoder_and_watch(&prepared, decode, fmt, generation)
             .await
         {
-            // The rebuilt stream failed. The preserved next track was taken out
-            // of the old chain, so stop()'s teardown can't reach it — cancel it
-            // here (otherwise its decoder parks forever filling a buffer with no
-            // consumer). Then resolve the Loading we just emitted to Stopped via
-            // stop(), the same hard-failure outcome the play path takes when
-            // audio output can't start, so the bar doesn't hang in buffering.
-            if let Some((next_source, _next_fmt)) = staged_next {
-                next_source.cancel();
+            Ok(started) => started,
+            Err(_) => {
+                // The rebuilt stream failed. The preserved next track was taken
+                // out of the old chain, so stop()'s teardown can't reach it —
+                // cancel it here (otherwise its decoder parks forever filling a
+                // buffer with no consumer). Then resolve the Loading we just
+                // emitted to Stopped via stop(), the same hard-failure outcome the
+                // play path takes when audio output can't start.
+                if let Some((next_source, _next_fmt)) = staged_next {
+                    next_source.cancel();
+                }
+                emit_progress(
+                    &self.progress_tx,
+                    PlaybackProgress::PlaybackError {
+                        reason: crate::ui::PlaybackErrorReason::internal(
+                            "Couldn't restart audio output after the seek.",
+                        ),
+                    },
+                );
+                self.stop().await;
+                return;
             }
-            emit_progress(
-                &self.progress_tx,
-                PlaybackProgress::PlaybackError {
-                    reason: crate::ui::PlaybackErrorReason::internal(
-                        "Couldn't restart audio output after the seek.",
-                    ),
-                },
-            );
-            self.stop().await;
-            return;
-        }
+        };
 
-        // Re-stage the preserved gapless next track into the rebuilt stream so
-        // post-seek auto-advance stays gapless without re-decoding. The init
-        // above guarantees current_playback_source is set on the success
-        // path — a silent skip here would leak the staged decoder, since
-        // TrackStream doesn't cancel on drop.
+        // Re-stage the preserved gapless next track into the rebuilt stream's
+        // source before it becomes current, so post-seek auto-advance stays
+        // gapless without re-decoding.
         if let Some((next_source, next_fmt)) = staged_next {
-            self.current_playback_source
-                .as_ref()
-                .expect("init_streaming succeeded above; gapless source must be set")
+            started
+                .parts
+                .source
                 .lock()
                 .unwrap()
                 .stage_next(next_source, next_fmt);
         }
+
+        // Reassemble the current track. The phase stays Loading (with this seek's
+        // generation and target) until the ready-watcher's TrackReady resolves it.
+        self.install_active_track(
+            prepared,
+            started,
+            TrackPhase::Loading { generation, target },
+        );
 
         let raw_pos_ms = position.as_millis() as u64;
         self.emit_position_display(raw_pos_ms, track_id);

--- a/bae-core/src/playback/service/slot.rs
+++ b/bae-core/src/playback/service/slot.rs
@@ -1,0 +1,170 @@
+//! The explicit playback slot state machine.
+//!
+//! `PlaybackSlot` is the service thread's single authority for what is playing
+//! and in what phase: `Stopped`, `Loading` (resolving a fresh load), or `Active`
+//! with a `CurrentTrack` in a definite `TrackPhase`. Modeling every combination
+//! as a variant keeps the illegal ones unrepresentable. The shared `AudioState`
+//! atomic is a projection of this (written by `PlaybackService::sync_audio_state`),
+//! never read back as truth.
+
+use super::*;
+
+/// Monotonic id for one decoder load (a fresh play or a seek). A track can be
+/// (re)loaded under the same track id — RepeatCurrent, RestartCurrent, and
+/// re-Play all replay the same id through a fresh load — so load identity is
+/// per-load, not per-track. Minted from a counter owned by `PlaybackService`; a
+/// `TrackReady` carrying a generation that no longer matches the current load
+/// belongs to an abandoned one and is ignored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LoadGeneration(pub(super) u64);
+
+/// The paused sub-state of a current track. `Manual` is a user pause;
+/// `SideEnded` is the automatic pause at a physical-side boundary, holding the
+/// `SidePauseDecision` for the track it resumes into. The public
+/// `PlaybackPauseReason` surfaces only the prompt; the resume target stays
+/// core-internal.
+#[derive(Debug, Clone)]
+pub(super) enum PausePhase {
+    Manual,
+    SideEnded(SidePauseDecision),
+}
+
+impl PausePhase {
+    pub(super) fn to_reason(&self) -> PlaybackPauseReason {
+        match self {
+            PausePhase::Manual => PlaybackPauseReason::Manual,
+            PausePhase::SideEnded(decision) => {
+                PlaybackPauseReason::SideEnded(decision.prompt.clone())
+            }
+        }
+    }
+}
+
+/// Where a starting load lands once its audio is ready. The value is absolute
+/// (set-state-don't-toggle): a caller that wants the incoming track paused
+/// computes this from the outgoing track's play intent before teardown.
+#[derive(Debug, Clone)]
+pub(super) enum PlayTarget {
+    Playing,
+    Paused(PausePhase),
+}
+
+impl PlayTarget {
+    pub(super) fn into_track_phase(self) -> TrackPhase {
+        match self {
+            PlayTarget::Playing => TrackPhase::Playing,
+            PlayTarget::Paused(pause) => TrackPhase::Paused(pause),
+        }
+    }
+}
+
+/// The play/pause/loading phase of the current track. This — not the shared
+/// `AudioState` atomic — is the service's authority; the atomic is written as a
+/// projection of it.
+pub(super) enum TrackPhase {
+    /// The decoder ring isn't confirmed full yet; a `TrackReady { generation }`
+    /// with a matching generation resolves the track to `target`.
+    Loading {
+        generation: LoadGeneration,
+        target: PlayTarget,
+    },
+    Playing,
+    Paused(PausePhase),
+    /// The track drained naturally: the audio callback set the atomic to Stopped
+    /// and the completion event was handled, but the stream/source/decoder are
+    /// retained because AutoAdvance and the side-pause decision still read them.
+    Completed,
+}
+
+/// The play/pause intent a phase projects — onto the `AudioState` atomic
+/// (`sync_audio_state`) and onto the toggle/preview/skip decisions. A load
+/// carries its target's intent; `Completed` is silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PlayIntent {
+    Playing,
+    Paused,
+    Stopped,
+}
+
+impl TrackPhase {
+    pub(super) fn intent(&self) -> PlayIntent {
+        match self {
+            TrackPhase::Playing
+            | TrackPhase::Loading {
+                target: PlayTarget::Playing,
+                ..
+            } => PlayIntent::Playing,
+            TrackPhase::Paused(_)
+            | TrackPhase::Loading {
+                target: PlayTarget::Paused(_),
+                ..
+            } => PlayIntent::Paused,
+            TrackPhase::Completed => PlayIntent::Stopped,
+        }
+    }
+}
+
+/// Everything that exists exactly when a track is current, held as one
+/// always-consistent whole.
+pub(super) struct CurrentTrack {
+    pub(super) prepared: PlaybackPreparedTrack,
+    pub(super) stream: Box<dyn AudioStream>,
+    pub(super) source: Arc<Mutex<source::PlaybackSource>>,
+    pub(super) decoder_handle: std::thread::JoinHandle<()>,
+    pub(super) audio_events: AudioEventReceiver,
+    pub(super) phase: TrackPhase,
+}
+
+pub(super) enum PlaybackSlot {
+    Stopped,
+    /// `play_track` has torn down the old track and is resolving the new one.
+    /// `resolved` is None before the metadata lookup and Some after — the two
+    /// Loading emissions the UI contract already expects.
+    Loading {
+        track_id: String,
+        resolved: Option<LoadingTrack>,
+    },
+    Active(CurrentTrack),
+}
+
+impl PlaybackSlot {
+    /// The current track's id, once one exists (Active in any phase). None while
+    /// the slot is Stopped or still resolving a fresh load.
+    pub(super) fn current_track_id(&self) -> Option<&str> {
+        match self {
+            PlaybackSlot::Active(cur) => Some(cur.prepared.track_info.track_id.as_str()),
+            _ => None,
+        }
+    }
+
+    /// The current track while it is actively streaming — Active and not yet
+    /// Completed. A Completed track keeps its receiver but stops being polled:
+    /// nothing reads its counters again, and the next stream replaces it whole.
+    fn streaming(&self) -> Option<&CurrentTrack> {
+        match self {
+            PlaybackSlot::Active(cur) if !matches!(cur.phase, TrackPhase::Completed) => Some(cur),
+            _ => None,
+        }
+    }
+
+    fn streaming_mut(&mut self) -> Option<&mut CurrentTrack> {
+        match self {
+            PlaybackSlot::Active(cur) if !matches!(cur.phase, TrackPhase::Completed) => Some(cur),
+            _ => None,
+        }
+    }
+
+    /// The audio-events receiver to poll on the drain tick, present only while a
+    /// track is actively streaming.
+    pub(super) fn pollable_audio_events(&mut self) -> Option<&mut AudioEventReceiver> {
+        self.streaming_mut().map(|cur| &mut cur.audio_events)
+    }
+
+    pub(super) fn pollable_audio_events_ref(&self) -> Option<&AudioEventReceiver> {
+        self.streaming().map(|cur| &cur.audio_events)
+    }
+
+    pub(super) fn has_pollable_audio_events(&self) -> bool {
+        self.streaming().is_some()
+    }
+}

--- a/bae-core/src/playback/service/state.rs
+++ b/bae-core/src/playback/service/state.rs
@@ -1,6 +1,12 @@
 use super::*;
 
 impl PlaybackService {
+    /// The current track's id, once one exists (Active in any phase). None while
+    /// the slot is Stopped or still resolving a fresh load.
+    pub(super) fn current_track_id(&self) -> Option<&str> {
+        self.slot.current_track_id()
+    }
+
     /// Compute the display values for `position_ms` on the current track,
     /// write them to `last_position_display`, and emit a `Seeked` progress event.
     ///
@@ -9,9 +15,10 @@ impl PlaybackService {
     /// NSView stale; emitting without writing the Arc would leave late-mounting
     /// views without a cached value to query. Always go through this helper.
     pub(super) fn emit_position_display(&self, position_ms: u64, track_id: String) {
-        let Some(prepared) = &self.current_prepared else {
+        let PlaybackSlot::Active(cur) = &self.slot else {
             return;
         };
+        let prepared = &cur.prepared;
         let raw_dur_ms = prepared.duration.as_millis() as u64;
         let pregap_ms = prepared.total_pregap_ms();
         let (adjusted_pos_ms, adjusted_dur_ms) =
@@ -32,45 +39,126 @@ impl PlaybackService {
         );
     }
 
-    /// The fields the Playing and Paused states share, read from the current
-    /// prepared track. Position data is excluded — it flows through
-    /// PositionUpdate/Seeked events.
-    pub(super) fn current_state_fields(&self) -> (PlaybackTrackInfo, u64) {
-        let prepared = self.current_prepared.as_ref().expect("no current_prepared");
-        (
-            prepared.track_info.clone(),
-            pregap_adjusted_duration(prepared),
+    /// Pure map of the current slot to the public `PlaybackState`. Position data
+    /// is excluded — it flows through `PositionUpdate`/`Seeked` events.
+    pub(super) fn playback_state(&self) -> PlaybackState {
+        match &self.slot {
+            PlaybackSlot::Stopped => PlaybackState::Stopped,
+            PlaybackSlot::Loading { track_id, resolved } => PlaybackState::Loading {
+                track_id: track_id.clone(),
+                resolved: resolved.clone(),
+            },
+            PlaybackSlot::Active(cur) => match &cur.phase {
+                TrackPhase::Loading { .. } => PlaybackState::Loading {
+                    track_id: cur.prepared.track_info.track_id.clone(),
+                    resolved: Some(LoadingTrack::from_prepared(&cur.prepared)),
+                },
+                TrackPhase::Playing => PlaybackState::Playing {
+                    track_info: cur.prepared.track_info.clone(),
+                    duration_ms: pregap_adjusted_duration(&cur.prepared),
+                },
+                TrackPhase::Paused(pause) => PlaybackState::Paused {
+                    track_info: cur.prepared.track_info.clone(),
+                    duration_ms: pregap_adjusted_duration(&cur.prepared),
+                    reason: pause.to_reason(),
+                },
+                // A Completed track emits no public state — the machine leaves
+                // Completed via AutoAdvance / stop / side-pause, each emitting its
+                // own terminal state. This arm is the assertion that nothing calls
+                // `emit_state` while Completed.
+                TrackPhase::Completed => {
+                    unreachable!("Completed is never emitted as a public state")
+                }
+            },
+        }
+    }
+
+    /// The ONLY place a `StateChanged` is emitted. Every transition mutates the
+    /// slot (and syncs the atomic), then calls this. Emitting while the current
+    /// track is Completed is a bug — `playback_state` treats it as unreachable.
+    pub(super) fn emit_state(&self) {
+        emit_progress(
+            &self.progress_tx,
+            PlaybackProgress::StateChanged {
+                state: self.playback_state(),
+            },
+        );
+    }
+
+    /// Write the shared `AudioState` atomic as a projection of the slot. The
+    /// atomic is the realtime plane the audio callback reads lock-free every
+    /// buffer; the slot is the truth. Call after every slot/phase mutation.
+    pub(super) fn sync_audio_state(&self) {
+        use crate::playback::audio_output::AudioState;
+        let projected = match &self.slot {
+            PlaybackSlot::Stopped => Some(AudioState::Stopped),
+            // No stream is attached, so the atomic is inert; leave it as it is
+            // until the load's stream attaches and this runs again.
+            PlaybackSlot::Loading { .. } => None,
+            PlaybackSlot::Active(cur) => Some(match cur.phase.intent() {
+                PlayIntent::Playing => AudioState::Playing,
+                PlayIntent::Paused => AudioState::Paused,
+                PlayIntent::Stopped => AudioState::Stopped,
+            }),
+        };
+        if let Some(state) = projected {
+            self.audio_output.set_state(state);
+        }
+    }
+
+    /// The play/pause intent to carry to a track we switch to (Next / Previous /
+    /// restart). A side-pause is meaningless for a different track, so it
+    /// collapses to a plain manual pause; Completed carries Playing.
+    pub(super) fn current_play_target(&self) -> PlayTarget {
+        match &self.slot {
+            PlaybackSlot::Active(cur) => match &cur.phase {
+                TrackPhase::Playing | TrackPhase::Completed => PlayTarget::Playing,
+                TrackPhase::Paused(_) => PlayTarget::Paused(PausePhase::Manual),
+                TrackPhase::Loading { target, .. } => match target {
+                    PlayTarget::Playing => PlayTarget::Playing,
+                    PlayTarget::Paused(_) => PlayTarget::Paused(PausePhase::Manual),
+                },
+            },
+            _ => PlayTarget::Playing,
+        }
+    }
+
+    /// Whether the current track is paused at a physical-side boundary.
+    pub(super) fn is_side_paused(&self) -> bool {
+        matches!(
+            &self.slot,
+            PlaybackSlot::Active(cur)
+                if matches!(cur.phase, TrackPhase::Paused(PausePhase::SideEnded(_)))
         )
     }
 
-    /// Build a Playing state from the current prepared track and track info.
-    pub(super) fn make_playing_state(&self) -> PlaybackState {
-        let (track_info, duration_ms) = self.current_state_fields();
-        PlaybackState::Playing {
-            track_info,
-            duration_ms,
-        }
-    }
-
-    /// Build a Paused state from the current prepared track and track info.
-    pub(super) fn make_paused_state(&self, reason: PlaybackPauseReason) -> PlaybackState {
-        let (track_info, duration_ms) = self.current_state_fields();
-        PlaybackState::Paused {
-            track_info,
-            duration_ms,
-            reason,
-        }
-    }
-
-    /// Emit a `StateChanged` for the current track's play/pause state. Shared
-    /// by the play, gapless-advance, and rebuild-advance paths.
-    pub(super) fn emit_current_state(&self) {
-        let state = if self.audio_output.is_paused() {
-            self.make_paused_state(PlaybackPauseReason::Manual)
-        } else {
-            self.make_playing_state()
+    /// Resolve a load's `TrackReady`: if it matches the current Loading phase's
+    /// generation, advance the phase to that load's target (Playing/Paused) and
+    /// emit. A stale generation (a superseded load, or a pause/preview that
+    /// collapsed the Loading phase) is dropped.
+    pub(super) fn resolve_track_ready(&mut self, track_id: String, generation: LoadGeneration) {
+        let resolved = match &mut self.slot {
+            PlaybackSlot::Active(cur) => match &cur.phase {
+                TrackPhase::Loading {
+                    generation: live, ..
+                } if *live == generation => {
+                    if let TrackPhase::Loading { target, .. } =
+                        std::mem::replace(&mut cur.phase, TrackPhase::Playing)
+                    {
+                        cur.phase = target.into_track_phase();
+                    }
+                    true
+                }
+                _ => false,
+            },
+            _ => false,
         };
-        emit_progress(&self.progress_tx, PlaybackProgress::StateChanged { state });
+        if resolved {
+            self.sync_audio_state();
+            self.emit_state();
+        } else {
+            debug!(track_id, "ignoring stale TrackReady from an abandoned load");
+        }
     }
 
     /// Restore playback from the validated device-local resume cache.
@@ -207,13 +295,12 @@ impl PlaybackService {
             .current_track_id()
             .map(|s| s.to_string())
         {
-            self.audio_output
-                .set_state(crate::playback::audio_output::AudioState::Paused);
             let start = parsed
                 .position_ms
                 .map(|pos| TrackStart::Position(std::time::Duration::from_millis(pos)))
                 .unwrap_or(TrackStart::Direct);
-            self.play_track(&track_id, start, true).await;
+            self.play_track(&track_id, start, PlayTarget::Paused(PausePhase::Manual))
+                .await;
 
             // Emit the position we restored to so late-mounting views can read it
             // on mount. `None` means none was captured — the track's start (0).
@@ -254,8 +341,15 @@ impl PlaybackService {
     /// The log is the never-mask escape hatch — a write failure is recorded, not
     /// conflated with "nothing was playing".
     pub(super) async fn persist_playback_state(&self) {
-        use crate::playback::audio_output::AudioState;
-        if self.audio_output.get_state() == AudioState::Stopped {
+        // Clear the durable row when there is nothing to resume: the slot is
+        // Stopped, or the track drained naturally (Completed). A Loading or
+        // playing/paused Active track writes the row.
+        let nothing_to_resume = matches!(&self.slot, PlaybackSlot::Stopped)
+            || matches!(
+                &self.slot,
+                PlaybackSlot::Active(cur) if matches!(cur.phase, TrackPhase::Completed)
+            );
+        if nothing_to_resume {
             if let Err(e) = self.library_manager.clear_playback_state().await {
                 warn!("couldn't clear playback state: {e}");
             }
@@ -295,16 +389,13 @@ impl PlaybackService {
     }
 
     pub(super) async fn pause(&mut self) {
-        self.pending_side_pause = None;
-        self.audio_output
-            .set_state(crate::playback::audio_output::AudioState::Paused);
-        if self.current_prepared.is_some() {
-            emit_progress(
-                &self.progress_tx,
-                PlaybackProgress::StateChanged {
-                    state: self.make_paused_state(PlaybackPauseReason::Manual),
-                },
-            );
+        // Pausing during a load collapses the Loading phase to Paused, so the
+        // pending TrackReady no longer matches and is ignored. A Stopped or
+        // still-resolving slot is a no-op (nothing is playing to pause).
+        if let PlaybackSlot::Active(cur) = &mut self.slot {
+            cur.phase = TrackPhase::Paused(PausePhase::Manual);
+            self.sync_audio_state();
+            self.emit_state();
         }
     }
 
@@ -314,20 +405,15 @@ impl PlaybackService {
             self.stop_preview_for_main_playback();
         }
 
-        if self.pending_side_pause.is_some() {
+        if self.is_side_paused() {
             self.resume_from_side_pause().await;
             return;
         }
 
-        self.audio_output
-            .set_state(crate::playback::audio_output::AudioState::Playing);
-        if self.current_prepared.is_some() {
-            emit_progress(
-                &self.progress_tx,
-                PlaybackProgress::StateChanged {
-                    state: self.make_playing_state(),
-                },
-            );
+        if let PlaybackSlot::Active(cur) = &mut self.slot {
+            cur.phase = TrackPhase::Playing;
+            self.sync_audio_state();
+            self.emit_state();
         }
     }
 }

--- a/bae-core/src/playback/service/tests.rs
+++ b/bae-core/src/playback/service/tests.rs
@@ -99,11 +99,8 @@ async fn test_playback_service() -> (
         playback_queue: PlaybackQueue::new(queue_ids),
         current_position_shared: Arc::new(std::sync::Mutex::new(None)),
         audio_output: Box::new(TestAudioOutput::new()),
-        stream: None,
-        current_prepared: None,
-        current_playback_source: None,
-        current_decoder_handle: None,
-        current_audio_events: None,
+        slot: PlaybackSlot::Stopped,
+        load_generation_counter: 0,
         preloaded_next: None,
         preview,
         main_was_playing_before_preview: false,
@@ -112,10 +109,26 @@ async fn test_playback_service() -> (
         position_update_interval_ms: 50,
         shared_file_buffers: HashMap::new(),
         last_position_display: Arc::new(std::sync::Mutex::new(None)),
-        pending_side_pause: None,
         fetch_arbiter: FetchArbiter::new(),
     };
     (home, service, progress_rx)
+}
+
+/// Build an `Active` slot from a prepared track, wrapping a fresh test stream
+/// source and audio-events channel. Tests that need a specific source or
+/// pending audio event build the slot inline instead.
+fn active_slot(prepared: PlaybackPreparedTrack, phase: TrackPhase) -> PlaybackSlot {
+    let (_sink, source, _ready) = create_track_stream_pair(prepared.sample_rate, prepared.channels);
+    let track_fmt = prepared.track_fmt(std::time::Duration::ZERO);
+    let (_tx, audio_events) = audio_event_channel();
+    PlaybackSlot::Active(CurrentTrack {
+        prepared,
+        stream: Box::new(TestAudioStream),
+        source: Arc::new(Mutex::new(source::PlaybackSource::new(source, track_fmt))),
+        decoder_handle: finished_decoder_handle(),
+        audio_events,
+        phase,
+    })
 }
 
 fn test_track_info(track_id: &str) -> PlaybackTrackInfo {
@@ -262,18 +275,25 @@ async fn seek_drains_pending_gapless_crossing_before_reading_current_track() {
 
     let finished_buffer = create_sparse_buffer(1_024);
     let incoming_buffer = create_sparse_buffer(1_024);
-    service.current_prepared = Some(test_prepared_track(
-        "finished-track",
-        finished_buffer.clone(),
-        false,
-    ));
-    service.current_playback_source = {
-        let (_sink, source, _ready) = create_track_stream_pair(44_100, 2);
-        Some(Arc::new(Mutex::new(source::PlaybackSource::new(
+    let (mut audio_tx, audio_rx) = audio_event_channel();
+    audio_tx.push_required(AudioEvent::TrackCrossing(TrackCrossing {
+        finished_fmt: Arc::new(test_track_fmt("finished-track")),
+        decode_error_count: 0,
+        samples_decoded: 44_100,
+        incoming_fmt: Arc::new(test_track_fmt("incoming-track")),
+    }));
+    let (_sink, source, _ready) = create_track_stream_pair(44_100, 2);
+    service.slot = PlaybackSlot::Active(CurrentTrack {
+        prepared: test_prepared_track("finished-track", finished_buffer.clone(), false),
+        stream: Box::new(TestAudioStream),
+        source: Arc::new(Mutex::new(source::PlaybackSource::new(
             source,
             test_track_fmt("finished-track"),
-        ))))
-    };
+        ))),
+        decoder_handle: finished_decoder_handle(),
+        audio_events: audio_rx,
+        phase: TrackPhase::Playing,
+    });
     service.current_position_shared =
         Arc::new(std::sync::Mutex::new(Some(std::time::Duration::ZERO)));
     service.preloaded_next = Some(PreloadedNext {
@@ -282,26 +302,9 @@ async fn seek_drains_pending_gapless_crossing_before_reading_current_track() {
         source: PreloadedNextSource::Staged,
     });
 
-    let (mut audio_tx, audio_rx) = audio_event_channel();
-    audio_tx.push_required(AudioEvent::TrackCrossing(TrackCrossing {
-        finished_fmt: Arc::new(test_track_fmt("finished-track")),
-        decode_error_count: 0,
-        samples_decoded: 44_100,
-        incoming_fmt: Arc::new(test_track_fmt("incoming-track")),
-    }));
-    service.current_audio_events = Some(audio_rx);
-
     service.seek(std::time::Duration::ZERO).await;
 
-    assert_eq!(
-        service
-            .current_prepared
-            .as_ref()
-            .unwrap()
-            .track_info
-            .track_id,
-        "incoming-track"
-    );
+    assert_eq!(service.slot.current_track_id().unwrap(), "incoming-track");
     let mut saw_incoming_seek = false;
     while let Ok(progress) = progress_rx.try_recv() {
         if let PlaybackProgress::Seeked { track_id, .. } = progress {
@@ -313,6 +316,98 @@ async fn seek_drains_pending_gapless_crossing_before_reading_current_track() {
         "seek should emit for the crossed-into track"
     );
     assert!(finished_buffer.is_cancelled());
+}
+
+/// After a track drains naturally, the decoder-completion callback flips the
+/// shared audio-state atomic to `Stopped` while the track's bookkeeping is
+/// retained (so AutoAdvance / the side-pause decision can still read it). A seek
+/// arriving in that window must resume audible playback at the seek target — not
+/// rebuild a stream that stays silent because the atomic is still `Stopped`.
+#[tokio::test]
+async fn seek_after_natural_completion_resumes_audibly() {
+    let (_home, mut service, _progress_rx) = test_playback_service().await;
+    service.playback_queue.play_release(
+        ContextSource::Release("release-id".to_string()),
+        vec!["finished-track".to_string()],
+        ContextStart::Index(0),
+    );
+
+    let buffer = create_sparse_buffer(1_024);
+    // The track drained: phase is Completed with its bookkeeping retained, and
+    // the audio callback already flipped the atomic to Stopped.
+    service.slot = active_slot(
+        test_prepared_track("finished-track", buffer.clone(), false),
+        TrackPhase::Completed,
+    );
+    service.current_position_shared =
+        Arc::new(std::sync::Mutex::new(Some(std::time::Duration::ZERO)));
+    service
+        .audio_output
+        .set_state(crate::playback::audio_output::AudioState::Stopped);
+
+    service.seek(std::time::Duration::from_millis(500)).await;
+
+    assert_eq!(
+        service.audio_output.get_state(),
+        crate::playback::audio_output::AudioState::Playing,
+        "seeking after a track finished naturally should resume audible playback"
+    );
+}
+
+/// Skipping to the next track after the current one drained naturally must
+/// resume audible playback, not carry the completion's Stopped atomic forward as
+/// a silent/paused next track. Drives the real `handle_next` over a Completed
+/// slot (the phase a track sits in briefly after natural completion, before
+/// AutoAdvance runs) with a preloaded next so no DB lookup is needed. This locks
+/// the `TrackPhase::Completed` arm of `current_play_target`; reverting that arm
+/// to a paused/stopped target turns the atomic assertion red.
+#[tokio::test]
+async fn next_after_natural_completion_resumes_audibly() {
+    let (_home, mut service, _progress_rx) = test_playback_service().await;
+    service.playback_queue.play_release(
+        ContextSource::Release("release-id".to_string()),
+        vec!["finished-track".to_string(), "next-track".to_string()],
+        ContextStart::Index(0),
+    );
+
+    // The current track drained naturally: phase Completed, and the audio
+    // callback already flipped the atomic to Stopped.
+    let finished_buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(
+        test_prepared_track("finished-track", finished_buffer, false),
+        TrackPhase::Completed,
+    );
+    service.current_position_shared =
+        Arc::new(std::sync::Mutex::new(Some(std::time::Duration::ZERO)));
+    service
+        .audio_output
+        .set_state(crate::playback::audio_output::AudioState::Stopped);
+
+    // A next track is preloaded and ready to play without a fresh decode.
+    let (_next_sink, next_source, _next_ready) = create_track_stream_pair(44_100, 2);
+    let next_buffer = create_sparse_buffer(1_024);
+    service.preloaded_next = Some(PreloadedNext {
+        prepared: test_prepared_track("next-track", next_buffer, false),
+        decoder_handle: finished_decoder_handle(),
+        source: PreloadedNextSource::Held(next_source),
+    });
+
+    service.handle_next().await;
+
+    assert_eq!(
+        service.audio_output.get_state(),
+        crate::playback::audio_output::AudioState::Playing,
+        "Next after natural completion should resume audible playback on the new track"
+    );
+    assert!(
+        matches!(
+            &service.slot,
+            PlaybackSlot::Active(cur)
+                if cur.prepared.track_info.track_id == "next-track"
+                    && matches!(cur.phase, TrackPhase::Playing)
+        ),
+        "the next track should be current and Playing"
+    );
 }
 
 #[tokio::test]
@@ -332,12 +427,15 @@ async fn gapless_crossing_evicts_finished_track_file_buffer() {
     service
         .shared_file_buffers
         .insert("incoming-file".to_string(), incoming_buffer.clone());
-    service.current_prepared = Some(test_prepared_track_with_file(
-        "finished-track",
-        "finished-file",
-        finished_buffer.clone(),
-        false,
-    ));
+    service.slot = active_slot(
+        test_prepared_track_with_file(
+            "finished-track",
+            "finished-file",
+            finished_buffer.clone(),
+            false,
+        ),
+        TrackPhase::Playing,
+    );
     service.preloaded_next = Some(PreloadedNext {
         prepared: test_prepared_track_with_file(
             "incoming-track",
@@ -376,12 +474,15 @@ async fn gapless_crossing_keeps_file_buffer_used_by_incoming_track() {
     service
         .shared_file_buffers
         .insert("shared-file".to_string(), shared_buffer.clone());
-    service.current_prepared = Some(test_prepared_track_with_file(
-        "finished-track",
-        "shared-file",
-        shared_buffer.clone(),
-        false,
-    ));
+    service.slot = active_slot(
+        test_prepared_track_with_file(
+            "finished-track",
+            "shared-file",
+            shared_buffer.clone(),
+            false,
+        ),
+        TrackPhase::Playing,
+    );
     service.preloaded_next = Some(PreloadedNext {
         prepared: test_prepared_track_with_file(
             "incoming-track",
@@ -404,6 +505,178 @@ async fn gapless_crossing_keeps_file_buffer_used_by_incoming_track() {
 
     assert!(service.shared_file_buffers.contains_key("shared-file"));
     assert!(!shared_buffer.is_cancelled());
+}
+
+/// A `TrackReady` from a superseded load (same track id, replayed through a
+/// fresh load) carries the old generation and must be dropped; only the live
+/// load's generation resolves the phase and emits. A same-id replay is exactly
+/// the case load identity must reject.
+#[tokio::test]
+async fn track_ready_with_stale_generation_is_ignored() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    let stale = service.next_load_generation();
+    let live = service.next_load_generation();
+    let buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(
+        test_prepared_track("t", buffer, false),
+        TrackPhase::Loading {
+            generation: live,
+            target: PlayTarget::Playing,
+        },
+    );
+
+    service.resolve_track_ready("t".to_string(), stale);
+    assert!(
+        progress_rx.try_recv().is_err(),
+        "a stale-generation TrackReady must not emit"
+    );
+    assert!(
+        matches!(
+            &service.slot,
+            PlaybackSlot::Active(cur) if matches!(cur.phase, TrackPhase::Loading { .. })
+        ),
+        "the phase must stay Loading after a stale signal"
+    );
+
+    service.resolve_track_ready("t".to_string(), live);
+    assert!(
+        matches!(
+            progress_rx.try_recv(),
+            Ok(PlaybackProgress::StateChanged {
+                state: PlaybackState::Playing { .. }
+            })
+        ),
+        "the live load resolves to Playing and emits"
+    );
+}
+
+/// Pausing during a load collapses the Loading phase to Paused (emitting Paused
+/// once); the pending `TrackReady` then no longer matches the phase and is
+/// dropped rather than re-emitting a second Paused.
+#[tokio::test]
+async fn pause_during_load_emits_paused_and_supersedes_track_ready() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    let generation = service.next_load_generation();
+    let buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(
+        test_prepared_track("t", buffer, false),
+        TrackPhase::Loading {
+            generation,
+            target: PlayTarget::Playing,
+        },
+    );
+
+    service.pause().await;
+    assert!(
+        matches!(
+            progress_rx.try_recv(),
+            Ok(PlaybackProgress::StateChanged {
+                state: PlaybackState::Paused {
+                    reason: PlaybackPauseReason::Manual,
+                    ..
+                }
+            })
+        ),
+        "pause during a load emits Paused(Manual)"
+    );
+
+    service.resolve_track_ready("t".to_string(), generation);
+    assert!(
+        progress_rx.try_recv().is_err(),
+        "the collapsed load's TrackReady must not emit a second state"
+    );
+}
+
+/// `halt_on_error` is a no-op when the slot is already Stopped, so a failure
+/// dispatched after a self-handled stop doesn't emit a duplicate Stopped.
+#[tokio::test]
+async fn halt_on_error_noops_when_stopped() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    // The slot starts Stopped.
+    service.halt_on_error().await;
+    assert!(
+        progress_rx.try_recv().is_err(),
+        "halting an already-stopped slot must emit nothing"
+    );
+}
+
+/// Table-drive `playback_state()` over each slot/phase.
+#[tokio::test]
+async fn playback_state_mapping() {
+    let (_home, mut service, _progress_rx) = test_playback_service().await;
+    let buffer = create_sparse_buffer(1_024);
+
+    service.slot = PlaybackSlot::Stopped;
+    assert!(matches!(service.playback_state(), PlaybackState::Stopped));
+
+    service.slot = PlaybackSlot::Loading {
+        track_id: "t".to_string(),
+        resolved: None,
+    };
+    assert!(matches!(
+        service.playback_state(),
+        PlaybackState::Loading { resolved: None, .. }
+    ));
+
+    let generation = service.next_load_generation();
+    service.slot = active_slot(
+        test_prepared_track("t", buffer.clone(), false),
+        TrackPhase::Loading {
+            generation,
+            target: PlayTarget::Playing,
+        },
+    );
+    assert!(matches!(
+        service.playback_state(),
+        PlaybackState::Loading {
+            resolved: Some(_),
+            ..
+        }
+    ));
+
+    service.slot = active_slot(
+        test_prepared_track("t", buffer.clone(), false),
+        TrackPhase::Playing,
+    );
+    assert!(matches!(
+        service.playback_state(),
+        PlaybackState::Playing { .. }
+    ));
+
+    service.slot = active_slot(
+        test_prepared_track("t", buffer.clone(), false),
+        TrackPhase::Paused(PausePhase::Manual),
+    );
+    assert!(matches!(
+        service.playback_state(),
+        PlaybackState::Paused {
+            reason: PlaybackPauseReason::Manual,
+            ..
+        }
+    ));
+
+    let prompt = PlaybackSidePausePrompt {
+        id: "id".to_string(),
+        title_key: SIDE_PAUSE_TITLE_KEY,
+        side_letter: "B".to_string(),
+        message_key: SIDE_PAUSE_VINYL_MESSAGE_KEY,
+    };
+    service.slot = active_slot(
+        test_prepared_track("t", buffer, false),
+        TrackPhase::Paused(PausePhase::SideEnded(SidePauseDecision {
+            track_id: "next".to_string(),
+            prompt,
+        })),
+    );
+    assert!(matches!(
+        service.playback_state(),
+        PlaybackState::Paused {
+            reason: PlaybackPauseReason::SideEnded(_),
+            ..
+        }
+    ));
+    // Completed is never emitted as a public state, so `playback_state` treats it
+    // as unreachable rather than mapping it — no arm to assert here.
 }
 
 #[test]


### PR DESCRIPTION
The playback service modeled "a track is current" as five parallel Option fields that had to flip together, plus a separate AudioState atomic in the output layer that held the real play/pause truth. Teardown nulled the five fields by hand; natural completion left a deliberately-partial teardown only comments explained; load identity was Arc::ptr_eq on a cancellation token; and ~12 sites each re-derived and emitted StateChanged themselves. Every one of those was a place for the internal state and the UI's picture of it to drift.

This PR replaces the field constellation with one PlaybackSlot enum (Stopped / Loading / Active(CurrentTrack)), where CurrentTrack owns the stream, source, decoder, events, and an explicit phase (Loading-with-generation / Playing / Paused(reason) / Completed — the formerly-implicit post-completion state, now named). The atomic is demoted to a projection written after every transition; the service never reads it back. One emit_state() derives the public state from the slot and is the only StateChanged emitter. Load identity is a monotonic LoadGeneration instead of pointer tricks.

Behavior is locked by the full playback behavior suite, unchanged. Two deliberate fixes ride along, both in the same family (the atomic said Stopped after natural completion, so post-completion commands silently froze): seek after completion and Next/Previous racing completion now resume audibly. Both were written test-first with red-test receipts. One pre-existing wart fixed en route: the preloaded-advance path swallowed audio-output start failures silently; it now emits a PlaybackError like the other start paths.

## Test plan
- [x] Full test_playback_behavior suite (61 tests) passes unchanged
- [x] New unit tests: stale-generation TrackReady ignored, pause-during-load collapse, slot→state mapping table, halt-on-error no-op, seek-after-completion, next-after-completion (each fix confirmed red against the old code)
- [x] Full bae-core suite with --features test-utils green; cargo check -p bae-bridge clean (public shapes untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)