### PR TITLE
Windows auto-update via Velopack

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,13 +1,15 @@
 name: Release Windows
 
 # Cuts a Windows release of both editions: an independent 0.N version line
-# (windows-v* tags). Each versioned release carries an UNSIGNED self-contained zip
-# per edition (bae-windows-x64.zip + baeium-windows-x64.zip) of the unpackaged
-# WinUI 3 app plus the native runtime DLLs. Unsigned for now — Authenticode
-# signing needs a Windows code-signing certificate the owner doesn't have yet;
-# SmartScreen warns on first launch until then. Edition differs only by exe/folder
-# name (unpackaged app → no OS-level package identity to collide); the baeium dll
-# omits the OAuth entry points, which the C# app already detects at runtime via
+# (windows-v* tags). Each versioned release carries a Velopack build per edition:
+# a Setup.exe that installs per-user and auto-updates, a Portable.zip that runs in
+# place, and the update feed (releases.<channel>.json + the .nupkg) the in-app
+# updater reads. Editions use distinct channels (full = win, baeium = baeium-win)
+# so their feeds don't collide in the one shared windows-v* release. Signing
+# engages when the WINDOWS_CODESIGN_PFX_BASE64 secret is set; a build without
+# it is unsigned and SmartScreen warns on first launch.
+# Edition differs only by exe/packId/channel; the baeium dll omits the
+# OAuth entry points, which the C# app detects at runtime via
 # NativeBae.SupportsOAuthProviders().
 
 on:
