### PR TITLE
Exhaustive destructuring in bridge converters

### DIFF
--- a/bae-bridge/src/bridge_utils.rs
+++ b/bae-bridge/src/bridge_utils.rs
@@ -4,249 +4,314 @@ use crate::types::{
     BridgeExportSelection, BridgeMcpConfig, BridgeSyncConfig, BridgeSyncProvider,
 };
 
-/// Convert a core `ExportLocation` to the bridge enum. A fixed folder's path
-/// crosses as a string.
-pub(crate) fn bridge_export_location(
-    location: &bae_core::config::ExportLocation,
-) -> BridgeExportLocation {
-    match location {
-        bae_core::config::ExportLocation::AskEachTime => BridgeExportLocation::AskEachTime,
-        bae_core::config::ExportLocation::Fixed(dir) => BridgeExportLocation::Fixed {
-            dir: dir.to_string_lossy().to_string(),
-        },
-    }
-}
-
-/// Convert the bridge enum back to a core `ExportLocation` for persisting.
-pub(crate) fn core_export_location(
-    location: BridgeExportLocation,
-) -> bae_core::config::ExportLocation {
-    match location {
-        BridgeExportLocation::AskEachTime => bae_core::config::ExportLocation::AskEachTime,
-        BridgeExportLocation::Fixed { dir } => {
-            bae_core::config::ExportLocation::Fixed(std::path::PathBuf::from(dir))
+impl BridgeExportLocation {
+    /// A fixed folder's path crosses as a string.
+    pub(crate) fn from_core(location: &bae_core::config::ExportLocation) -> Self {
+        match location {
+            bae_core::config::ExportLocation::AskEachTime => BridgeExportLocation::AskEachTime,
+            bae_core::config::ExportLocation::Fixed(dir) => BridgeExportLocation::Fixed {
+                dir: dir.to_string_lossy().to_string(),
+            },
         }
     }
-}
 
-pub(crate) fn bridge_export_bit_depth(
-    bit_depth: bae_core::config::ExportBitDepth,
-) -> BridgeExportBitDepth {
-    match bit_depth {
-        bae_core::config::ExportBitDepth::Source => BridgeExportBitDepth::Source,
-        bae_core::config::ExportBitDepth::Bits16 => BridgeExportBitDepth::Bits16,
-        bae_core::config::ExportBitDepth::Bits24 => BridgeExportBitDepth::Bits24,
-        bae_core::config::ExportBitDepth::Bits32 => BridgeExportBitDepth::Bits32,
-    }
-}
-
-pub(crate) fn core_export_bit_depth(
-    bit_depth: BridgeExportBitDepth,
-) -> bae_core::config::ExportBitDepth {
-    match bit_depth {
-        BridgeExportBitDepth::Source => bae_core::config::ExportBitDepth::Source,
-        BridgeExportBitDepth::Bits16 => bae_core::config::ExportBitDepth::Bits16,
-        BridgeExportBitDepth::Bits24 => bae_core::config::ExportBitDepth::Bits24,
-        BridgeExportBitDepth::Bits32 => bae_core::config::ExportBitDepth::Bits32,
-    }
-}
-
-pub(crate) fn bridge_export_preset_codec(
-    codec: &bae_core::config::ExportPresetCodec,
-) -> BridgeExportPresetCodec {
-    match codec {
-        bae_core::config::ExportPresetCodec::Flac { bit_depth } => BridgeExportPresetCodec::Flac {
-            bit_depth: bridge_export_bit_depth(*bit_depth),
-        },
-        bae_core::config::ExportPresetCodec::Mp3 { bitrate_kbps } => BridgeExportPresetCodec::Mp3 {
-            bitrate_kbps: *bitrate_kbps,
-        },
-        bae_core::config::ExportPresetCodec::OpusOgg { bitrate_kbps } => {
-            BridgeExportPresetCodec::OpusOgg {
-                bitrate_kbps: *bitrate_kbps,
+    pub(crate) fn into_core(self) -> bae_core::config::ExportLocation {
+        match self {
+            BridgeExportLocation::AskEachTime => bae_core::config::ExportLocation::AskEachTime,
+            BridgeExportLocation::Fixed { dir } => {
+                bae_core::config::ExportLocation::Fixed(std::path::PathBuf::from(dir))
             }
         }
-        bae_core::config::ExportPresetCodec::Wav { bit_depth } => BridgeExportPresetCodec::Wav {
-            bit_depth: bridge_export_bit_depth(*bit_depth),
-        },
-        bae_core::config::ExportPresetCodec::Aiff { bit_depth } => BridgeExportPresetCodec::Aiff {
-            bit_depth: bridge_export_bit_depth(*bit_depth),
-        },
     }
 }
 
-pub(crate) fn core_export_preset_codec(
-    codec: BridgeExportPresetCodec,
-) -> bae_core::config::ExportPresetCodec {
-    match codec {
-        BridgeExportPresetCodec::Flac { bit_depth } => bae_core::config::ExportPresetCodec::Flac {
-            bit_depth: core_export_bit_depth(bit_depth),
-        },
-        BridgeExportPresetCodec::Mp3 { bitrate_kbps } => {
-            bae_core::config::ExportPresetCodec::Mp3 { bitrate_kbps }
+impl BridgeExportBitDepth {
+    pub(crate) fn from_core(bit_depth: bae_core::config::ExportBitDepth) -> Self {
+        match bit_depth {
+            bae_core::config::ExportBitDepth::Source => BridgeExportBitDepth::Source,
+            bae_core::config::ExportBitDepth::Bits16 => BridgeExportBitDepth::Bits16,
+            bae_core::config::ExportBitDepth::Bits24 => BridgeExportBitDepth::Bits24,
+            bae_core::config::ExportBitDepth::Bits32 => BridgeExportBitDepth::Bits32,
         }
-        BridgeExportPresetCodec::OpusOgg { bitrate_kbps } => {
-            bae_core::config::ExportPresetCodec::OpusOgg { bitrate_kbps }
-        }
-        BridgeExportPresetCodec::Wav { bit_depth } => bae_core::config::ExportPresetCodec::Wav {
-            bit_depth: core_export_bit_depth(bit_depth),
-        },
-        BridgeExportPresetCodec::Aiff { bit_depth } => bae_core::config::ExportPresetCodec::Aiff {
-            bit_depth: core_export_bit_depth(bit_depth),
-        },
     }
-}
 
-pub(crate) fn bridge_export_pregap_placement(
-    placement: bae_core::config::ExportPregapPlacement,
-) -> BridgeExportPregapPlacement {
-    match placement {
-        bae_core::config::ExportPregapPlacement::AppendToPreviousExceptHtoa => {
-            BridgeExportPregapPlacement::AppendToPreviousExceptHtoa
-        }
-        bae_core::config::ExportPregapPlacement::AppendToPreviousIncludingHtoa => {
-            BridgeExportPregapPlacement::AppendToPreviousIncludingHtoa
-        }
-        bae_core::config::ExportPregapPlacement::Exclude => BridgeExportPregapPlacement::Exclude,
-        bae_core::config::ExportPregapPlacement::SingleFileWithCue => {
-            BridgeExportPregapPlacement::SingleFileWithCue
+    pub(crate) fn into_core(self) -> bae_core::config::ExportBitDepth {
+        match self {
+            BridgeExportBitDepth::Source => bae_core::config::ExportBitDepth::Source,
+            BridgeExportBitDepth::Bits16 => bae_core::config::ExportBitDepth::Bits16,
+            BridgeExportBitDepth::Bits24 => bae_core::config::ExportBitDepth::Bits24,
+            BridgeExportBitDepth::Bits32 => bae_core::config::ExportBitDepth::Bits32,
         }
     }
 }
 
-pub(crate) fn core_export_pregap_placement(
-    placement: BridgeExportPregapPlacement,
-) -> bae_core::config::ExportPregapPlacement {
-    match placement {
-        BridgeExportPregapPlacement::AppendToPreviousExceptHtoa => {
-            bae_core::config::ExportPregapPlacement::AppendToPreviousExceptHtoa
-        }
-        BridgeExportPregapPlacement::AppendToPreviousIncludingHtoa => {
-            bae_core::config::ExportPregapPlacement::AppendToPreviousIncludingHtoa
-        }
-        BridgeExportPregapPlacement::Exclude => bae_core::config::ExportPregapPlacement::Exclude,
-        BridgeExportPregapPlacement::SingleFileWithCue => {
-            bae_core::config::ExportPregapPlacement::SingleFileWithCue
-        }
-    }
-}
-
-pub(crate) fn bridge_export_selection(
-    selection: &bae_core::config::ExportSelection,
-) -> BridgeExportSelection {
-    match selection {
-        bae_core::config::ExportSelection::Original => BridgeExportSelection::Original,
-        bae_core::config::ExportSelection::Preset { preset_id } => BridgeExportSelection::Preset {
-            preset_id: preset_id.clone(),
-        },
-    }
-}
-
-pub(crate) fn core_export_selection(
-    selection: BridgeExportSelection,
-) -> bae_core::config::ExportSelection {
-    match selection {
-        BridgeExportSelection::Original => bae_core::config::ExportSelection::Original,
-        BridgeExportSelection::Preset { preset_id } => {
-            bae_core::config::ExportSelection::Preset { preset_id }
-        }
-    }
-}
-
-pub(crate) fn bridge_export_preset(preset: &bae_core::config::ExportPreset) -> BridgeExportPreset {
-    BridgeExportPreset {
-        id: preset.id.clone(),
-        name: preset.name.clone(),
-        codec: bridge_export_preset_codec(&preset.codec),
-        extension: preset.codec.extension().to_string(),
-        filename_template: preset.filename_template.clone(),
-        pregap_placement: bridge_export_pregap_placement(preset.pregap_placement),
-        applies_to_track: preset.applies_to_track,
-        applies_to_release: preset.applies_to_release,
-    }
-}
-
-pub(crate) fn core_export_preset(preset: BridgeExportPreset) -> bae_core::config::ExportPreset {
-    bae_core::config::ExportPreset {
-        id: preset.id,
-        name: preset.name,
-        codec: core_export_preset_codec(preset.codec),
-        filename_template: preset.filename_template,
-        pregap_placement: core_export_pregap_placement(preset.pregap_placement),
-        applies_to_track: preset.applies_to_track,
-        applies_to_release: preset.applies_to_release,
-    }
-}
-
-/// Convert a core `Config` to `BridgeConfig` for the UI. Pure translation —
-/// `cloud_account_display` is a core method; this just reads it. `sync` is
-/// `Some` whenever a provider is set in YAML. Sync-loop running status is
-/// runtime state, not config — it lives in the sync-status snapshot, not on
-/// `BridgeConfig`.
-pub(crate) fn build_bridge_config(config: &bae_core::config::Config) -> BridgeConfig {
-    let discogs_status = config.discogs_token_status();
-    BridgeConfig {
-        library_id: config.library_id.clone(),
-        library_name: config.library_name.clone(),
-        library_path: config.library_dir.to_string_lossy().to_string(),
-        encryption_key_stored: config.encryption_key_stored,
-        encryption_key_fingerprint: config.encryption_key_fingerprint.clone(),
-        pause_between_sides: config.pause_between_sides,
-        export_location: bridge_export_location(&config.export_location),
-        export_filename_template: config.export_filename_template.clone(),
-        export_presets: config
-            .export_presets
-            .iter()
-            .map(bridge_export_preset)
-            .collect(),
-        default_track_export_selection: bridge_export_selection(
-            &config.default_track_export_selection,
-        ),
-        default_release_export_selection: bridge_export_selection(
-            &config.default_release_export_selection,
-        ),
-        mcp: BridgeMcpConfig {
-            enabled: config.mcp.enabled,
-            port: config.mcp.port,
-        },
-        discogs_usable: discogs_status.is_usable(),
-        discogs_token_status: match discogs_status {
-            bae_core::config::DiscogsTokenStatus::NotConfigured => {
-                BridgeDiscogsTokenStatus::NotConfigured
+impl BridgeExportPresetCodec {
+    pub(crate) fn from_core(codec: &bae_core::config::ExportPresetCodec) -> Self {
+        match codec {
+            bae_core::config::ExportPresetCodec::Flac { bit_depth } => {
+                BridgeExportPresetCodec::Flac {
+                    bit_depth: BridgeExportBitDepth::from_core(*bit_depth),
+                }
             }
-            bae_core::config::DiscogsTokenStatus::Valid => BridgeDiscogsTokenStatus::Valid,
-            bae_core::config::DiscogsTokenStatus::Unvalidated => {
-                BridgeDiscogsTokenStatus::Unvalidated
+            bae_core::config::ExportPresetCodec::Mp3 { bitrate_kbps } => {
+                BridgeExportPresetCodec::Mp3 {
+                    bitrate_kbps: *bitrate_kbps,
+                }
             }
-            bae_core::config::DiscogsTokenStatus::Rejected => BridgeDiscogsTokenStatus::Rejected,
-        },
-        sync: config
-            .cloud_home
-            .provider
-            .as_ref()
-            .map(|provider| BridgeSyncConfig {
-                provider: bridge_sync_provider(provider, &config.cloud_home),
-                cloud_account_display: config.cloud_account_display(),
-            }),
+            bae_core::config::ExportPresetCodec::OpusOgg { bitrate_kbps } => {
+                BridgeExportPresetCodec::OpusOgg {
+                    bitrate_kbps: *bitrate_kbps,
+                }
+            }
+            bae_core::config::ExportPresetCodec::Wav { bit_depth } => {
+                BridgeExportPresetCodec::Wav {
+                    bit_depth: BridgeExportBitDepth::from_core(*bit_depth),
+                }
+            }
+            bae_core::config::ExportPresetCodec::Aiff { bit_depth } => {
+                BridgeExportPresetCodec::Aiff {
+                    bit_depth: BridgeExportBitDepth::from_core(*bit_depth),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::config::ExportPresetCodec {
+        match self {
+            BridgeExportPresetCodec::Flac { bit_depth } => {
+                bae_core::config::ExportPresetCodec::Flac {
+                    bit_depth: bit_depth.into_core(),
+                }
+            }
+            BridgeExportPresetCodec::Mp3 { bitrate_kbps } => {
+                bae_core::config::ExportPresetCodec::Mp3 { bitrate_kbps }
+            }
+            BridgeExportPresetCodec::OpusOgg { bitrate_kbps } => {
+                bae_core::config::ExportPresetCodec::OpusOgg { bitrate_kbps }
+            }
+            BridgeExportPresetCodec::Wav { bit_depth } => {
+                bae_core::config::ExportPresetCodec::Wav {
+                    bit_depth: bit_depth.into_core(),
+                }
+            }
+            BridgeExportPresetCodec::Aiff { bit_depth } => {
+                bae_core::config::ExportPresetCodec::Aiff {
+                    bit_depth: bit_depth.into_core(),
+                }
+            }
+        }
     }
 }
 
-/// Map a connected provider + its cloud-home settings to the bridge enum,
-/// carrying only the fields that provider uses.
-fn bridge_sync_provider(
-    provider: &bae_core::config::CloudProvider,
-    cloud_home: &bae_core::config::CloudHomeConfig,
-) -> BridgeSyncProvider {
-    use bae_core::config::CloudProvider;
-    match provider {
-        CloudProvider::S3 => BridgeSyncProvider::S3 {
-            bucket: cloud_home.s3_bucket.clone(),
-            region: cloud_home.s3_region.clone(),
-            endpoint: cloud_home.s3_endpoint.clone(),
-        },
-        CloudProvider::GoogleDrive => BridgeSyncProvider::GoogleDrive,
-        CloudProvider::Dropbox => BridgeSyncProvider::Dropbox,
-        CloudProvider::OneDrive => BridgeSyncProvider::OneDrive,
-        CloudProvider::CloudKit => BridgeSyncProvider::CloudKit,
+impl BridgeExportPregapPlacement {
+    pub(crate) fn from_core(placement: bae_core::config::ExportPregapPlacement) -> Self {
+        match placement {
+            bae_core::config::ExportPregapPlacement::AppendToPreviousExceptHtoa => {
+                BridgeExportPregapPlacement::AppendToPreviousExceptHtoa
+            }
+            bae_core::config::ExportPregapPlacement::AppendToPreviousIncludingHtoa => {
+                BridgeExportPregapPlacement::AppendToPreviousIncludingHtoa
+            }
+            bae_core::config::ExportPregapPlacement::Exclude => {
+                BridgeExportPregapPlacement::Exclude
+            }
+            bae_core::config::ExportPregapPlacement::SingleFileWithCue => {
+                BridgeExportPregapPlacement::SingleFileWithCue
+            }
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::config::ExportPregapPlacement {
+        match self {
+            BridgeExportPregapPlacement::AppendToPreviousExceptHtoa => {
+                bae_core::config::ExportPregapPlacement::AppendToPreviousExceptHtoa
+            }
+            BridgeExportPregapPlacement::AppendToPreviousIncludingHtoa => {
+                bae_core::config::ExportPregapPlacement::AppendToPreviousIncludingHtoa
+            }
+            BridgeExportPregapPlacement::Exclude => {
+                bae_core::config::ExportPregapPlacement::Exclude
+            }
+            BridgeExportPregapPlacement::SingleFileWithCue => {
+                bae_core::config::ExportPregapPlacement::SingleFileWithCue
+            }
+        }
+    }
+}
+
+impl BridgeExportSelection {
+    pub(crate) fn from_core(selection: &bae_core::config::ExportSelection) -> Self {
+        match selection {
+            bae_core::config::ExportSelection::Original => BridgeExportSelection::Original,
+            bae_core::config::ExportSelection::Preset { preset_id } => {
+                BridgeExportSelection::Preset {
+                    preset_id: preset_id.clone(),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::config::ExportSelection {
+        match self {
+            BridgeExportSelection::Original => bae_core::config::ExportSelection::Original,
+            BridgeExportSelection::Preset { preset_id } => {
+                bae_core::config::ExportSelection::Preset { preset_id }
+            }
+        }
+    }
+}
+
+impl BridgeExportPreset {
+    pub(crate) fn from_core(preset: &bae_core::config::ExportPreset) -> Self {
+        let bae_core::config::ExportPreset {
+            id,
+            name,
+            codec,
+            filename_template,
+            pregap_placement,
+            applies_to_track,
+            applies_to_release,
+        } = preset;
+        BridgeExportPreset {
+            id: id.clone(),
+            name: name.clone(),
+            codec: BridgeExportPresetCodec::from_core(codec),
+            // Derived from the codec; the core preset re-derives it on `into_core`.
+            extension: codec.extension().to_string(),
+            filename_template: filename_template.clone(),
+            pregap_placement: BridgeExportPregapPlacement::from_core(*pregap_placement),
+            applies_to_track: *applies_to_track,
+            applies_to_release: *applies_to_release,
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::config::ExportPreset {
+        let BridgeExportPreset {
+            id,
+            name,
+            codec,
+            filename_template,
+            pregap_placement,
+            applies_to_track,
+            applies_to_release,
+            // Derived from `codec` on `from_core`; the core preset recomputes it
+            // via `codec.extension()`, so the bridge-carried value is dropped.
+            extension: _,
+        } = self;
+        bae_core::config::ExportPreset {
+            id,
+            name,
+            codec: codec.into_core(),
+            filename_template,
+            pregap_placement: pregap_placement.into_core(),
+            applies_to_track,
+            applies_to_release,
+        }
+    }
+}
+
+impl BridgeConfig {
+    /// Convert a core `Config` to `BridgeConfig` for the UI. Pure translation —
+    /// `cloud_account_display` is a core method; this just reads it. `sync` is
+    /// `Some` whenever a provider is set in YAML. Sync-loop running status is
+    /// runtime state, not config — it lives in the sync-status snapshot, not on
+    /// `BridgeConfig`.
+    ///
+    /// bae-core's own `Config` fields are exhaustively destructured so a new one
+    /// fails the build here. The coven `inner` sub-config it embeds is an
+    /// external crate's type — exempt from the destructure — so its fields
+    /// (`library_id`, `cloud_home`, …) stay dotted reads through `inner`.
+    pub(crate) fn from_core(config: &bae_core::config::Config) -> Self {
+        let discogs_status = config.discogs_token_status();
+        let cloud_account_display = config.cloud_account_display();
+        let bae_core::config::Config {
+            inner,
+            // Read via the derived `discogs_token_status()` above.
+            discogs: _,
+            // Playback loudness policy; not surfaced on the config screen.
+            replay_gain_mode: _,
+            export_location,
+            export_filename_template,
+            export_presets,
+            default_track_export_selection,
+            default_release_export_selection,
+            pause_between_sides,
+            // Import-time decode verification; not surfaced on the config screen.
+            verify_decode_on_import: _,
+            mcp,
+        } = config;
+
+        let bae_core::config::McpConfig { enabled, port } = mcp;
+
+        BridgeConfig {
+            // `inner` is coven's config (external crate) — exempt from the
+            // exhaustive destructure; these stay dotted reads.
+            library_id: inner.library_id.clone(),
+            library_name: inner.library_name.clone(),
+            library_path: inner.library_dir.to_string_lossy().to_string(),
+            encryption_key_stored: inner.encryption_key_stored,
+            encryption_key_fingerprint: inner.encryption_key_fingerprint.clone(),
+            pause_between_sides: *pause_between_sides,
+            export_location: BridgeExportLocation::from_core(export_location),
+            export_filename_template: export_filename_template.clone(),
+            export_presets: export_presets
+                .iter()
+                .map(BridgeExportPreset::from_core)
+                .collect(),
+            default_track_export_selection: BridgeExportSelection::from_core(
+                default_track_export_selection,
+            ),
+            default_release_export_selection: BridgeExportSelection::from_core(
+                default_release_export_selection,
+            ),
+            mcp: BridgeMcpConfig {
+                enabled: *enabled,
+                port: *port,
+            },
+            discogs_usable: discogs_status.is_usable(),
+            discogs_token_status: match discogs_status {
+                bae_core::config::DiscogsTokenStatus::NotConfigured => {
+                    BridgeDiscogsTokenStatus::NotConfigured
+                }
+                bae_core::config::DiscogsTokenStatus::Valid => BridgeDiscogsTokenStatus::Valid,
+                bae_core::config::DiscogsTokenStatus::Unvalidated => {
+                    BridgeDiscogsTokenStatus::Unvalidated
+                }
+                bae_core::config::DiscogsTokenStatus::Rejected => {
+                    BridgeDiscogsTokenStatus::Rejected
+                }
+            },
+            sync: inner
+                .cloud_home
+                .provider
+                .as_ref()
+                .map(|provider| BridgeSyncConfig {
+                    provider: BridgeSyncProvider::from_core(provider, &inner.cloud_home),
+                    cloud_account_display,
+                }),
+        }
+    }
+}
+
+impl BridgeSyncProvider {
+    /// Map a connected provider + its cloud-home settings to the bridge enum,
+    /// carrying only the fields that provider uses. `CloudHomeConfig` is coven's
+    /// (external crate) type, so its fields stay dotted reads.
+    fn from_core(
+        provider: &bae_core::config::CloudProvider,
+        cloud_home: &bae_core::config::CloudHomeConfig,
+    ) -> Self {
+        use bae_core::config::CloudProvider;
+        match provider {
+            CloudProvider::S3 => BridgeSyncProvider::S3 {
+                bucket: cloud_home.s3_bucket.clone(),
+                region: cloud_home.s3_region.clone(),
+                endpoint: cloud_home.s3_endpoint.clone(),
+            },
+            CloudProvider::GoogleDrive => BridgeSyncProvider::GoogleDrive,
+            CloudProvider::Dropbox => BridgeSyncProvider::Dropbox,
+            CloudProvider::OneDrive => BridgeSyncProvider::OneDrive,
+            CloudProvider::CloudKit => BridgeSyncProvider::CloudKit,
+        }
     }
 }

--- a/bae-bridge/src/cloudkit.rs
+++ b/bae-bridge/src/cloudkit.rs
@@ -120,7 +120,7 @@ impl coven::CloudKitOps for CloudKitDriverAdapter {
     ) -> Result<coven::CloudKitShare, coven::CloudHomeError> {
         self.driver
             .grant_share(member_pubkey.to_string())
-            .map(bridge_share_to_coven)
+            .map(BridgeCloudKitShare::into_core)
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 
@@ -133,7 +133,7 @@ impl coven::CloudKitOps for CloudKitDriverAdapter {
     fn accept_share(&self, share_url: &str) -> Result<coven::CloudKitShare, coven::CloudHomeError> {
         self.driver
             .accept_share(share_url.to_string())
-            .map(bridge_share_to_coven)
+            .map(BridgeCloudKitShare::into_core)
             .map_err(cloudkit_err_to_cloud_home_err)
     }
 }
@@ -148,11 +148,18 @@ fn scope_fields(scope: &coven::CloudKitScope) -> (Option<String>, Option<String>
     }
 }
 
-fn bridge_share_to_coven(share: BridgeCloudKitShare) -> coven::CloudKitShare {
-    coven::CloudKitShare {
-        share_url: share.share_url,
-        owner_name: share.owner_name,
-        zone_name: share.zone_name,
+impl BridgeCloudKitShare {
+    fn into_core(self) -> coven::CloudKitShare {
+        let BridgeCloudKitShare {
+            share_url,
+            owner_name,
+            zone_name,
+        } = self;
+        coven::CloudKitShare {
+            share_url,
+            owner_name,
+            zone_name,
+        }
     }
 }
 

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -8,9 +8,6 @@ use bae_core::playback::QueueEntryId;
 use bae_core::signals::ExtractionSource;
 use tracing::info;
 
-use crate::bridge_utils::build_bridge_config;
-#[cfg(feature = "oauth-providers")]
-use crate::types::bridge_cloud_provider_to_core;
 #[cfg(feature = "oauth-providers")]
 use crate::types::BridgeCloudProvider;
 #[cfg(feature = "desktop")]
@@ -20,21 +17,20 @@ use crate::types::BridgeHomeStorage;
 #[cfg(feature = "desktop")]
 use crate::types::BridgeRemoteCover;
 use crate::types::{
-    bridge_composer_sort_to_core, bridge_home_storage_to_core, bridge_sort_to_core, BridgeAlbum,
-    BridgeAlbumDetail, BridgeAlbumSearchResult, BridgeComposerDetail, BridgeComposerSortCriterion,
-    BridgeComposerSummary, BridgeComposerWorkGroup, BridgeConfig, BridgeCoverSelection,
-    BridgeError, BridgeFile, BridgeGalleryItem, BridgeGallerySource, BridgeMetadataSource,
-    BridgeQueueSnapshot, BridgeRelease, BridgeReleaseRoleSummary, BridgeReleaseSummary,
-    BridgeRepeatMode, BridgeSaveSyncConfig, BridgeSearchResults, BridgeSortCriterion,
-    BridgeStorageFilter, BridgeStoragePage, BridgeStorageRow, BridgeStorageSort,
-    BridgeSyncStatusSnapshot, BridgeTrack, BridgeTrackGroup, BridgeTrackRoleSummary,
-    BridgeTrackSearchResult, BridgeWorkDetail, BridgeWorkReleaseSummary, BridgeWorkSummary,
-    BridgeWorkTrackSummary,
+    BridgeAlbum, BridgeAlbumDetail, BridgeAlbumSearchResult, BridgeComposerDetail,
+    BridgeComposerSortCriterion, BridgeComposerSummary, BridgeComposerWorkGroup, BridgeConfig,
+    BridgeCoverSelection, BridgeError, BridgeFile, BridgeGalleryItem, BridgeGallerySource,
+    BridgeMetadataSource, BridgeQueueSnapshot, BridgeRelease, BridgeReleaseRoleSummary,
+    BridgeReleaseSummary, BridgeRepeatMode, BridgeSaveSyncConfig, BridgeSearchResults,
+    BridgeSortCriterion, BridgeStorageFilter, BridgeStoragePage, BridgeStorageRow,
+    BridgeStorageSort, BridgeSyncStatusSnapshot, BridgeTrack, BridgeTrackGroup,
+    BridgeTrackRoleSummary, BridgeTrackSearchResult, BridgeWorkDetail, BridgeWorkReleaseSummary,
+    BridgeWorkSummary, BridgeWorkTrackSummary,
 };
 #[cfg(feature = "desktop")]
 use crate::types::{
-    bridge_storage_mode_to_core, BridgeImportCandidateSnapshot, BridgeImportCandidatesSnapshot,
-    BridgeMcpServerStatus, BridgeStorageMode,
+    BridgeImportCandidateSnapshot, BridgeImportCandidatesSnapshot, BridgeMcpServerStatus,
+    BridgeStorageMode,
 };
 
 #[derive(uniffi::Object)]
@@ -72,8 +68,10 @@ impl AppHandle {
         offset: u64,
         limit: u64,
     ) -> Result<Vec<BridgeAlbum>, BridgeError> {
-        let sort: Vec<bae_core::db::AlbumSortCriterion> =
-            sort_criteria.iter().map(bridge_sort_to_core).collect();
+        let sort: Vec<bae_core::db::AlbumSortCriterion> = sort_criteria
+            .into_iter()
+            .map(BridgeSortCriterion::into_core)
+            .collect();
         let albums = self
             .services
             .library_manager()
@@ -81,7 +79,7 @@ impl AppHandle {
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))?;
 
-        Ok(albums.into_iter().map(convert_album_summary).collect())
+        Ok(albums.into_iter().map(BridgeAlbum::from_core).collect())
     }
 
     /// 0-based position of `album_id` under the given sort, matching
@@ -93,8 +91,10 @@ impl AppHandle {
         sort_criteria: Vec<BridgeSortCriterion>,
         album_id: String,
     ) -> Result<Option<u64>, BridgeError> {
-        let sort: Vec<bae_core::db::AlbumSortCriterion> =
-            sort_criteria.iter().map(bridge_sort_to_core).collect();
+        let sort: Vec<bae_core::db::AlbumSortCriterion> = sort_criteria
+            .into_iter()
+            .map(BridgeSortCriterion::into_core)
+            .collect();
         self.services
             .library_manager()
             .get_album_index(&sort, &album_id)
@@ -124,7 +124,7 @@ impl AppHandle {
         offset: u64,
         limit: u64,
     ) -> Result<Vec<BridgeComposerSummary>, BridgeError> {
-        let sort = bridge_composer_sort_to_core(&sort_criterion);
+        let sort = sort_criterion.into_core();
         let composers = self
             .services
             .library_manager()
@@ -133,7 +133,7 @@ impl AppHandle {
             .map_err(|e| BridgeError::database(format!("{e}")))?;
         Ok(composers
             .into_iter()
-            .map(convert_composer_summary)
+            .map(BridgeComposerSummary::from_core)
             .collect())
     }
 
@@ -147,7 +147,7 @@ impl AppHandle {
             .get_composer_detail(&artist_id)
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))?;
-        Ok(detail.map(convert_composer_detail))
+        Ok(detail.map(BridgeComposerDetail::from_core))
     }
 
     pub async fn get_work_detail(
@@ -160,7 +160,7 @@ impl AppHandle {
             .get_work_detail(&work_id)
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))?;
-        Ok(detail.map(convert_work_detail))
+        Ok(detail.map(BridgeWorkDetail::from_core))
     }
 
     /// Filesystem path for the user's own external file behind a library file
@@ -193,7 +193,7 @@ impl AppHandle {
                 id: album_id.to_string(),
             })?;
 
-        Ok(convert_album_detail(detail))
+        Ok(BridgeAlbumDetail::from_core(detail))
     }
 
     /// Fat release detail (tracks, files, gallery) for the album-detail
@@ -208,7 +208,7 @@ impl AppHandle {
             .find_release_detail(&release_id)
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))?;
-        Ok(detail.map(convert_release_detail))
+        Ok(detail.map(BridgeRelease::from_core))
     }
 
     /// One page of the Storage Manager list, pre-sorted and
@@ -221,8 +221,8 @@ impl AppHandle {
         offset: u64,
         limit: u64,
     ) -> Result<BridgeStoragePage, BridgeError> {
-        let core_sort = crate::types::bridge_storage_sort_to_core(&sort);
-        let core_filter = crate::types::bridge_storage_filter_to_core(filter);
+        let core_sort = sort.into_core();
+        let core_filter = filter.into_core();
         let page = self
             .services
             .library_manager()
@@ -230,16 +230,13 @@ impl AppHandle {
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))?;
 
-        Ok(BridgeStoragePage {
-            rows: page.rows.into_iter().map(convert_storage_row).collect(),
-            total_count: page.total_count,
-        })
+        Ok(BridgeStoragePage::from_core(page))
     }
 
     /// Count of storage rows matching `filter`. Matches
     /// `storage_page`'s `total_count` for the same filter.
     pub async fn storage_count(&self, filter: BridgeStorageFilter) -> Result<u64, BridgeError> {
-        let core_filter = crate::types::bridge_storage_filter_to_core(filter);
+        let core_filter = filter.into_core();
         self.services
             .library_manager()
             .get_storage_count(core_filter)
@@ -258,35 +255,22 @@ impl AppHandle {
             albums: results
                 .albums
                 .into_iter()
-                .map(|a| BridgeAlbumSearchResult {
-                    id: a.id,
-                    title: a.title,
-                    year: a.year,
-                    artist_name: a.artist_name,
-                    cover: a.cover.map(crate::types::BridgeImageRef::from_core),
-                })
+                .map(BridgeAlbumSearchResult::from_core)
                 .collect(),
             tracks: results
                 .tracks
                 .into_iter()
-                .map(|t| BridgeTrackSearchResult {
-                    id: t.id,
-                    title: t.title,
-                    duration_ms: t.duration_ms,
-                    album_id: t.album_id,
-                    album_title: t.album_title,
-                    artist_name: t.artist_name,
-                })
+                .map(BridgeTrackSearchResult::from_core)
                 .collect(),
             composers: results
                 .composers
                 .into_iter()
-                .map(convert_composer_summary)
+                .map(BridgeComposerSummary::from_core)
                 .collect(),
             works: results
                 .works
                 .into_iter()
-                .map(convert_work_summary)
+                .map(BridgeWorkSummary::from_core)
                 .collect(),
         })
     }
@@ -360,7 +344,7 @@ impl AppHandle {
     }
 
     pub fn set_repeat_mode(&self, mode: BridgeRepeatMode) {
-        let core_mode = mode.to_core();
+        let core_mode = mode.into_core();
         self.services.playback().set_repeat_mode(core_mode);
     }
 
@@ -421,7 +405,7 @@ impl AppHandle {
             .get_queue_snapshot()
             .await
             .map_err(BridgeError::internal)?;
-        Ok(convert_queue_snapshot(snapshot))
+        Ok(BridgeQueueSnapshot::from_core(snapshot))
     }
 
     /// Resolve a list of IDs (album or track) to track IDs.
@@ -469,7 +453,7 @@ impl AppHandle {
     // =========================================================================
 
     pub fn get_config(&self) -> BridgeConfig {
-        build_bridge_config(&self.services.library_manager().get_config())
+        BridgeConfig::from_core(&self.services.library_manager().get_config())
     }
 
     pub fn set_pause_between_sides(&self, enabled: bool) -> Result<(), BridgeError> {
@@ -486,7 +470,7 @@ impl AppHandle {
     ) -> Result<(), BridgeError> {
         self.services
             .library_manager()
-            .set_export_location(crate::bridge_utils::core_export_location(location))
+            .set_export_location(crate::types::BridgeExportLocation::into_core(location))
             .map_err(BridgeError::config)
     }
 
@@ -507,7 +491,7 @@ impl AppHandle {
             .set_export_presets(
                 presets
                     .into_iter()
-                    .map(crate::bridge_utils::core_export_preset)
+                    .map(crate::types::BridgeExportPreset::into_core)
                     .collect(),
             )
             .map_err(BridgeError::config)
@@ -519,7 +503,7 @@ impl AppHandle {
     ) -> Result<(), BridgeError> {
         self.services
             .library_manager()
-            .set_default_track_export_selection(crate::bridge_utils::core_export_selection(
+            .set_default_track_export_selection(crate::types::BridgeExportSelection::into_core(
                 selection,
             ))
             .map_err(BridgeError::config)
@@ -531,7 +515,7 @@ impl AppHandle {
     ) -> Result<(), BridgeError> {
         self.services
             .library_manager()
-            .set_default_release_export_selection(crate::bridge_utils::core_export_selection(
+            .set_default_release_export_selection(crate::types::BridgeExportSelection::into_core(
                 selection,
             ))
             .map_err(BridgeError::config)
@@ -592,7 +576,7 @@ impl AppHandle {
             }
             BridgeCoverSelection::RemoteCover { selection } => CoverSelection::RemoteCover {
                 url: selection.url,
-                source: selection.source.to_core(),
+                source: selection.source.into_core(),
             },
         };
 
@@ -685,7 +669,7 @@ impl AppHandle {
                 key_prefix: config_data.key_prefix,
                 access_key: config_data.access_key,
                 secret_key: config_data.secret_key,
-                storage: bridge_home_storage_to_core(config_data.storage),
+                storage: crate::types::BridgeHomeStorage::into_core(config_data.storage),
             })
             .await
             .map_err(BridgeError::config)
@@ -727,7 +711,7 @@ impl AppHandle {
             .get_members()
             .await
             .map_err(BridgeError::internal)?;
-        Ok(crate::types::bridge_membership(membership))
+        Ok(crate::types::BridgeMembership::from_core(membership))
     }
 
     /// Approve a joining device by its public key (from its join-request code),
@@ -776,7 +760,7 @@ impl AppHandle {
     }
 
     pub fn get_sync_status(&self) -> BridgeSyncStatusSnapshot {
-        convert_sync_status_snapshot(self.services.get_sync_status())
+        crate::types::BridgeSyncStatusSnapshot::from_core(self.services.get_sync_status())
     }
 
     /// The current cloud outbox processing snapshot. Outbox invalidations tell
@@ -790,7 +774,7 @@ impl AppHandle {
             .outbox_snapshot()
             .await
             .map_err(BridgeError::internal)?;
-        Ok(convert_outbox_snapshot(snapshot))
+        Ok(crate::types::BridgeOutboxSnapshot::from_core(snapshot))
     }
 
     /// Retry failed uploads now (clears their backoff and kicks the sync loop).
@@ -838,7 +822,9 @@ impl AppHandle {
     /// The current download-queue snapshot. Download invalidations tell the
     /// Downloads pane to read it again.
     pub fn get_download_snapshot(&self) -> crate::types::BridgeDownloadSnapshot {
-        convert_download_snapshot(self.services.library_manager().download_snapshot())
+        crate::types::BridgeDownloadSnapshot::from_core(
+            self.services.library_manager().download_snapshot(),
+        )
     }
 
     /// Enqueue releases to pin for offline. They join the in-memory serial
@@ -876,7 +862,9 @@ impl AppHandle {
     /// The current export-queue snapshot. Export invalidations tell the
     /// Exporting pane to read it again.
     pub fn get_export_snapshot(&self) -> crate::types::BridgeExportSnapshot {
-        convert_export_snapshot(self.services.library_manager().export_snapshot())
+        crate::types::BridgeExportSnapshot::from_core(
+            self.services.library_manager().export_snapshot(),
+        )
     }
 
     /// Enqueue a release export to `target_dir`. It joins
@@ -894,7 +882,7 @@ impl AppHandle {
             .enqueue_export(
                 &release_id,
                 std::path::PathBuf::from(target_dir),
-                crate::bridge_utils::core_export_selection(selection),
+                crate::types::BridgeExportSelection::into_core(selection),
             )
             .await
             .map_err(BridgeError::export)
@@ -920,30 +908,35 @@ impl AppHandle {
 }
 
 #[cfg(feature = "desktop")]
-fn bridge_mcp_status(status: bae_desktop::McpServerStatus) -> BridgeMcpServerStatus {
-    match status {
-        bae_desktop::McpServerStatus::Disabled => BridgeMcpServerStatus::Disabled,
-        bae_desktop::McpServerStatus::Running { url } => BridgeMcpServerStatus::Running { url },
-        bae_desktop::McpServerStatus::Error { error } => BridgeMcpServerStatus::Error {
-            error: bridge_mcp_error(error),
-        },
+impl BridgeMcpServerStatus {
+    fn from_core(status: bae_desktop::McpServerStatus) -> Self {
+        match status {
+            bae_desktop::McpServerStatus::Disabled => BridgeMcpServerStatus::Disabled,
+            bae_desktop::McpServerStatus::Running { url } => BridgeMcpServerStatus::Running { url },
+            bae_desktop::McpServerStatus::Error { error } => BridgeMcpServerStatus::Error {
+                error: crate::types::BridgeMcpServerError::from_core(error),
+            },
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-fn bridge_mcp_error(error: bae_desktop::McpServerError) -> crate::types::BridgeMcpServerError {
-    match error {
-        bae_desktop::McpServerError::InvalidConfig { detail } => {
-            crate::types::BridgeMcpServerError::InvalidConfig { detail }
-        }
-        bae_desktop::McpServerError::TokenUnavailable { detail } => {
-            crate::types::BridgeMcpServerError::TokenUnavailable { detail }
-        }
-        bae_desktop::McpServerError::BindFailed { detail } => {
-            crate::types::BridgeMcpServerError::BindFailed { detail }
-        }
-        bae_desktop::McpServerError::ServerFailed { detail } => {
-            crate::types::BridgeMcpServerError::ServerFailed { detail }
+impl crate::types::BridgeMcpServerError {
+    fn from_core(error: bae_desktop::McpServerError) -> Self {
+        use crate::types::BridgeMcpServerError;
+        match error {
+            bae_desktop::McpServerError::InvalidConfig { detail } => {
+                BridgeMcpServerError::InvalidConfig { detail }
+            }
+            bae_desktop::McpServerError::TokenUnavailable { detail } => {
+                BridgeMcpServerError::TokenUnavailable { detail }
+            }
+            bae_desktop::McpServerError::BindFailed { detail } => {
+                BridgeMcpServerError::BindFailed { detail }
+            }
+            bae_desktop::McpServerError::ServerFailed { detail } => {
+                BridgeMcpServerError::ServerFailed { detail }
+            }
         }
     }
 }
@@ -1009,7 +1002,7 @@ impl AppHandle {
 #[uniffi::export(async_runtime = "tokio")]
 impl AppHandle {
     pub async fn use_cloudkit(&self, storage: BridgeHomeStorage) -> Result<(), BridgeError> {
-        let storage = bridge_home_storage_to_core(storage);
+        let storage = crate::types::BridgeHomeStorage::into_core(storage);
         self.services
             .library_manager()
             .use_cloudkit(storage)
@@ -1033,8 +1026,8 @@ impl AppHandle {
         // OAuth + cloud-folder setup then starts sync. Cancellation (the Swift
         // Task dropping this future) tears down the OAuth listener via coven's
         // own drop guard.
-        let core_provider = bridge_cloud_provider_to_core(provider);
-        let storage = bridge_home_storage_to_core(storage);
+        let core_provider = crate::types::BridgeCloudProvider::into_core(provider);
+        let storage = crate::types::BridgeHomeStorage::into_core(storage);
         self.services
             .library_manager()
             .sign_in_cloud_provider(core_provider, storage)
@@ -1057,7 +1050,7 @@ impl AppHandle {
     }
 
     pub fn get_mcp_server_status(&self) -> BridgeMcpServerStatus {
-        bridge_mcp_status(self.app.mcp_server_status())
+        BridgeMcpServerStatus::from_core(self.app.mcp_server_status())
     }
 
     pub fn get_mcp_token(&self) -> Result<String, BridgeError> {
@@ -1091,7 +1084,7 @@ impl AppHandle {
             .import()
             .save_discogs_token(&token)
             .await
-            .map(BridgeDiscogsSaveOutcome::from)
+            .map(BridgeDiscogsSaveOutcome::from_core)
             .map_err(BridgeError::config)
     }
 
@@ -1160,7 +1153,7 @@ impl AppHandle {
     ) {
         self.services
             .identify()
-            .toggle_signal(&candidate_key, signal.to_core());
+            .toggle_signal(&candidate_key, signal.into_core());
     }
 
     /// Re-run a candidate's lookups from the toolbar. The identify driver
@@ -1188,7 +1181,7 @@ impl AppHandle {
         release_id: String,
         identity_choice: crate::types::BridgeIdentityChoice,
     ) -> Result<String, BridgeError> {
-        let core_choice = identity_choice.to_core();
+        let core_choice = identity_choice.into_core();
         let library_manager = self.services.library_manager();
         library_manager
             .re_identify_release(&release_id, core_choice)
@@ -1212,13 +1205,15 @@ impl AppHandle {
     }
 
     pub fn get_import_candidates(&self) -> BridgeImportCandidatesSnapshot {
-        convert_import_candidates_snapshot(self.services.get_import_candidates())
+        crate::types::BridgeImportCandidatesSnapshot::from_core(
+            self.services.get_import_candidates(),
+        )
     }
 
     pub fn get_candidate(&self, key: String) -> Option<BridgeImportCandidateSnapshot> {
         self.services
             .get_candidate(&key)
-            .map(convert_import_candidate_snapshot)
+            .map(crate::types::BridgeImportCandidateSnapshot::from_core)
     }
 
     pub fn add_watched_folder(&self, path: String) -> Result<(), BridgeError> {
@@ -1272,7 +1267,7 @@ impl AppHandle {
                 SearchQuery::General {
                     artist,
                     album,
-                    source: source.to_core(),
+                    source: source.into_core(),
                 },
                 crate::types::BridgeSearchQueryKind::General,
                 source,
@@ -1283,7 +1278,7 @@ impl AppHandle {
             } => (
                 SearchQuery::CatalogNumber {
                     catalog_number,
-                    source: source.to_core(),
+                    source: source.into_core(),
                 },
                 crate::types::BridgeSearchQueryKind::CatalogNumber,
                 source,
@@ -1291,7 +1286,7 @@ impl AppHandle {
             crate::types::BridgeSearchQuery::Barcode { barcode, source } => (
                 SearchQuery::Barcode {
                     barcode,
-                    source: source.to_core(),
+                    source: source.into_core(),
                 },
                 crate::types::BridgeSearchQueryKind::Barcode,
                 source,
@@ -1305,20 +1300,11 @@ impl AppHandle {
             .await
             .map_err(BridgeError::import)?;
 
-        Ok(crate::types::BridgeCandidateSearchResults {
+        Ok(crate::types::BridgeCandidateSearchResults::from_core(
+            grouped,
             tab,
-            source: bridge_source,
-            groups: grouped
-                .groups
-                .into_iter()
-                .map(crate::types::release_group_to_bridge)
-                .collect(),
-            statuses: grouped
-                .statuses
-                .into_iter()
-                .map(crate::types::library_status_to_bridge)
-                .collect(),
-        })
+            bridge_source,
+        ))
     }
 
     pub async fn is_source_folder_name_imported(&self, name: String) -> Result<bool, BridgeError> {
@@ -1342,9 +1328,9 @@ impl AppHandle {
         identity_choice: crate::types::BridgeIdentityChoice,
         user_edit: Option<crate::types::BridgeReleaseUserEdit>,
     ) -> Result<(), BridgeError> {
-        let cover = selected_cover.map(crate::types::bridge_cover_to_import);
+        let cover = selected_cover.map(crate::types::BridgeCoverSelection::into_core);
 
-        let user_edit = user_edit.map(crate::types::release_user_edit_from_bridge);
+        let user_edit = user_edit.map(crate::types::BridgeReleaseUserEdit::into_core);
 
         self.services
             .import()
@@ -1352,9 +1338,9 @@ impl AppHandle {
                 &candidate_key,
                 std::path::PathBuf::from(&folder_path),
                 cover,
-                bridge_storage_mode_to_core(storage_mode),
+                storage_mode.into_core(),
                 pin,
-                identity_choice.to_core(),
+                identity_choice.into_core(),
                 user_edit,
             )
             .map(|_| ())
@@ -1376,7 +1362,7 @@ impl AppHandle {
             .preview_file_tags_for_folder(std::path::PathBuf::from(&folder_path))
             .await
             .map_err(BridgeError::import)?;
-        Ok(crate::types::release_user_edit_to_bridge(edit))
+        Ok(crate::types::BridgeReleaseUserEdit::from_core(edit))
     }
 
     /// Apply a user-supplied metadata edit (from the edit-metadata sheet) to a
@@ -1387,7 +1373,7 @@ impl AppHandle {
         release_id: String,
         edit: crate::types::BridgeReleaseUserEdit,
     ) -> Result<(), BridgeError> {
-        let core_edit = crate::types::release_user_edit_from_bridge(edit);
+        let core_edit = crate::types::BridgeReleaseUserEdit::into_core(edit);
         self.services
             .library_manager()
             .apply_release_metadata_user_edit(&release_id, &core_edit)
@@ -1408,7 +1394,7 @@ impl AppHandle {
             .release_edit_seed(&release_id)
             .await
             .map_err(BridgeError::import)?;
-        Ok(crate::types::raw_release_edit_to_bridge(raw))
+        Ok(crate::types::BridgeRawReleaseEdit::from_core(raw))
     }
 
     /// Re-project a release's metadata from its `metadata_source` /
@@ -1427,7 +1413,7 @@ impl AppHandle {
             .reset_metadata_to_source(&release_id)
             .await
             .map_err(BridgeError::import)?;
-        Ok(crate::types::release_user_edit_to_bridge(edit))
+        Ok(crate::types::BridgeReleaseUserEdit::from_core(edit))
     }
 
     pub async fn prefetch_release(
@@ -1439,10 +1425,10 @@ impl AppHandle {
         let detail = self
             .services
             .import()
-            .prefetch_release(&release_id, source.to_core())
+            .prefetch_release(&release_id, source.into_core())
             .await
             .map_err(BridgeError::import)?;
-        Ok(crate::types::release_detail_to_bridge(
+        Ok(crate::types::BridgeReleaseDetail::from_core(
             detail,
             local_track_count,
         ))
@@ -1460,7 +1446,7 @@ impl AppHandle {
             .map_err(BridgeError::import)?;
         Ok(covers
             .into_iter()
-            .map(crate::types::remote_cover_data_to_bridge)
+            .map(crate::types::BridgeRemoteCover::from_core)
             .collect())
     }
 
@@ -1495,7 +1481,7 @@ impl AppHandle {
             .export_track(
                 &track_id,
                 std::path::Path::new(&output_path),
-                crate::bridge_utils::core_export_selection(selection),
+                crate::types::BridgeExportSelection::into_core(selection),
             )
             .await
             .map_err(|e| BridgeError::export(format!("{e}")))
@@ -1524,7 +1510,7 @@ impl AppHandle {
             .library_manager()
             .export_track_extension(
                 &track_id,
-                crate::bridge_utils::core_export_selection(selection),
+                crate::types::BridgeExportSelection::into_core(selection),
             )
             .await
             .map_err(|e| BridgeError::export(format!("{e}")))
@@ -1573,351 +1559,559 @@ async fn pump_ui_events(
     }
 }
 
-/// Translate bae-core's outbox snapshot to its bridge mirror. `last_error` is
-/// `last_error` is lifted out of the `Failed` variant into a flat field
-/// beside the three-state enum so the UI doesn't switch on associated data.
+impl crate::types::BridgeUploadReleaseGroup {
+    fn from_core(g: bae_core::library::UploadReleaseGroup) -> Self {
+        let bae_core::library::UploadReleaseGroup {
+            release_id,
+            display_title,
+            file_count,
+            progress,
+        } = g;
+        Self {
+            release_id,
+            display_title,
+            file_count,
+            progress: crate::types::BridgeUploadProgress::from_core(progress),
+        }
+    }
+}
+
+impl crate::types::BridgeDeleteOp {
+    fn from_core(op: bae_core::library::DeleteOp) -> Self {
+        let bae_core::library::DeleteOp {
+            id,
+            cloud_key,
+            created_at,
+        } = op;
+        Self {
+            id,
+            cloud_key,
+            created_at,
+        }
+    }
+}
+
+/// Translate bae-core's outbox snapshot to its bridge mirror.
 ///
 /// Ungated (unlike `convert_ui_event`): `get_outbox_snapshot` lives in the
 /// ungated `AppHandle` impl block, so this helper must exist on every target it
 /// can be called from. It references only cross-platform types.
-fn convert_outbox_snapshot(
-    snapshot: bae_core::library::OutboxSnapshot,
-) -> crate::types::BridgeOutboxSnapshot {
-    use crate::types::{BridgeDeleteOp, BridgeOutboxSnapshot, BridgeUploadReleaseGroup};
-
-    let per_release = snapshot
-        .per_release_progress()
-        .into_iter()
-        .map(|(release_id, progress)| (release_id, convert_upload_progress(progress)))
-        .collect();
-    let pending_deletes = snapshot.pending_delete_count();
-
-    let upload_groups: Vec<_> = snapshot
-        .upload_groups
-        .into_iter()
-        .map(|g| BridgeUploadReleaseGroup {
-            release_id: g.release_id,
-            display_title: g.display_title,
-            file_count: g.file_count,
-            progress: convert_upload_progress(g.progress),
-        })
-        .collect();
-
-    let deletes: Vec<_> = snapshot
-        .deletes
-        .into_iter()
-        .map(|op| BridgeDeleteOp {
-            id: op.id,
-            cloud_key: op.cloud_key,
-            created_at: op.created_at,
-        })
-        .collect();
-
-    BridgeOutboxSnapshot {
-        upload_groups,
-        deletes,
-        per_release,
-        total: convert_upload_progress(snapshot.total),
-        active_bytes_total: snapshot.active_bytes_total,
-        pending_deletes,
-        paused: snapshot.paused,
-        throughput_bps: snapshot.throughput_bps,
-        eta_seconds: snapshot.eta_seconds,
-    }
-}
-
-fn convert_upload_progress(
-    p: bae_core::library::UploadProgress,
-) -> crate::types::BridgeUploadProgress {
-    crate::types::BridgeUploadProgress {
-        queued: p.queued,
-        active: p.active,
-        failed: p.failed,
-        bytes_done: p.bytes_done,
-        bytes_total: p.bytes_total,
-        activity: p.activity().map(convert_upload_activity),
-    }
-}
-
-fn convert_upload_activity(
-    a: bae_core::library::UploadActivity,
-) -> crate::types::BridgeUploadActivity {
-    use crate::types::BridgeUploadActivity;
-    use bae_core::library::UploadActivity;
-    match a {
-        UploadActivity::Uploading => BridgeUploadActivity::Uploading,
-        UploadActivity::Retrying => BridgeUploadActivity::Retrying,
-        UploadActivity::Queued => BridgeUploadActivity::Queued,
-    }
-}
-
-fn convert_download_snapshot(
-    snapshot: bae_core::library::DownloadSnapshot,
-) -> crate::types::BridgeDownloadSnapshot {
-    use crate::types::{
-        BridgeDownloadOp, BridgeDownloadSnapshot, BridgeDownloadState,
-        BridgeDownloadTransferProgress,
-    };
-    use bae_core::library::DownloadState;
-
-    let downloads = snapshot
-        .ops
-        .into_iter()
-        .map(|op| {
-            let state = match op.state {
-                DownloadState::Queued => BridgeDownloadState::Queued,
-                DownloadState::Active { progress } => BridgeDownloadState::Active {
-                    progress: BridgeDownloadTransferProgress {
-                        bytes_done: progress.bytes_done,
-                        bytes_total: progress.bytes_total,
-                        fraction: progress.fraction,
-                    },
-                },
-                DownloadState::Failed { error } => BridgeDownloadState::Failed { error },
-            };
-            BridgeDownloadOp {
-                release_id: op.release_id,
-                title: op.title,
-                file_count: op.file_count,
-                total_size: op.total_size,
-                created_at: op.created_at,
-                state,
-            }
-        })
-        .collect();
-
-    BridgeDownloadSnapshot {
-        downloads,
-        total: convert_download_progress(snapshot.total),
-        paused: snapshot.paused,
-    }
-}
-
-fn convert_download_progress(
-    p: bae_core::library::DownloadProgress,
-) -> crate::types::BridgeDownloadProgress {
-    crate::types::BridgeDownloadProgress {
-        queued: p.queued,
-        active: p.active,
-        failed: p.failed,
-    }
-}
-
-fn convert_export_snapshot(
-    snapshot: bae_core::library::ExportSnapshot,
-) -> crate::types::BridgeExportSnapshot {
-    use crate::types::{BridgeExportOp, BridgeExportSnapshot, BridgeExportState};
-    use bae_core::library::ExportState;
-
-    let exports = snapshot
-        .ops
-        .into_iter()
-        .map(|op| {
-            let state = match op.state {
-                ExportState::Queued => BridgeExportState::Queued,
-                ExportState::Active { progress } => BridgeExportState::Active { percent: progress },
-                ExportState::Failed { error } => BridgeExportState::Failed { error },
-            };
-            BridgeExportOp {
-                release_id: op.release_id,
-                target_dir: op.payload.target_dir.to_string_lossy().to_string(),
-                title: op.title,
-                file_count: op.file_count,
-                total_size: op.total_size,
-                created_at: op.created_at,
-                state,
-            }
-        })
-        .collect();
-
-    BridgeExportSnapshot {
-        exports,
-        total: convert_export_progress(snapshot.total),
-        paused: snapshot.paused,
-    }
-}
-
-fn convert_export_progress(
-    p: bae_core::library::ExportProgress,
-) -> crate::types::BridgeExportProgress {
-    crate::types::BridgeExportProgress {
-        queued: p.queued,
-        active: p.active,
-        failed: p.failed,
-    }
-}
-
-fn convert_queue_entry(i: bae_core::queue::QueueItem) -> crate::types::BridgeQueueEntry {
-    crate::types::BridgeQueueEntry {
-        entry_id: i.entry_id,
-        track_id: i.track_id,
-        title: i.title,
-        artist_names: i.artist_names,
-        duration_ms: i.duration_ms,
-        album_title: i.album_title,
-        cover_image_id: i.cover_image_id,
-    }
-}
-
-fn convert_playback_context(
-    context: bae_core::queue::ResolvedContext,
-) -> crate::types::BridgePlaybackContext {
-    crate::types::BridgePlaybackContext {
-        kind: crate::types::BridgePlaybackSourceKind::from_core(&context.source),
-        shuffled: context.shuffled,
-        upcoming: context
-            .upcoming
+impl crate::types::BridgeOutboxSnapshot {
+    fn from_core(snapshot: bae_core::library::OutboxSnapshot) -> Self {
+        // Derived aggregates borrow `&snapshot`; compute them before the move.
+        let per_release = snapshot
+            .per_release_progress()
             .into_iter()
-            .map(convert_queue_entry)
-            .collect(),
+            .map(|(release_id, progress)| {
+                (
+                    release_id,
+                    crate::types::BridgeUploadProgress::from_core(progress),
+                )
+            })
+            .collect();
+        let pending_deletes = snapshot.pending_delete_count();
+
+        let bae_core::library::OutboxSnapshot {
+            upload_groups,
+            deletes,
+            total,
+            active_bytes_total,
+            paused,
+            throughput_bps,
+            eta_seconds,
+        } = snapshot;
+
+        crate::types::BridgeOutboxSnapshot {
+            upload_groups: upload_groups
+                .into_iter()
+                .map(crate::types::BridgeUploadReleaseGroup::from_core)
+                .collect(),
+            deletes: deletes
+                .into_iter()
+                .map(crate::types::BridgeDeleteOp::from_core)
+                .collect(),
+            per_release,
+            total: crate::types::BridgeUploadProgress::from_core(total),
+            active_bytes_total,
+            pending_deletes,
+            paused,
+            throughput_bps,
+            eta_seconds,
+        }
     }
 }
 
-fn convert_queue_snapshot(
-    snapshot: bae_core::queue::ResolvedQueueSnapshot,
-) -> crate::types::BridgeQueueSnapshot {
-    crate::types::BridgeQueueSnapshot {
-        manual: snapshot
-            .manual
-            .into_iter()
-            .map(convert_queue_entry)
-            .collect(),
-        context: snapshot.context.map(convert_playback_context),
-        has_next: snapshot.has_next,
-        has_previous: snapshot.has_previous,
+impl crate::types::BridgeUploadProgress {
+    fn from_core(p: bae_core::library::UploadProgress) -> Self {
+        // `activity()` borrows `&p`; compute it before destructuring `p`.
+        let activity = p
+            .activity()
+            .map(crate::types::BridgeUploadActivity::from_core);
+        let bae_core::library::UploadProgress {
+            queued,
+            active,
+            failed,
+            bytes_done,
+            bytes_total,
+        } = p;
+        crate::types::BridgeUploadProgress {
+            queued,
+            active,
+            failed,
+            bytes_done,
+            bytes_total,
+            activity,
+        }
     }
 }
 
-fn convert_sync_status_snapshot(
-    snapshot: bae_core::library::SyncStatusSnapshot,
-) -> crate::types::BridgeSyncStatusSnapshot {
-    crate::types::BridgeSyncStatusSnapshot {
-        error: snapshot.error.map(crate::types::bridge_error),
-        last_sync_time: snapshot.last_sync_time,
-        syncing: snapshot.syncing,
-        sync_ready: snapshot.sync_ready,
+impl crate::types::BridgeUploadActivity {
+    fn from_core(a: bae_core::library::UploadActivity) -> Self {
+        use crate::types::BridgeUploadActivity;
+        use bae_core::library::UploadActivity;
+        match a {
+            UploadActivity::Uploading => BridgeUploadActivity::Uploading,
+            UploadActivity::Retrying => BridgeUploadActivity::Retrying,
+            UploadActivity::Queued => BridgeUploadActivity::Queued,
+        }
+    }
+}
+
+impl crate::types::BridgeDownloadTransferProgress {
+    fn from_core(p: bae_core::library::DownloadTransferProgress) -> Self {
+        let bae_core::library::DownloadTransferProgress {
+            bytes_done,
+            bytes_total,
+            fraction,
+        } = p;
+        Self {
+            bytes_done,
+            bytes_total,
+            fraction,
+        }
+    }
+}
+
+impl crate::types::BridgeDownloadState {
+    fn from_core(state: bae_core::library::DownloadState) -> Self {
+        use crate::types::BridgeDownloadState;
+        use bae_core::library::DownloadState;
+        match state {
+            DownloadState::Queued => BridgeDownloadState::Queued,
+            DownloadState::Active { progress } => BridgeDownloadState::Active {
+                progress: crate::types::BridgeDownloadTransferProgress::from_core(progress),
+            },
+            DownloadState::Failed { error } => BridgeDownloadState::Failed { error },
+        }
+    }
+}
+
+impl crate::types::BridgeDownloadOp {
+    fn from_core(op: bae_core::library::DownloadOp) -> Self {
+        let bae_core::library::release_queue::ReleaseQueueOp {
+            release_id,
+            title,
+            file_count,
+            total_size,
+            created_at,
+            // Downloads carry no operation-specific payload.
+            payload: (),
+            state,
+        } = op;
+        crate::types::BridgeDownloadOp {
+            release_id,
+            title,
+            file_count,
+            total_size,
+            created_at,
+            state: crate::types::BridgeDownloadState::from_core(state),
+        }
+    }
+}
+
+/// Shared projection for the download and export queue snapshots, which are both
+/// aliases of the same generic `ReleaseQueueSnapshot`. Parameterized over the
+/// per-op and per-progress converters so each snapshot keeps its own named fields.
+fn project_release_queue_snapshot<Extra, Progress, Op, Prog>(
+    snapshot: bae_core::library::release_queue::ReleaseQueueSnapshot<Extra, Progress>,
+    op_from_core: impl Fn(bae_core::library::release_queue::ReleaseQueueOp<Extra, Progress>) -> Op,
+    progress_from_core: impl Fn(bae_core::library::release_queue::ReleaseQueueProgress) -> Prog,
+) -> (Vec<Op>, Prog, bool) {
+    let bae_core::library::release_queue::ReleaseQueueSnapshot { ops, total, paused } = snapshot;
+    (
+        ops.into_iter().map(op_from_core).collect(),
+        progress_from_core(total),
+        paused,
+    )
+}
+
+/// Shared projection for the download and export per-state counts, both aliases
+/// of the same generic `ReleaseQueueProgress`.
+fn release_queue_progress_counts(
+    p: bae_core::library::release_queue::ReleaseQueueProgress,
+) -> (u32, u32, u32) {
+    let bae_core::library::release_queue::ReleaseQueueProgress {
+        queued,
+        active,
+        failed,
+    } = p;
+    (queued, active, failed)
+}
+
+impl crate::types::BridgeDownloadSnapshot {
+    fn from_core(snapshot: bae_core::library::DownloadSnapshot) -> Self {
+        let (downloads, total, paused) = project_release_queue_snapshot(
+            snapshot,
+            crate::types::BridgeDownloadOp::from_core,
+            crate::types::BridgeDownloadProgress::from_core,
+        );
+        crate::types::BridgeDownloadSnapshot {
+            downloads,
+            total,
+            paused,
+        }
+    }
+}
+
+impl crate::types::BridgeDownloadProgress {
+    fn from_core(p: bae_core::library::DownloadProgress) -> Self {
+        let (queued, active, failed) = release_queue_progress_counts(p);
+        crate::types::BridgeDownloadProgress {
+            queued,
+            active,
+            failed,
+        }
+    }
+}
+
+impl crate::types::BridgeExportState {
+    fn from_core(state: bae_core::library::ExportState) -> Self {
+        use crate::types::BridgeExportState;
+        use bae_core::library::ExportState;
+        match state {
+            ExportState::Queued => BridgeExportState::Queued,
+            ExportState::Active { progress } => BridgeExportState::Active { percent: progress },
+            ExportState::Failed { error } => BridgeExportState::Failed { error },
+        }
+    }
+}
+
+impl crate::types::BridgeExportOp {
+    fn from_core(op: bae_core::library::ExportOp) -> Self {
+        let bae_core::library::release_queue::ReleaseQueueOp {
+            release_id,
+            title,
+            file_count,
+            total_size,
+            created_at,
+            payload,
+            state,
+        } = op;
+        let bae_core::library::export_snapshot::ExportRequest {
+            target_dir,
+            // The chosen codec/format selection drives the copy, not this row.
+            selection: _,
+        } = payload;
+        crate::types::BridgeExportOp {
+            release_id,
+            target_dir: target_dir.to_string_lossy().to_string(),
+            title,
+            file_count,
+            total_size,
+            created_at,
+            state: crate::types::BridgeExportState::from_core(state),
+        }
+    }
+}
+
+impl crate::types::BridgeExportSnapshot {
+    fn from_core(snapshot: bae_core::library::ExportSnapshot) -> Self {
+        let (exports, total, paused) = project_release_queue_snapshot(
+            snapshot,
+            crate::types::BridgeExportOp::from_core,
+            crate::types::BridgeExportProgress::from_core,
+        );
+        crate::types::BridgeExportSnapshot {
+            exports,
+            total,
+            paused,
+        }
+    }
+}
+
+impl crate::types::BridgeExportProgress {
+    fn from_core(p: bae_core::library::ExportProgress) -> Self {
+        let (queued, active, failed) = release_queue_progress_counts(p);
+        crate::types::BridgeExportProgress {
+            queued,
+            active,
+            failed,
+        }
+    }
+}
+
+impl crate::types::BridgeQueueEntry {
+    fn from_core(i: bae_core::queue::QueueItem) -> Self {
+        let bae_core::queue::QueueItem {
+            entry_id,
+            track_id,
+            title,
+            artist_names,
+            duration_ms,
+            album_title,
+            cover_image_id,
+        } = i;
+        crate::types::BridgeQueueEntry {
+            entry_id,
+            track_id,
+            title,
+            artist_names,
+            duration_ms,
+            album_title,
+            cover_image_id,
+        }
+    }
+}
+
+impl crate::types::BridgePlaybackContext {
+    fn from_core(context: bae_core::queue::ResolvedContext) -> Self {
+        let bae_core::queue::ResolvedContext {
+            source,
+            shuffled,
+            upcoming,
+        } = context;
+        crate::types::BridgePlaybackContext {
+            kind: crate::types::BridgePlaybackSourceKind::from_core(&source),
+            shuffled,
+            upcoming: upcoming
+                .into_iter()
+                .map(crate::types::BridgeQueueEntry::from_core)
+                .collect(),
+        }
+    }
+}
+
+impl crate::types::BridgeQueueSnapshot {
+    fn from_core(snapshot: bae_core::queue::ResolvedQueueSnapshot) -> Self {
+        let bae_core::queue::ResolvedQueueSnapshot {
+            manual,
+            context,
+            has_next,
+            has_previous,
+        } = snapshot;
+        crate::types::BridgeQueueSnapshot {
+            manual: manual
+                .into_iter()
+                .map(crate::types::BridgeQueueEntry::from_core)
+                .collect(),
+            context: context.map(crate::types::BridgePlaybackContext::from_core),
+            has_next,
+            has_previous,
+        }
+    }
+}
+
+impl crate::types::BridgeSyncStatusSnapshot {
+    fn from_core(snapshot: bae_core::library::SyncStatusSnapshot) -> Self {
+        let bae_core::library::SyncStatusSnapshot {
+            error,
+            last_sync_time,
+            syncing,
+            sync_ready,
+        } = snapshot;
+        crate::types::BridgeSyncStatusSnapshot {
+            error: error.map(crate::types::BridgeError::from_core),
+            last_sync_time,
+            syncing,
+            sync_ready,
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn convert_folder_candidate(
-    candidate: bae_core::import::FolderCandidate,
-) -> crate::types::BridgeFolderCandidate {
-    let track_count = candidate.track_count();
-    crate::types::BridgeFolderCandidate {
-        folder_path: candidate.path.to_string_lossy().to_string(),
-        source_folder_name: candidate.name,
-        watched_folder_path: candidate.watched_folder_path,
-        files: crate::types::categorized_files_to_bridge(candidate.files),
-        track_count,
-        skipped: candidate.skipped,
-        is_added: candidate.is_added,
+impl crate::types::BridgeFolderCandidate {
+    fn from_core(candidate: bae_core::import::FolderCandidate) -> Self {
+        // `track_count()` borrows `&candidate`; compute it before the move.
+        let track_count = candidate.track_count();
+        let bae_core::import::FolderCandidate {
+            path,
+            name,
+            files,
+            watched_folder_path,
+            skipped,
+            is_added,
+        } = candidate;
+        crate::types::BridgeFolderCandidate {
+            folder_path: path.to_string_lossy().to_string(),
+            source_folder_name: name,
+            watched_folder_path,
+            files: crate::types::BridgeCandidateFiles::from_core(files),
+            track_count,
+            skipped,
+            is_added,
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn convert_invalid_candidate(
-    candidate: bae_core::import::InvalidCandidate,
-) -> crate::types::BridgeInvalidCandidate {
-    crate::types::BridgeInvalidCandidate {
-        folder_path: candidate.path.to_string_lossy().to_string(),
-        source_folder_name: candidate.name,
-        watched_folder_path: candidate.watched_folder_path,
-        reason: crate::types::invalid_reason_to_bridge(candidate.reason),
-    }
-}
-
-#[cfg(feature = "desktop")]
-fn convert_import_candidate_snapshot(
-    candidate: bae_core::import::ImportCandidateSnapshot,
-) -> crate::types::BridgeImportCandidateSnapshot {
-    match candidate {
-        bae_core::import::ImportCandidateSnapshot::Folder { candidate, runtime } => {
-            crate::types::BridgeImportCandidateSnapshot::Folder {
-                candidate: convert_folder_candidate(candidate),
-                runtime_snapshot: convert_candidate_runtime_snapshot(runtime),
-            }
-        }
-        bae_core::import::ImportCandidateSnapshot::Invalid(candidate) => {
-            crate::types::BridgeImportCandidateSnapshot::Invalid {
-                candidate: convert_invalid_candidate(candidate),
-            }
-        }
-        bae_core::import::ImportCandidateSnapshot::Runtime { key, runtime } => {
-            crate::types::BridgeImportCandidateSnapshot::Runtime {
-                key,
-                runtime_snapshot: convert_candidate_runtime_snapshot(runtime),
-            }
+impl crate::types::BridgeInvalidCandidate {
+    fn from_core(candidate: bae_core::import::InvalidCandidate) -> Self {
+        let bae_core::import::InvalidCandidate {
+            path,
+            name,
+            watched_folder_path,
+            reason,
+        } = candidate;
+        crate::types::BridgeInvalidCandidate {
+            folder_path: path.to_string_lossy().to_string(),
+            source_folder_name: name,
+            watched_folder_path,
+            reason: crate::types::BridgeInvalidReason::from_core(reason),
         }
     }
 }
 
 #[cfg(feature = "desktop")]
-fn convert_candidate_runtime_snapshot(
-    runtime: bae_core::import::CandidateRuntimeSnapshot,
-) -> crate::types::BridgeCandidateRuntimeSnapshot {
-    crate::types::BridgeCandidateRuntimeSnapshot {
-        identify_state: crate::types::identify_state_to_bridge(runtime.identify_state),
-        signals_toolbar: crate::types::toolbar_to_bridge(runtime.toolbar),
-        signals: runtime.signals.map(crate::types::signals_to_bridge),
-        import_status: runtime.import_status.map(convert_candidate_import_status),
+impl crate::types::BridgeImportCandidateSnapshot {
+    fn from_core(candidate: bae_core::import::ImportCandidateSnapshot) -> Self {
+        match candidate {
+            bae_core::import::ImportCandidateSnapshot::Folder { candidate, runtime } => {
+                crate::types::BridgeImportCandidateSnapshot::Folder {
+                    candidate: crate::types::BridgeFolderCandidate::from_core(candidate),
+                    runtime_snapshot: crate::types::BridgeCandidateRuntimeSnapshot::from_core(
+                        runtime,
+                    ),
+                }
+            }
+            bae_core::import::ImportCandidateSnapshot::Invalid(candidate) => {
+                crate::types::BridgeImportCandidateSnapshot::Invalid {
+                    candidate: crate::types::BridgeInvalidCandidate::from_core(candidate),
+                }
+            }
+            bae_core::import::ImportCandidateSnapshot::Runtime { key, runtime } => {
+                crate::types::BridgeImportCandidateSnapshot::Runtime {
+                    key,
+                    runtime_snapshot: crate::types::BridgeCandidateRuntimeSnapshot::from_core(
+                        runtime,
+                    ),
+                }
+            }
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-fn convert_candidate_import_status(
-    status: bae_core::import::CandidateImportStatusSnapshot,
-) -> crate::types::BridgeCandidateImportStatus {
-    match status {
-        bae_core::import::CandidateImportStatusSnapshot::Importing {
-            progress_percent,
-            step,
-        } => crate::types::BridgeCandidateImportStatus::Importing {
-            progress_percent,
-            step: step.map(crate::types::import_step_to_bridge),
-        },
-        bae_core::import::CandidateImportStatusSnapshot::Complete {
-            release_id,
+impl crate::types::BridgeCandidateRuntimeSnapshot {
+    fn from_core(runtime: bae_core::import::CandidateRuntimeSnapshot) -> Self {
+        let bae_core::import::CandidateRuntimeSnapshot {
+            identify_state,
+            toolbar,
+            signals,
+            import_status,
+        } = runtime;
+        crate::types::BridgeCandidateRuntimeSnapshot {
+            identify_state: crate::types::BridgeIdentifyState::from_core(identify_state),
+            signals_toolbar: crate::types::BridgeSignalsToolbar::from_core(toolbar),
+            signals: signals.map(crate::types::BridgeSignals::from_core),
+            import_status: import_status.map(crate::types::BridgeCandidateImportStatus::from_core),
+        }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl crate::types::BridgeCandidateImportStatus {
+    fn from_core(status: bae_core::import::CandidateImportStatusSnapshot) -> Self {
+        match status {
+            bae_core::import::CandidateImportStatusSnapshot::Importing {
+                progress_percent,
+                step,
+            } => crate::types::BridgeCandidateImportStatus::Importing {
+                progress_percent,
+                step: step.map(crate::types::BridgeImportStep::from_core),
+            },
+            bae_core::import::CandidateImportStatusSnapshot::Complete {
+                release_id,
+                album_id,
+            } => crate::types::BridgeCandidateImportStatus::Complete {
+                release_id,
+                album_id,
+            },
+            bae_core::import::CandidateImportStatusSnapshot::Error { error } => {
+                crate::types::BridgeCandidateImportStatus::Error {
+                    error: crate::types::BridgeError::from_core(bae_core::ui::UiError::import(
+                        error,
+                    )),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl crate::types::BridgeFolderImportCandidateSnapshot {
+    fn from_core(snapshot: bae_core::import::FolderImportCandidateSnapshot) -> Self {
+        let bae_core::import::FolderImportCandidateSnapshot { candidate, runtime } = snapshot;
+        crate::types::BridgeFolderImportCandidateSnapshot {
+            candidate: crate::types::BridgeFolderCandidate::from_core(candidate),
+            runtime: crate::types::BridgeCandidateRuntimeSnapshot::from_core(runtime),
+        }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl crate::types::BridgeImportCandidatesSnapshot {
+    fn from_core(snapshot: bae_core::import::ImportCandidatesSnapshot) -> Self {
+        let bae_core::import::ImportCandidatesSnapshot {
+            watched_folders,
+            folder_candidates,
+            invalid_candidates,
+        } = snapshot;
+        crate::types::BridgeImportCandidatesSnapshot {
+            watched_folders: watched_folders
+                .into_iter()
+                .map(crate::types::BridgeWatchedFolder::from_core)
+                .collect(),
+            folder_candidates: folder_candidates
+                .into_iter()
+                .map(crate::types::BridgeFolderImportCandidateSnapshot::from_core)
+                .collect(),
+            invalid_candidates: invalid_candidates
+                .into_iter()
+                .map(crate::types::BridgeInvalidCandidate::from_core)
+                .collect(),
+        }
+    }
+}
+
+impl crate::types::BridgeLoadingTrackInfo {
+    fn from_core(t: bae_core::playback::LoadingTrack) -> Self {
+        let bae_core::playback::LoadingTrack {
+            track_info,
+            duration_ms,
+        } = t;
+        let bae_core::playback::PlaybackTrackInfo {
+            track_title,
+            artist_names,
             album_id,
-        } => crate::types::BridgeCandidateImportStatus::Complete {
-            release_id,
+            album_title,
+            cover_image_id,
+            // The now-playing bar's loading state renders only the fields above;
+            // identity/side detail belongs to the full Playing/Paused events.
+            track_id: _,
+            artist_id: _,
+            release_id: _,
+            side: _,
+        } = track_info;
+        crate::types::BridgeLoadingTrackInfo {
+            track_title,
+            artist_names,
             album_id,
-        },
-        bae_core::import::CandidateImportStatusSnapshot::Error { error } => {
-            crate::types::BridgeCandidateImportStatus::Error {
-                error: crate::types::bridge_error(bae_core::ui::UiError::import(error)),
-            }
+            album_title,
+            cover_image_id,
+            duration_ms,
         }
-    }
-}
-
-#[cfg(feature = "desktop")]
-fn convert_import_candidates_snapshot(
-    snapshot: bae_core::import::ImportCandidatesSnapshot,
-) -> crate::types::BridgeImportCandidatesSnapshot {
-    crate::types::BridgeImportCandidatesSnapshot {
-        watched_folders: snapshot
-            .watched_folders
-            .into_iter()
-            .map(crate::types::BridgeWatchedFolder::from_core)
-            .collect(),
-        folder_candidates: snapshot
-            .folder_candidates
-            .into_iter()
-            .map(
-                |snapshot| crate::types::BridgeFolderImportCandidateSnapshot {
-                    candidate: convert_folder_candidate(snapshot.candidate),
-                    runtime: convert_candidate_runtime_snapshot(snapshot.runtime),
-                },
-            )
-            .collect(),
-        invalid_candidates: snapshot
-            .invalid_candidates
-            .into_iter()
-            .map(convert_invalid_candidate)
-            .collect(),
     }
 }
 
@@ -1935,18 +2129,11 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
         // ── Playback ───────────────────────────────────────────────
         UiBusEvent::PlaybackStopped => Some(BridgeUiEvent::PlaybackStopped),
         UiBusEvent::PlaybackError { reason } => Some(BridgeUiEvent::PlaybackError {
-            reason: crate::types::bridge_playback_error_reason(reason),
+            reason: crate::types::BridgePlaybackErrorReason::from_core(reason),
         }),
         UiBusEvent::PlaybackLoading { track_id, track } => Some(BridgeUiEvent::PlaybackLoading {
             track_id,
-            track: track.map(|t| BridgeLoadingTrackInfo {
-                track_title: t.track_info.track_title,
-                artist_names: t.track_info.artist_names,
-                album_id: t.track_info.album_id,
-                album_title: t.track_info.album_title,
-                cover_image_id: t.track_info.cover_image_id,
-                duration_ms: t.duration_ms,
-            }),
+            track: track.map(BridgeLoadingTrackInfo::from_core),
         }),
         UiBusEvent::PlaybackPlaying {
             track_id,
@@ -2016,7 +2203,7 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
             mode: BridgeRepeatMode::from_core(mode),
         }),
         UiBusEvent::QueueUpdated(snapshot) => Some(BridgeUiEvent::QueueUpdated {
-            snapshot: convert_queue_snapshot(snapshot),
+            snapshot: BridgeQueueSnapshot::from_core(snapshot),
         }),
         UiBusEvent::QueueItemsAdded { count } => Some(BridgeUiEvent::QueueItemsAdded { count }),
 
@@ -2062,294 +2249,642 @@ fn convert_ui_event(event: bae_core::ui::UiBusEvent) -> Option<crate::types::Bri
 
         // ── Errors ─────────────────────────────────────────────────
         UiBusEvent::Error { error } => Some(BridgeUiEvent::Error {
-            error: crate::types::bridge_error(error),
+            error: crate::types::BridgeError::from_core(error),
         }),
         UiBusEvent::ErrorCleared => Some(BridgeUiEvent::ErrorCleared),
     }
 }
 
-fn convert_release_detail(rel: bae_core::album_detail::ReleaseDetail) -> BridgeRelease {
-    let convert_file = |f: bae_core::album_detail::FileDetail| BridgeFile {
-        id: f.id,
-        original_filename: f.original_filename,
-        file_size: f.file_size,
-        is_image: f.is_image,
-        content_type: f.content_type,
-        audio_format: f.audio_format.map(crate::types::audio_format_to_bridge),
-    };
-    let convert_gallery_item = |g: bae_core::album_detail::GalleryItem| BridgeGalleryItem {
-        id: g.id,
-        label: g.label,
-        source: match g.source {
-            bae_core::album_detail::GallerySource::Cover(image) => {
-                crate::types::BridgeGallerySource::Cover {
-                    image: crate::types::BridgeImageRef::from_core(image),
+impl BridgeFile {
+    fn from_core(f: bae_core::album_detail::FileDetail) -> Self {
+        let bae_core::album_detail::FileDetail {
+            id,
+            original_filename,
+            file_size,
+            is_image,
+            content_type,
+            audio_format,
+        } = f;
+        BridgeFile {
+            id,
+            original_filename,
+            file_size,
+            is_image,
+            content_type,
+            audio_format: audio_format.map(crate::types::BridgeAudioFormat::from_core),
+        }
+    }
+}
+
+impl BridgeGalleryItem {
+    fn from_core(g: bae_core::album_detail::GalleryItem) -> Self {
+        let bae_core::album_detail::GalleryItem { id, label, source } = g;
+        BridgeGalleryItem {
+            id,
+            label,
+            source: match source {
+                bae_core::album_detail::GallerySource::Cover(image) => {
+                    crate::types::BridgeGallerySource::Cover {
+                        image: crate::types::BridgeImageRef::from_core(image),
+                    }
                 }
-            }
-            bae_core::album_detail::GallerySource::ReleaseFile { file_id } => {
-                crate::types::BridgeGallerySource::ReleaseFile { file_id }
-            }
-        },
-    };
-    let convert_track = |t: bae_core::album_detail::TrackDetail| BridgeTrack {
-        id: t.id,
-        title: t.title,
-        side: t.side,
-        track_number: t.track_number,
-        duration_ms: t.duration_ms,
-        artist_names: t.artist_names,
-        position_text: t.position_text,
-    };
-    let summary = rel.summary;
-    BridgeRelease {
-        id: summary.id,
-        album_id: summary.album_id,
-        display_name: rel.display_name,
-        release_name: rel.release_name,
-        year: rel.year,
-        format: summary.format,
-        label: rel.label,
-        catalog_number: rel.catalog_number,
-        country: rel.country,
-        storage_state: crate::types::BridgeReleaseStorageState::from_core(summary.storage_state),
-        pinned: summary.pinned,
-        storage_actions: summary
-            .storage_actions
-            .into_iter()
-            .map(crate::types::BridgeReleaseStorageAction::from_core)
-            .collect(),
-        transfer_action: summary
-            .transfer_action
-            .map(crate::types::BridgeReleaseStorageAction::from_core),
-        total_duration_ms: rel.total_duration_ms,
-        tracks: rel.tracks.into_iter().map(convert_track).collect(),
-        track_groups: rel
-            .track_groups
-            .into_iter()
-            .map(|g| BridgeTrackGroup {
-                side: crate::types::BridgeTrackSide::from_core(g.side),
-                tracks: g.tracks.into_iter().map(convert_track).collect(),
-            })
-            .collect(),
-        image_files: rel.image_files.into_iter().map(convert_file).collect(),
-        files: rel.files.into_iter().map(convert_file).collect(),
-        gallery_items: rel
-            .gallery_items
-            .into_iter()
-            .map(convert_gallery_item)
-            .collect(),
-        file_count: summary.file_count,
-        total_size: summary.total_size,
-        cover: summary.cover.map(crate::types::BridgeImageRef::from_core),
+                bae_core::album_detail::GallerySource::ReleaseFile { file_id } => {
+                    crate::types::BridgeGallerySource::ReleaseFile { file_id }
+                }
+            },
+        }
     }
 }
 
-fn convert_storage_row(raw: bae_core::album_detail::StorageRow) -> BridgeStorageRow {
-    BridgeStorageRow {
-        release: convert_release_summary(raw.release),
-        album: convert_album_summary(raw.album),
+impl BridgeTrack {
+    fn from_core(t: bae_core::album_detail::TrackDetail) -> Self {
+        let bae_core::album_detail::TrackDetail {
+            id,
+            title,
+            side,
+            track_number,
+            duration_ms,
+            artist_names,
+            position_text,
+            // Structured position drives core-side grouping (`track_groups`); the
+            // UI renders `position_text` and the group headers, not this.
+            position: _,
+        } = t;
+        BridgeTrack {
+            id,
+            title,
+            side,
+            track_number,
+            duration_ms,
+            artist_names,
+            position_text,
+        }
     }
 }
 
-fn convert_release_summary(s: bae_core::album_detail::ReleaseSummary) -> BridgeReleaseSummary {
-    BridgeReleaseSummary {
-        id: s.id,
-        album_id: s.album_id,
-        format: s.format,
-        storage_state: crate::types::BridgeReleaseStorageState::from_core(s.storage_state),
-        pinned: s.pinned,
-        storage_actions: s
-            .storage_actions
-            .into_iter()
-            .map(crate::types::BridgeReleaseStorageAction::from_core)
-            .collect(),
-        transfer_action: s
-            .transfer_action
-            .map(crate::types::BridgeReleaseStorageAction::from_core),
-        file_count: s.file_count,
-        total_size: s.total_size,
-        cover: s.cover.map(crate::types::BridgeImageRef::from_core),
+impl BridgeTrackGroup {
+    fn from_core(g: bae_core::album_detail::TrackGroup) -> Self {
+        let bae_core::album_detail::TrackGroup { side, tracks } = g;
+        BridgeTrackGroup {
+            side: crate::types::BridgeTrackSide::from_core(side),
+            tracks: tracks.into_iter().map(BridgeTrack::from_core).collect(),
+        }
     }
 }
 
-fn convert_album_detail(detail: bae_core::album_detail::AlbumDetail) -> BridgeAlbumDetail {
-    let release_ids: Vec<String> = detail
-        .releases
-        .iter()
-        .map(|r| r.summary.id.clone())
-        .collect();
-    let releases: Vec<BridgeRelease> = detail
-        .releases
-        .into_iter()
-        .map(convert_release_detail)
-        .collect();
+impl BridgeRelease {
+    fn from_core(rel: bae_core::album_detail::ReleaseDetail) -> Self {
+        let bae_core::album_detail::ReleaseDetail {
+            summary,
+            display_name,
+            release_name,
+            year,
+            label,
+            catalog_number,
+            country,
+            total_duration_ms,
+            tracks,
+            track_groups,
+            files,
+            image_files,
+            gallery_items,
+        } = rel;
+        // Single-source the summary-derived fields through BridgeReleaseSummary,
+        // then exhaustively destructure it into BridgeRelease's flat fields so the
+        // storage/cover projection lives in one place.
+        let BridgeReleaseSummary {
+            id,
+            album_id,
+            format,
+            storage_state,
+            pinned,
+            storage_actions,
+            transfer_action,
+            file_count,
+            total_size,
+            cover,
+        } = BridgeReleaseSummary::from_core(summary);
+        BridgeRelease {
+            id,
+            album_id,
+            display_name,
+            release_name,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            storage_state,
+            pinned,
+            storage_actions,
+            transfer_action,
+            total_duration_ms,
+            tracks: tracks.into_iter().map(BridgeTrack::from_core).collect(),
+            track_groups: track_groups
+                .into_iter()
+                .map(BridgeTrackGroup::from_core)
+                .collect(),
+            image_files: image_files.into_iter().map(BridgeFile::from_core).collect(),
+            files: files.into_iter().map(BridgeFile::from_core).collect(),
+            gallery_items: gallery_items
+                .into_iter()
+                .map(BridgeGalleryItem::from_core)
+                .collect(),
+            file_count,
+            total_size,
+            cover,
+        }
+    }
+}
 
-    BridgeAlbumDetail {
-        album: BridgeAlbum {
-            id: detail.album.id,
-            title: detail.album.title,
-            year: detail.album.year,
-            is_compilation: detail.album.is_compilation,
-            artist_names: detail.artist_names,
-            primary_release_id: detail.primary_release_id,
+impl BridgeAlbumSearchResult {
+    fn from_core(a: bae_core::album_detail::AlbumSearchResult) -> Self {
+        let bae_core::album_detail::AlbumSearchResult {
+            id,
+            title,
+            year,
+            artist_name,
+            cover,
+        } = a;
+        BridgeAlbumSearchResult {
+            id,
+            title,
+            year,
+            artist_name,
+            cover: cover.map(crate::types::BridgeImageRef::from_core),
+        }
+    }
+}
+
+impl BridgeTrackSearchResult {
+    fn from_core(t: bae_core::album_detail::TrackSearchResult) -> Self {
+        let bae_core::db::DbTrackSearchResult {
+            id,
+            title,
+            duration_ms,
+            album_id,
+            album_title,
+            artist_name,
+        } = t;
+        BridgeTrackSearchResult {
+            id,
+            title,
+            duration_ms,
+            album_id,
+            album_title,
+            artist_name,
+        }
+    }
+}
+
+impl BridgeStoragePage {
+    fn from_core(page: bae_core::album_detail::StoragePage) -> Self {
+        let bae_core::album_detail::StoragePage { rows, total_count } = page;
+        BridgeStoragePage {
+            rows: rows.into_iter().map(BridgeStorageRow::from_core).collect(),
+            total_count,
+        }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl crate::types::BridgeCandidateSearchResults {
+    /// Echoes back the `tab` and `source` the search ran against so the caller
+    /// routes results into the matching slot even if the user changed either
+    /// during the await.
+    fn from_core(
+        grouped: bae_core::import::GroupedSearchResults,
+        tab: crate::types::BridgeSearchQueryKind,
+        source: crate::types::BridgeMetadataSource,
+    ) -> Self {
+        let bae_core::import::GroupedSearchResults { groups, statuses } = grouped;
+        crate::types::BridgeCandidateSearchResults {
+            tab,
+            source,
+            groups: groups
+                .into_iter()
+                .map(crate::types::BridgeReleaseGroup::from_core)
+                .collect(),
+            statuses: statuses
+                .into_iter()
+                .map(crate::types::BridgeLibraryStatus::from_core)
+                .collect(),
+        }
+    }
+}
+
+impl BridgeStorageRow {
+    fn from_core(raw: bae_core::album_detail::StorageRow) -> Self {
+        let bae_core::album_detail::StorageRow { release, album } = raw;
+        BridgeStorageRow {
+            release: BridgeReleaseSummary::from_core(release),
+            album: BridgeAlbum::from_core(album),
+        }
+    }
+}
+
+impl BridgeReleaseSummary {
+    fn from_core(s: bae_core::album_detail::ReleaseSummary) -> Self {
+        let bae_core::album_detail::ReleaseSummary {
+            id,
+            album_id,
+            format,
+            storage_state,
+            pinned,
+            storage_actions,
+            transfer_action,
+            file_count,
+            total_size,
+            cover,
+        } = s;
+        BridgeReleaseSummary {
+            id,
+            album_id,
+            format,
+            storage_state: crate::types::BridgeReleaseStorageState::from_core(storage_state),
+            pinned,
+            storage_actions: storage_actions
+                .into_iter()
+                .map(crate::types::BridgeReleaseStorageAction::from_core)
+                .collect(),
+            transfer_action: transfer_action
+                .map(crate::types::BridgeReleaseStorageAction::from_core),
+            file_count,
+            total_size,
+            cover: cover.map(crate::types::BridgeImageRef::from_core),
+        }
+    }
+}
+
+impl BridgeAlbumDetail {
+    fn from_core(detail: bae_core::album_detail::AlbumDetail) -> Self {
+        let bae_core::album_detail::AlbumDetail {
+            album,
+            artist_names,
+            releases,
+            primary_release_id,
+            cover,
+        } = detail;
+        let release_ids: Vec<String> = releases.iter().map(|r| r.summary.id.clone()).collect();
+        let bae_core::db::DbAlbum {
+            id,
+            title,
+            year,
+            is_compilation,
+            // The album's own artist FK / created_at aren't surfaced, and the
+            // primary release comes from the detail-level field below.
+            artist_id: _,
+            primary_release_id: _,
+            created_at: _,
+        } = album;
+        // Reassemble the album's slim summary from the detail's DbAlbum plus the
+        // detail-level artist_names/primary_release_id/cover, then reuse
+        // BridgeAlbum::from_core so the BridgeAlbum projection lives in one place.
+        let album = BridgeAlbum::from_core(bae_core::album_detail::AlbumSummary {
+            id,
+            title,
+            year,
+            is_compilation,
+            artist_names,
             release_ids,
-            cover: detail.cover.map(crate::types::BridgeImageRef::from_core),
-        },
-        releases,
+            primary_release_id,
+            cover,
+        });
+        BridgeAlbumDetail {
+            album,
+            releases: releases.into_iter().map(BridgeRelease::from_core).collect(),
+        }
     }
 }
 
-fn convert_album_summary(a: bae_core::album_detail::AlbumSummary) -> BridgeAlbum {
-    BridgeAlbum {
-        id: a.id,
-        title: a.title,
-        year: a.year,
-        is_compilation: a.is_compilation,
-        artist_names: a.artist_names,
-        release_ids: a.release_ids,
-        primary_release_id: a.primary_release_id,
-        cover: a.cover.map(crate::types::BridgeImageRef::from_core),
+impl BridgeAlbum {
+    fn from_core(a: bae_core::album_detail::AlbumSummary) -> Self {
+        let bae_core::album_detail::AlbumSummary {
+            id,
+            title,
+            year,
+            is_compilation,
+            artist_names,
+            release_ids,
+            primary_release_id,
+            cover,
+        } = a;
+        BridgeAlbum {
+            id,
+            title,
+            year,
+            is_compilation,
+            artist_names,
+            release_ids,
+            primary_release_id,
+            cover: cover.map(crate::types::BridgeImageRef::from_core),
+        }
+    }
+
+    fn into_core(self) -> bae_core::album_detail::AlbumSummary {
+        let BridgeAlbum {
+            id,
+            title,
+            year,
+            is_compilation,
+            artist_names,
+            release_ids,
+            primary_release_id,
+            cover,
+        } = self;
+        bae_core::album_detail::AlbumSummary {
+            id,
+            title,
+            year,
+            is_compilation,
+            artist_names,
+            release_ids,
+            primary_release_id,
+            cover: cover.map(crate::types::BridgeImageRef::into_core),
+        }
     }
 }
 
-fn convert_composer_summary(s: bae_core::album_detail::ComposerSummary) -> BridgeComposerSummary {
-    BridgeComposerSummary {
-        artist_id: s.raw.artist.id,
-        name: s.raw.artist.name,
-        sort_name: s.raw.artist.sort_name,
-        work_count: s.raw.work_count,
-        linked_release_count: s.raw.linked_release_count,
-        unlinked_credit_count: s.raw.unlinked_credit_count,
-        image: s.image.map(crate::types::BridgeImageRef::from_core),
+impl BridgeComposerSummary {
+    fn from_core(s: bae_core::album_detail::ComposerSummary) -> Self {
+        let bae_core::album_detail::ComposerSummary { raw, image } = s;
+        let bae_core::db::DbComposerSummary {
+            artist,
+            work_count,
+            linked_release_count,
+            unlinked_credit_count,
+        } = raw;
+        let bae_core::db::DbArtist {
+            id: artist_id,
+            name,
+            sort_name,
+            // Per-source dedup ids and the row timestamp don't cross to the UI.
+            discogs_artist_id: _,
+            musicbrainz_artist_id: _,
+            created_at: _,
+        } = artist;
+        BridgeComposerSummary {
+            artist_id,
+            name,
+            sort_name,
+            work_count,
+            linked_release_count,
+            unlinked_credit_count,
+            image: image.map(crate::types::BridgeImageRef::from_core),
+        }
     }
 }
 
-fn convert_work_summary(s: bae_core::album_detail::WorkSummary) -> BridgeWorkSummary {
-    BridgeWorkSummary {
-        work_id: s.raw.work.id,
-        title: s.raw.work.title,
-        disambiguation: s.raw.work.disambiguation,
-        work_type: s.raw.work.work_type,
-        parent_work_id: s.raw.parent_work_id,
-        composer_names: s.raw.composer_names,
-        linked_release_count: s.raw.linked_release_count,
-        representative_release_id: s.raw.representative_release_id,
-        representative_cover: s
-            .representative_cover
-            .map(crate::types::BridgeImageRef::from_core),
+impl BridgeWorkSummary {
+    fn from_core(s: bae_core::album_detail::WorkSummary) -> Self {
+        let bae_core::album_detail::WorkSummary {
+            raw,
+            representative_cover,
+        } = s;
+        let bae_core::db::DbWorkSummary {
+            work,
+            parent_work_id,
+            representative_release_id,
+            composer_names,
+            linked_release_count,
+        } = raw;
+        let bae_core::db::DbWork {
+            id: work_id,
+            title,
+            disambiguation,
+            work_type,
+            // Row timestamp isn't surfaced.
+            created_at: _,
+        } = work;
+        BridgeWorkSummary {
+            work_id,
+            title,
+            disambiguation,
+            work_type,
+            parent_work_id,
+            composer_names,
+            linked_release_count,
+            representative_release_id,
+            representative_cover: representative_cover.map(crate::types::BridgeImageRef::from_core),
+        }
     }
 }
 
-fn convert_release_role_summary(
-    s: bae_core::album_detail::ReleaseRoleSummary,
-) -> BridgeReleaseRoleSummary {
-    BridgeReleaseRoleSummary {
-        release_id: s.role.release_id,
-        album_id: s.album.id,
-        album_title: s.album.title,
-        source: BridgeMetadataSource::from_core(s.role.source),
-        source_credit: s.role.source_credit,
+impl BridgeReleaseRoleSummary {
+    fn from_core(s: bae_core::album_detail::ReleaseRoleSummary) -> Self {
+        let bae_core::db::DbReleaseRoleSummary { role, album } = s;
+        let bae_core::db::DbReleaseArtistRole {
+            release_id,
+            source,
+            source_credit,
+            id: _,
+            artist_id: _,
+            position: _,
+            created_at: _,
+        } = role;
+        let bae_core::db::DbAlbum {
+            id: album_id,
+            title: album_title,
+            artist_id: _,
+            year: _,
+            primary_release_id: _,
+            is_compilation: _,
+            created_at: _,
+        } = album;
+        BridgeReleaseRoleSummary {
+            release_id,
+            album_id,
+            album_title,
+            source: BridgeMetadataSource::from_core(source),
+            source_credit,
+        }
     }
 }
 
-fn convert_track_role_summary(
-    s: bae_core::album_detail::TrackRoleSummary,
-) -> BridgeTrackRoleSummary {
-    BridgeTrackRoleSummary {
-        track_id: s.role.track_id,
-        track_title: s.track.title,
-        release_id: s.track.release_id,
-        album_id: s.album.id,
-        album_title: s.album.title,
-        artist_id: s.role.artist_id,
-        artist_name: s.artist.name,
-        source: BridgeMetadataSource::from_core(s.role.source),
-        source_credit: s.role.source_credit,
+impl BridgeTrackRoleSummary {
+    fn from_core(s: bae_core::album_detail::TrackRoleSummary) -> Self {
+        let bae_core::db::DbTrackRoleSummary {
+            role,
+            track,
+            album,
+            artist,
+        } = s;
+        let bae_core::db::DbTrackArtistRole {
+            track_id,
+            artist_id,
+            source,
+            source_credit,
+            id: _,
+            position: _,
+            created_at: _,
+        } = role;
+        let bae_core::db::DbTrack {
+            title: track_title,
+            release_id,
+            id: _,
+            side: _,
+            track_number: _,
+            duration_ms: _,
+            discogs_position: _,
+            created_at: _,
+        } = track;
+        let bae_core::db::DbAlbum {
+            id: album_id,
+            title: album_title,
+            artist_id: _,
+            year: _,
+            primary_release_id: _,
+            is_compilation: _,
+            created_at: _,
+        } = album;
+        let bae_core::db::DbArtist {
+            name: artist_name,
+            id: _,
+            sort_name: _,
+            discogs_artist_id: _,
+            musicbrainz_artist_id: _,
+            created_at: _,
+        } = artist;
+        BridgeTrackRoleSummary {
+            track_id,
+            track_title,
+            release_id,
+            album_id,
+            album_title,
+            artist_id,
+            artist_name,
+            source: BridgeMetadataSource::from_core(source),
+            source_credit,
+        }
     }
 }
 
-fn convert_work_track_summary(
-    s: bae_core::album_detail::WorkTrackSummary,
-) -> BridgeWorkTrackSummary {
-    BridgeWorkTrackSummary {
-        track_id: s.link.track_id,
-        track_title: s.track.title,
-        release_id: s.track.release_id,
-        album_id: s.album.id,
-        album_title: s.album.title,
+impl BridgeWorkTrackSummary {
+    fn from_core(s: bae_core::album_detail::WorkTrackSummary) -> Self {
+        let bae_core::db::DbWorkTrackSummary { link, track, album } = s;
+        let bae_core::db::DbTrackWork {
+            track_id,
+            id: _,
+            work_id: _,
+            position: _,
+            source: _,
+            created_at: _,
+        } = link;
+        let bae_core::db::DbTrack {
+            title: track_title,
+            release_id,
+            id: _,
+            side: _,
+            track_number: _,
+            duration_ms: _,
+            discogs_position: _,
+            created_at: _,
+        } = track;
+        let bae_core::db::DbAlbum {
+            id: album_id,
+            title: album_title,
+            artist_id: _,
+            year: _,
+            primary_release_id: _,
+            is_compilation: _,
+            created_at: _,
+        } = album;
+        BridgeWorkTrackSummary {
+            track_id,
+            track_title,
+            release_id,
+            album_id,
+            album_title,
+        }
     }
 }
 
-fn convert_work_release_summary(
-    s: bae_core::album_detail::WorkReleaseSummary,
-) -> BridgeWorkReleaseSummary {
-    BridgeWorkReleaseSummary {
-        release_id: s.release_id,
-        album_id: s.album_id,
-        album_title: s.album_title,
-        display_name: s.display_name,
-        format: s.format,
-        cover: s.cover.map(crate::types::BridgeImageRef::from_core),
+impl BridgeWorkReleaseSummary {
+    fn from_core(s: bae_core::album_detail::WorkReleaseSummary) -> Self {
+        let bae_core::album_detail::WorkReleaseSummary {
+            release_id,
+            album_id,
+            album_title,
+            display_name,
+            format,
+            cover,
+        } = s;
+        BridgeWorkReleaseSummary {
+            release_id,
+            album_id,
+            album_title,
+            display_name,
+            format,
+            cover: cover.map(crate::types::BridgeImageRef::from_core),
+        }
     }
 }
 
-fn convert_composer_detail(d: bae_core::album_detail::ComposerDetail) -> BridgeComposerDetail {
-    BridgeComposerDetail {
-        composer: convert_composer_summary(d.composer),
-        work_groups: d
-            .work_groups
-            .into_iter()
-            .map(|group| BridgeComposerWorkGroup {
-                id: group.id,
-                parent: group.parent.map(convert_work_summary),
-                works: group.works.into_iter().map(convert_work_summary).collect(),
-            })
-            .collect(),
-        unlinked_release_roles: d
-            .unlinked_release_roles
-            .into_iter()
-            .map(convert_release_role_summary)
-            .collect(),
-        unlinked_track_roles: d
-            .unlinked_track_roles
-            .into_iter()
-            .map(convert_track_role_summary)
-            .collect(),
-        default_work_id: d.default_work_id,
+impl BridgeComposerWorkGroup {
+    fn from_core(group: bae_core::album_detail::ComposerWorkGroup) -> Self {
+        let bae_core::album_detail::ComposerWorkGroup { id, parent, works } = group;
+        BridgeComposerWorkGroup {
+            id,
+            parent: parent.map(BridgeWorkSummary::from_core),
+            works: works
+                .into_iter()
+                .map(BridgeWorkSummary::from_core)
+                .collect(),
+        }
     }
 }
 
-fn convert_work_detail(d: bae_core::album_detail::WorkDetail) -> BridgeWorkDetail {
-    BridgeWorkDetail {
-        work: convert_work_summary(d.work),
-        child_works: d
-            .child_works
-            .into_iter()
-            .map(convert_work_summary)
-            .collect(),
-        releases: d
-            .releases
-            .into_iter()
-            .map(convert_work_release_summary)
-            .collect(),
-        tracks: d
-            .tracks
-            .into_iter()
-            .map(convert_work_track_summary)
-            .collect(),
+impl BridgeComposerDetail {
+    fn from_core(d: bae_core::album_detail::ComposerDetail) -> Self {
+        let bae_core::album_detail::ComposerDetail {
+            composer,
+            work_groups,
+            unlinked_release_roles,
+            unlinked_track_roles,
+            default_work_id,
+        } = d;
+        BridgeComposerDetail {
+            composer: BridgeComposerSummary::from_core(composer),
+            work_groups: work_groups
+                .into_iter()
+                .map(BridgeComposerWorkGroup::from_core)
+                .collect(),
+            unlinked_release_roles: unlinked_release_roles
+                .into_iter()
+                .map(BridgeReleaseRoleSummary::from_core)
+                .collect(),
+            unlinked_track_roles: unlinked_track_roles
+                .into_iter()
+                .map(BridgeTrackRoleSummary::from_core)
+                .collect(),
+            default_work_id,
+        }
     }
 }
 
-fn bridge_album_to_summary(a: BridgeAlbum) -> bae_core::album_detail::AlbumSummary {
-    bae_core::album_detail::AlbumSummary {
-        id: a.id,
-        title: a.title,
-        year: a.year,
-        is_compilation: a.is_compilation,
-        artist_names: a.artist_names,
-        release_ids: a.release_ids,
-        primary_release_id: a.primary_release_id,
-        cover: a.cover.map(crate::types::BridgeImageRef::into_core),
+impl BridgeWorkDetail {
+    fn from_core(d: bae_core::album_detail::WorkDetail) -> Self {
+        let bae_core::album_detail::WorkDetail {
+            work,
+            child_works,
+            releases,
+            tracks,
+        } = d;
+        BridgeWorkDetail {
+            work: BridgeWorkSummary::from_core(work),
+            child_works: child_works
+                .into_iter()
+                .map(BridgeWorkSummary::from_core)
+                .collect(),
+            releases: releases
+                .into_iter()
+                .map(BridgeWorkReleaseSummary::from_core)
+                .collect(),
+            tracks: tracks
+                .into_iter()
+                .map(BridgeWorkTrackSummary::from_core)
+                .collect(),
+        }
     }
 }
 
@@ -2363,11 +2898,13 @@ pub fn sort_albums(
     criteria: Vec<BridgeSortCriterion>,
 ) -> Vec<BridgeAlbum> {
     let mut summaries: Vec<bae_core::album_detail::AlbumSummary> =
-        albums.into_iter().map(bridge_album_to_summary).collect();
-    let core_criteria: Vec<bae_core::db::AlbumSortCriterion> =
-        criteria.iter().map(bridge_sort_to_core).collect();
+        albums.into_iter().map(BridgeAlbum::into_core).collect();
+    let core_criteria: Vec<bae_core::db::AlbumSortCriterion> = criteria
+        .into_iter()
+        .map(BridgeSortCriterion::into_core)
+        .collect();
     bae_core::db::sort_albums(&mut summaries, &core_criteria);
-    summaries.into_iter().map(convert_album_summary).collect()
+    summaries.into_iter().map(BridgeAlbum::from_core).collect()
 }
 
 /// Project a prefetched release detail into the editor's user-edit shape,
@@ -2382,10 +2919,10 @@ pub fn shape_user_edit_from_release_detail(
     detail: crate::types::BridgeReleaseDetail,
     choice: crate::types::BridgeIdentityChoice,
 ) -> crate::types::BridgeReleaseUserEdit {
-    let core_detail = crate::types::release_detail_from_bridge(detail);
-    let core_choice = choice.to_core();
+    let core_detail = detail.into_core();
+    let core_choice = choice.into_core();
     let edit = bae_core::import::shape_user_edit_from_search_detail(&core_detail, &core_choice);
-    crate::types::release_user_edit_to_bridge(edit)
+    crate::types::BridgeReleaseUserEdit::from_core(edit)
 }
 
 /// Normalize + validate the editor's raw form into a wire edit. `Valid`
@@ -2399,13 +2936,13 @@ pub fn shape_user_edit_from_release_detail(
 pub fn shape_release_edit(
     raw: crate::types::BridgeRawReleaseEdit,
 ) -> crate::types::BridgeShapeResult {
-    let core_raw = crate::types::raw_release_edit_from_bridge(raw);
+    let core_raw = raw.into_core();
     match core_raw.shape() {
         Ok(edit) => crate::types::BridgeShapeResult::Valid {
-            edit: crate::types::release_user_edit_to_bridge(edit),
+            edit: crate::types::BridgeReleaseUserEdit::from_core(edit),
         },
         Err(e) => crate::types::BridgeShapeResult::Invalid {
-            reason: validation_reason_from_core(e),
+            reason: crate::types::BridgeValidationReason::from_core(e),
         },
     }
 }
@@ -2413,15 +2950,15 @@ pub fn shape_release_edit(
 /// Map bae-core's validation error to its bridge mirror. Kept here, not as a
 /// `From` in bae-core, so bae-core stays unaware of bridge types.
 #[cfg(feature = "desktop")]
-fn validation_reason_from_core(
-    e: bae_core::import::EditValidationError,
-) -> crate::types::BridgeValidationReason {
-    use crate::types::BridgeValidationReason as R;
-    use bae_core::import::EditValidationError as E;
-    match e {
-        E::EmptyAlbumTitle => R::EmptyAlbumTitle,
-        E::NoAlbumArtist => R::NoAlbumArtist,
-        E::InvalidYear => R::InvalidYear,
+impl crate::types::BridgeValidationReason {
+    fn from_core(e: bae_core::import::EditValidationError) -> Self {
+        use crate::types::BridgeValidationReason as R;
+        use bae_core::import::EditValidationError as E;
+        match e {
+            E::EmptyAlbumTitle => R::EmptyAlbumTitle,
+            E::NoAlbumArtist => R::NoAlbumArtist,
+            E::InvalidYear => R::InvalidYear,
+        }
     }
 }
 
@@ -2446,9 +2983,9 @@ pub fn raw_release_edit_from_user_edit(
     edit: crate::types::BridgeReleaseUserEdit,
     track_id_prefix: String,
 ) -> crate::types::BridgeRawReleaseEdit {
-    let core_edit = crate::types::release_user_edit_from_bridge(edit);
+    let core_edit = edit.into_core();
     let raw = bae_core::import::RawReleaseEdit::from_user_edit(core_edit, &track_id_prefix);
-    crate::types::raw_release_edit_to_bridge(raw)
+    crate::types::BridgeRawReleaseEdit::from_core(raw)
 }
 
 #[cfg(test)]
@@ -2714,7 +3251,7 @@ mod tests {
             default_work_id: Some("work-parent-a".to_string()),
         };
 
-        let bridge = super::convert_composer_detail(detail);
+        let bridge = super::BridgeComposerDetail::from_core(detail);
 
         assert_eq!(bridge.work_groups.len(), 1);
         assert_eq!(bridge.default_work_id.as_deref(), Some("work-parent-a"));
@@ -2769,7 +3306,7 @@ mod tests {
             tracks: Vec::new(),
         };
 
-        let bridge = super::convert_work_detail(detail);
+        let bridge = super::BridgeWorkDetail::from_core(detail);
 
         assert_eq!(bridge.releases.len(), 1);
         let release = &bridge.releases[0];
@@ -2778,5 +3315,29 @@ mod tests {
         assert_eq!(release.album_title, "Album Title A");
         assert_eq!(release.display_name, "2026 CD");
         assert_eq!(release.format.as_deref(), Some("CD"));
+    }
+
+    /// Round-trips a fully-populated album summary through `from_core` then
+    /// `into_core`, guarding the `BridgeAlbum` ↔ `AlbumSummary` pair against a
+    /// transposed same-typed field (`AlbumSummary` has no `PartialEq`, so the
+    /// `Debug` forms are compared). Placeholder names only.
+    #[test]
+    fn album_summary_round_trips() {
+        let core = bae_core::album_detail::AlbumSummary {
+            id: "album-a".to_string(),
+            title: "Album Title A".to_string(),
+            year: Some(1990),
+            is_compilation: false,
+            artist_names: "Artist Name A".to_string(),
+            release_ids: vec!["rel-1".to_string(), "rel-2".to_string()],
+            primary_release_id: "rel-1".to_string(),
+            cover: Some(bae_core::album_detail::ImageRef {
+                id: "rel-1".to_string(),
+                version: "v1".to_string(),
+                image_type: bae_core::db::LibraryImageType::Cover,
+            }),
+        };
+        let back = super::BridgeAlbum::from_core(core.clone()).into_core();
+        assert_eq!(format!("{core:?}"), format!("{back:?}"));
     }
 }

--- a/bae-bridge/src/identify.rs
+++ b/bae-bridge/src/identify.rs
@@ -23,10 +23,21 @@ impl ArtworkAnalyzerAdapter {
 
 impl ArtworkAnalyzer for ArtworkAnalyzerAdapter {
     fn analyze(&self, path: &Path) -> ArtworkAnalysis {
-        let analysis = self.callback.analyze(path.to_string_lossy().into_owned());
+        self.callback
+            .analyze(path.to_string_lossy().into_owned())
+            .into_core()
+    }
+}
+
+impl crate::types::BridgeArtworkAnalysis {
+    fn into_core(self) -> ArtworkAnalysis {
+        let crate::types::BridgeArtworkAnalysis {
+            barcodes,
+            text_lines,
+        } = self;
         ArtworkAnalysis {
-            barcodes: analysis.barcodes,
-            text_lines: analysis.text_lines,
+            barcodes,
+            text_lines,
         }
     }
 }

--- a/bae-bridge/src/init.rs
+++ b/bae-bridge/src/init.rs
@@ -150,16 +150,29 @@ impl BridgeDiagnosticsConfig {
 
 impl BridgeDatadogDiagnosticsConfig {
     fn into_core(self) -> DiagnosticsConfig {
+        let BridgeDatadogDiagnosticsConfig {
+            datadog_site,
+            client_token,
+            source,
+            app,
+        } = self;
+        let BridgeAppDiagnosticMetadata {
+            service,
+            environment,
+            app_version,
+            edition,
+            git_commit,
+        } = app;
         let config = DatadogDiagnosticsConfig {
-            datadog_site: self.datadog_site,
-            client_token: self.client_token,
-            source: self.source,
+            datadog_site,
+            client_token,
+            source,
             app: AppDiagnosticMetadata {
-                service: self.app.service,
-                environment: self.app.environment,
-                app_version: self.app.app_version,
-                edition: self.app.edition,
-                git_commit: self.app.git_commit,
+                service,
+                environment,
+                app_version,
+                edition,
+                git_commit,
             },
         };
 
@@ -180,7 +193,9 @@ impl BridgeDiagnosticLevel {
 }
 
 fn bridge_fields(fields: Vec<BridgeDiagnosticField>) -> impl Iterator<Item = (String, String)> {
-    fields.into_iter().map(|field| (field.key, field.value))
+    fields
+        .into_iter()
+        .map(|BridgeDiagnosticField { key, value }| (key, value))
 }
 
 fn diagnostics_error_to_bridge(e: DiagnosticsError) -> BridgeError {

--- a/bae-bridge/src/setup.rs
+++ b/bae-bridge/src/setup.rs
@@ -30,8 +30,8 @@ pub fn available_cloud_providers() -> Vec<BridgeCloudProvider> {
 }
 
 /// Build a BridgeLibrary from its raw parts. The two call sites that wrap
-/// this — `local_library_active` for a freshly-opened Config,
-/// `local_library_from_info` for a discovery-scan entry — just differ in
+/// this — `BridgeLibrary::from_core` for a freshly-opened Config,
+/// `BridgeLibrary::from_core_info` for a discovery-scan entry — just differ in
 /// where the fields come from.
 fn local_library(
     id: String,
@@ -51,35 +51,38 @@ fn local_library(
         id,
         path,
         name,
-        cloud_provider: cloud_provider.map(bridge_cloud_provider),
+        cloud_provider: cloud_provider.map(BridgeCloudProvider::from_core),
         is_active,
     })
 }
 
-/// `BridgeLibrary` for a freshly-created/restored local library Config.
-/// Always active (the operation just made it the active one).
-fn local_library_active(config: &bae_core::config::Config) -> Result<BridgeLibrary, BridgeError> {
-    local_library(
-        config.library_id.clone(),
-        config.library_name.clone(),
-        std::path::PathBuf::from(&*config.library_dir),
-        config.cloud_home.provider.as_ref(),
-        true,
-    )
-}
+impl BridgeLibrary {
+    /// `BridgeLibrary` for a freshly-created/restored local library Config.
+    /// Always active (the operation just made it the active one). The `Config`
+    /// it reads is coven's (external crate) via `Deref`, so its fields stay
+    /// dotted reads rather than an exhaustive destructure.
+    fn from_core(config: &bae_core::config::Config) -> Result<Self, BridgeError> {
+        local_library(
+            config.library_id.clone(),
+            config.library_name.clone(),
+            std::path::PathBuf::from(&*config.library_dir),
+            config.cloud_home.provider.as_ref(),
+            true,
+        )
+    }
 
-/// `BridgeLibrary` for a discovered local library — path and active flag
-/// come from the discovery scan.
-pub(crate) fn local_library_from_info(
-    info: bae_core::config::LibraryInfo,
-) -> Result<BridgeLibrary, BridgeError> {
-    local_library(
-        info.id,
-        info.name,
-        info.path,
-        info.cloud_provider.as_ref(),
-        info.is_active,
-    )
+    /// `BridgeLibrary` for a discovered local library — path and active flag
+    /// come from the discovery scan.
+    pub(crate) fn from_core_info(info: bae_core::config::LibraryInfo) -> Result<Self, BridgeError> {
+        let bae_core::config::LibraryInfo {
+            id,
+            name,
+            path,
+            is_active,
+            cloud_provider,
+        } = info;
+        local_library(id, name, path, cloud_provider.as_ref(), is_active)
+    }
 }
 
 use std::sync::{Arc, Mutex};
@@ -89,12 +92,9 @@ use tracing::info;
 use bae_core::config::Config;
 use bae_core::library::{CancellationToken, JoinFromCodeError, RestoreFromCodeError};
 
-#[cfg(feature = "oauth-providers")]
-use crate::types::bridge_cloud_provider_to_core;
 use crate::types::{
-    bridge_cloud_provider, BridgeCloudProvider, BridgeError, BridgeInviteCodeInfo,
-    BridgeJoinRequest, BridgeJoinRequestInfo, BridgeLibrary, BridgeRestoreCodeInfo,
-    BridgeRestoreSource,
+    BridgeCloudProvider, BridgeError, BridgeInviteCodeInfo, BridgeJoinRequest,
+    BridgeJoinRequestInfo, BridgeLibrary, BridgeRestoreCodeInfo, BridgeRestoreSource,
 };
 
 #[cfg(feature = "cloudkit")]
@@ -205,7 +205,7 @@ pub fn discover_libraries() -> Result<Vec<BridgeLibrary>, BridgeError> {
     Config::discover_libraries()
         .map_err(BridgeError::config)?
         .into_iter()
-        .map(local_library_from_info)
+        .map(BridgeLibrary::from_core_info)
         .collect()
 }
 
@@ -219,7 +219,7 @@ pub fn create_library(name: Option<String>) -> Result<BridgeLibrary, BridgeError
     }
     .map_err(|e| BridgeError::config(format!("{e}")))?;
 
-    local_library_active(&config)
+    BridgeLibrary::from_core(&config)
 }
 
 /// Run the future built by `make_fut` on a worker of a shared onboarding
@@ -330,8 +330,21 @@ pub fn restore_from_cloud(
         .await
         .map_err(|e| BridgeError::internal(format!("Failed to restore library: {e}")))?;
 
-        local_library_active(&config)
+        BridgeLibrary::from_core(&config)
     })
+}
+
+impl BridgeRestoreCodeInfo {
+    /// `RestoreCodeInfo` is coven's (external crate) type — exempt from the
+    /// exhaustive destructure — so its fields stay dotted reads.
+    fn from_core(info: coven::sync::restore_code::RestoreCodeInfo) -> Self {
+        BridgeRestoreCodeInfo {
+            library_id: info.library_id,
+            library_name: info.library_name,
+            cloud_provider: BridgeCloudProvider::from_core(&info.cloud_provider),
+            needs_oauth: info.needs_oauth,
+        }
+    }
 }
 
 /// Decode a restore code string and return info for UI preview.
@@ -339,12 +352,7 @@ pub fn restore_from_cloud(
 pub fn decode_restore_code(code: String) -> Result<BridgeRestoreCodeInfo, BridgeError> {
     let info = bae_core::sync::decode_restore_code_info(&code).map_err(BridgeError::config)?;
 
-    Ok(BridgeRestoreCodeInfo {
-        library_id: info.library_id,
-        library_name: info.library_name,
-        cloud_provider: bridge_cloud_provider(&info.cloud_provider),
-        needs_oauth: info.needs_oauth,
-    })
+    Ok(BridgeRestoreCodeInfo::from_core(info))
 }
 
 /// Restore a library from a restore code string.
@@ -363,7 +371,7 @@ pub fn restore_from_code(
 
         let config = restore_from_code_config(code, oauth_tokens, get_cloudkit_ops(), None).await?;
 
-        local_library_active(&config)
+        BridgeLibrary::from_core(&config)
     })
 }
 
@@ -413,7 +421,7 @@ impl RestoreFromCodeOperation {
             let config =
                 restore_from_code_config(code, oauth_tokens, cloudkit_ops, Some(cancel)).await?;
 
-            local_library_active(&config)
+            BridgeLibrary::from_core(&config)
         })
     }
 
@@ -439,10 +447,14 @@ impl RestoreFromCodeOperation {
 pub fn generate_join_request(email: Option<String>) -> Result<BridgeJoinRequest, BridgeError> {
     let request = bae_core::sync::membership::generate_join_request(email)
         .map_err(|e| BridgeError::config(format!("Failed to generate join request: {e}")))?;
-    Ok(BridgeJoinRequest {
-        code: request.code,
-        fingerprint: request.fingerprint,
-    })
+    Ok(BridgeJoinRequest::from_core(request))
+}
+
+impl BridgeJoinRequest {
+    fn from_core(request: bae_core::sync::membership::JoinRequest) -> Self {
+        let bae_core::sync::membership::JoinRequest { code, fingerprint } = request;
+        BridgeJoinRequest { code, fingerprint }
+    }
 }
 
 /// Fetch the email of the OAuth account `oauth_token_json` authenticated, so the
@@ -455,7 +467,7 @@ pub fn fetch_account_email(
     oauth_token_json: String,
 ) -> Result<String, BridgeError> {
     let tokens = parse_oauth_tokens(&oauth_token_json)?;
-    let core_provider = bridge_cloud_provider_to_core(provider);
+    let core_provider = provider.into_core();
     on_worker(move || async move {
         bae_core::sync::membership::fetch_account_email(core_provider, &tokens)
             .await
@@ -468,11 +480,22 @@ pub fn fetch_account_email(
 pub fn decode_join_request(code: String) -> Result<BridgeJoinRequestInfo, BridgeError> {
     let req =
         bae_core::sync::membership::decode_join_request(&code).map_err(BridgeError::config)?;
-    Ok(BridgeJoinRequestInfo {
-        pubkey: req.pubkey,
-        fingerprint: req.fingerprint,
-        email: req.email,
-    })
+    Ok(BridgeJoinRequestInfo::from_core(req))
+}
+
+impl BridgeJoinRequestInfo {
+    fn from_core(req: bae_core::sync::membership::JoinRequestInfo) -> Self {
+        let bae_core::sync::membership::JoinRequestInfo {
+            pubkey,
+            fingerprint,
+            email,
+        } = req;
+        BridgeJoinRequestInfo {
+            pubkey,
+            fingerprint,
+            email,
+        }
+    }
 }
 
 /// Decode an invite code string and return info for UI preview (before joining).
@@ -480,14 +503,28 @@ pub fn decode_join_request(code: String) -> Result<BridgeJoinRequestInfo, Bridge
 pub fn decode_invite_code(code: String) -> Result<BridgeInviteCodeInfo, BridgeError> {
     let info =
         bae_core::sync::membership::decode_invite_code_info(&code).map_err(BridgeError::config)?;
-    Ok(BridgeInviteCodeInfo {
-        library_id: info.library_id,
-        library_name: info.library_name,
-        owner_pubkey: info.owner_pubkey,
-        owner_fingerprint: info.owner_fingerprint,
-        cloud_provider: bridge_cloud_provider(&info.cloud_provider),
-        needs_oauth: info.needs_oauth,
-    })
+    Ok(BridgeInviteCodeInfo::from_core(info))
+}
+
+impl BridgeInviteCodeInfo {
+    fn from_core(info: bae_core::sync::membership::InviteCodeInfo) -> Self {
+        let bae_core::sync::membership::InviteCodeInfo {
+            library_id,
+            library_name,
+            owner_pubkey,
+            owner_fingerprint,
+            cloud_provider,
+            needs_oauth,
+        } = info;
+        BridgeInviteCodeInfo {
+            library_id,
+            library_name,
+            owner_pubkey,
+            owner_fingerprint,
+            cloud_provider: BridgeCloudProvider::from_core(&cloud_provider),
+            needs_oauth,
+        }
+    }
 }
 
 fn join_error_to_bridge(error: JoinFromCodeError) -> BridgeError {
@@ -540,7 +577,7 @@ pub fn join_from_code(
 
         let config = join_from_code_config(code, oauth_tokens, get_cloudkit_ops(), None).await?;
 
-        local_library_active(&config)
+        BridgeLibrary::from_core(&config)
     })
 }
 
@@ -590,7 +627,7 @@ impl JoinFromCodeOperation {
             let config =
                 join_from_code_config(code, oauth_tokens, cloudkit_ops, Some(cancel)).await?;
 
-            local_library_active(&config)
+            BridgeLibrary::from_core(&config)
         })
     }
 
@@ -620,7 +657,7 @@ pub fn oauth_authorize(provider: BridgeCloudProvider) -> Result<String, BridgeEr
     let cancel = new_oauth_cancel();
 
     let result = on_worker(move || async move {
-        let core_provider = bridge_cloud_provider_to_core(provider);
+        let core_provider = provider.into_core();
         let clock = std::sync::Arc::new(coven::SystemClock);
         let tokens = coven::authorize_provider(core_provider, cancel, clock.as_ref())
             .await
@@ -694,7 +731,7 @@ pub fn oauth_begin(
     provider: BridgeCloudProvider,
     redirect_uri: String,
 ) -> Result<BridgeOAuthRequest, BridgeError> {
-    let core_provider = bridge_cloud_provider_to_core(provider);
+    let core_provider = provider.into_core();
     let req = coven::build_authorize_request_for_provider(core_provider, &redirect_uri)
         .map_err(|e| BridgeError::config(format!("OAuth begin failed: {e}")))?;
     let auth_url = req.auth_url.clone();
@@ -718,7 +755,7 @@ pub fn oauth_complete(
     request_id: String,
     redirect_uri: String,
 ) -> Result<String, BridgeError> {
-    let core_provider = bridge_cloud_provider_to_core(provider);
+    let core_provider = provider.into_core();
     let request = lock_bridge_mutex(&OAUTH_REQUESTS)
         .remove(&request_id)
         .ok_or_else(|| {
@@ -783,7 +820,7 @@ mod tests {
             cloud_provider: None,
         };
 
-        let error = local_library_from_info(info).expect_err("non-UTF-8 path should fail");
+        let error = BridgeLibrary::from_core_info(info).expect_err("non-UTF-8 path should fail");
         match error {
             BridgeError::Diagnostic { category, detail } => {
                 assert_eq!(category, BridgeErrorCategory::Config);

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -18,9 +18,12 @@ pub enum BridgeDiscogsSaveOutcome {
     Rejected,
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
-impl From<bae_core::import::DiscogsSaveOutcome> for BridgeDiscogsSaveOutcome {
-    fn from(outcome: bae_core::import::DiscogsSaveOutcome) -> Self {
+// Gated to `desktop` (not just non-mobile) because the sole caller,
+// `save_discogs_token`, is desktop-only; as an inherent fn (unlike the trait
+// impl it replaced) it would otherwise warn as dead code on non-desktop builds.
+#[cfg(feature = "desktop")]
+impl BridgeDiscogsSaveOutcome {
+    pub(crate) fn from_core(outcome: bae_core::import::DiscogsSaveOutcome) -> Self {
         use bae_core::import::DiscogsSaveOutcome;
         match outcome {
             DiscogsSaveOutcome::Valid => Self::Valid,
@@ -37,7 +40,7 @@ pub enum BridgeMetadataSource {
 }
 
 impl BridgeMetadataSource {
-    pub fn to_core(self) -> bae_core::import::MetadataSource {
+    pub fn into_core(self) -> bae_core::import::MetadataSource {
         match self {
             BridgeMetadataSource::MusicBrainz => bae_core::import::MetadataSource::MusicBrainz,
             BridgeMetadataSource::Discogs => bae_core::import::MetadataSource::Discogs,
@@ -95,20 +98,18 @@ pub enum BridgeLibraryImageType {
     Artist,
 }
 
-impl From<bae_core::db::LibraryImageType> for BridgeLibraryImageType {
-    fn from(value: bae_core::db::LibraryImageType) -> Self {
+impl BridgeLibraryImageType {
+    pub(crate) fn from_core(value: bae_core::db::LibraryImageType) -> Self {
         match value {
             bae_core::db::LibraryImageType::Cover => Self::Cover,
             bae_core::db::LibraryImageType::Artist => Self::Artist,
         }
     }
-}
 
-impl From<BridgeLibraryImageType> for bae_core::db::LibraryImageType {
-    fn from(value: BridgeLibraryImageType) -> Self {
-        match value {
-            BridgeLibraryImageType::Cover => Self::Cover,
-            BridgeLibraryImageType::Artist => Self::Artist,
+    pub(crate) fn into_core(self) -> bae_core::db::LibraryImageType {
+        match self {
+            BridgeLibraryImageType::Cover => bae_core::db::LibraryImageType::Cover,
+            BridgeLibraryImageType::Artist => bae_core::db::LibraryImageType::Artist,
         }
     }
 }
@@ -127,18 +128,28 @@ pub struct BridgeImageRef {
 
 impl BridgeImageRef {
     pub fn from_core(r: bae_core::album_detail::ImageRef) -> Self {
+        let bae_core::album_detail::ImageRef {
+            id,
+            version,
+            image_type,
+        } = r;
         Self {
-            id: r.id,
-            version: r.version,
-            image_type: r.image_type.into(),
+            id,
+            version,
+            image_type: BridgeLibraryImageType::from_core(image_type),
         }
     }
 
     pub fn into_core(self) -> bae_core::album_detail::ImageRef {
+        let BridgeImageRef {
+            id,
+            version,
+            image_type,
+        } = self;
         bae_core::album_detail::ImageRef {
-            id: self.id,
-            version: self.version,
-            image_type: self.image_type.into(),
+            id,
+            version,
+            image_type: image_type.into_core(),
         }
     }
 }
@@ -313,14 +324,14 @@ pub enum BridgeIdentityChoice {
 }
 
 impl BridgeIdentityChoice {
-    pub fn to_core(self) -> bae_core::import::IdentityChoice {
+    pub fn into_core(self) -> bae_core::import::IdentityChoice {
         match self {
             Self::Exact { release_id, source } => bae_core::import::IdentityChoice::Exact {
-                release_ref: bae_core::import::MetadataRef::new(release_id, source.to_core()),
+                release_ref: bae_core::import::MetadataRef::new(release_id, source.into_core()),
             },
             Self::Approximate { release_id, source } => {
                 bae_core::import::IdentityChoice::Approximate {
-                    release_ref: bae_core::import::MetadataRef::new(release_id, source.to_core()),
+                    release_ref: bae_core::import::MetadataRef::new(release_id, source.into_core()),
                 }
             }
             Self::Unknown => bae_core::import::IdentityChoice::Unknown,
@@ -409,13 +420,22 @@ pub struct BridgeAudioFormat {
     pub channels: i64,
 }
 
-pub(crate) fn audio_format_to_bridge(f: bae_core::album_detail::AudioFormat) -> BridgeAudioFormat {
-    BridgeAudioFormat {
-        codec: f.codec,
-        sample_rate_hz: f.sample_rate_hz,
-        bits_per_sample: f.bits_per_sample,
-        bitrate_kbps: f.bitrate_kbps,
-        channels: f.channels,
+impl BridgeAudioFormat {
+    pub(crate) fn from_core(f: bae_core::album_detail::AudioFormat) -> Self {
+        let bae_core::album_detail::AudioFormat {
+            codec,
+            sample_rate_hz,
+            bits_per_sample,
+            bitrate_kbps,
+            channels,
+        } = f;
+        Self {
+            codec,
+            sample_rate_hz,
+            bits_per_sample,
+            bitrate_kbps,
+            channels,
+        }
     }
 }
 
@@ -496,7 +516,7 @@ pub enum BridgeRepeatMode {
 }
 
 impl BridgeRepeatMode {
-    pub fn to_core(self) -> bae_core::playback::RepeatMode {
+    pub fn into_core(self) -> bae_core::playback::RepeatMode {
         match self {
             Self::Off => bae_core::playback::RepeatMode::Off,
             Self::Track => bae_core::playback::RepeatMode::Track,
@@ -567,11 +587,17 @@ pub struct BridgeSidePausePrompt {
 
 impl BridgeSidePausePrompt {
     pub(crate) fn from_core(prompt: bae_core::playback::PlaybackSidePausePrompt) -> Self {
+        let bae_core::playback::PlaybackSidePausePrompt {
+            id,
+            title_key,
+            side_letter,
+            message_key,
+        } = prompt;
         Self {
-            id: prompt.id,
-            title_key: prompt.title_key.to_string(),
-            side_letter: prompt.side_letter,
-            message_key: prompt.message_key.to_string(),
+            id,
+            title_key: title_key.to_string(),
+            side_letter,
+            message_key: message_key.to_string(),
         }
     }
 }
@@ -686,16 +712,18 @@ impl BridgeInvalidReason {
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn invalid_reason_to_bridge(r: bae_core::import::InvalidReason) -> BridgeInvalidReason {
-    use bae_core::import::InvalidReason as R;
-    match r {
-        R::CorruptAudioFile { path } => BridgeInvalidReason::CorruptAudioFile { path },
-        R::CorruptImage { path } => BridgeInvalidReason::CorruptImage { path },
-        R::CueMissingAudio => BridgeInvalidReason::CueMissingAudio,
-        R::CueParseFailed { path } => BridgeInvalidReason::CueParseFailed { path },
-        R::CueUnsupportedLayout => BridgeInvalidReason::CueUnsupportedLayout,
-        R::CueUnsupportedCodec { codec } => BridgeInvalidReason::CueUnsupportedCodec { codec },
-        R::NoValidAudio => BridgeInvalidReason::NoValidAudio,
+impl BridgeInvalidReason {
+    pub(crate) fn from_core(r: bae_core::import::InvalidReason) -> Self {
+        use bae_core::import::InvalidReason as R;
+        match r {
+            R::CorruptAudioFile { path } => BridgeInvalidReason::CorruptAudioFile { path },
+            R::CorruptImage { path } => BridgeInvalidReason::CorruptImage { path },
+            R::CueMissingAudio => BridgeInvalidReason::CueMissingAudio,
+            R::CueParseFailed { path } => BridgeInvalidReason::CueParseFailed { path },
+            R::CueUnsupportedLayout => BridgeInvalidReason::CueUnsupportedLayout,
+            R::CueUnsupportedCodec { codec } => BridgeInvalidReason::CueUnsupportedCodec { codec },
+            R::NoValidAudio => BridgeInvalidReason::NoValidAudio,
+        }
     }
 }
 
@@ -785,10 +813,8 @@ pub struct BridgeWatchedFolder {
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl BridgeWatchedFolder {
     pub fn from_core(folder: bae_core::import::WatchedFolder) -> Self {
-        Self {
-            path: folder.path,
-            name: folder.name,
-        }
+        let bae_core::import::WatchedFolder { path, name } = folder;
+        Self { path, name }
     }
 }
 
@@ -887,25 +913,27 @@ pub enum BridgeImportStep {
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn import_step_to_bridge(s: bae_core::import::ImportStep) -> BridgeImportStep {
-    use bae_core::import::{ImportPhase, ImportStep, PrepareStep};
-    match s {
-        ImportStep::Preparing(p) => BridgeImportStep::Preparing {
-            step: match p {
-                PrepareStep::ParsingMetadata => BridgePrepareStep::ParsingMetadata,
-                PrepareStep::WritingCoverArt => BridgePrepareStep::WritingCoverArt,
-                PrepareStep::DiscoveringFiles => BridgePrepareStep::DiscoveringFiles,
-                PrepareStep::ValidatingTracks => BridgePrepareStep::ValidatingTracks,
-                PrepareStep::SavingToDatabase => BridgePrepareStep::SavingToDatabase,
+impl BridgeImportStep {
+    pub(crate) fn from_core(s: bae_core::import::ImportStep) -> Self {
+        use bae_core::import::{ImportPhase, ImportStep, PrepareStep};
+        match s {
+            ImportStep::Preparing(p) => BridgeImportStep::Preparing {
+                step: match p {
+                    PrepareStep::ParsingMetadata => BridgePrepareStep::ParsingMetadata,
+                    PrepareStep::WritingCoverArt => BridgePrepareStep::WritingCoverArt,
+                    PrepareStep::DiscoveringFiles => BridgePrepareStep::DiscoveringFiles,
+                    PrepareStep::ValidatingTracks => BridgePrepareStep::ValidatingTracks,
+                    PrepareStep::SavingToDatabase => BridgePrepareStep::SavingToDatabase,
+                },
             },
-        },
-        ImportStep::Running(phase) => BridgeImportStep::Running {
-            phase: match phase {
-                ImportPhase::ReferencingFiles => BridgeImportPhase::ReferencingFiles,
-                ImportPhase::MeasuringLoudness => BridgeImportPhase::MeasuringLoudness,
-                ImportPhase::Finalizing => BridgeImportPhase::Finalizing,
+            ImportStep::Running(phase) => BridgeImportStep::Running {
+                phase: match phase {
+                    ImportPhase::ReferencingFiles => BridgeImportPhase::ReferencingFiles,
+                    ImportPhase::MeasuringLoudness => BridgeImportPhase::MeasuringLoudness,
+                    ImportPhase::Finalizing => BridgeImportPhase::Finalizing,
+                },
             },
-        },
+        }
     }
 }
 
@@ -967,13 +995,22 @@ pub enum BridgeSearchQuery {
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn library_status_to_bridge(s: bae_core::db::LibraryStatus) -> BridgeLibraryStatus {
-    BridgeLibraryStatus {
-        release_id: s.release_id,
-        release_in_library: s.release_in_library,
-        album_in_library: s.album_in_library,
-        album_title: s.album_title,
-        album_id: s.album_id,
+impl BridgeLibraryStatus {
+    pub(crate) fn from_core(s: bae_core::db::LibraryStatus) -> Self {
+        let bae_core::db::LibraryStatus {
+            release_id,
+            release_in_library,
+            album_in_library,
+            album_title,
+            album_id,
+        } = s;
+        Self {
+            release_id,
+            release_in_library,
+            album_in_library,
+            album_title,
+            album_id,
+        }
     }
 }
 
@@ -998,7 +1035,7 @@ pub enum BridgeExcludedSignal {
 
 impl BridgeExcludedSignal {
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
-    pub fn to_core(self) -> bae_core::identify::ExcludedSignal {
+    pub fn into_core(self) -> bae_core::identify::ExcludedSignal {
         use bae_core::identify::ExcludedSignal;
         match self {
             Self::Disc => ExcludedSignal::Disc,
@@ -1023,15 +1060,17 @@ pub enum BridgeSignalOrigin {
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn signal_origin_to_bridge(o: bae_core::signals::SignalOrigin) -> BridgeSignalOrigin {
-    use bae_core::signals::SignalOrigin;
-    match o {
-        SignalOrigin::DiscToc => BridgeSignalOrigin::DiscToc,
-        SignalOrigin::CueSheet => BridgeSignalOrigin::CueSheet,
-        SignalOrigin::Artwork => BridgeSignalOrigin::Artwork,
-        SignalOrigin::FolderName => BridgeSignalOrigin::FolderName,
-        SignalOrigin::Filename => BridgeSignalOrigin::Filename,
-        SignalOrigin::TextFile => BridgeSignalOrigin::TextFile,
+impl BridgeSignalOrigin {
+    fn from_core(o: bae_core::signals::SignalOrigin) -> Self {
+        use bae_core::signals::SignalOrigin;
+        match o {
+            SignalOrigin::DiscToc => BridgeSignalOrigin::DiscToc,
+            SignalOrigin::CueSheet => BridgeSignalOrigin::CueSheet,
+            SignalOrigin::Artwork => BridgeSignalOrigin::Artwork,
+            SignalOrigin::FolderName => BridgeSignalOrigin::FolderName,
+            SignalOrigin::Filename => BridgeSignalOrigin::Filename,
+            SignalOrigin::TextFile => BridgeSignalOrigin::TextFile,
+        }
     }
 }
 
@@ -1045,10 +1084,13 @@ pub struct BridgeSourcedValue {
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn sourced_value_to_bridge(s: bae_core::signals::SourcedValue) -> BridgeSourcedValue {
-    BridgeSourcedValue {
-        value: s.value,
-        origin: signal_origin_to_bridge(s.origin),
+impl BridgeSourcedValue {
+    fn from_core(s: bae_core::signals::SourcedValue) -> Self {
+        let bae_core::signals::SourcedValue { value, origin } = s;
+        Self {
+            value,
+            origin: BridgeSignalOrigin::from_core(origin),
+        }
     }
 }
 
@@ -1092,14 +1134,16 @@ pub enum BridgeLookupFailure {
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn lookup_failure_to_bridge(f: bae_core::signals::LookupFailure) -> BridgeLookupFailure {
-    use bae_core::signals::LookupFailure;
-    match f {
-        LookupFailure::Network => BridgeLookupFailure::Network,
-        LookupFailure::Provider { status } => BridgeLookupFailure::Provider { status },
-        LookupFailure::Timeout => BridgeLookupFailure::Timeout,
-        LookupFailure::ArtworkAnalysis => BridgeLookupFailure::ArtworkAnalysis,
-        LookupFailure::Diagnostic { detail } => BridgeLookupFailure::Diagnostic { detail },
+impl BridgeLookupFailure {
+    fn from_core(f: bae_core::signals::LookupFailure) -> Self {
+        use bae_core::signals::LookupFailure;
+        match f {
+            LookupFailure::Network => BridgeLookupFailure::Network,
+            LookupFailure::Provider { status } => BridgeLookupFailure::Provider { status },
+            LookupFailure::Timeout => BridgeLookupFailure::Timeout,
+            LookupFailure::ArtworkAnalysis => BridgeLookupFailure::ArtworkAnalysis,
+            LookupFailure::Diagnostic { detail } => BridgeLookupFailure::Diagnostic { detail },
+        }
     }
 }
 
@@ -1161,48 +1205,63 @@ pub struct BridgeSignalsToolbar {
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn signal_state_to_bridge(s: bae_core::identify::SignalState) -> BridgeSignalState {
-    use bae_core::identify::SignalState;
-    match s {
-        SignalState::LookingUp => BridgeSignalState::LookingUp,
-        SignalState::Found { count } => BridgeSignalState::Found { count },
-        SignalState::NoMatch => BridgeSignalState::NoMatch,
-        SignalState::Skipped => BridgeSignalState::Skipped,
-        SignalState::Failed { failure } => BridgeSignalState::Failed {
-            failure: lookup_failure_to_bridge(failure),
-        },
-        SignalState::Confirms { count } => BridgeSignalState::Confirms { count },
+impl BridgeSignalState {
+    fn from_core(s: bae_core::identify::SignalState) -> Self {
+        use bae_core::identify::SignalState;
+        match s {
+            SignalState::LookingUp => BridgeSignalState::LookingUp,
+            SignalState::Found { count } => BridgeSignalState::Found { count },
+            SignalState::NoMatch => BridgeSignalState::NoMatch,
+            SignalState::Skipped => BridgeSignalState::Skipped,
+            SignalState::Failed { failure } => BridgeSignalState::Failed {
+                failure: BridgeLookupFailure::from_core(failure),
+            },
+            SignalState::Confirms { count } => BridgeSignalState::Confirms { count },
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn toolbar_signal_to_bridge(s: bae_core::identify::ToolbarSignal) -> BridgeToolbarSignal {
-    use bae_core::identify::{SignalKind, SignalRole};
-    BridgeToolbarSignal {
-        kind: match s.kind {
-            SignalKind::DiscId => BridgeSignalKind::DiscId,
-            SignalKind::Barcode => BridgeSignalKind::Barcode,
-            SignalKind::Catalog => BridgeSignalKind::Catalog,
-        },
-        role: match s.role {
-            SignalRole::Identity => BridgeSignalRole::Identity,
-            SignalRole::Filter => BridgeSignalRole::Filter,
-        },
-        value: s.value,
-        origin: signal_origin_to_bridge(s.origin),
-        state: signal_state_to_bridge(s.state),
-        excluded: s.excluded,
+impl BridgeToolbarSignal {
+    fn from_core(s: bae_core::identify::ToolbarSignal) -> Self {
+        use bae_core::identify::{SignalKind, SignalRole, ToolbarSignal};
+        let ToolbarSignal {
+            kind,
+            role,
+            value,
+            origin,
+            state,
+            excluded,
+        } = s;
+        BridgeToolbarSignal {
+            kind: match kind {
+                SignalKind::DiscId => BridgeSignalKind::DiscId,
+                SignalKind::Barcode => BridgeSignalKind::Barcode,
+                SignalKind::Catalog => BridgeSignalKind::Catalog,
+            },
+            role: match role {
+                SignalRole::Identity => BridgeSignalRole::Identity,
+                SignalRole::Filter => BridgeSignalRole::Filter,
+            },
+            value,
+            origin: BridgeSignalOrigin::from_core(origin),
+            state: BridgeSignalState::from_core(state),
+            excluded,
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn toolbar_to_bridge(
-    toolbar: Vec<bae_core::identify::ToolbarSignal>,
-) -> BridgeSignalsToolbar {
-    BridgeSignalsToolbar {
-        signals: toolbar.into_iter().map(toolbar_signal_to_bridge).collect(),
+impl BridgeSignalsToolbar {
+    pub(crate) fn from_core(toolbar: Vec<bae_core::identify::ToolbarSignal>) -> Self {
+        BridgeSignalsToolbar {
+            signals: toolbar
+                .into_iter()
+                .map(BridgeToolbarSignal::from_core)
+                .collect(),
+        }
     }
 }
 
@@ -2703,235 +2762,295 @@ pub enum CloudKitError {
 
 // =========================================================================
 // Core <-> Bridge conversions
+//
+// Convention: every conversion is an associated function on the `Bridge*` type.
+// Core → bridge is `BridgeX::from_core(core_value) -> Self`; bridge → core is
+// `BridgeX::into_core(self) -> core::X`. Record converters exhaustively
+// destructure their core input(s) — no `..` in any struct or enum-variant
+// pattern — so a new bae-core field fails the build here instead of silently
+// never crossing the bridge. A field the bridge deliberately drops is named
+// explicitly (`field: _`), with a comment when the drop isn't obvious. Fields of
+// external-crate types (coven's `Config`/`CloudHomeConfig`, etc.) are exempt —
+// the bridge can't police a pinned crate's field list — and stay dotted reads.
 // =========================================================================
 
-pub(crate) fn bridge_error_category(
-    category: bae_core::ui::UiErrorCategory,
-) -> BridgeErrorCategory {
-    use bae_core::ui::UiErrorCategory;
-    match category {
-        UiErrorCategory::Database => BridgeErrorCategory::Database,
-        UiErrorCategory::Config => BridgeErrorCategory::Config,
-        UiErrorCategory::Internal => BridgeErrorCategory::Internal,
-        UiErrorCategory::Import => BridgeErrorCategory::Import,
-        UiErrorCategory::Export => BridgeErrorCategory::Export,
+impl BridgeErrorCategory {
+    pub(crate) fn from_core(category: bae_core::ui::UiErrorCategory) -> Self {
+        use bae_core::ui::UiErrorCategory;
+        match category {
+            UiErrorCategory::Database => BridgeErrorCategory::Database,
+            UiErrorCategory::Config => BridgeErrorCategory::Config,
+            UiErrorCategory::Internal => BridgeErrorCategory::Internal,
+            UiErrorCategory::Import => BridgeErrorCategory::Import,
+            UiErrorCategory::Export => BridgeErrorCategory::Export,
+        }
     }
 }
 
-fn bridge_entity_kind(entity: bae_core::ui::UiEntityKind) -> BridgeEntityKind {
-    use bae_core::ui::UiEntityKind;
-    match entity {
-        UiEntityKind::Library => BridgeEntityKind::Library,
-        UiEntityKind::Album => BridgeEntityKind::Album,
-        UiEntityKind::Release => BridgeEntityKind::Release,
-        UiEntityKind::Track => BridgeEntityKind::Track,
-        UiEntityKind::File => BridgeEntityKind::File,
+impl BridgeEntityKind {
+    fn from_core(entity: bae_core::ui::UiEntityKind) -> Self {
+        use bae_core::ui::UiEntityKind;
+        match entity {
+            UiEntityKind::Library => BridgeEntityKind::Library,
+            UiEntityKind::Album => BridgeEntityKind::Album,
+            UiEntityKind::Release => BridgeEntityKind::Release,
+            UiEntityKind::Track => BridgeEntityKind::Track,
+            UiEntityKind::File => BridgeEntityKind::File,
+        }
     }
 }
 
-pub(crate) fn bridge_error(error: bae_core::ui::UiError) -> BridgeError {
-    use bae_core::ui::UiError;
-    match error {
-        UiError::NotFound { entity, id } => BridgeError::NotFound {
-            entity: bridge_entity_kind(entity),
-            id,
-        },
-        UiError::Diagnostic { category, detail } => BridgeError::Diagnostic {
-            category: bridge_error_category(category),
-            detail,
-        },
+impl BridgeError {
+    pub(crate) fn from_core(error: bae_core::ui::UiError) -> Self {
+        use bae_core::ui::UiError;
+        match error {
+            UiError::NotFound { entity, id } => BridgeError::NotFound {
+                entity: BridgeEntityKind::from_core(entity),
+                id,
+            },
+            UiError::Diagnostic { category, detail } => BridgeError::Diagnostic {
+                category: BridgeErrorCategory::from_core(category),
+                detail,
+            },
+        }
     }
 }
 
-pub(crate) fn bridge_playback_error_reason(
-    reason: bae_core::ui::PlaybackErrorReason,
-) -> BridgePlaybackErrorReason {
-    use bae_core::ui::PlaybackErrorReason;
-    match reason {
-        PlaybackErrorReason::SyncDisconnected => BridgePlaybackErrorReason::SyncDisconnected,
-        PlaybackErrorReason::UploadPending => BridgePlaybackErrorReason::UploadPending,
-        PlaybackErrorReason::Diagnostic { error } => BridgePlaybackErrorReason::Diagnostic {
-            error: bridge_error(error),
-        },
+impl BridgePlaybackErrorReason {
+    pub(crate) fn from_core(reason: bae_core::ui::PlaybackErrorReason) -> Self {
+        use bae_core::ui::PlaybackErrorReason;
+        match reason {
+            PlaybackErrorReason::SyncDisconnected => BridgePlaybackErrorReason::SyncDisconnected,
+            PlaybackErrorReason::UploadPending => BridgePlaybackErrorReason::UploadPending,
+            PlaybackErrorReason::Diagnostic { error } => BridgePlaybackErrorReason::Diagnostic {
+                error: BridgeError::from_core(error),
+            },
+        }
     }
 }
 
 /// Map the UI's storage-state choice to the core's `StorageMode`. Pinned-ness is
 /// orthogonal — the caller passes the import's `pin` choice separately.
 #[cfg(feature = "desktop")]
-pub(crate) fn bridge_storage_mode_to_core(
-    mode: BridgeStorageMode,
-) -> bae_core::import::StorageMode {
-    use bae_core::import::StorageMode;
-    match mode {
-        BridgeStorageMode::Local => StorageMode::Local,
-        BridgeStorageMode::Remote => StorageMode::Remote,
+impl BridgeStorageMode {
+    pub(crate) fn into_core(self) -> bae_core::import::StorageMode {
+        use bae_core::import::StorageMode;
+        match self {
+            BridgeStorageMode::Local => StorageMode::Local,
+            BridgeStorageMode::Remote => StorageMode::Remote,
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn bridge_cover_to_import(c: BridgeCoverSelection) -> bae_core::import::CoverSelection {
-    match c {
-        BridgeCoverSelection::ReleaseImage { file_id } => {
-            bae_core::import::CoverSelection::Local(file_id)
+impl BridgeCoverSelection {
+    pub(crate) fn into_core(self) -> bae_core::import::CoverSelection {
+        match self {
+            BridgeCoverSelection::ReleaseImage { file_id } => {
+                bae_core::import::CoverSelection::Local(file_id)
+            }
+            BridgeCoverSelection::RemoteCover { selection } => {
+                bae_core::import::CoverSelection::Remote(
+                    selection.url,
+                    selection.source.into_core(),
+                )
+            }
         }
-        BridgeCoverSelection::RemoteCover { selection } => {
-            bae_core::import::CoverSelection::Remote(selection.url, selection.source.to_core())
+    }
+}
+
+impl BridgeCloudProvider {
+    pub(crate) fn from_core(p: &bae_core::config::CloudProvider) -> Self {
+        use bae_core::config::CloudProvider;
+        match p {
+            CloudProvider::S3 => BridgeCloudProvider::S3,
+            CloudProvider::GoogleDrive => BridgeCloudProvider::GoogleDrive,
+            CloudProvider::Dropbox => BridgeCloudProvider::Dropbox,
+            CloudProvider::OneDrive => BridgeCloudProvider::OneDrive,
+            CloudProvider::CloudKit => BridgeCloudProvider::CloudKit,
         }
     }
 }
 
-pub(crate) fn bridge_cloud_provider(p: &bae_core::config::CloudProvider) -> BridgeCloudProvider {
-    use bae_core::config::CloudProvider;
-    match p {
-        CloudProvider::S3 => BridgeCloudProvider::S3,
-        CloudProvider::GoogleDrive => BridgeCloudProvider::GoogleDrive,
-        CloudProvider::Dropbox => BridgeCloudProvider::Dropbox,
-        CloudProvider::OneDrive => BridgeCloudProvider::OneDrive,
-        CloudProvider::CloudKit => BridgeCloudProvider::CloudKit,
+impl BridgeMemberRole {
+    pub(crate) fn from_core(role: bae_core::sync::membership::MemberRole) -> Self {
+        use bae_core::sync::membership::MemberRole;
+        match role {
+            MemberRole::Owner => BridgeMemberRole::Owner,
+            MemberRole::Member => BridgeMemberRole::Member,
+            MemberRole::Follower => BridgeMemberRole::Follower,
+        }
     }
 }
 
-pub(crate) fn bridge_member_role(role: bae_core::sync::membership::MemberRole) -> BridgeMemberRole {
-    use bae_core::sync::membership::MemberRole;
-    match role {
-        MemberRole::Owner => BridgeMemberRole::Owner,
-        MemberRole::Member => BridgeMemberRole::Member,
-        MemberRole::Follower => BridgeMemberRole::Follower,
+impl BridgeMember {
+    fn from_core(m: bae_core::sync::membership::MembershipMember) -> Self {
+        let bae_core::sync::membership::MembershipMember {
+            pubkey,
+            role,
+            is_self,
+            fingerprint,
+            can_remove,
+        } = m;
+        BridgeMember {
+            pubkey,
+            role: BridgeMemberRole::from_core(role),
+            is_self,
+            fingerprint,
+            can_remove,
+        }
     }
 }
 
-fn bridge_member(m: bae_core::sync::membership::MembershipMember) -> BridgeMember {
-    BridgeMember {
-        pubkey: m.pubkey,
-        role: bridge_member_role(m.role),
-        is_self: m.is_self,
-        fingerprint: m.fingerprint,
-        can_remove: m.can_remove,
-    }
-}
-
-pub(crate) fn bridge_membership(
-    membership: bae_core::sync::membership::Membership,
-) -> BridgeMembership {
-    BridgeMembership {
-        members: membership.members.into_iter().map(bridge_member).collect(),
-        self_is_owner: membership.self_is_owner,
+impl BridgeMembership {
+    pub(crate) fn from_core(membership: bae_core::sync::membership::Membership) -> Self {
+        let bae_core::sync::membership::Membership {
+            members,
+            self_is_owner,
+        } = membership;
+        BridgeMembership {
+            members: members.into_iter().map(BridgeMember::from_core).collect(),
+            self_is_owner,
+        }
     }
 }
 
 /// Only the OAuth sign-in and authorize flows still map a bare bridge provider
 /// back to core; gated so non-OAuth builds don't carry a dead mapping.
 #[cfg(feature = "oauth-providers")]
-pub(crate) fn bridge_cloud_provider_to_core(
-    p: BridgeCloudProvider,
-) -> bae_core::config::CloudProvider {
-    use bae_core::config::CloudProvider;
-    match p {
-        BridgeCloudProvider::S3 => CloudProvider::S3,
-        BridgeCloudProvider::GoogleDrive => CloudProvider::GoogleDrive,
-        BridgeCloudProvider::Dropbox => CloudProvider::Dropbox,
-        BridgeCloudProvider::OneDrive => CloudProvider::OneDrive,
-        BridgeCloudProvider::CloudKit => CloudProvider::CloudKit,
+impl BridgeCloudProvider {
+    pub(crate) fn into_core(self) -> bae_core::config::CloudProvider {
+        use bae_core::config::CloudProvider;
+        match self {
+            BridgeCloudProvider::S3 => CloudProvider::S3,
+            BridgeCloudProvider::GoogleDrive => CloudProvider::GoogleDrive,
+            BridgeCloudProvider::Dropbox => CloudProvider::Dropbox,
+            BridgeCloudProvider::OneDrive => CloudProvider::OneDrive,
+            BridgeCloudProvider::CloudKit => CloudProvider::CloudKit,
+        }
     }
 }
 
-pub(crate) fn bridge_home_storage_to_core(s: BridgeHomeStorage) -> bae_core::config::HomeStorage {
-    use bae_core::config::HomeStorage;
-    match s {
-        BridgeHomeStorage::Opaque => HomeStorage::Opaque,
-        BridgeHomeStorage::Browsable => HomeStorage::Browsable,
+impl BridgeHomeStorage {
+    pub(crate) fn into_core(self) -> bae_core::config::HomeStorage {
+        use bae_core::config::HomeStorage;
+        match self {
+            BridgeHomeStorage::Opaque => HomeStorage::Opaque,
+            BridgeHomeStorage::Browsable => HomeStorage::Browsable,
+        }
     }
 }
 
-pub(crate) fn bridge_storage_sort_to_core(
-    sort: &BridgeStorageSort,
-) -> bae_core::album_detail::StorageSort {
-    bae_core::album_detail::StorageSort {
-        field: match sort.field {
-            BridgeStorageSortField::AlbumTitle => {
-                bae_core::album_detail::StorageSortField::AlbumTitle
-            }
-            BridgeStorageSortField::ArtistNames => {
-                bae_core::album_detail::StorageSortField::ArtistNames
-            }
-            BridgeStorageSortField::Format => bae_core::album_detail::StorageSortField::Format,
-            BridgeStorageSortField::FileCount => {
-                bae_core::album_detail::StorageSortField::FileCount
-            }
-            BridgeStorageSortField::TotalSize => {
-                bae_core::album_detail::StorageSortField::TotalSize
-            }
-        },
-        direction: match sort.direction {
-            BridgeStorageSortDirection::Ascending => {
-                bae_core::album_detail::StorageSortDirection::Ascending
-            }
-            BridgeStorageSortDirection::Descending => {
-                bae_core::album_detail::StorageSortDirection::Descending
-            }
-        },
+impl BridgeStorageSort {
+    pub(crate) fn into_core(self) -> bae_core::album_detail::StorageSort {
+        let BridgeStorageSort { field, direction } = self;
+        bae_core::album_detail::StorageSort {
+            field: match field {
+                BridgeStorageSortField::AlbumTitle => {
+                    bae_core::album_detail::StorageSortField::AlbumTitle
+                }
+                BridgeStorageSortField::ArtistNames => {
+                    bae_core::album_detail::StorageSortField::ArtistNames
+                }
+                BridgeStorageSortField::Format => bae_core::album_detail::StorageSortField::Format,
+                BridgeStorageSortField::FileCount => {
+                    bae_core::album_detail::StorageSortField::FileCount
+                }
+                BridgeStorageSortField::TotalSize => {
+                    bae_core::album_detail::StorageSortField::TotalSize
+                }
+            },
+            direction: match direction {
+                BridgeStorageSortDirection::Ascending => {
+                    bae_core::album_detail::StorageSortDirection::Ascending
+                }
+                BridgeStorageSortDirection::Descending => {
+                    bae_core::album_detail::StorageSortDirection::Descending
+                }
+            },
+        }
     }
 }
 
-pub(crate) fn bridge_storage_filter_to_core(
-    filter: BridgeStorageFilter,
-) -> bae_core::album_detail::StorageFilter {
-    match filter {
-        BridgeStorageFilter::All => bae_core::album_detail::StorageFilter::All,
-        BridgeStorageFilter::Remote => bae_core::album_detail::StorageFilter::Remote,
-        BridgeStorageFilter::Local => bae_core::album_detail::StorageFilter::Local,
-        BridgeStorageFilter::Uploading => bae_core::album_detail::StorageFilter::Uploading,
+impl BridgeStorageFilter {
+    pub(crate) fn into_core(self) -> bae_core::album_detail::StorageFilter {
+        match self {
+            BridgeStorageFilter::All => bae_core::album_detail::StorageFilter::All,
+            BridgeStorageFilter::Remote => bae_core::album_detail::StorageFilter::Remote,
+            BridgeStorageFilter::Local => bae_core::album_detail::StorageFilter::Local,
+            BridgeStorageFilter::Uploading => bae_core::album_detail::StorageFilter::Uploading,
+        }
     }
 }
 
-pub(crate) fn bridge_composer_sort_to_core(
-    c: &BridgeComposerSortCriterion,
-) -> bae_core::db::ComposerSortCriterion {
-    bae_core::db::ComposerSortCriterion {
-        field: match c.field {
-            BridgeComposerSortField::Name => bae_core::db::ComposerSortField::Name,
-            BridgeComposerSortField::WorkCount => bae_core::db::ComposerSortField::WorkCount,
-            BridgeComposerSortField::LinkedReleaseCount => {
-                bae_core::db::ComposerSortField::LinkedReleaseCount
-            }
-        },
-        direction: bridge_sort_direction_to_core(&c.direction),
+impl BridgeComposerSortCriterion {
+    pub(crate) fn into_core(self) -> bae_core::db::ComposerSortCriterion {
+        let BridgeComposerSortCriterion { field, direction } = self;
+        bae_core::db::ComposerSortCriterion {
+            field: match field {
+                BridgeComposerSortField::Name => bae_core::db::ComposerSortField::Name,
+                BridgeComposerSortField::WorkCount => bae_core::db::ComposerSortField::WorkCount,
+                BridgeComposerSortField::LinkedReleaseCount => {
+                    bae_core::db::ComposerSortField::LinkedReleaseCount
+                }
+            },
+            direction: direction.into_core(),
+        }
     }
 }
 
-fn bridge_sort_direction_to_core(direction: &BridgeSortDirection) -> bae_core::db::SortDirection {
-    match direction {
-        BridgeSortDirection::Ascending => bae_core::db::SortDirection::Ascending,
-        BridgeSortDirection::Descending => bae_core::db::SortDirection::Descending,
+impl BridgeSortDirection {
+    pub(crate) fn into_core(self) -> bae_core::db::SortDirection {
+        match self {
+            BridgeSortDirection::Ascending => bae_core::db::SortDirection::Ascending,
+            BridgeSortDirection::Descending => bae_core::db::SortDirection::Descending,
+        }
     }
 }
 
-pub(crate) fn bridge_sort_to_core(c: &BridgeSortCriterion) -> bae_core::db::AlbumSortCriterion {
-    bae_core::db::AlbumSortCriterion {
-        field: match c.field {
-            BridgeSortField::Title => bae_core::db::AlbumSortField::Title,
-            BridgeSortField::Artist => bae_core::db::AlbumSortField::Artist,
-            BridgeSortField::Year => bae_core::db::AlbumSortField::Year,
-            BridgeSortField::DateAdded => bae_core::db::AlbumSortField::DateAdded,
-        },
-        direction: bridge_sort_direction_to_core(&c.direction),
+impl BridgeSortCriterion {
+    pub(crate) fn into_core(self) -> bae_core::db::AlbumSortCriterion {
+        let BridgeSortCriterion { field, direction } = self;
+        bae_core::db::AlbumSortCriterion {
+            field: match field {
+                BridgeSortField::Title => bae_core::db::AlbumSortField::Title,
+                BridgeSortField::Artist => bae_core::db::AlbumSortField::Artist,
+                BridgeSortField::Year => bae_core::db::AlbumSortField::Year,
+                BridgeSortField::DateAdded => bae_core::db::AlbumSortField::DateAdded,
+            },
+            direction: direction.into_core(),
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn metadata_result_to_bridge(
-    r: bae_core::import::search::MetadataResult,
-) -> BridgeMetadataResult {
-    BridgeMetadataResult {
-        source: BridgeMetadataSource::from_core(r.source),
-        release_id: r.release_id,
-        year: r.year,
-        format: r.format,
-        label: r.label,
-        catalog_number: r.catalog_number,
-        country: r.country,
+impl BridgeMetadataResult {
+    pub(crate) fn from_core(r: bae_core::import::search::MetadataResult) -> Self {
+        let bae_core::import::search::MetadataResult {
+            source,
+            release_id,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            // Dropped: the card carries the album's title/artist/cover, so a
+            // pressing projection keeps only pressing-distinguishing fields.
+            title: _,
+            artist: _,
+            cover_art: _,
+            source_group_id: _,
+        } = r;
+        BridgeMetadataResult {
+            source: BridgeMetadataSource::from_core(source),
+            release_id,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+        }
     }
 }
 
@@ -2940,14 +3059,20 @@ pub(crate) fn metadata_result_to_bridge(
     not(any(target_os = "ios", target_os = "android"))
 ))]
 #[cfg(feature = "desktop")]
-pub(crate) fn remote_cover_data_to_bridge(
-    c: bae_core::import::cover_art::RemoteCover,
-) -> BridgeRemoteCover {
-    let selection = bridge_remote_cover_selection(c.url, c.source);
-    let cover_choice = remote_cover_choice_to_bridge(&selection, &c.thumbnail_url);
-    BridgeRemoteCover {
-        cover_choice,
-        label: c.label,
+impl BridgeRemoteCover {
+    pub(crate) fn from_core(c: bae_core::import::cover_art::RemoteCover) -> Self {
+        let bae_core::import::cover_art::RemoteCover {
+            url,
+            thumbnail_url,
+            label,
+            source,
+        } = c;
+        let selection = bridge_remote_cover_selection(url, source);
+        let cover_choice = remote_cover_choice_to_bridge(&selection, &thumbnail_url);
+        BridgeRemoteCover {
+            cover_choice,
+            label,
+        }
     }
 }
 
@@ -2989,338 +3114,471 @@ fn remote_cover_choice_to_bridge(
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn release_detail_to_bridge(
-    d: bae_core::import::search::ImportSearchReleaseDetail,
-    local_track_count: Option<u32>,
-) -> BridgeReleaseDetail {
-    let track_count_mismatch = d.track_count_mismatch(local_track_count);
-    let default_cover = d
-        .default_cover()
-        .cloned()
-        .map(remote_cover_data_to_bridge)
-        .map(|c| c.cover_choice);
-    let cover_art: Vec<BridgeRemoteCover> = d
-        .cover_art
-        .into_iter()
-        .map(remote_cover_data_to_bridge)
-        .collect();
-    BridgeReleaseDetail {
-        release_id: d.release_id,
-        source: BridgeMetadataSource::from_core(d.source),
-        source_group_id: d.source_group_id,
-        title: d.title,
-        artist: d.artist,
-        year: d.year,
-        format: d.format,
-        label: d.label,
-        catalog_number: d.catalog_number,
-        country: d.country,
-        barcode: d.barcode,
-        track_count: d.track_count,
-        track_count_mismatch,
-        tracks: d
-            .tracks
-            .into_iter()
-            .map(|t| BridgeReleaseTrack {
-                title: t.title,
-                artist: t.artist,
-                duration_ms: t.duration_ms,
-                position: t.position,
-                side: t.side,
-            })
-            .collect(),
-        cover_art,
-        default_cover,
+impl BridgeReleaseDetail {
+    pub(crate) fn from_core(
+        d: bae_core::import::search::ImportSearchReleaseDetail,
+        local_track_count: Option<u32>,
+    ) -> Self {
+        // Derived values borrow `&d`; compute them before destructuring `d`.
+        let track_count_mismatch = d.track_count_mismatch(local_track_count);
+        let default_cover = d
+            .default_cover()
+            .cloned()
+            .map(BridgeRemoteCover::from_core)
+            .map(|c| c.cover_choice);
+        let bae_core::import::search::ImportSearchReleaseDetail {
+            release_id,
+            source,
+            source_group_id,
+            title,
+            artist,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+            track_count,
+            tracks,
+            cover_art,
+        } = d;
+        BridgeReleaseDetail {
+            release_id,
+            source: BridgeMetadataSource::from_core(source),
+            source_group_id,
+            title,
+            artist,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+            track_count,
+            track_count_mismatch,
+            tracks: tracks
+                .into_iter()
+                .map(BridgeReleaseTrack::from_core)
+                .collect(),
+            cover_art: cover_art
+                .into_iter()
+                .map(BridgeRemoteCover::from_core)
+                .collect(),
+            default_cover,
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-fn bridge_remote_cover_to_core(c: BridgeRemoteCover) -> bae_core::import::cover_art::RemoteCover {
-    let BridgeCoverChoice {
-        selection,
-        thumbnail_source,
-        ..
-    } = c.cover_choice;
-    let BridgeCoverSelection::RemoteCover { selection } = selection else {
-        unreachable!("BridgeRemoteCover must carry a remote cover selection");
-    };
-    let BridgeCoverImageSource::Remote { url: thumbnail_url } = thumbnail_source else {
-        unreachable!("BridgeRemoteCover must carry a remote cover thumbnail");
-    };
-    bae_core::import::cover_art::RemoteCover {
-        url: selection.url,
-        thumbnail_url,
-        label: c.label,
-        source: selection.source.to_core(),
+impl BridgeReleaseTrack {
+    pub(crate) fn from_core(t: bae_core::import::search::ReleaseTrack) -> Self {
+        let bae_core::import::search::ReleaseTrack {
+            title,
+            artist,
+            duration_ms,
+            position,
+            side,
+        } = t;
+        Self {
+            title,
+            artist,
+            duration_ms,
+            position,
+            side,
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::import::search::ReleaseTrack {
+        let BridgeReleaseTrack {
+            title,
+            artist,
+            duration_ms,
+            position,
+            side,
+        } = self;
+        bae_core::import::search::ReleaseTrack {
+            title,
+            artist,
+            duration_ms,
+            position,
+            side,
+        }
     }
 }
 
-/// Reverse of [`release_detail_to_bridge`]. Used by the user-edit shaping
+#[cfg(feature = "desktop")]
+impl BridgeRemoteCover {
+    pub(crate) fn into_core(self) -> bae_core::import::cover_art::RemoteCover {
+        let BridgeRemoteCover {
+            cover_choice,
+            label,
+        } = self;
+        let BridgeCoverChoice {
+            selection,
+            thumbnail_source,
+            // The preview and thumbnail sources are the same remote URL; the
+            // core cover carries only the one thumbnail URL, read below.
+            preview_source: _,
+        } = cover_choice;
+        let BridgeCoverSelection::RemoteCover { selection } = selection else {
+            unreachable!("BridgeRemoteCover must carry a remote cover selection");
+        };
+        let BridgeCoverImageSource::Remote { url: thumbnail_url } = thumbnail_source else {
+            unreachable!("BridgeRemoteCover must carry a remote cover thumbnail");
+        };
+        bae_core::import::cover_art::RemoteCover {
+            url: selection.url,
+            thumbnail_url,
+            label,
+            source: selection.source.into_core(),
+        }
+    }
+}
+
+/// Reverse of [`BridgeReleaseDetail::from_core`]. Used by the user-edit shaping
 /// path (the bridge has the detail in bridge shape from the prefetch, and
-/// the shaping function in bae-core takes the core type). Drops the
-/// bridge-computed `track_count_mismatch` field — shaping doesn't read it.
+/// the shaping function in bae-core takes the core type).
 #[cfg(feature = "desktop")]
-pub(crate) fn release_detail_from_bridge(
-    d: BridgeReleaseDetail,
-) -> bae_core::import::search::ImportSearchReleaseDetail {
-    bae_core::import::search::ImportSearchReleaseDetail {
-        release_id: d.release_id,
-        source: d.source.to_core(),
-        source_group_id: d.source_group_id,
-        title: d.title,
-        artist: d.artist,
-        year: d.year,
-        format: d.format,
-        label: d.label,
-        catalog_number: d.catalog_number,
-        country: d.country,
-        barcode: d.barcode,
-        track_count: d.track_count,
-        tracks: d
-            .tracks
-            .into_iter()
-            .map(|t| bae_core::import::search::ReleaseTrack {
-                title: t.title,
-                artist: t.artist,
-                duration_ms: t.duration_ms,
-                position: t.position,
-                side: t.side,
-            })
-            .collect(),
-        cover_art: d
-            .cover_art
-            .into_iter()
-            .map(bridge_remote_cover_to_core)
-            .collect(),
+impl BridgeReleaseDetail {
+    pub(crate) fn into_core(self) -> bae_core::import::search::ImportSearchReleaseDetail {
+        let BridgeReleaseDetail {
+            release_id,
+            source,
+            source_group_id,
+            title,
+            artist,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+            track_count,
+            tracks,
+            cover_art,
+            // Both are bridge-computed for the UI; the core detail carries
+            // neither, and shaping doesn't read them.
+            track_count_mismatch: _,
+            default_cover: _,
+        } = self;
+        bae_core::import::search::ImportSearchReleaseDetail {
+            release_id,
+            source: source.into_core(),
+            source_group_id,
+            title,
+            artist,
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+            track_count,
+            tracks: tracks
+                .into_iter()
+                .map(BridgeReleaseTrack::into_core)
+                .collect(),
+            cover_art: cover_art
+                .into_iter()
+                .map(BridgeRemoteCover::into_core)
+                .collect(),
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn identify_source_to_bridge(
-    s: bae_core::identify::IdentifySource,
-) -> BridgeIdentifySource {
-    match s {
-        bae_core::identify::IdentifySource::Discid => BridgeIdentifySource::Discid,
-        bae_core::identify::IdentifySource::Barcode => BridgeIdentifySource::Barcode,
-        bae_core::identify::IdentifySource::Combined => BridgeIdentifySource::Combined,
+impl BridgeIdentifySource {
+    pub(crate) fn from_core(s: bae_core::identify::IdentifySource) -> Self {
+        match s {
+            bae_core::identify::IdentifySource::Discid => BridgeIdentifySource::Discid,
+            bae_core::identify::IdentifySource::Barcode => BridgeIdentifySource::Barcode,
+            bae_core::identify::IdentifySource::Combined => BridgeIdentifySource::Combined,
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn discid_progress_to_bridge(p: bae_core::identify::DiscidProgress) -> BridgeDiscidProgress {
-    use bae_core::identify::DiscidProgress;
-    match p {
-        DiscidProgress::Computing => BridgeDiscidProgress::Computing,
-        DiscidProgress::LookingUp => BridgeDiscidProgress::LookingUp,
-        DiscidProgress::Done { results, .. } => BridgeDiscidProgress::Done {
-            n_results: results.len() as u32,
-        },
-        DiscidProgress::Skipped { .. } => BridgeDiscidProgress::Skipped,
-        DiscidProgress::Failed { failure, .. } => BridgeDiscidProgress::Failed {
-            failure: lookup_failure_to_bridge(failure),
-        },
+impl BridgeDiscidProgress {
+    fn from_core(p: bae_core::identify::DiscidProgress) -> Self {
+        use bae_core::identify::DiscidProgress;
+        match p {
+            DiscidProgress::Computing => BridgeDiscidProgress::Computing,
+            DiscidProgress::LookingUp => BridgeDiscidProgress::LookingUp,
+            DiscidProgress::Done {
+                results,
+                track_count: _,
+            } => BridgeDiscidProgress::Done {
+                n_results: results.len() as u32,
+            },
+            DiscidProgress::Skipped { track_count: _ } => BridgeDiscidProgress::Skipped,
+            DiscidProgress::Failed {
+                failure,
+                track_count: _,
+            } => BridgeDiscidProgress::Failed {
+                failure: BridgeLookupFailure::from_core(failure),
+            },
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn barcode_progress_to_bridge(p: bae_core::identify::BarcodeProgress) -> BridgeBarcodeProgress {
-    use bae_core::identify::BarcodeProgress;
-    match p {
-        BarcodeProgress::Scanning => BridgeBarcodeProgress::Scanning,
-        BarcodeProgress::LookingUp {
-            current,
-            position,
-            total,
-            ..
-        } => BridgeBarcodeProgress::LookingUp {
-            current,
-            position,
-            total,
-        },
-        BarcodeProgress::Done { results, .. } => BridgeBarcodeProgress::Done {
-            n_results: results.len() as u32,
-        },
-        BarcodeProgress::Failed { failure } => BridgeBarcodeProgress::Failed {
-            failure: lookup_failure_to_bridge(failure),
-        },
-        BarcodeProgress::Skipped => BridgeBarcodeProgress::Skipped,
+impl BridgeBarcodeProgress {
+    fn from_core(p: bae_core::identify::BarcodeProgress) -> Self {
+        use bae_core::identify::BarcodeProgress;
+        match p {
+            BarcodeProgress::Scanning => BridgeBarcodeProgress::Scanning,
+            BarcodeProgress::LookingUp {
+                current,
+                position,
+                total,
+                remaining: _,
+            } => BridgeBarcodeProgress::LookingUp {
+                current,
+                position,
+                total,
+            },
+            BarcodeProgress::Done {
+                matched: _,
+                results,
+            } => BridgeBarcodeProgress::Done {
+                n_results: results.len() as u32,
+            },
+            BarcodeProgress::Failed { failure } => BridgeBarcodeProgress::Failed {
+                failure: BridgeLookupFailure::from_core(failure),
+            },
+            BarcodeProgress::Skipped => BridgeBarcodeProgress::Skipped,
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn release_group_to_bridge(
-    g: bae_core::import::release_group::ReleaseGroup,
-) -> BridgeReleaseGroup {
-    BridgeReleaseGroup {
-        id: g.id,
-        title: g.title,
-        artist: g.artist,
-        cover_art: g.cover_art.map(remote_cover_data_to_bridge),
-        source_label: g.source_label,
-        group_url: g.group_url,
-        year_min: g.year_min,
-        year_max: g.year_max,
-        pressings: g
-            .pressings
-            .into_iter()
-            .map(metadata_result_to_bridge)
-            .collect(),
+impl BridgeReleaseGroup {
+    pub(crate) fn from_core(g: bae_core::import::release_group::ReleaseGroup) -> Self {
+        let bae_core::import::release_group::ReleaseGroup {
+            id,
+            title,
+            artist,
+            cover_art,
+            source_label,
+            group_url,
+            year_min,
+            year_max,
+            pressings,
+        } = g;
+        BridgeReleaseGroup {
+            id,
+            title,
+            artist,
+            cover_art: cover_art.map(BridgeRemoteCover::from_core),
+            source_label,
+            group_url,
+            year_min,
+            year_max,
+            pressings: pressings
+                .into_iter()
+                .map(BridgeMetadataResult::from_core)
+                .collect(),
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn signals_to_bridge(s: bae_core::signals::Signals) -> BridgeSignals {
-    use bae_core::signals::{BarcodeSignal, DiscIdSignal, TextSignal};
+impl BridgeSignals {
+    pub(crate) fn from_core(s: bae_core::signals::Signals) -> Self {
+        use bae_core::signals::{BarcodeSignal, DiscIdSignal, Signals, TextSignal};
 
-    let disc_id = match s.disc_id {
-        DiscIdSignal::Computed {
+        fn sourced_values(values: Vec<bae_core::signals::SourcedValue>) -> Vec<BridgeSourcedValue> {
+            values
+                .into_iter()
+                .map(BridgeSourcedValue::from_core)
+                .collect()
+        }
+
+        let Signals {
             disc_id,
-            track_count,
-        } => BridgeDiscIdSignal::Computed {
+            barcode,
+            text,
+        } = s;
+
+        let disc_id = match disc_id {
+            DiscIdSignal::Computed {
+                disc_id,
+                track_count,
+            } => BridgeDiscIdSignal::Computed {
+                disc_id,
+                track_count,
+            },
+            DiscIdSignal::Absent { track_count } => BridgeDiscIdSignal::Absent { track_count },
+            DiscIdSignal::Failed {
+                failure,
+                track_count,
+            } => BridgeDiscIdSignal::Failed {
+                failure: BridgeLookupFailure::from_core(failure),
+                track_count,
+            },
+        };
+
+        let barcode = match barcode {
+            BarcodeSignal::Scanning { codes } => BridgeBarcodeSignal::Scanning {
+                codes: sourced_values(codes),
+            },
+            BarcodeSignal::Settled { codes } => BridgeBarcodeSignal::Settled {
+                codes: sourced_values(codes),
+            },
+            BarcodeSignal::Failed { failure, codes } => BridgeBarcodeSignal::Failed {
+                failure: BridgeLookupFailure::from_core(failure),
+                codes: sourced_values(codes),
+            },
+            BarcodeSignal::Absent => BridgeBarcodeSignal::Absent,
+        };
+
+        let text = match text {
+            TextSignal::Scanning {
+                catalogs,
+                free_text,
+            } => BridgeTextSignal::Scanning {
+                catalogs: sourced_values(catalogs),
+                free_text,
+            },
+            TextSignal::Settled {
+                catalogs,
+                free_text,
+            } => BridgeTextSignal::Settled {
+                catalogs: sourced_values(catalogs),
+                free_text,
+            },
+            TextSignal::Failed {
+                failure,
+                catalogs,
+                free_text,
+            } => BridgeTextSignal::Failed {
+                failure: BridgeLookupFailure::from_core(failure),
+                catalogs: sourced_values(catalogs),
+                free_text,
+            },
+        };
+
+        BridgeSignals {
             disc_id,
-            track_count,
-        },
-        DiscIdSignal::Absent { track_count } => BridgeDiscIdSignal::Absent { track_count },
-        DiscIdSignal::Failed {
-            failure,
-            track_count,
-        } => BridgeDiscIdSignal::Failed {
-            failure: lookup_failure_to_bridge(failure),
-            track_count,
-        },
-    };
-
-    let barcode = match s.barcode {
-        BarcodeSignal::Scanning { codes } => BridgeBarcodeSignal::Scanning {
-            codes: codes.into_iter().map(sourced_value_to_bridge).collect(),
-        },
-        BarcodeSignal::Settled { codes } => BridgeBarcodeSignal::Settled {
-            codes: codes.into_iter().map(sourced_value_to_bridge).collect(),
-        },
-        BarcodeSignal::Failed { failure, codes } => BridgeBarcodeSignal::Failed {
-            failure: lookup_failure_to_bridge(failure),
-            codes: codes.into_iter().map(sourced_value_to_bridge).collect(),
-        },
-        BarcodeSignal::Absent => BridgeBarcodeSignal::Absent,
-    };
-
-    let text = match s.text {
-        TextSignal::Scanning {
-            catalogs,
-            free_text,
-        } => BridgeTextSignal::Scanning {
-            catalogs: catalogs.into_iter().map(sourced_value_to_bridge).collect(),
-            free_text,
-        },
-        TextSignal::Settled {
-            catalogs,
-            free_text,
-        } => BridgeTextSignal::Settled {
-            catalogs: catalogs.into_iter().map(sourced_value_to_bridge).collect(),
-            free_text,
-        },
-        TextSignal::Failed {
-            failure,
-            catalogs,
-            free_text,
-        } => BridgeTextSignal::Failed {
-            failure: lookup_failure_to_bridge(failure),
-            catalogs: catalogs.into_iter().map(sourced_value_to_bridge).collect(),
-            free_text,
-        },
-    };
-
-    BridgeSignals {
-        disc_id,
-        barcode,
-        text,
+            barcode,
+            text,
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn provenance_to_bridge(p: bae_core::identify::ResultProvenance) -> BridgeResultProvenance {
-    BridgeResultProvenance {
-        by_disc_id: p.by_disc_id,
-        by_barcode: p.by_barcode,
-        matches_catalog: p.matches_catalog,
+impl BridgeResultProvenance {
+    fn from_core(p: bae_core::identify::ResultProvenance) -> Self {
+        let bae_core::identify::ResultProvenance {
+            by_disc_id,
+            by_barcode,
+            matches_catalog,
+        } = p;
+        BridgeResultProvenance {
+            by_disc_id,
+            by_barcode,
+            matches_catalog,
+        }
     }
 }
 
 /// Convert a core identify state into its bridge mirror.
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn identify_state_to_bridge(
-    s: bae_core::identify::IdentifyState,
-) -> BridgeIdentifyState {
-    use bae_core::identify::IdentifyState;
-    match s {
-        IdentifyState::Idle => BridgeIdentifyState::Idle,
-        IdentifyState::Triangulating {
-            discid, barcode, ..
-        } => BridgeIdentifyState::Triangulating {
-            discid: discid_progress_to_bridge(discid),
-            barcode: barcode_progress_to_bridge(barcode),
-        },
-        IdentifyState::Found {
-            matches,
-            library_statuses,
-            track_count,
-            group,
-            source,
-            provenance,
-            context: _,
-        } => {
-            // `matches` all share `group` (combine guarantees a single group)
-            // and `provenance` is index-aligned with them. Key the provenance
-            // by release id before folding the matches into the group card so
-            // the UI looks each pressing's badges up directly.
-            let provenance = matches
-                .iter()
-                .map(|m| m.release_id.clone())
-                .zip(provenance.into_iter().map(provenance_to_bridge))
-                .collect();
-            let group = bae_core::import::release_group::ReleaseGroup::from_group(group, matches);
-            BridgeIdentifyState::Found {
-                group: release_group_to_bridge(group),
-                library_statuses: library_statuses
-                    .into_iter()
-                    .map(|s| (s.release_id.clone(), library_status_to_bridge(s)))
-                    .collect(),
+impl BridgeIdentifyState {
+    pub(crate) fn from_core(s: bae_core::identify::IdentifyState) -> Self {
+        use bae_core::identify::IdentifyState;
+        match s {
+            IdentifyState::Idle => BridgeIdentifyState::Idle,
+            IdentifyState::Triangulating {
+                discid,
+                barcode,
+                context: _,
+            } => BridgeIdentifyState::Triangulating {
+                discid: BridgeDiscidProgress::from_core(discid),
+                barcode: BridgeBarcodeProgress::from_core(barcode),
+            },
+            IdentifyState::Found {
+                matches,
+                library_statuses,
                 track_count,
-                source: identify_source_to_bridge(source),
+                group,
+                source,
                 provenance,
+                context: _,
+            } => {
+                // `matches` all share `group` (combine guarantees a single group)
+                // and `provenance` is index-aligned with them. Key the provenance
+                // by release id before folding the matches into the group card so
+                // the UI looks each pressing's badges up directly.
+                let provenance = matches
+                    .iter()
+                    .map(|m| m.release_id.clone())
+                    .zip(
+                        provenance
+                            .into_iter()
+                            .map(BridgeResultProvenance::from_core),
+                    )
+                    .collect();
+                let group =
+                    bae_core::import::release_group::ReleaseGroup::from_group(group, matches);
+                BridgeIdentifyState::Found {
+                    group: BridgeReleaseGroup::from_core(group),
+                    library_statuses: library_statuses
+                        .into_iter()
+                        .map(|s| (s.release_id.clone(), BridgeLibraryStatus::from_core(s)))
+                        .collect(),
+                    track_count,
+                    source: BridgeIdentifySource::from_core(source),
+                    provenance,
+                }
             }
-        }
-        IdentifyState::Conflict { context } => {
-            // The per-signal sections come from the context's settled results.
-            // Disc-id results all share one source; name it for the section
-            // header. `None` when the disc-id side is empty (no section).
-            let discid_source_label = context
-                .discid_results
-                .first()
-                .map(|(m, _)| m.source.display_name().to_string());
-            let (discid_matches, discid_statuses) = results_and_status_map(context.discid_results);
-            let (barcode_matches, barcode_statuses) =
-                results_and_status_map(context.barcode_results);
-            BridgeIdentifyState::Conflict {
-                discid_results: discid_matches,
-                discid_library_statuses: discid_statuses,
-                barcode_results: barcode_matches,
-                barcode_library_statuses: barcode_statuses,
-                discid_source_label,
-                matched_barcode: context.matched_barcode,
-                track_count: context.track_count,
+            IdentifyState::Conflict { context } => {
+                let bae_core::identify::state::SignalsContext {
+                    discid_results,
+                    barcode_results,
+                    matched_barcode,
+                    track_count,
+                    // The conflict surface renders only the two settled result
+                    // sets and the matched barcode. The raw signal inputs
+                    // (`disc_id`, `barcode_codes`, `catalogs`), the user's
+                    // `excluded` toggles, and the settled `barcode_failure` drive
+                    // triangulation in core, not this UI state, so they don't cross.
+                    disc_id: _,
+                    barcode_codes: _,
+                    catalogs: _,
+                    excluded: _,
+                    barcode_failure: _,
+                } = context;
+                // The per-signal sections come from the context's settled results.
+                // Disc-id results all share one source; name it for the section
+                // header. `None` when the disc-id side is empty (no section).
+                let discid_source_label = discid_results
+                    .first()
+                    .map(|(m, _)| m.source.display_name().to_string());
+                let (discid_matches, discid_statuses) = results_and_status_map(discid_results);
+                let (barcode_matches, barcode_statuses) = results_and_status_map(barcode_results);
+                BridgeIdentifyState::Conflict {
+                    discid_results: discid_matches,
+                    discid_library_statuses: discid_statuses,
+                    barcode_results: barcode_matches,
+                    barcode_library_statuses: barcode_statuses,
+                    discid_source_label,
+                    matched_barcode,
+                    track_count,
+                }
             }
-        }
-        IdentifyState::NotFoundAnywhere { .. } => BridgeIdentifyState::NotFoundAnywhere,
-        IdentifyState::ManualOnly { track_count, .. } => {
-            BridgeIdentifyState::ManualOnly { track_count }
+            IdentifyState::NotFoundAnywhere { context: _ } => BridgeIdentifyState::NotFoundAnywhere,
+            IdentifyState::ManualOnly {
+                track_count,
+                context: _,
+            } => BridgeIdentifyState::ManualOnly { track_count },
         }
     }
 }
@@ -3342,194 +3600,373 @@ fn results_and_status_map(
     let mut matches = Vec::with_capacity(pairs.len());
     let mut statuses = std::collections::HashMap::with_capacity(pairs.len());
     for (m, s) in pairs {
-        statuses.insert(s.release_id.clone(), library_status_to_bridge(s));
-        matches.push(metadata_result_to_bridge(m));
+        statuses.insert(s.release_id.clone(), BridgeLibraryStatus::from_core(s));
+        matches.push(BridgeMetadataResult::from_core(m));
     }
     (matches, statuses)
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn scanned_file_to_bridge(f: bae_core::import::folder_scanner::ScannedFile) -> BridgeFileInfo {
-    BridgeFileInfo {
-        name: f.relative_path,
-        size: f.size,
-        dir_prefix: f.dir_prefix,
-        file_name: f.file_name,
-        local_path: f.path.to_string_lossy().to_string(),
+impl BridgeFileInfo {
+    fn from_core(f: bae_core::import::folder_scanner::ScannedFile) -> Self {
+        let bae_core::import::folder_scanner::ScannedFile {
+            path,
+            relative_path,
+            size,
+            dir_prefix,
+            file_name,
+        } = f;
+        BridgeFileInfo {
+            name: relative_path,
+            size,
+            dir_prefix,
+            file_name,
+            local_path: path.to_string_lossy().to_string(),
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-fn scanned_artwork_to_bridge(
-    f: bae_core::import::folder_scanner::ScannedFile,
-) -> BridgeArtworkFile {
-    let file_id = f.relative_path.clone();
-    let path = f.path.to_string_lossy().to_string();
-    BridgeArtworkFile {
-        file: scanned_file_to_bridge(f),
-        cover_choice: BridgeCoverChoice {
-            selection: BridgeCoverSelection::ReleaseImage { file_id },
-            preview_source: BridgeCoverImageSource::Local { path: path.clone() },
-            thumbnail_source: BridgeCoverImageSource::Local { path },
-        },
+impl BridgeArtworkFile {
+    fn from_core(f: bae_core::import::folder_scanner::ScannedFile) -> Self {
+        // `file_id` is the scanned file's relative path and `path` its absolute
+        // path on disk; read them off the `BridgeFileInfo` (whose `name` /
+        // `local_path` carry exactly those) so the exhaustive destructure of
+        // `ScannedFile` lives solely in `BridgeFileInfo::from_core`.
+        let file = BridgeFileInfo::from_core(f);
+        let file_id = file.name.clone();
+        let path = file.local_path.clone();
+        BridgeArtworkFile {
+            file,
+            cover_choice: BridgeCoverChoice {
+                selection: BridgeCoverSelection::ReleaseImage { file_id },
+                preview_source: BridgeCoverImageSource::Local { path: path.clone() },
+                thumbnail_source: BridgeCoverImageSource::Local { path },
+            },
+        }
     }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[cfg(feature = "desktop")]
-pub(crate) fn categorized_files_to_bridge(
-    files: bae_core::import::folder_scanner::CategorizedFiles,
-) -> BridgeCandidateFiles {
-    use bae_core::import::folder_scanner::AudioContent;
+impl BridgeCueFlacPair {
+    fn from_core(p: bae_core::import::folder_scanner::ScannedCueFlacPair) -> Self {
+        let bae_core::import::folder_scanner::ScannedCueFlacPair {
+            cue_file,
+            audio_file,
+            cue_sheet,
+            total_size,
+            // The bridge lists only the first audio file (`audio_file`); the full
+            // referenced set drives export/import, not this preview row.
+            audio_files: _,
+        } = p;
+        // `cue_sheet.tracks.len()` is a derived count, not a carried field —
+        // `CueSheet` is a large parse product the bridge doesn't mirror.
+        let track_count = cue_sheet.tracks.len() as u32;
+        // Compose BridgeFileInfo (which owns the ScannedFile destructure) for each
+        // side, then destructure the bridge value into this row's flat fields.
+        let BridgeFileInfo {
+            name: cue_name,
+            size: cue_size,
+            local_path: cue_local_path,
+            dir_prefix: _,
+            file_name: _,
+        } = BridgeFileInfo::from_core(cue_file);
+        let BridgeFileInfo {
+            name: flac_name,
+            local_path: flac_local_path,
+            size: _,
+            dir_prefix: _,
+            file_name: _,
+        } = BridgeFileInfo::from_core(audio_file);
+        BridgeCueFlacPair {
+            cue_name,
+            cue_size,
+            cue_local_path,
+            flac_name,
+            flac_local_path,
+            total_size,
+            track_count,
+        }
+    }
+}
 
-    let audio = match files.audio {
-        AudioContent::CueFlacPairs { pairs, .. } => BridgeAudioContent::CueFlacPairs {
-            pairs: pairs
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+#[cfg(feature = "desktop")]
+impl BridgeCandidateFiles {
+    pub(crate) fn from_core(files: bae_core::import::folder_scanner::CategorizedFiles) -> Self {
+        use bae_core::import::folder_scanner::{AudioContent, CategorizedFiles};
+
+        let CategorizedFiles {
+            audio,
+            artwork,
+            documents,
+            // Parsed-signal data, not a file the preview lists; the CUE it came
+            // from is already carried under `documents`.
+            unpaired_cue_sheets: _,
+        } = files;
+
+        let audio = match audio {
+            AudioContent::CueFlacPairs {
+                pairs,
+                format_label: _,
+            } => BridgeAudioContent::CueFlacPairs {
+                pairs: pairs
+                    .into_iter()
+                    .map(BridgeCueFlacPair::from_core)
+                    .collect(),
+            },
+            AudioContent::TrackFiles {
+                tracks,
+                format_label: _,
+            } => BridgeAudioContent::TrackFiles {
+                files: tracks.into_iter().map(BridgeFileInfo::from_core).collect(),
+            },
+        };
+
+        BridgeCandidateFiles {
+            audio,
+            artwork: artwork
                 .into_iter()
-                .map(|p| BridgeCueFlacPair {
-                    cue_name: p.cue_file.relative_path,
-                    cue_size: p.cue_file.size,
-                    cue_local_path: p.cue_file.path.to_string_lossy().to_string(),
-                    flac_name: p.audio_file.relative_path,
-                    flac_local_path: p.audio_file.path.to_string_lossy().to_string(),
-                    total_size: p.total_size,
-                    track_count: p.cue_sheet.tracks.len() as u32,
-                })
+                .map(BridgeArtworkFile::from_core)
                 .collect(),
-        },
-        AudioContent::TrackFiles { tracks, .. } => BridgeAudioContent::TrackFiles {
-            files: tracks.into_iter().map(scanned_file_to_bridge).collect(),
-        },
-    };
-
-    BridgeCandidateFiles {
-        audio,
-        artwork: files
-            .artwork
-            .into_iter()
-            .map(scanned_artwork_to_bridge)
-            .collect(),
-        documents: files
-            .documents
-            .into_iter()
-            .map(scanned_file_to_bridge)
-            .collect(),
+            documents: documents
+                .into_iter()
+                .map(BridgeFileInfo::from_core)
+                .collect(),
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn release_user_edit_from_bridge(
-    e: BridgeReleaseUserEdit,
-) -> bae_core::import::ReleaseUserEdit {
-    bae_core::import::ReleaseUserEdit {
-        album_title: e.album_title,
-        album_artist_names: e.album_artist_names,
-        pressing: bae_core::import::PressingEdit {
-            year: e.pressing.year,
-            format: e.pressing.format,
-            label: e.pressing.label,
-            catalog_number: e.pressing.catalog_number,
-            country: e.pressing.country,
-            barcode: e.pressing.barcode,
-        },
-        tracks: e
-            .tracks
-            .into_iter()
-            .map(|t| bae_core::import::TrackUserEdit {
-                title: t.title,
-                side: t.side,
-                track_number: t.track_number,
-                artist_names: t.artist_names,
-            })
-            .collect(),
+impl BridgePressingEdit {
+    fn from_core(p: bae_core::import::PressingEdit) -> Self {
+        let bae_core::import::PressingEdit {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        } = p;
+        Self {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        }
+    }
+
+    fn into_core(self) -> bae_core::import::PressingEdit {
+        let BridgePressingEdit {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        } = self;
+        bae_core::import::PressingEdit {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn release_user_edit_to_bridge(
-    e: bae_core::import::ReleaseUserEdit,
-) -> BridgeReleaseUserEdit {
-    BridgeReleaseUserEdit {
-        album_title: e.album_title,
-        album_artist_names: e.album_artist_names,
-        pressing: BridgePressingEdit {
-            year: e.pressing.year,
-            format: e.pressing.format,
-            label: e.pressing.label,
-            catalog_number: e.pressing.catalog_number,
-            country: e.pressing.country,
-            barcode: e.pressing.barcode,
-        },
-        tracks: e
-            .tracks
-            .into_iter()
-            .map(|t| BridgeTrackUserEdit {
-                title: t.title,
-                side: t.side,
-                track_number: t.track_number,
-                artist_names: t.artist_names,
-            })
-            .collect(),
+impl BridgeTrackUserEdit {
+    fn from_core(t: bae_core::import::TrackUserEdit) -> Self {
+        let bae_core::import::TrackUserEdit {
+            title,
+            side,
+            track_number,
+            artist_names,
+        } = t;
+        Self {
+            title,
+            side,
+            track_number,
+            artist_names,
+        }
+    }
+
+    fn into_core(self) -> bae_core::import::TrackUserEdit {
+        let BridgeTrackUserEdit {
+            title,
+            side,
+            track_number,
+            artist_names,
+        } = self;
+        bae_core::import::TrackUserEdit {
+            title,
+            side,
+            track_number,
+            artist_names,
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn raw_release_edit_from_bridge(
-    e: BridgeRawReleaseEdit,
-) -> bae_core::import::RawReleaseEdit {
-    bae_core::import::RawReleaseEdit {
-        album_title: e.album_title,
-        album_artist_text: e.album_artist_text,
-        pressing: bae_core::import::RawPressingEdit {
-            year: e.pressing.year,
-            format: e.pressing.format,
-            label: e.pressing.label,
-            catalog_number: e.pressing.catalog_number,
-            country: e.pressing.country,
-            barcode: e.pressing.barcode,
-        },
-        tracks: e
-            .tracks
-            .into_iter()
-            .map(|t| bae_core::import::RawTrackEdit {
-                id: t.id,
-                title: t.title,
-                artist_text: t.artist_text,
-                side: t.side,
-                track_number: t.track_number,
-            })
-            .collect(),
+impl BridgeReleaseUserEdit {
+    pub(crate) fn from_core(e: bae_core::import::ReleaseUserEdit) -> Self {
+        let bae_core::import::ReleaseUserEdit {
+            album_title,
+            album_artist_names,
+            pressing,
+            tracks,
+        } = e;
+        BridgeReleaseUserEdit {
+            album_title,
+            album_artist_names,
+            pressing: BridgePressingEdit::from_core(pressing),
+            tracks: tracks
+                .into_iter()
+                .map(BridgeTrackUserEdit::from_core)
+                .collect(),
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::import::ReleaseUserEdit {
+        let BridgeReleaseUserEdit {
+            album_title,
+            album_artist_names,
+            pressing,
+            tracks,
+        } = self;
+        bae_core::import::ReleaseUserEdit {
+            album_title,
+            album_artist_names,
+            pressing: pressing.into_core(),
+            tracks: tracks
+                .into_iter()
+                .map(BridgeTrackUserEdit::into_core)
+                .collect(),
+        }
     }
 }
 
 #[cfg(feature = "desktop")]
-pub(crate) fn raw_release_edit_to_bridge(
-    e: bae_core::import::RawReleaseEdit,
-) -> BridgeRawReleaseEdit {
-    BridgeRawReleaseEdit {
-        album_title: e.album_title,
-        album_artist_text: e.album_artist_text,
-        pressing: BridgeRawPressingEdit {
-            year: e.pressing.year,
-            format: e.pressing.format,
-            label: e.pressing.label,
-            catalog_number: e.pressing.catalog_number,
-            country: e.pressing.country,
-            barcode: e.pressing.barcode,
-        },
-        tracks: e
-            .tracks
-            .into_iter()
-            .map(|t| BridgeRawTrackEdit {
-                id: t.id,
-                title: t.title,
-                artist_text: t.artist_text,
-                side: t.side,
-                track_number: t.track_number,
-            })
-            .collect(),
+impl BridgeRawPressingEdit {
+    fn from_core(p: bae_core::import::RawPressingEdit) -> Self {
+        let bae_core::import::RawPressingEdit {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        } = p;
+        Self {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        }
+    }
+
+    fn into_core(self) -> bae_core::import::RawPressingEdit {
+        let BridgeRawPressingEdit {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        } = self;
+        bae_core::import::RawPressingEdit {
+            year,
+            format,
+            label,
+            catalog_number,
+            country,
+            barcode,
+        }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl BridgeRawTrackEdit {
+    fn from_core(t: bae_core::import::RawTrackEdit) -> Self {
+        let bae_core::import::RawTrackEdit {
+            id,
+            title,
+            artist_text,
+            side,
+            track_number,
+        } = t;
+        Self {
+            id,
+            title,
+            artist_text,
+            side,
+            track_number,
+        }
+    }
+
+    fn into_core(self) -> bae_core::import::RawTrackEdit {
+        let BridgeRawTrackEdit {
+            id,
+            title,
+            artist_text,
+            side,
+            track_number,
+        } = self;
+        bae_core::import::RawTrackEdit {
+            id,
+            title,
+            artist_text,
+            side,
+            track_number,
+        }
+    }
+}
+
+#[cfg(feature = "desktop")]
+impl BridgeRawReleaseEdit {
+    pub(crate) fn from_core(e: bae_core::import::RawReleaseEdit) -> Self {
+        let bae_core::import::RawReleaseEdit {
+            album_title,
+            album_artist_text,
+            pressing,
+            tracks,
+        } = e;
+        BridgeRawReleaseEdit {
+            album_title,
+            album_artist_text,
+            pressing: BridgeRawPressingEdit::from_core(pressing),
+            tracks: tracks
+                .into_iter()
+                .map(BridgeRawTrackEdit::from_core)
+                .collect(),
+        }
+    }
+
+    pub(crate) fn into_core(self) -> bae_core::import::RawReleaseEdit {
+        let BridgeRawReleaseEdit {
+            album_title,
+            album_artist_text,
+            pressing,
+            tracks,
+        } = self;
+        bae_core::import::RawReleaseEdit {
+            album_title,
+            album_artist_text,
+            pressing: pressing.into_core(),
+            tracks: tracks
+                .into_iter()
+                .map(BridgeRawTrackEdit::into_core)
+                .collect(),
+        }
     }
 }
 
@@ -3894,11 +4331,144 @@ mod identify_progress_tests {
             },
         };
 
-        match barcode_progress_to_bridge(progress) {
+        match BridgeBarcodeProgress::from_core(progress) {
             BridgeBarcodeProgress::Failed {
                 failure: BridgeLookupFailure::Diagnostic { detail },
             } => assert_eq!(detail, "provider lookup failed"),
             other => panic!("expected failed barcode progress, got {other:?}"),
         }
+    }
+}
+
+/// Round-trips a fully-populated sample through `from_core` then `into_core` and
+/// asserts equality with the original. The one bug the exhaustive-destructure
+/// compile checks can't catch is a transposed same-typed field introduced during
+/// a rewrite; these catch it for both directions in one assertion (types without
+/// `PartialEq` compare their `Debug` forms). Placeholder names only.
+#[cfg(test)]
+mod conversion_roundtrip {
+    use super::*;
+
+    #[test]
+    fn image_ref_round_trips() {
+        let core = bae_core::album_detail::ImageRef {
+            id: "rel-123".to_string(),
+            version: "v1".to_string(),
+            image_type: bae_core::db::LibraryImageType::Artist,
+        };
+        assert_eq!(core, BridgeImageRef::from_core(core.clone()).into_core());
+    }
+
+    #[test]
+    fn export_preset_round_trips_and_re_derives_extension() {
+        let core = bae_core::config::ExportPreset {
+            id: "preset-1".to_string(),
+            name: "Preset One".to_string(),
+            codec: bae_core::config::ExportPresetCodec::Flac {
+                bit_depth: bae_core::config::ExportBitDepth::Bits24,
+            },
+            filename_template: "{artist} - {title}".to_string(),
+            pregap_placement: bae_core::config::ExportPregapPlacement::Exclude,
+            applies_to_track: true,
+            applies_to_release: false,
+        };
+        let bridge = BridgeExportPreset::from_core(&core);
+        // `extension` is derived from the codec, not carried in the core preset.
+        assert_eq!(bridge.extension, core.codec.extension());
+        assert_eq!(core, bridge.into_core());
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn release_user_edit_round_trips() {
+        let core = bae_core::import::ReleaseUserEdit {
+            album_title: "Album Title".to_string(),
+            album_artist_names: vec!["Artist Name".to_string(), "Second Artist".to_string()],
+            pressing: bae_core::import::PressingEdit {
+                year: Some(1990),
+                format: Some("CD".to_string()),
+                label: Some("Label Name".to_string()),
+                catalog_number: Some("CAT-1".to_string()),
+                country: Some("US".to_string()),
+                barcode: Some("012345678905".to_string()),
+            },
+            tracks: vec![bae_core::import::TrackUserEdit {
+                title: "Track Title".to_string(),
+                side: 1,
+                track_number: Some(1),
+                artist_names: vec!["Track Artist".to_string()],
+            }],
+        };
+        assert_eq!(
+            core,
+            BridgeReleaseUserEdit::from_core(core.clone()).into_core()
+        );
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn raw_release_edit_round_trips() {
+        let core = bae_core::import::RawReleaseEdit {
+            album_title: "Album Title".to_string(),
+            album_artist_text: "Artist Name, Second Artist".to_string(),
+            pressing: bae_core::import::RawPressingEdit {
+                year: "1990".to_string(),
+                format: "CD".to_string(),
+                label: "Label Name".to_string(),
+                catalog_number: "CAT-1".to_string(),
+                country: "US".to_string(),
+                barcode: "012345678905".to_string(),
+            },
+            tracks: vec![bae_core::import::RawTrackEdit {
+                id: "row-1".to_string(),
+                title: "Track Title".to_string(),
+                artist_text: "Track Artist".to_string(),
+                side: 1,
+                track_number: Some(1),
+            }],
+        };
+        assert_eq!(
+            core,
+            BridgeRawReleaseEdit::from_core(core.clone()).into_core()
+        );
+    }
+
+    #[cfg(feature = "desktop")]
+    #[test]
+    fn release_detail_round_trips_and_derives_mismatch() {
+        let core = bae_core::import::search::ImportSearchReleaseDetail {
+            release_id: "rel-123".to_string(),
+            source: bae_core::import::MetadataSource::MusicBrainz,
+            source_group_id: Some("rg-1".to_string()),
+            title: "Album Title".to_string(),
+            artist: Some("Artist Name".to_string()),
+            year: Some(1990),
+            format: Some("CD".to_string()),
+            label: Some("Label Name".to_string()),
+            catalog_number: Some("CAT-1".to_string()),
+            country: Some("US".to_string()),
+            barcode: Some("012345678905".to_string()),
+            track_count: 10,
+            tracks: vec![bae_core::import::search::ReleaseTrack {
+                title: "Track Title".to_string(),
+                artist: Some("Track Artist".to_string()),
+                duration_ms: Some(210_000),
+                position: "A1".to_string(),
+                side: 1,
+            }],
+            cover_art: vec![bae_core::import::cover_art::RemoteCover {
+                url: "https://example.test/cover.jpg".to_string(),
+                thumbnail_url: "https://example.test/thumb.jpg".to_string(),
+                label: "Front".to_string(),
+                source: bae_core::import::MetadataSource::MusicBrainz,
+            }],
+        };
+        // 11 local tracks vs 10 on the source is a mismatch; `default_cover` is
+        // derived from the first cover. Both are bridge-only and dropped on the
+        // way back, so the round-tripped core still equals the original.
+        let bridge = BridgeReleaseDetail::from_core(core.clone(), Some(11));
+        assert!(bridge.track_count_mismatch);
+        assert!(bridge.default_cover.is_some());
+        assert_eq!(format!("{core:?}"), format!("{:?}", bridge.into_core()));
     }
 }


### PR DESCRIPTION
Every record converter in bae-bridge read fields off the core value with dotted access, so when a bae-core struct gained a field, the converters kept compiling and the field silently never reached the UI. The enum/event path was already drift-safe (exhaustive variant matches); the record path was the hole.

This PR makes every converter exhaustively destructure its core input — derived values computed first, then a full destructure with deliberate drops written as explicit `field: _` (commented where non-obvious), no `..` anywhere. A new core field is now a compile error at the exact converter that must decide whether it crosses. The rewrite also unifies five coexisting conversion idioms into `BridgeX::from_core` / `BridgeX::into_core` associated functions, promotes inline conversion closures to named converters, and single-sources nested conversions (release detail composes the summary converter; the CUE/FLAC pair composes the file-info converter; download/export snapshots share one generic queue projection).

The one bug class the compiler can't catch here — transposing two same-typed fields during the rewrite — is covered by six new round-trip tests over the two-way pairs, which also lock the documented one-way drops. Conversions stay bridge-side; bae-core is untouched. Splitting types.rs into domain modules is deferred to a pure-move follow-up so this diff stays a readable mechanical rewrite.

## Test plan
- [x] cargo test -p bae-bridge: 16 passed default / 19 passed with desktop features, including loc_key_coverage and the six new round-trip tests
- [x] Builds + clippy clean (-D warnings) across default, desktop, oauth-providers, cloudkit feature sets
- [x] Self-audit greps: zero `..` in converter patterns; zero undocumented dotted core reads
- [x] Pre-commit macOS app build green (no generated-binding surface changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)