### PR TITLE
Advance the active-library pointer only over a fully-realized open

### DIFF
--- a/bae-core/Cargo.toml
+++ b/bae-core/Cargo.toml
@@ -141,6 +141,11 @@ path = "tests/test_s3_setup_validation.rs"
 required-features = ["test-utils"]
 
 [[test]]
+name = "test_bootstrap_pointer"
+path = "tests/test_bootstrap_pointer.rs"
+required-features = ["test-utils"]
+
+[[test]]
 name = "test_cue_ape"
 path = "tests/test_cue_ape.rs"
 required-features = ["test-utils"]

--- a/bae-core/src/app.rs
+++ b/bae-core/src/app.rs
@@ -48,6 +48,10 @@ pub enum BootstrapError {
 /// tick. Returns once the DB is open, sync is attached (if the library is
 /// unlocked on this device), and playback (plus the desktop import pipeline) is
 /// running; background work continues on the returned runtime.
+///
+/// Opening by registered id records the library as this device's active library
+/// only once the open fully completes and the library is unlocked on this device;
+/// a locked or failed open leaves the pointer unchanged.
 pub fn bootstrap(
     library_id: String,
     position_update_interval_ms: u32,
@@ -110,11 +114,6 @@ fn bootstrap_inner(
     let ids: IdRef = Arc::new(UuidProvider);
 
     let (config, save_active_library) = load_bootstrap_config(target, ids.as_ref())?;
-    if save_active_library {
-        config
-            .save_active_library()
-            .map_err(|e| BootstrapError::Config(e.to_string()))?;
-    }
     let library_id = config.library_id.clone();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -168,6 +167,12 @@ fn bootstrap_inner(
     } else {
         None
     };
+
+    // Locked: encryption was set up but this device's keyring lacks the key.
+    // Bootstrap still completes (sync deferred); the caller diverts to an unlock
+    // screen the user may cancel without ever entering this library.
+    let locked = config.encryption_key_stored && pending_enc.is_none();
+    let advance_active_pointer = save_active_library && !locked;
 
     // A browsable home (a provider is configured but the home is stored in the
     // clear) has no key, so the opaque/locked resolution above leaves
@@ -268,6 +273,21 @@ fn bootstrap_inner(
     let ui_event_bus = UiEventBus::new();
     ui_event_bus.wire(&app_services, runtime.handle());
 
+    // The durable active-library pointer names the library the user last actually
+    // landed in, so launch ordering (discovery sorts active-first), the CLI's
+    // active-library selector, and forget_library's pointer check all refer to a
+    // library that opens. It advances only over a fully-realized open: written
+    // after every fallible step above has succeeded, and never for a locked
+    // library — cancelling the unlock screen must leave the previously-active
+    // library in charge. A successful unlock re-runs bootstrap unlocked, which
+    // advances the pointer then.
+    if advance_active_pointer {
+        config_handle
+            .config()
+            .save_active_library()
+            .map_err(|e| BootstrapError::Config(e.to_string()))?;
+    }
+
     Ok(RunningApp {
         runtime,
         services: app_services,
@@ -275,6 +295,10 @@ fn bootstrap_inner(
     })
 }
 
+/// Load the config for a bootstrap target. The returned bool is whether this
+/// open should advance the active-library pointer once fully realized:
+/// registered-id targets yes (they name a device library), explicit-path targets
+/// no.
 fn load_bootstrap_config(
     target: BootstrapTarget,
     ids: &dyn coven::IdProvider,

--- a/bae-core/tests/test_bootstrap_pointer.rs
+++ b/bae-core/tests/test_bootstrap_pointer.rs
@@ -1,0 +1,217 @@
+#![cfg(feature = "test-utils")]
+//! The durable active-library pointer (`~/.bae/active-library`) must name a
+//! library the user actually landed in. `app::bootstrap` writes it only after a
+//! fully-realized open, and never for a library that opened locked (encryption
+//! configured but this device's keyring lacks the key) — so cancelling the
+//! unlock screen leaves the previously-active library in charge.
+//!
+//! These drive `app::bootstrap` end to end and each overrides `HOME`, so they
+//! run in their own process and `#[serial]` to keep the env mutation from
+//! racing sibling tests in this binary.
+
+mod support;
+
+use std::path::Path;
+
+use bae_core::app::bootstrap;
+use bae_core::config::{CloudProvider, Config};
+use bae_core::keys::KeyService;
+use bae_core::library::{create_library, unlock_library};
+use coven::{EncryptionService, LibraryDir, UuidProvider};
+use serial_test::serial;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+/// A valid 32-byte encryption key in hex, used to compute a fixture's stored
+/// fingerprint.
+const KEY_HEX: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+/// A `TempDir` standing in for the user's home directory, with the env isolated
+/// so no ambient dev secret un-locks a fixture. Bind it for the whole test — the
+/// directory (and thus `~/.bae`) is deleted when it drops.
+fn fake_home() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    std::env::set_var("HOME", tmp.path());
+    // A `.env` in an ancestor directory (loaded into the process env) would let
+    // `seed_dev_keyring` mint the key for a locked fixture; drop the dev secrets
+    // so the locked branch is actually reached.
+    std::env::remove_var("BAE_ENCRYPTION_KEY");
+    std::env::remove_var("BAE_CLOUD_HOME_CREDENTIALS");
+    std::env::remove_var("BAE_DISCOGS_API_KEY");
+    bae_core::config::install_test_keyring();
+    tmp
+}
+
+/// The registered-library directory `~/.bae/libraries/<id>/`. The config layer's
+/// own path helpers (`registered_library_path` / `registered_library_dir`) are
+/// `pub(crate)`, so an integration test can't reach them; the literal layout is
+/// duplicated here.
+fn registered_library_dir(home: &Path, id: &str) -> LibraryDir {
+    LibraryDir::new(home.join(".bae").join("libraries").join(id))
+}
+
+/// Write a fixture library under `~/.bae/libraries/<id>/` and return its id.
+/// `configure` mutates the config before it is saved — a plain local library
+/// passes an empty closure; a locked fixture sets its encryption + cloud fields.
+/// Does not touch the active pointer.
+fn write_library(home: &Path, name: &str, configure: impl FnOnce(&mut Config)) -> String {
+    let id = Uuid::new_v4().to_string();
+    let mut config = Config::with_defaults(
+        id.clone(),
+        Uuid::new_v4().to_string(),
+        registered_library_dir(home, &id),
+        name.to_string(),
+    );
+    configure(&mut config);
+    config.save_to_config_yaml().unwrap();
+    id
+}
+
+/// A fixture library that presents as locked on this device: the config records
+/// an encryption key (fingerprint + `encryption_key_stored`) and an opaque S3
+/// home, but no key is placed in the keyring — the "keychain wiped, config
+/// preserved" shape a returning user hits.
+fn write_locked_library(home: &Path, name: &str) -> String {
+    write_library(home, name, |config| {
+        config.encryption_key_stored = true;
+        config.encryption_key_fingerprint =
+            Some(EncryptionService::new(KEY_HEX).unwrap().fingerprint());
+        config.cloud_home.provider = Some(CloudProvider::S3);
+        config.cloud_home.s3_bucket = Some("bae-locked-fixture".to_string());
+        config.cloud_home.s3_region = Some("us-east-1".to_string());
+    })
+}
+
+/// A plain local fixture library: no encryption, no cloud home.
+fn write_plain_library(home: &Path, name: &str) -> String {
+    write_library(home, name, |_| {})
+}
+
+fn active_pointer() -> Option<String> {
+    Config::active_library_id().unwrap()
+}
+
+/// Bootstrapping a locked library succeeds with sync deferred, but leaves the
+/// active pointer naming the library the user last actually opened.
+#[test]
+#[serial]
+fn bootstrap_of_locked_library_leaves_active_pointer() {
+    let home = fake_home();
+    let a = create_library("Library A".into(), &UuidProvider).unwrap();
+    let a_id = a.library_id.clone();
+    let b_id = write_locked_library(home.path(), "Library B");
+
+    let app = bootstrap(b_id, 200, None).expect("a locked open completes with sync deferred");
+
+    assert!(
+        !app.services.library_manager().has_encryption(),
+        "the locked library must have taken the sync-deferred branch"
+    );
+    assert_eq!(
+        active_pointer().as_deref(),
+        Some(a_id.as_str()),
+        "a locked open must not advance the active pointer"
+    );
+    drop(app);
+}
+
+/// Bootstrapping an unlocked library advances the active pointer to it — the
+/// guard against overshooting into "never advance".
+#[test]
+#[serial]
+fn bootstrap_of_unlocked_library_advances_active_pointer() {
+    let home = fake_home();
+    create_library("Library A".into(), &UuidProvider).unwrap();
+    let b_id = write_plain_library(home.path(), "Library B");
+
+    let app = bootstrap(b_id.clone(), 200, None).expect("a plain local open completes");
+
+    assert_eq!(
+        active_pointer().as_deref(),
+        Some(b_id.as_str()),
+        "a fully-realized open advances the active pointer"
+    );
+    drop(app);
+}
+
+/// A bootstrap that fails opening the database does not advance the active
+/// pointer — the write is the last step, after every fallible step above.
+#[test]
+#[serial]
+fn bootstrap_that_fails_leaves_active_pointer() {
+    let home = fake_home();
+    let a = create_library("Library A".into(), &UuidProvider).unwrap();
+    let a_id = a.library_id.clone();
+    let b_id = write_plain_library(home.path(), "Library B");
+
+    // A directory where the SQLite file belongs makes the DB open fail.
+    let db_path = registered_library_dir(home.path(), &b_id).db_path();
+    std::fs::create_dir(&db_path).unwrap();
+
+    let result = bootstrap(b_id, 200, None);
+    assert!(
+        result.is_err(),
+        "a directory at the db path must fail the open"
+    );
+    assert_eq!(
+        active_pointer().as_deref(),
+        Some(a_id.as_str()),
+        "a failed open must not advance the active pointer"
+    );
+}
+
+/// A successful unlock re-runs bootstrap unlocked, which advances the pointer.
+/// Needs a reachable cloud home to mint the key and attach sync, so it is minio-
+/// backed and `#[ignore]`d like the rest of the S3 suite.
+#[test]
+#[ignore]
+#[serial]
+fn unlock_then_reopen_advances_active_pointer() {
+    use bae_core::keys::BaeKeyServiceExt;
+    use support::TestS3Endpoint;
+
+    let _home = fake_home();
+    let s3 = TestS3Endpoint::from_env();
+    let bucket = format!("bae-unlock-reopen-{}", Uuid::new_v4());
+
+    // Library B: create it, open it, and configure an opaque S3 home. save_s3_config
+    // mints the encryption key and records its fingerprint.
+    let b = create_library("Library B".into(), &UuidProvider).unwrap();
+    let b_id = b.library_id.clone();
+    let app = bootstrap(b_id.clone(), 200, None).expect("open the fresh library");
+    app.runtime.block_on(s3.provision_bucket(&bucket));
+    app.runtime
+        .block_on(
+            app.services
+                .library_manager()
+                .save_s3_config(s3.config(&bucket, None)),
+        )
+        .expect("configure the opaque S3 home");
+    let key_hex = KeyService::new(b_id.clone())
+        .get_encryption_key()
+        .unwrap()
+        .expect("save_s3_config minted an encryption key");
+    drop(app);
+
+    // Library A becomes the active library.
+    create_library("Library A".into(), &UuidProvider).unwrap();
+
+    // Lock B (the "Lock Library" core call removes the key from the keyring).
+    KeyService::new(b_id.clone())
+        .forget_encryption_key()
+        .expect("lock library B");
+
+    // Reopening B is now locked: it succeeds with sync deferred, pointer stays A.
+    let locked = bootstrap(b_id.clone(), 200, None).expect("locked open of B succeeds");
+    assert!(!locked.services.library_manager().has_encryption());
+    let a_after_lock = active_pointer();
+    drop(locked);
+    assert_ne!(a_after_lock.as_deref(), Some(b_id.as_str()));
+
+    // Unlock B, then reopen: sync attaches and the pointer advances to B.
+    unlock_library(&b_id, &key_hex).expect("unlock B");
+    let unlocked = bootstrap(b_id.clone(), 200, None).expect("unlocked open of B succeeds");
+    assert!(unlocked.services.library_manager().has_encryption());
+    assert_eq!(active_pointer().as_deref(), Some(b_id.as_str()));
+    drop(unlocked);
+}

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -535,10 +535,10 @@ public sealed partial class MainWindow : Window
     }
 
     // Switch the active library: persist the current one's playback state, tear
-    // down its handle and view state, then open the target. generated bridge init writes the
-    // target as the new active library; a locked target lands on the unlock
-    // prompt. Used for switching to an existing library and for a freshly
-    // created one.
+    // down its handle and view state, then open the target. generated bridge init records the
+    // target as the active library once it opens unlocked; a locked target lands
+    // on the unlock prompt. Used for switching to an existing library and for a
+    // freshly created one.
     private async System.Threading.Tasks.Task SwitchLibrary(string libraryId)
     {
         await TearDownLibrary();


### PR DESCRIPTION
Opening a library by id wrote the durable active-library pointer immediately after loading its config — before the locked-library determination, and before any of the fallible open steps. Cancelling the unlock screen (reachable from the library switchers on every platform) therefore left the pointer naming a library the user never entered: the next launch opened the locked library and landed on the unlock prompt (discovery sorts active-first), forgetting the actually-open library failed its pointer-match check with a confusing error, and the CLI's active-library selector pointed headless automation at a locked target.

The pointer now advances as the last step of bootstrap, only when the open fully realizes and the library is unlocked on this device. Nothing between the old and new write points reads the pointer (verified). No unlock-path change is needed: every platform re-bootstraps after a successful unlock, and that unlocked open advances the pointer naturally. The bridge surface is unchanged; the only edit outside bae-core is a comment correction in the Windows unlock flow.

Both defect tests were written first and confirmed failing against the unmodified code (pointer wrongly advanced to the locked/failed library) before the fix; a minio-backed test covering the full lock → unlock → reopen pointer advance ships #[ignore]d per the suite's S3-test convention and has not been executed here (no minio available in this environment).

## Test plan

- [x] test_bootstrap_pointer: locked open leaves pointer (failed first), unlocked open advances, failed open leaves pointer (failed first)
- [x] Full bae-core suite, fmt, clippy
- [ ] Minio-backed unlock→reopen roundtrip (`cargo test --test test_bootstrap_pointer --features bae-core/test-utils -- --ignored` with minio up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tK3JoFW9Nsdb2Tc139iLH