@@ -28,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.calc.outputs.version }}
+      pack_version: ${{ steps.calc.outputs.pack_version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -50,10 +53,18 @@ jobs:
           fi
         fi
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-        echo "::notice::Windows release version $VERSION (build ${{ github.run_number }})"
+        # Velopack requires a full SemVer; the tag stays windows-v0.N but the
+        # package version is normalized to 0.N.0.
+        if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+          PACK_VERSION="$VERSION.0"
+        else
+          PACK_VERSION="$VERSION"
+        fi
+        echo "pack_version=$PACK_VERSION" >> "$GITHUB_OUTPUT"
+        echo "::notice::Windows release version $VERSION (pack $PACK_VERSION, build ${{ github.run_number }})"
 
   build:
-    name: Build ${{ matrix.edition }} zip
+    name: Build ${{ matrix.edition }} package
     runs-on: windows-latest
     needs: calculate-version
     env:
@@ -68,25 +79,34 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Resolve edition (cargo features, exe + zip names)
+      - name: Resolve edition (cargo features, exe + packaging names)
         shell: pwsh
         run: |
           # full = OAuth providers on (bae.exe); baeium = no features (baeium.exe).
           # The C# app is identical for both; only the dll's exported symbols differ.
+          # PACK_ID/CHANNEL are baked into the Velopack package so each installed
+          # edition reads only its own feed; SETUP_NAME/PORTABLE_NAME give the
+          # website stable asset URLs.
           if ("${{ matrix.edition }}" -eq "baeium") {
             "BAE_BRIDGE_FEATURES=desktop" | Out-File $env:GITHUB_ENV -Append
             "BAE_BRIDGE_CSHARP_BINDINGS_DIR=bae-bridge/csharp-bindings-baeium" | Out-File $env:GITHUB_ENV -Append
             "MSBUILD_BRIDGE_BINDINGS_DIR=..\bae-bridge\csharp-bindings-baeium" | Out-File $env:GITHUB_ENV -Append
             "EXE_NAME=baeium.exe" | Out-File $env:GITHUB_ENV -Append
-            "ZIP_NAME=baeium-windows-x64.zip" | Out-File $env:GITHUB_ENV -Append
             "STAGE_DIR=baeium" | Out-File $env:GITHUB_ENV -Append
+            "PACK_ID=baeium" | Out-File $env:GITHUB_ENV -Append
+            "CHANNEL=baeium-win" | Out-File $env:GITHUB_ENV -Append
+            "SETUP_NAME=baeium-windows-x64-setup.exe" | Out-File $env:GITHUB_ENV -Append
+            "PORTABLE_NAME=baeium-windows-x64-portable.zip" | Out-File $env:GITHUB_ENV -Append
           } else {
             "BAE_BRIDGE_FEATURES=oauth-providers,desktop" | Out-File $env:GITHUB_ENV -Append
             "BAE_BRIDGE_CSHARP_BINDINGS_DIR=bae-bridge/csharp-bindings-full" | Out-File $env:GITHUB_ENV -Append
             "MSBUILD_BRIDGE_BINDINGS_DIR=..\bae-bridge\csharp-bindings-full" | Out-File $env:GITHUB_ENV -Append
             "EXE_NAME=bae.exe" | Out-File $env:GITHUB_ENV -Append
-            "ZIP_NAME=bae-windows-x64.zip" | Out-File $env:GITHUB_ENV -Append
             "STAGE_DIR=bae" | Out-File $env:GITHUB_ENV -Append
+            "PACK_ID=bae" | Out-File $env:GITHUB_ENV -Append
+            "CHANNEL=win" | Out-File $env:GITHUB_ENV -Append
+            "SETUP_NAME=bae-windows-x64-setup.exe" | Out-File $env:GITHUB_ENV -Append
+            "PORTABLE_NAME=bae-windows-x64-portable.zip" | Out-File $env:GITHUB_ENV -Append
           }
 
       - name: Install Rust (pinned toolchain)
@@ -158,6 +178,7 @@ jobs:
             /p:Configuration=Release /p:Platform=x64 `
             /p:SelfContained=true /p:RuntimeIdentifier=win-x64 `
             /p:PublishDir=publish\ `
+            /p:Version=${{ needs.calculate-version.outputs.pack_version }} `
             /p:BAE_ENVIRONMENT="$env:BAE_ENVIRONMENT" `
             /p:BAE_DATADOG_SITE="$env:BAE_DATADOG_SITE" `
             /p:BAE_DATADOG_CLIENT_TOKEN="$env:BAE_DATADOG_CLIENT_TOKEN" `
@@ -211,13 +232,12 @@ jobs:
             Copy-Item $crashpadHandler.FullName $stage -Force
           }
 
-          # Name the launcher per edition (bae.exe / baeium.exe).
+          # Name the launcher per edition (bae.exe / baeium.exe); vpk packs the
+          # staged dir into the installer/portable/feed below.
           $exe = Get-ChildItem $stage -Filter "bae-windows.exe" | Select-Object -First 1
           if (-not $exe) { Write-Host "FAIL: bae-windows.exe not found in staged output"; exit 1 }
           Rename-Item $exe.FullName $env:EXE_NAME
-
-          Compress-Archive -Path "$PWD\stage\$env:STAGE_DIR" -DestinationPath "$PWD\$env:ZIP_NAME" -Force
-          Write-Host "PASS: built $env:ZIP_NAME"
+          Write-Host "PASS: staged $env:STAGE_DIR"
 
       - name: Upload Windows symbols to Sentry
         if: matrix.edition == 'full'
@@ -234,11 +254,72 @@ jobs:
           npm install -g @sentry/cli
           sentry-cli debug-files upload --org "$env:SENTRY_ORG" --project "$env:SENTRY_PROJECT" "$PWD\stage\$env:STAGE_DIR"
 
-      - name: Upload zip artifact
+      - name: Install the Velopack CLI (vpk)
+        # Must match the Velopack NuGet version the app references; the library
+        # and CLI are released in lockstep. Global dotnet tools are on PATH here.
+        run: dotnet tool install --global vpk --version 1.2.0
+
+      - name: Prepare code-signing material
+        shell: pwsh
+        env:
+          WINDOWS_CODESIGN_PFX_BASE64: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 }}
+        run: |
+          # Signing runs when WINDOWS_CODESIGN_PFX_BASE64 is set: decode it to a
+          # .pfx the pack step signs with. Unset: builds are unsigned and
+          # SmartScreen warns on first launch (noted in the release body).
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CODESIGN_PFX_BASE64)) {
+            Write-Host "code signing skipped: WINDOWS_CODESIGN_PFX_BASE64 unset"
+            exit 0
+          }
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\codesign.pfx", [Convert]::FromBase64String($env:WINDOWS_CODESIGN_PFX_BASE64))
+          Write-Host "code signing enabled"
+
+      - name: Pack the Velopack release (installer + portable + feed)
+        shell: pwsh
+        env:
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
+        run: |
+          $packArgs = @(
+            "pack",
+            "--packId", $env:PACK_ID,
+            "--packVersion", "${{ needs.calculate-version.outputs.pack_version }}",
+            "--packDir", "$PWD\stage\$env:STAGE_DIR",
+            "--mainExe", $env:EXE_NAME,
+            "--channel", $env:CHANNEL,
+            "--packTitle", $env:PACK_ID,
+            "--outputDir", "$PWD\velopack"
+          )
+          if (Test-Path "$env:RUNNER_TEMP\codesign.pfx") {
+            $packArgs += @("--signParams", "/f $env:RUNNER_TEMP\codesign.pfx /p $env:WINDOWS_CODESIGN_PASSWORD /tr http://timestamp.digicert.com /td sha256 /fd sha256")
+          }
+          vpk @packArgs
+          if ($LASTEXITCODE -ne 0) { Write-Host "FAIL: vpk pack exited $LASTEXITCODE"; exit 1 }
+
+          # Rename ONLY the Setup and Portable outputs for stable website URLs.
+          # releases.<channel>.json references the .nupkg by name, so the feed and
+          # nupkg keep vpk's names.
+          $setup = Get-ChildItem "$PWD\velopack" -Filter "*Setup.exe" | Select-Object -First 1
+          $portable = Get-ChildItem "$PWD\velopack" -Filter "*Portable.zip" | Select-Object -First 1
+          if (-not $setup) { Write-Host "FAIL: Setup.exe not produced"; exit 1 }
+          if (-not $portable) { Write-Host "FAIL: Portable.zip not produced"; exit 1 }
+          Rename-Item $setup.FullName $env:SETUP_NAME
+          Rename-Item $portable.FullName $env:PORTABLE_NAME
+
+          # Pin the naming assumptions at release time: fail loud if the feed, the
+          # package, or the renamed outputs are missing, rather than shipping a
+          # broken feed.
+          $nupkg = Get-ChildItem "$PWD\velopack" -Filter "*.nupkg" | Select-Object -First 1
+          if (-not (Test-Path "$PWD\velopack\releases.$env:CHANNEL.json")) { Write-Host "FAIL: releases.$env:CHANNEL.json missing"; exit 1 }
+          if (-not $nupkg) { Write-Host "FAIL: .nupkg missing"; exit 1 }
+          if (-not (Test-Path "$PWD\velopack\$env:SETUP_NAME")) { Write-Host "FAIL: $env:SETUP_NAME missing"; exit 1 }
+          if (-not (Test-Path "$PWD\velopack\$env:PORTABLE_NAME")) { Write-Host "FAIL: $env:PORTABLE_NAME missing"; exit 1 }
+          Write-Host "PASS: packed $env:PACK_ID ($env:CHANNEL)"
+
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v7
         with:
           name: bae-windows-release-${{ matrix.edition }}
-          path: ${{ env.ZIP_NAME }}
+          path: velopack/
           retention-days: 30
 
   publish:
@@ -253,10 +334,13 @@ jobs:
       with:
         ref: ${{ github.sha }}
 
-    - name: Download both editions' zips
+    - name: Download both editions' packages
+      # Filenames are distinct across editions (packId/channel are in them), so
+      # merging both editions' velopack/ dirs into one is collision-free.
       uses: actions/download-artifact@v8
       with:
         pattern: bae-windows-release-*
+        path: release-assets
         merge-multiple: true
 
     - name: Create git tag
@@ -269,20 +353,42 @@ jobs:
           git push origin "windows-v$VERSION"
         fi
 
+    # One immutable release per windows-v* tag carries both editions, so `vpk
+    # upload github` (which creates/publishes its own release, once per channel)
+    # can't be used — two invocations against one immutable tag would collide.
+    # Create the release once with every asset via softprops instead, mirroring
+    # release-macos.yml.
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: windows-v${{ needs.calculate-version.outputs.version }}
-        files: |
-          bae-windows-x64.zip
-          baeium-windows-x64.zip
+        files: release-assets/*
         body: |
-          Windows builds are **unsigned** zips of the unpackaged app — extract and
-          run bae.exe / baeium.exe. Windows SmartScreen may warn on first launch
-          (no code-signing certificate yet).
+          Windows builds. The setup installer installs bae per-user and keeps
+          itself up to date; the portable zip runs in place. These builds are
+          not code-signed, so SmartScreen may warn on first launch.
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Verify the update feeds and installers are attached
+      # The in-app updater's GithubSource scans releases newest-first for one
+      # carrying releases.<channel>.json; a release missing it (other platforms')
+      # is skipped. Confirm both channels' feeds and setup installers resolve as
+      # release assets before the website redeploys against them.
+      run: |
+        TAG="windows-v${{ needs.calculate-version.outputs.version }}"
+        base="https://github.com/${{ github.repository }}/releases/download/$TAG"
+        for asset in \
+          releases.win.json \
+          releases.baeium-win.json \
+          bae-windows-x64-setup.exe \
+          baeium-windows-x64-setup.exe; do
+          url="$base/$asset"
+          curl -fsIL --retry 5 --retry-delay 3 "$url" -o /dev/null
+          echo "asset reachable: $url"
+        done
+        echo "PASS: both feeds and setup installers are attached"
 
   refresh-website:
     # Republish the website so its build-time latest.json and download buttons

--- a/bae-windows.Tests/UpdateFlowTests.cs
+++ b/bae-windows.Tests/UpdateFlowTests.cs
@@ -1,0 +1,110 @@
+﻿using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the pure update-flow decisions in <see cref="UpdateFlowDisplay"/> and
+/// <see cref="UpdateFlowState"/>: which status key each state renders, download
+/// percent clamping, the check/restart button gating, and the version-string
+/// normalization. The Velopack shell that produces these states is verified by
+/// compilation, not here.
+/// </summary>
+public sealed class UpdateFlowTests
+{
+    [Fact]
+    public void StatusFor_Idle_IsNull()
+    {
+        Assert.Null(UpdateFlowDisplay.StatusFor(new UpdateFlowState.Idle()));
+    }
+
+    [Fact]
+    public void StatusFor_Checking_MapsKeyWithoutArgs()
+    {
+        var status = UpdateFlowDisplay.StatusFor(new UpdateFlowState.Checking());
+        Assert.NotNull(status);
+        Assert.Equal("settings.updates.checking", status!.Value.Key);
+        Assert.Null(status.Value.Args);
+    }
+
+    [Fact]
+    public void StatusFor_UpToDate_MapsKeyWithoutArgs()
+    {
+        var status = UpdateFlowDisplay.StatusFor(new UpdateFlowState.UpToDate());
+        Assert.NotNull(status);
+        Assert.Equal("settings.updates.up_to_date", status!.Value.Key);
+        Assert.Null(status.Value.Args);
+    }
+
+    [Fact]
+    public void StatusFor_Failed_MapsKeyWithoutArgs()
+    {
+        var status = UpdateFlowDisplay.StatusFor(new UpdateFlowState.Failed());
+        Assert.NotNull(status);
+        Assert.Equal("settings.updates.failed", status!.Value.Key);
+        Assert.Null(status.Value.Args);
+    }
+
+    [Fact]
+    public void StatusFor_Downloading_CarriesClampedPercent()
+    {
+        var status = UpdateFlowDisplay.StatusFor(new UpdateFlowState.Downloading(42));
+        Assert.NotNull(status);
+        Assert.Equal("settings.updates.downloading", status!.Value.Key);
+        Assert.NotNull(status.Value.Args);
+        Assert.Equal(42, status.Value.Args!["percent"]);
+    }
+
+    [Fact]
+    public void StatusFor_Ready_CarriesNormalizedVersion()
+    {
+        var status = UpdateFlowDisplay.StatusFor(new UpdateFlowState.Ready("0.5.0"));
+        Assert.NotNull(status);
+        Assert.Equal("settings.updates.ready", status!.Value.Key);
+        Assert.NotNull(status.Value.Args);
+        Assert.Equal("0.5", status.Value.Args!["version"]);
+    }
+
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(37, 37)]
+    [InlineData(100, 100)]
+    [InlineData(250, 100)]
+    public void Downloading_ClampsPercentToRange(int input, int expected)
+    {
+        Assert.Equal(expected, new UpdateFlowState.Downloading(input).Percent);
+    }
+
+    [Fact]
+    public void CheckEnabled_TrueExceptWhileCheckingOrDownloading()
+    {
+        Assert.True(UpdateFlowDisplay.CheckEnabled(new UpdateFlowState.Idle()));
+        Assert.True(UpdateFlowDisplay.CheckEnabled(new UpdateFlowState.UpToDate()));
+        Assert.True(UpdateFlowDisplay.CheckEnabled(new UpdateFlowState.Ready("0.5")));
+        Assert.True(UpdateFlowDisplay.CheckEnabled(new UpdateFlowState.Failed()));
+        Assert.False(UpdateFlowDisplay.CheckEnabled(new UpdateFlowState.Checking()));
+        Assert.False(UpdateFlowDisplay.CheckEnabled(new UpdateFlowState.Downloading(50)));
+    }
+
+    [Fact]
+    public void RestartVisible_OnlyForReady()
+    {
+        Assert.True(UpdateFlowDisplay.RestartVisible(new UpdateFlowState.Ready("0.5")));
+        Assert.False(UpdateFlowDisplay.RestartVisible(new UpdateFlowState.Idle()));
+        Assert.False(UpdateFlowDisplay.RestartVisible(new UpdateFlowState.Checking()));
+        Assert.False(UpdateFlowDisplay.RestartVisible(new UpdateFlowState.UpToDate()));
+        Assert.False(UpdateFlowDisplay.RestartVisible(new UpdateFlowState.Downloading(50)));
+        Assert.False(UpdateFlowDisplay.RestartVisible(new UpdateFlowState.Failed()));
+    }
+
+    [Theory]
+    [InlineData("0.5.0", "0.5")]
+    [InlineData("0.5.1", "0.5.1")]
+    [InlineData("0.10.0", "0.10")]
+    [InlineData("0.5", "0.5")]
+    public void VersionDisplay_DropsTrailingZeroPatch(string semver, string expected)
+    {
+        Assert.Equal(expected, UpdateFlowDisplay.VersionDisplay(semver));
+    }
+}

--- a/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows.Tests/bae-windows.Tests.csproj
@@ -19,6 +19,11 @@
       now-playing-bar seek/position math and the sync-indicator precedence, split
       out of MainWindow as plain BCL types (the stores that hold bridge snapshots
       and the WinUI views that render them are verified by compilation).
+    - The update-flow layer (UpdateFlow) — the state machine and display mapping
+      behind the settings "updates" section (status keys, percent clamping,
+      button gating, version-string normalization), over plain BCL types with no
+      WinUI or Velopack dependency (the Velopack shell that produces its states
+      lives in UpdateService and is verified by compilation).
 
     The rest of bae-windows' pure logic (ReleaseCandidateChoice.Summary,
     ImportCandidate status/ToString, BridgeDisplay) depends on the generated
@@ -44,6 +49,7 @@
     <Compile Include="../bae-windows/MediaControlState.cs" Link="MediaControlState.cs" />
     <Compile Include="../bae-windows/Stores/PlaybackPositionModel.cs" Link="PlaybackPositionModel.cs" />
     <Compile Include="../bae-windows/Stores/SyncIndicatorModel.cs" Link="SyncIndicatorModel.cs" />
+    <Compile Include="../bae-windows/UpdateFlow.cs" Link="UpdateFlow.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bae-windows/AppMetadata.cs
+++ b/bae-windows/AppMetadata.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// Build-time values baked into the assembly as
+/// <see cref="AssemblyMetadataAttribute"/> entries (the Datadog / Sentry
+/// credentials, the environment, and the git commit). Returns null when the
+/// value is blank or still an unexpanded MSBuild placeholder (<c>$(...)</c>), so
+/// a build that did not supply one reads as absent rather than as the literal
+/// token.
+/// </summary>
+internal static class AppMetadata
+{
+    private static readonly Assembly AppAssembly = Assembly.GetExecutingAssembly();
+
+    internal static string? ConfiguredString(string name)
+    {
+        var value = AppAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => attribute.Key == name)
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.StartsWith("$(", StringComparison.Ordinal) ? null : trimmed;
+    }
+}

--- a/bae-windows/BaeCrashReporting.cs
+++ b/bae-windows/BaeCrashReporting.cs
@@ -44,9 +44,9 @@ internal static class BaeCrashReporting
             return null;
         }
         var appVersion = AppAssembly.GetName().Version;
-        var dsn = ConfiguredString("BaeSentryDsn");
-        var environment = ConfiguredString("BaeEnvironment");
-        var gitCommit = ConfiguredString("BaeGitCommit");
+        var dsn = AppMetadata.ConfiguredString("BaeSentryDsn");
+        var environment = AppMetadata.ConfiguredString("BaeEnvironment");
+        var gitCommit = AppMetadata.ConfiguredString("BaeGitCommit");
         if (appVersion is null || dsn is null || environment is null || gitCommit is null)
         {
             return null;
@@ -101,20 +101,6 @@ internal static class BaeCrashReporting
         {
             BaeDiagnostics.Logger.Error("Failed to load native crash reporting", exception);
         }
-    }
-
-    private static string? ConfiguredString(string name)
-    {
-        var value = AppAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-            .FirstOrDefault(attribute => attribute.Key == name)
-            ?.Value;
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        var trimmed = value.Trim();
-        return trimmed.StartsWith("$(", StringComparison.Ordinal) ? null : trimmed;
     }
 }
 

--- a/bae-windows/BaeLogger.cs
+++ b/bae-windows/BaeLogger.cs
@@ -19,14 +19,14 @@ internal static class BaeDiagnostics
         }
 
         var error = NativeBae.ConfigureDiagnostics(
-            ConfiguredString("BaeDatadogSite"),
-            ConfiguredString("BaeDatadogClientToken"),
+            AppMetadata.ConfiguredString("BaeDatadogSite"),
+            AppMetadata.ConfiguredString("BaeDatadogClientToken"),
             "windows",
             "bae",
-            ConfiguredString("BaeEnvironment"),
+            AppMetadata.ConfiguredString("BaeEnvironment"),
             appVersion.ToString(),
             NativeBae.SupportsOAuthProviders() ? "bae" : "baeium",
-            ConfiguredString("BaeGitCommit"));
+            AppMetadata.ConfiguredString("BaeGitCommit"));
         if (error is not null)
         {
             Trace.TraceError($"Failed to configure diagnostics: {error}");
@@ -40,20 +40,6 @@ internal static class BaeDiagnostics
         {
             Trace.TraceError($"Failed to flush diagnostics: {error}");
         }
-    }
-
-    private static string? ConfiguredString(string name)
-    {
-        var value = AppAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-            .FirstOrDefault(attribute => attribute.Key == name)
-            ?.Value;
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        var trimmed = value.Trim();
-        return trimmed.StartsWith("$(", StringComparison.Ordinal) ? null : trimmed;
     }
 }
 

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -104,6 +104,11 @@ public sealed partial class MainWindow : Window
     // dialog is open so config invalidations refresh it live, null when closed.
     private Action? _refreshSettings;
 
+    // Drives the settings "updates" section: a launch-time background check and
+    // the manual check/download/apply from settings. Inert on a dev run or a
+    // loose-zip copy (IsAvailable is false).
+    private readonly UpdateService _updateService = new();
+
     // Reloads the storage dialog's release rows; set while that dialog is open so
     // album/release invalidations refresh each row's state badge and actions, not
     // just the album grid.
@@ -188,6 +193,11 @@ public sealed partial class MainWindow : Window
         RegisterProjections();
 
         LoadLibrary();
+
+        // Check for an update in the background at launch, like macOS's Sparkle
+        // check-on-appear. Fire-and-forget: the service catches and logs every
+        // failure and this is async I/O, so it never blocks startup.
+        _ = _updateService.CheckInBackgroundAsync();
     }
 
     // Wire core's invalidations to the reloads they drive. Static consumers (the
@@ -6121,6 +6131,75 @@ public sealed partial class MainWindow : Window
         content.Children.Add(showRecoveryCode);
         content.Children.Add(recoveryCode);
 
+        // Updates: the installed version, and — for a Velopack install — a manual
+        // check that downloads in the background and applies on restart. A dev run
+        // or a loose-zip copy is not an install, so only the version line shows.
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("settings.updates.title"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        var installedVersion = _updateService.InstalledVersion is { } version
+            ? UpdateFlowDisplay.VersionDisplay(version)
+            : AppMetadata.ConfiguredString("BaeGitCommit");
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("settings.updates.version", "version", installedVersion),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        });
+
+        var restartUpdateRequested = false;
+        Button? updateRestartButton = null;
+        Action? unsubscribeUpdates = null;
+        if (_updateService.IsAvailable)
+        {
+            var updateStatus = new TextBlock
+            {
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            };
+            var checkUpdates = new Button { Content = Loc.Chrome("settings.updates.check") };
+            var restartUpdate = new Button { Content = Loc.Chrome("settings.updates.restart") };
+            updateRestartButton = restartUpdate;
+
+            void RenderUpdates(UpdateFlowState state)
+            {
+                if (UpdateFlowDisplay.StatusFor(state) is { } mapped)
+                {
+                    updateStatus.Text = mapped.Args is { } args
+                        ? Loc.Chrome(mapped.Key, args)
+                        : Loc.Chrome(mapped.Key);
+                    updateStatus.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    updateStatus.Text = string.Empty;
+                    updateStatus.Visibility = Visibility.Collapsed;
+                }
+                checkUpdates.IsEnabled = UpdateFlowDisplay.CheckEnabled(state);
+                restartUpdate.Visibility = UpdateFlowDisplay.RestartVisible(state)
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+            }
+
+            checkUpdates.Click += async (_, _) => await _updateService.CheckAsync();
+
+            // State transitions arrive on a worker thread; marshal to the UI
+            // thread. Subscribed for the dialog's lifetime, so reopening settings
+            // reflects a background download that finished while it was closed
+            // (the phase lives on the service, not the dialog).
+            void OnUpdateStateChanged(UpdateFlowState state) =>
+                DispatcherQueue.TryEnqueue(() => RenderUpdates(state));
+            _updateService.StateChanged += OnUpdateStateChanged;
+            unsubscribeUpdates = () => _updateService.StateChanged -= OnUpdateStateChanged;
+
+            RenderUpdates(_updateService.State);
+            content.Children.Add(updateStatus);
+            content.Children.Add(checkUpdates);
+            content.Children.Add(restartUpdate);
+        }
+
         // Lock this library: forget its encryption key on this device. Sync stops
         // and the library reopens to the unlock prompt; local files stay.
         var lockRequested = false;
@@ -6139,6 +6218,18 @@ public sealed partial class MainWindow : Window
             lockRequested = true;
             dialog.Hide();
         };
+
+        // The restart button applies a staged update: hide the dialog and run the
+        // apply after ShowAsync returns (a nested dialog can't open over this one,
+        // same as the lock dance). Only wired when the updates section rendered it.
+        if (updateRestartButton is not null)
+        {
+            updateRestartButton.Click += (_, _) =>
+            {
+                restartUpdateRequested = true;
+                dialog.Hide();
+            };
+        }
 
         // Now that the dialog exists, load the device list into its placeholder.
         // The add-device button (owner-only) arms the approve flow and closes the
@@ -6179,6 +6270,18 @@ public sealed partial class MainWindow : Window
 
         await dialog.ShowAsync();
         _refreshSettings = null;
+        unsubscribeUpdates?.Invoke();
+
+        if (restartUpdateRequested)
+        {
+            // ApplyUpdatesAndRestart exits the process, so persist playback state
+            // and flush diagnostics first — the work OnClosed would otherwise do.
+            await ShutdownAndFreeCurrentHandle();
+            BaeDiagnostics.Flush();
+            _updateService.ApplyAndRestart();
+            return;
+        }
+
         if (lockRequested)
         {
             var (lockCurrent, error) = await RunForCurrentHandle(NativeBae.LockActiveLibrary);

--- a/bae-windows/Program.cs
+++ b/bae-windows/Program.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.InteropServices;
+using Microsoft.UI.Dispatching;
+using Velopack;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// The app entry point, replacing the one WinUI generates
+/// (<c>DISABLE_XAML_GENERATED_MAIN</c> turns that off) so the Velopack hook runs
+/// before any UI. The body otherwise replicates the generated Main: XAML process
+/// checks, COM wrappers, and the dispatcher-bound <see cref="App"/>.
+/// </summary>
+public static class Program
+{
+    [DllImport("Microsoft.ui.xaml.dll")]
+    private static extern void XamlCheckProcessRequirements();
+
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        // Must run before anything else: handles the Velopack install / update /
+        // uninstall hook arguments and exits the process for them.
+        VelopackApp.Build().Run();
+
+        XamlCheckProcessRequirements();
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+        Microsoft.UI.Xaml.Application.Start(p =>
+        {
+            var context = new DispatcherQueueSynchronizationContext(
+                DispatcherQueue.GetForCurrentThread());
+            SynchronizationContext.SetSynchronizationContext(context);
+            _ = new App();
+        });
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>جارٍ التحقق…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>إيقاف مؤقت بين الجانبين</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>المكتبة: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>تحديثات</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>الإصدار {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>التحقق من التحديثات</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>جارٍ التحقق…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>محدَّث</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>جارٍ التنزيل… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>الإصدار {version} جاهز — أعد التشغيل للتحديث</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>إعادة التشغيل الآن</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>تعذّر التحقق من التحديثات</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>قفل المكتبة</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>الاسترداد</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>رمز الاسترداد الخاص بك يستعيد هذه المكتبة على جهاز جديد عندما لا يتوفر لديك جهاز آخر للموافقة عليه. أي شخص لديه هذا الرمز يملك وصولًا كاملًا — أبقه سريًا.</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Потвърждаване…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Пауза между страните</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Библиотека: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>актуализации</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>версия {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Проверка за актуализации</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>проверява се…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>актуално</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>изтегля се… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>версия {version} е готова — рестартирайте, за да обновите</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Рестартиране сега</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>неуспешна проверка за актуализации</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>заключване на библиотеката</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>възстановяване</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>кодът ви за възстановяване възстановява тази библиотека на ново устройство, когато нямате друго устройство, с което да го одобрите. всеки с него има пълен достъп — пазете го в тайна.</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>যাচাই করা হচ্ছে…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>সাইডের মাঝে বিরতি</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>লাইব্রেরি: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>আপডেট</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>সংস্করণ {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>আপডেট পরীক্ষা করুন</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>পরীক্ষা করা হচ্ছে…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>হালনাগাদ</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ডাউনলোড হচ্ছে… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>সংস্করণ {version} প্রস্তুত — আপডেট করতে পুনরায় চালু করুন</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>এখন পুনরায় চালু করুন</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>আপডেট পরীক্ষা করা যায়নি</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>লাইব্রেরি লক করুন</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>রিকভারি</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>অনুমোদনের জন্য অন্য কোনো ডিভাইস না থাকলে আপনার রিকভারি কোড নতুন ডিভাইসে এই লাইব্রেরি ফিরিয়ে আনে। এটি যার কাছে আছে, সে পূর্ণ অ্যাক্সেস পাবে — গোপন রাখুন।</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Ověřování…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pauza mezi stranami</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Knihovna: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>aktualizace</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>verze {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Zkontrolovat aktualizace</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>kontroluje se…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>aktuální</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>stahuje se… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>verze {version} je připravena — restartujte pro aktualizaci</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Restartovat nyní</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>aktualizace se nepodařilo zkontrolovat</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>zamknout knihovnu</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>obnovení</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>váš kód pro obnovení obnoví tuto knihovnu na novém zařízení, když nemáte k dispozici žádné jiné zařízení pro schválení. každý, kdo ho má, má plný přístup — uchovejte ho v tajnosti.</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Wird überprüft …</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pause zwischen Seiten</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Bibliothek: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>Aktualisierungen</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>Version {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Nach Updates suchen</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>wird geprüft…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>aktuell</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>wird heruntergeladen… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>Version {version} ist bereit — zum Aktualisieren neu starten</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Jetzt neu starten</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>Suche nach Updates fehlgeschlagen</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>Bibliothek sperren</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>Wiederherstellung</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>dein Wiederherstellungscode stellt diese Mediathek auf einem neuen Gerät wieder her, wenn kein anderes Gerät zum Genehmigen verfügbar ist. jeder mit diesem Code hat vollen Zugriff — halte ihn geheim.</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Validating…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pause between sides</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Library: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>updates</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>version {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Check for updates</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>checking…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>up to date</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>downloading… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>version {version} is ready — restart to update</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Restart now</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>couldn't check for updates</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>lock library</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>recovery</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>your recovery code restores this library on a new device when you have no other device available to approve it. anyone with it has full access — keep it secret.</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Validando…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pausa entre caras</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Biblioteca: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>actualizaciones</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>versión {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Buscar actualizaciones</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>comprobando…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>actualizado</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>descargando… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>la versión {version} está lista — reinicia para actualizar</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Reiniciar ahora</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>no se pudo buscar actualizaciones</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>bloquear biblioteca</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>recuperación</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>tu código de recuperación restaura esta biblioteca en un dispositivo nuevo cuando no tienes otro dispositivo disponible para aprobarlo. cualquiera que lo tenga tendrá acceso completo — mantenlo secreto.</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Validation…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pause entre les faces</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Bibliothèque : {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>mises à jour</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>version {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Rechercher des mises à jour</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>vérification…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>à jour</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>téléchargement… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>la version {version} est prête — redémarrez pour mettre à jour</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Redémarrer maintenant</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>impossible de rechercher des mises à jour</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>verrouiller la bibliothèque</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>récupération</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>votre code de récupération restaure cette bibliothèque sur un nouvel appareil lorsque vous n’avez aucun autre appareil disponible pour l’approuver. toute personne qui le possède a un accès complet — gardez-le secret.</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>માન્ય થઈ રહ્યું છે…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>બાજુઓ વચ્ચે વિરામ</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>લાઇબ્રેરી: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>અપડેટ્સ</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>આવૃત્તિ {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>અપડેટ્સ તપાસો</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>તપાસી રહ્યું છે…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>અદ્યતન</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ડાઉનલોડ થઈ રહ્યું છે… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>આવૃત્તિ {version} તૈયાર છે — અપડેટ કરવા પુનઃપ્રારંભ કરો</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>હમણાં પુનઃપ્રારંભ કરો</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>અપડેટ્સ તપાસી શકાયું નહીં</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>લાઇબ્રેરી લૉક કરો</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>પુનઃપ્રાપ્તિ</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>તમારો પુનઃપ્રાપ્તિ કોડ આ લાઇબ્રેરીને નવા ઉપકરણ પર પુનઃસ્થાપિત કરે છે જ્યારે તેને મંજૂર કરવા માટે તમારી પાસે બીજું ઉપકરણ ઉપલબ્ધ ન હોય. જેની પાસે તે હશે તેને સંપૂર્ણ ઍક્સેસ મળશે — તેને ગુપ્ત રાખો.</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>מאמת…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>השהיה בין צדדים</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>ספרייה: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>עדכונים</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>גרסה {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>בדיקת עדכונים</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>בודק…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>מעודכן</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>מוריד… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>גרסה {version} מוכנה — הפעל מחדש כדי לעדכן</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>הפעל מחדש עכשיו</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>לא ניתן היה לבדוק עדכונים</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>נעל ספרייה</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>שחזור</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>קוד השחזור שלך משחזר את הספרייה הזו במכשיר חדש כשאין לך מכשיר אחר זמין לאישור. לכל מי שיש אותו יש גישה מלאה — שמרו עליו סודי.</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>सत्यापित हो रहा है…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>पक्षों के बीच रोकें</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>लाइब्रेरी: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>अपडेट</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>संस्करण {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>अपडेट जांचें</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>जांच हो रही है…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>अद्यतित</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>डाउनलोड हो रहा है… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>संस्करण {version} तैयार है — अपडेट के लिए पुनः आरंभ करें</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>अभी पुनः आरंभ करें</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>अपडेट जांच नहीं सके</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>लाइब्रेरी लॉक करें</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>पुनर्प्राप्ति</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>आपका पुनर्प्राप्ति कोड इस लाइब्रेरी को नए उपकरण पर बहाल करता है जब मंजूर करने के लिए कोई दूसरा उपकरण उपलब्ध नहीं होता। जिसके पास यह होगा उसे पूरी पहुंच होगी — इसे गुप्त रखें।</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Provjera…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pauza između strana</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Fonoteka: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>ažuriranja</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>verzija {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Provjeri ažuriranja</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>provjeravam…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>ažurno</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>preuzimam… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>verzija {version} je spremna — ponovno pokreni za ažuriranje</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Ponovno pokreni sada</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>nije moguće provjeriti ažuriranja</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>zaključaj fonoteku</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>oporavak</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>vaš kod za oporavak vraća ovu fonoteku na novi uređaj kada nemate drugi uređaj dostupan za odobravanje. svatko tko ga ima ima puni pristup — čuvajte ga tajnim.</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Convalida…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pausa tra i lati</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Libreria: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>aggiornamenti</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>versione {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Controlla aggiornamenti</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>controllo in corso…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>aggiornato</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>download in corso… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>la versione {version} è pronta — riavvia per aggiornare</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Riavvia ora</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>impossibile controllare gli aggiornamenti</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>lock Libreria</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>recupero</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>il tuo codice di recupero ripristina questa libreria su un nuovo dispositivo quando non hai altri dispositivi disponibili per approvarlo. chiunque lo abbia ha accesso completo — tienilo segreto.</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>検証中…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>面の間で一時停止</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>ライブラリ: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>アップデート</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>バージョン {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>アップデートを確認</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>確認中…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>最新です</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ダウンロード中… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>バージョン {version} の準備ができました — 再起動して更新</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>今すぐ再起動</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>アップデートを確認できませんでした</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>ライブラリをロック</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>リカバリー</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>承認に使えるほかのデバイスがないとき、リカバリーコードでこのライブラリを新しいデバイスに復元できます。これを持つ人は誰でも完全にアクセスできます — 秘密にしてください。</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>ಮಾನ್ಯಗೊಳಿಸಲಾಗುತ್ತಿದೆ…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>ಬದಿಗಳ ನಡುವೆ ವಿರಾಮ</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>ಲೈಬ್ರರಿ: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>ನವೀಕರಣಗಳು</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>ಆವೃತ್ತಿ {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>ನವೀಕರಣಗಳನ್ನು ಪರಿಶೀಲಿಸಿ</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>ಅಪ್‌ಟುಡೇಟ್</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>ಆವೃತ್ತಿ {version} ಸಿದ್ಧವಾಗಿದೆ — ನವೀಕರಿಸಲು ಮರುಪ್ರಾರಂಭಿಸಿ</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>ಈಗ ಮರುಪ್ರಾರಂಭಿಸಿ</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>ನವೀಕರಣಗಳನ್ನು ಪರಿಶೀಲಿಸಲಾಗಲಿಲ್ಲ</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>ಗ್ರಂಥಾಲಯ ಲಾಕ್ ಮಾಡಿ</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>ಮರುಪಡೆಯುವಿಕೆ</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>ಅನುಮೋದಿಸಲು ಬೇರೆ ಸಾಧನ ಲಭ್ಯವಿಲ್ಲದಾಗ, ನಿಮ್ಮ ಮರುಪಡೆಯುವ ಕೋಡ್ ಈ ಲೈಬ್ರರಿಯನ್ನು ಹೊಸ ಸಾಧನದಲ್ಲಿ ಮರುಸ್ಥಾಪಿಸುತ್ತದೆ. ಅದಿರುವ ಯಾರಿಗಾದರೂ ಪೂರ್ಣ ಪ್ರವೇಶವಿರುತ್ತದೆ — ಅದನ್ನು ರಹಸ್ಯವಾಗಿಡಿ.</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>검증 중…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>면 사이에 일시정지</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>라이브러리: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>업데이트</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>버전 {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>업데이트 확인</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>확인 중…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>최신 상태</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>다운로드 중… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>버전 {version} 준비 완료 — 업데이트하려면 다시 시작</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>지금 다시 시작</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>업데이트를 확인할 수 없습니다</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>라이브러리 잠금</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>복구</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>승인할 수 있는 다른 기기가 없을 때 복구 코드로 이 라이브러리를 새 기기에 복원할 수 있습니다. 이 코드를 가진 사람은 누구나 완전히 접근할 수 있으니 비밀로 보관하세요.</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>സാധൂകരിക്കുന്നു…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>വശങ്ങൾക്കിടയിൽ താൽക്കാലികമായി നിർത്തുക</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>ലൈബ്രറി: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>അപ്‌ഡേറ്റുകൾ</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>പതിപ്പ് {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>അപ്‌ഡേറ്റുകൾ പരിശോധിക്കുക</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>പരിശോധിക്കുന്നു…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>കാലികം</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ഡൗൺലോഡ് ചെയ്യുന്നു… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>പതിപ്പ് {version} തയ്യാറാണ് — അപ്‌ഡേറ്റ് ചെയ്യാൻ പുനരാരംഭിക്കുക</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>ഇപ്പോൾ പുനരാരംഭിക്കുക</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>അപ്‌ഡേറ്റുകൾ പരിശോധിക്കാനായില്ല</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>ലൈബ്രറി ലോക്ക് ചെയ്യുക</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>വീണ്ടെടുപ്പ്</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>അംഗീകരിക്കാൻ മറ്റൊരു ഉപകരണം ലഭ്യമല്ലാത്തപ്പോൾ നിങ്ങളുടെ വീണ്ടെടുപ്പ് കോഡ് ഈ ശേഖരം പുതിയ ഉപകരണത്തിൽ പുനഃസ്ഥാപിക്കുന്നു. അത് ഉള്ള ഏവർക്കും പൂർണ്ണ പ്രവേശനമുണ്ട് — രഹസ്യമായി സൂക്ഷിക്കുക.</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>वैध करत आहे…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>बाजूंमध्ये विराम</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>लायब्ररी: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>अद्यतने</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>आवृत्ती {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>अद्यतने तपासा</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>तपासत आहे…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>अद्ययावत</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>डाउनलोड होत आहे… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>आवृत्ती {version} तयार आहे — अद्यतनासाठी पुन्हा सुरू करा</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>आता पुन्हा सुरू करा</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>अद्यतने तपासता आली नाहीत</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>लायब्ररी लॉक करा</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>पुनर्प्राप्ती</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>मंजूर करण्यासाठी दुसरे डिव्हाइस उपलब्ध नसताना तुमचा पुनर्प्राप्ती संकेत हे संग्रहालय नवीन डिव्हाइसवर पुनर्संचयित करतो. तो असलेल्या कोणालाही पूर्ण प्रवेश आहे — तो गुप्त ठेवा.</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Valideren…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pauze tussen kanten</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Bibliotheek: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>updates</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>versie {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Controleren op updates</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>bezig met controleren…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>up-to-date</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>bezig met downloaden… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>versie {version} is klaar — herstart om bij te werken</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Nu herstarten</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>kon niet op updates controleren</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>lock Bibliotheek</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>herstel</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>je herstelcode herstelt deze bibliotheek op een nieuw apparaat wanneer je geen ander apparaat beschikbaar hebt om dit goed te keuren. iedereen die deze heeft, heeft volledige toegang — houd deze geheim.</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>ਪਰਖਿਆ ਜਾ ਰਿਹਾ ਹੈ…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>ਸਾਈਡਾਂ ਵਿਚਕਾਰ ਠਹਿਰਾਓ</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>ਅੱਪਡੇਟ</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>ਵਰਜ਼ਨ {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>ਅੱਪਡੇਟ ਦੀ ਜਾਂਚ ਕਰੋ</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>ਜਾਂਚ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>ਅੱਪ ਟੂ ਡੇਟ</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>ਵਰਜ਼ਨ {version} ਤਿਆਰ ਹੈ — ਅੱਪਡੇਟ ਲਈ ਮੁੜ ਚਾਲੂ ਕਰੋ</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>ਹੁਣੇ ਮੁੜ ਚਾਲੂ ਕਰੋ</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>ਅੱਪਡੇਟ ਦੀ ਜਾਂਚ ਨਹੀਂ ਹੋ ਸਕੀ</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਲਾਕ ਕਰੋ</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>ਰਿਕਵਰੀ</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>ਤੁਹਾਡਾ ਰਿਕਵਰੀ ਕੋਡ ਇਸ ਲਾਇਬ੍ਰੇਰੀ ਨੂੰ ਨਵੇਂ ਡਿਵਾਈਸ ਉੱਤੇ ਮੁੜ-ਬਹਾਲ ਕਰਦਾ ਹੈ ਜਦੋਂ ਮਨਜ਼ੂਰੀ ਲਈ ਕੋਈ ਹੋਰ ਡਿਵਾਈਸ ਉਪਲਬਧ ਨਹੀਂ ਹੁੰਦਾ। ਜਿਸ ਕੋਲ ਇਹ ਹੈ ਉਸਨੂੰ ਪੂਰੀ ਪਹੁੰਚ ਹੈ — ਇਸਨੂੰ ਗੁਪਤ ਰੱਖੋ।</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Weryfikowanie…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pauza między stronami</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Biblioteka: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>aktualizacje</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>wersja {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Sprawdź aktualizacje</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>sprawdzanie…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>aktualne</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>pobieranie… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>wersja {version} jest gotowa — uruchom ponownie, aby zaktualizować</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Uruchom ponownie teraz</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>nie udało się sprawdzić aktualizacji</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>zablokuj bibliotekę</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>odzyskiwanie</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>twój kod odzyskiwania przywraca tę bibliotekę na nowym urządzeniu, gdy nie masz dostępnego innego urządzenia, aby je zatwierdzić. każdy, kto go ma, ma pełny dostęp — zachowaj go w tajemnicy.</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Validando…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Pausa entre lados</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Biblioteca: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>atualizações</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>versão {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Verificar atualizações</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>verificando…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>atualizado</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>baixando… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>a versão {version} está pronta — reinicie para atualizar</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Reiniciar agora</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>não foi possível verificar atualizações</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>bloquear biblioteca</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>recuperação</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>seu código de recuperação restaura esta biblioteca em um novo dispositivo quando você não tem outro dispositivo disponível para aprová-lo. qualquer pessoa com ele tem acesso total — mantenha-o secreto.</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>சரிபார்க்கப்படுகிறது…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>பக்கங்களுக்கு இடையில் இடைநிறுத்து</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>நூலகம்: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>புதுப்பிப்புகள்</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>பதிப்பு {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>புதுப்பிப்புகளைச் சரிபார்க்கவும்</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>சரிபார்க்கிறது…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>புதுப்பித்த நிலையில்</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>பதிவிறக்குகிறது… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>பதிப்பு {version} தயார் — புதுப்பிக்க மீண்டும் தொடங்கவும்</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>இப்போது மீண்டும் தொடங்கு</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>புதுப்பிப்புகளைச் சரிபார்க்க முடியவில்லை</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>நூலகத்தைப் பூட்டு</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>மீட்பு</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>ஒப்புதல் அளிக்க வேறு சாதனம் இல்லாதபோது, உங்கள் மீட்பு குறியீடு இந்த நூலகத்தை புதிய சாதனத்தில் மீட்டமைக்கும். அது உள்ள யாருக்கும் முழு அணுகல் இருக்கும் — அதை ரகசியமாக வைத்திருங்கள்.</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>ధృవీకరిస్తోంది…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>వైపుల మధ్య విరామం</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>లైబ్రరీ: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>నవీకరణలు</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>సంస్కరణ {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>నవీకరణల కోసం తనిఖీ చేయండి</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>తనిఖీ చేస్తోంది…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>తాజాగా ఉంది</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>డౌన్‌లోడ్ అవుతోంది… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>సంస్కరణ {version} సిద్ధంగా ఉంది — నవీకరించడానికి పునఃప్రారంభించండి</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>ఇప్పుడు పునఃప్రారంభించండి</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>నవీకరణల కోసం తనిఖీ చేయలేకపోయాం</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>లైబ్రరీని లాక్ చేయండి</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>రికవరీ</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>ఆమోదించడానికి మీ దగ్గర ఇతర పరికరం లేనప్పుడు, మీ రికవరీ కోడ్ ఈ లైబ్రరీని కొత్త పరికరంలో పునరుద్ధరిస్తుంది. అది ఉన్న ఎవరికైనా పూర్తి యాక్సెస్ ఉంటుంది — దాన్ని రహస్యంగా ఉంచండి.</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>กำลังตรวจสอบ…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>หยุดพักระหว่างด้าน</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>ไลบรารี: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>การอัปเดต</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>เวอร์ชัน {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>ตรวจหาการอัปเดต</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>กำลังตรวจสอบ…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>เป็นเวอร์ชันล่าสุด</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>กำลังดาวน์โหลด… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>เวอร์ชัน {version} พร้อมแล้ว — รีสตาร์ทเพื่ออัปเดต</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>รีสตาร์ทตอนนี้</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>ตรวจหาการอัปเดตไม่สำเร็จ</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>ล็อกคลัง</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>การกู้คืน</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>รหัสกู้คืนของคุณใช้คืนค่าคลังนี้บนอุปกรณ์ใหม่เมื่อคุณไม่มีอุปกรณ์อื่นให้อนุมัติ ผู้ที่มีรหัสนี้จะเข้าถึงได้เต็มรูปแบบ — เก็บไว้เป็นความลับ</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Doğrulanıyor…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Yüzler arasında duraklat</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Kitaplık: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>güncellemeler</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>sürüm {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Güncellemeleri denetle</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>denetleniyor…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>güncel</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>indiriliyor… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>sürüm {version} hazır — güncellemek için yeniden başlat</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Şimdi yeniden başlat</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>güncellemeler denetlenemedi</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>lock Kitaplık</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>kurtarma</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>onaylamak için başka cihazınız olmadığında kurtarma kodunuz bu arşivi yeni bir cihazda geri yükler. ona sahip olan herkes tam erişim sağlar — gizli tutun.</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Перевірка…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Пауза між сторонами</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Бібліотека: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>оновлення</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>версія {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Перевірити оновлення</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>перевіряється…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>актуально</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>завантаження… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>версія {version} готова — перезапустіть, щоб оновити</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Перезапустити зараз</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>не вдалося перевірити оновлення</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>заблокувати бібліотеку</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>відновлення</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>ваш код відновлення відновлює цю бібліотеку на новому пристрої, коли немає іншого пристрою, щоб схвалити його. будь-хто з ним має повний доступ — тримайте його в таємниці.</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>توثیق ہو رہی ہے…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>اطراف کے درمیان وقفہ</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>لائبریری: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>اپ ڈیٹس</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>ورژن {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>اپ ڈیٹس کی جانچ کریں</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>جانچ ہو رہی ہے…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>تازہ ترین</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>ڈاؤن لوڈ ہو رہا ہے… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>ورژن {version} تیار ہے — اپ ڈیٹ کے لیے دوبارہ شروع کریں</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>ابھی دوبارہ شروع کریں</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>اپ ڈیٹس کی جانچ نہیں ہو سکی</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>لائبریری مقفل کریں</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>بازیابی</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>آپ کا بازیابی رمز اس کتب خانے کو نئے آلے پر بحال کرتا ہے جب منظوری کے لیے کوئی دوسرا آلہ دستیاب نہ ہو۔ جس کے پاس یہ ہو اسے مکمل رسائی ہے — اسے خفیہ رکھیں۔</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>Đang xác thực…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>Tạm dừng giữa các mặt</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>Thư viện: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>bản cập nhật</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>phiên bản {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>Kiểm tra bản cập nhật</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>đang kiểm tra…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>đã cập nhật</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>đang tải xuống… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>phiên bản {version} đã sẵn sàng — khởi động lại để cập nhật</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>Khởi động lại ngay</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>không thể kiểm tra bản cập nhật</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>lock Thư viện</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>khôi phục</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>mã khôi phục của bạn khôi phục thư viện này trên thiết bị mới khi bạn không có thiết bị nào khác để phê duyệt. bất kỳ ai có mã này đều có toàn quyền truy cập — hãy giữ bí mật.</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>校验中…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>面之间暂停</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>库：{name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>更新</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>版本 {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>检查更新</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>正在检查…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>已是最新</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>正在下载… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>版本 {version} 已就绪 — 重启以更新</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>立即重启</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>无法检查更新</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>锁定库</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>恢复</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>当你没有其他可用于批准的设备时，你的恢复代码可在新设备上恢复此曲库。任何拥有它的人都能完全访问——请保密。</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -191,6 +191,15 @@
   <data name="settings.discogs.validating" xml:space="preserve"><value>正在驗證…</value></data>
   <data name="settings.playback.pause_between_sides" xml:space="preserve"><value>面與面之間暫停</value></data>
   <data name="settings.library_label" xml:space="preserve"><value>資料庫: {name}</value></data>
+  <data name="settings.updates.title" xml:space="preserve"><value>更新</value></data>
+  <data name="settings.updates.version" xml:space="preserve"><value>版本 {version}</value></data>
+  <data name="settings.updates.check" xml:space="preserve"><value>檢查更新</value></data>
+  <data name="settings.updates.checking" xml:space="preserve"><value>正在檢查…</value></data>
+  <data name="settings.updates.up_to_date" xml:space="preserve"><value>已是最新</value></data>
+  <data name="settings.updates.downloading" xml:space="preserve"><value>正在下載… {percent}%</value></data>
+  <data name="settings.updates.ready" xml:space="preserve"><value>版本 {version} 已就緒 — 重新啟動以更新</value></data>
+  <data name="settings.updates.restart" xml:space="preserve"><value>立即重新啟動</value></data>
+  <data name="settings.updates.failed" xml:space="preserve"><value>無法檢查更新</value></data>
   <data name="settings.lock_library" xml:space="preserve"><value>鎖定資料庫</value></data>
   <data name="settings.recovery.title" xml:space="preserve"><value>復原</value></data>
   <data name="settings.recovery.intro" xml:space="preserve"><value>當你沒有其他可用裝置核准時，復原碼可在新裝置上還原此資料庫。任何持有它的人都能完整存取 — 請保密。</value></data>

--- a/bae-windows/UpdateFlow.cs
+++ b/bae-windows/UpdateFlow.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// The phase of the settings "updates" section, driving what the dialog renders.
+/// Pure over plain BCL types with no WinUI or Velopack dependency, so it compiles
+/// in the test project on any host; the Velopack calls that produce these states
+/// live in <see cref="UpdateService"/>.
+/// </summary>
+internal abstract record UpdateFlowState
+{
+    internal sealed record Idle : UpdateFlowState;
+    internal sealed record Checking : UpdateFlowState;
+    internal sealed record UpToDate : UpdateFlowState;
+
+    /// <summary>Download progress. Clamped to 0..100 at construction so a
+    /// provider that reports outside the range can't push an invalid percent to
+    /// the display.</summary>
+    internal sealed record Downloading(int Percent) : UpdateFlowState
+    {
+        internal int Percent { get; } = Math.Clamp(Percent, 0, 100);
+    }
+
+    /// <summary>An update is downloaded and staged; the app applies it on the
+    /// next exit. <paramref name="Version"/> is the raw package version string.</summary>
+    internal sealed record Ready(string Version) : UpdateFlowState;
+
+    internal sealed record Failed : UpdateFlowState;
+}
+
+/// <summary>
+/// Pure rendering decisions for the settings "updates" section, derived from an
+/// <see cref="UpdateFlowState"/>. The dialog reads a localized status key,
+/// whether the check button is enabled, and whether the restart button shows;
+/// none of it touches WinUI, so it is exercised directly by the unit tests.
+/// </summary>
+internal static class UpdateFlowDisplay
+{
+    /// <summary>The status line's chrome key and its MessageFormat arguments, or
+    /// null when the state has no status line (idle).</summary>
+    internal static (string Key, IReadOnlyDictionary<string, object?>? Args)? StatusFor(UpdateFlowState state) =>
+        state switch
+        {
+            UpdateFlowState.Idle => null,
+            UpdateFlowState.Checking => ("settings.updates.checking", null),
+            UpdateFlowState.UpToDate => ("settings.updates.up_to_date", null),
+            UpdateFlowState.Downloading downloading =>
+                ("settings.updates.downloading",
+                    new Dictionary<string, object?> { ["percent"] = downloading.Percent }),
+            UpdateFlowState.Ready ready =>
+                ("settings.updates.ready",
+                    new Dictionary<string, object?> { ["version"] = VersionDisplay(ready.Version) }),
+            UpdateFlowState.Failed => ("settings.updates.failed", null),
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown update flow state"),
+        };
+
+    /// <summary>Whether the check button accepts a click. A check already in
+    /// flight (checking or downloading) disables it.</summary>
+    internal static bool CheckEnabled(UpdateFlowState state) =>
+        state is not (UpdateFlowState.Checking or UpdateFlowState.Downloading);
+
+    /// <summary>Whether the restart button shows: only once an update is staged
+    /// and ready to apply.</summary>
+    internal static bool RestartVisible(UpdateFlowState state) => state is UpdateFlowState.Ready;
+
+    /// <summary>The version string shown to the user, normalized to the release
+    /// line's form: a full <c>0.5.0</c> package version drops its trailing zero
+    /// patch to read as <c>0.5</c> (matching the <c>windows-v0.5</c> tag), while
+    /// a non-zero patch (<c>0.5.1</c>) and an already-short version (<c>0.5</c>)
+    /// pass through unchanged.</summary>
+    internal static string VersionDisplay(string semver)
+    {
+        var parts = semver.Split('.');
+        return parts.Length == 3 && parts[2] == "0"
+            ? $"{parts[0]}.{parts[1]}"
+            : semver;
+    }
+}

--- a/bae-windows/UpdateService.cs
+++ b/bae-windows/UpdateService.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Velopack;
+using Velopack.Sources;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// The thin Velopack wrapper behind the settings "updates" section: it checks
+/// the GitHub release feed, downloads a staged package, and applies it on
+/// restart. All decision logic lives in <see cref="UpdateFlowState"/> /
+/// <see cref="UpdateFlowDisplay"/>; this shell only turns Velopack calls into
+/// state transitions.
+///
+/// <see cref="StateChanged"/> is raised on the worker thread that runs a check,
+/// so subscribers must marshal to the UI thread.
+/// </summary>
+internal sealed class UpdateService
+{
+    // The public repository's GitHub releases are the feed. Anonymous access is
+    // one API call per check; the installed package's channel selects its own
+    // releases.<channel>.json, so no edition branching is needed here.
+    private readonly UpdateManager _manager = new(
+        new GithubSource("https://github.com/bae-fm/bae", null, false));
+
+    // The checked-and-downloaded update awaiting apply-on-restart, set once a
+    // check reaches Ready. null until then.
+    private UpdateInfo? _pending;
+
+    // One check at a time: the background check at launch and a manual check from
+    // settings can't overlap. 0 = idle, 1 = a check is running.
+    private int _inFlight;
+
+    internal UpdateFlowState State { get; private set; } = new UpdateFlowState.Idle();
+
+    internal event Action<UpdateFlowState>? StateChanged;
+
+    /// <summary>Whether this process is a Velopack install (as opposed to a dev
+    /// run or a loose-zip copy). Gates every affordance: the throwing Velopack
+    /// calls are only valid on an install.</summary>
+    internal bool IsAvailable => _manager.IsInstalled;
+
+    /// <summary>The installed package version, or null when this isn't an
+    /// install.</summary>
+    internal string? InstalledVersion =>
+        _manager.IsInstalled ? _manager.CurrentVersion?.ToString() : null;
+
+    private void SetState(UpdateFlowState state)
+    {
+        State = state;
+        StateChanged?.Invoke(state);
+    }
+
+    /// <summary>Launch-time silent check: if an update exists, download and stage
+    /// it to apply on the next exit, landing in <c>Ready</c>. Any failure
+    /// (offline, unreachable feed, checksum mismatch) is logged and leaves the
+    /// state <c>Idle</c> — a background check never surfaces UI. No-op off an
+    /// install.</summary>
+    internal async Task CheckInBackgroundAsync()
+    {
+        if (!IsAvailable || Interlocked.CompareExchange(ref _inFlight, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var info = await _manager.CheckForUpdatesAsync();
+            if (info is null)
+            {
+                return;
+            }
+
+            await _manager.DownloadUpdatesAsync(info);
+            _pending = info;
+            _manager.WaitExitThenApplyUpdates(info.TargetFullRelease, silent: true, restart: false);
+            SetState(new UpdateFlowState.Ready(info.TargetFullRelease.Version.ToString()));
+        }
+        catch (Exception exception)
+        {
+            BaeDiagnostics.Logger.Warning("Background update check failed.", exception);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _inFlight, 0);
+        }
+    }
+
+    /// <summary>Manual check from settings: <c>Checking</c> → <c>UpToDate</c> |
+    /// <c>Downloading</c> (progress) → <c>Ready</c>, or <c>Failed</c> on any
+    /// error (logged; clicking again retries). No-op off an install.</summary>
+    internal async Task CheckAsync()
+    {
+        if (!IsAvailable)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _inFlight, 1, 0) != 0)
+        {
+            // A launch-time background check is still running; it owns the flow.
+            BaeDiagnostics.Logger.Debug("Manual update check skipped: a check is already in flight.");
+            return;
+        }
+
+        try
+        {
+            SetState(new UpdateFlowState.Checking());
+            var info = await _manager.CheckForUpdatesAsync();
+            if (info is null)
+            {
+                SetState(new UpdateFlowState.UpToDate());
+                return;
+            }
+
+            await _manager.DownloadUpdatesAsync(
+                info, percent => SetState(new UpdateFlowState.Downloading(percent)));
+            _pending = info;
+            SetState(new UpdateFlowState.Ready(info.TargetFullRelease.Version.ToString()));
+        }
+        catch (Exception exception)
+        {
+            BaeDiagnostics.Logger.Warning("Update check failed.", exception);
+            SetState(new UpdateFlowState.Failed());
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _inFlight, 0);
+        }
+    }
+
+    /// <summary>Apply the staged update and relaunch. This exits the process, so
+    /// the caller must persist playback state first.</summary>
+    internal void ApplyAndRestart() => _manager.ApplyUpdatesAndRestart(_pending!.TargetFullRelease);
+}

--- a/bae-windows/bae-windows.csproj
+++ b/bae-windows/bae-windows.csproj
@@ -32,6 +32,15 @@
     <WindowsPackageType>None</WindowsPackageType>
 
     <!--
+      Hand-written entry point (Program.Main) instead of WinUI's generated one so
+      Velopack's install/update/uninstall hook runs before any UI starts.
+      DISABLE_XAML_GENERATED_MAIN suppresses the generated Main; StartupObject
+      points at the replacement.
+    -->
+    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+    <StartupObject>Bae.Windows.Program</StartupObject>
+
+    <!--
       The localization .resw are included explicitly (the Strings/**/*.resw
       PRIResource group below). Turn off the SDK's default PRIResource
       auto-include so the same files aren't added twice (NETSDK1022). The
@@ -83,6 +92,13 @@
     -->
     <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="ZXing.Net" Version="0.16.9" />
+    <!--
+      Installer + auto-update. Builds the Setup.exe / Portable.zip and the update
+      feed (releases.<channel>.json + .nupkg) in the release workflow, and drives
+      the in-app check/download/apply from the GitHub release assets. The vpk CLI
+      that packs the release must match this version exactly.
+    -->
+    <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/website/src/content/docs/guide/installation.mdx
+++ b/website/src/content/docs/guide/installation.mdx
@@ -41,7 +41,7 @@ Enable installing from your browser/files when prompted, then open the `.apk`.
 
 ## Windows
 
-Windows builds are **unsigned** zips of the unpackaged app. Extract and run `bae.exe` / `baeium.exe`. SmartScreen may warn on first launch.
+The Windows download is an installer that installs per-user and keeps itself up to date. Builds are not code-signed, so SmartScreen may warn on first launch. A portable zip that runs in place is also attached to each [GitHub release](https://github.com/bae-fm/bae/releases).
 
 <DownloadButton platform="windows" edition="full" class="sl-button primary">Download bae for Windows</DownloadButton>
 <DownloadButton platform="windows" edition="baeium" class="sl-button">Download baeium for Windows</DownloadButton>

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -19,7 +19,7 @@ const ASSETS: Record<Platform, Record<Edition, string>> = {
   macos: { full: 'bae-macos.dmg', baeium: 'baeium-macos.dmg' },
   ios: { full: 'bae-ios.ipa', baeium: 'baeium-ios.ipa' },
   android: { full: 'bae-android.apk', baeium: 'baeium-android.apk' },
-  windows: { full: 'bae-windows-x64.zip', baeium: 'baeium-windows-x64.zip' },
+  windows: { full: 'bae-windows-x64-setup.exe', baeium: 'baeium-windows-x64-setup.exe' },
 };
 
 export interface EditionDownload {


### PR DESCRIPTION
Windows had no update mechanism: users downloaded a zip, extracted it, and did it all again for every release, while macOS has had Sparkle-driven background updates. This wires the whole path — client, packaging, and publishing.

The app now ships as a Velopack package. A hand-written entry point runs the Velopack host hooks before any UI (WinUI's generated Main is disabled), a launch-time background check downloads updates silently and applies them on exit, and the settings dialog grows an updates section with the installed version, a manual check with live status, and a restart-to-update button whose handler persists playback state and flushes diagnostics before the process is swapped — the same teardown the window close performs, so an update never loses the queue or position. All decision logic (state transitions, status keys, button gating, version display) lives in a WinRT-free layer unit-tested on this host; the Velopack calls are a thin shell gated on IsInstalled, so dev runs and legacy loose-zip installs see only a version line. Dev-run/portable installs never touch the updater.

The release workflow packs both editions with vpk under distinct channels (win, baeium-win) so their feeds coexist in the one immutable windows-v* release, renames only the installer/portable artifacts (the feed json references the nupkg filenames), fails loudly if any expected output is missing, and verifies the uploaded feed URLs after publishing. Signing engages automatically when the certificate secret is configured. The website download buttons now point at the setup installers.

## User TODO

Add repo secrets `WINDOWS_CODESIGN_PFX_BASE64` (base64 of the Authenticode .pfx) and `WINDOWS_CODESIGN_PASSWORD` once a code-signing certificate is acquired — the workflow's signing step engages automatically when the first one is set. Until configured, builds are unsigned and SmartScreen warns on first launch.

First release after merge needs a manual workflow_dispatch to validate the feed end-to-end (install the setup, confirm the settings version line, cut a second release, confirm check → download → restart lands it).

## Test plan

- [x] 73 tests in bae-windows.Tests incl. new UpdateFlowTests (status mapping, clamping, gating truth table, version display)
- [x] actionlint on the workflow; loc-chrome-orphans (9 new keys × 31 locales)
- [ ] Windows CI compile of both binding variants
- [ ] Post-merge: dispatch release-windows.yml and verify the feed + installer end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tK3JoFW9Nsdb2Tc139iLH