### PR TITLE
Share one streaming-playback unit between the main and preview players

### DIFF
--- a/bae-core/src/playback/audio_output.rs
+++ b/bae-core/src/playback/audio_output.rs
@@ -581,6 +581,39 @@ impl AudioOutput for CaptureAudioOutput {
     capture_output_control_methods!();
 }
 
+/// A test audio output whose `create_stream` always fails, for exercising the
+/// stream-build failure path shared by both players.
+#[cfg(all(test, feature = "test-utils"))]
+pub(crate) struct FailingAudioOutput;
+
+#[cfg(all(test, feature = "test-utils"))]
+impl AudioOutput for FailingAudioOutput {
+    fn create_stream(
+        &mut self,
+        _source: Arc<Mutex<PlaybackSource>>,
+        _source_sample_rate: u32,
+        _source_channels: u32,
+        _audio_events: AudioEventSender,
+        _position_update_interval_ms: u32,
+    ) -> Result<Box<dyn AudioStream>, AudioError> {
+        Err(AudioError::StreamBuildError(
+            "stream build failure".to_string(),
+        ))
+    }
+
+    fn set_state(&self, _state: AudioState) {}
+
+    fn get_state(&self) -> AudioState {
+        AudioState::Stopped
+    }
+
+    fn set_volume(&self, _volume: f32) {}
+
+    fn get_volume(&self) -> f32 {
+        1.0
+    }
+}
+
 #[cfg(feature = "test-utils")]
 impl AudioOutput for RealtimeCaptureAudioOutput {
     fn create_stream(

--- a/bae-core/src/playback/mod.rs
+++ b/bae-core/src/playback/mod.rs
@@ -16,6 +16,7 @@ mod repeat_mode;
 pub mod service;
 pub mod source;
 pub mod sparse_buffer;
+pub mod stream_pipeline;
 pub mod track_stream;
 
 #[cfg(feature = "test-utils")]

--- a/bae-core/src/playback/preview_player.rs
+++ b/bae-core/src/playback/preview_player.rs
@@ -1,32 +1,31 @@
 //! # Preview Player
 //!
 //! A self-contained second audio player for auditioning a local file before
-//! import. It owns its own audio output, stream, decoder, buffer, and listener
-//! tasks — entirely separate from the main playback pipeline. The only point of
+//! import. It owns its own audio output and runs one shared `StreamPipeline` at
+//! a time — entirely separate from the main playback pipeline. The only point of
 //! contact with the main player is that previewing pauses the main player and
 //! stopping resumes it; that coordination lives in `PlaybackService`, not here.
 //!
 //! Preview has only Idle/Playing/Paused — no Loading/Buffering state — so it
-//! emits Playing/Paused immediately and skips the ready-watcher the main player
-//! uses. The demand-driven local fill keeps the ring fed; the audio callback
-//! outputs silence until the first samples land.
+//! emits Playing/Paused immediately and drops the pipeline's ready receiver (the
+//! main player uses it to arm a ready-watcher). The demand-driven local fill
+//! keeps the ring fed; the audio callback outputs silence until the first
+//! samples land.
 
-use crate::playback::audio_output::{AudioEvent, AudioOutput, AudioStream};
+use crate::playback::audio_output::{AudioEvent, AudioEventReceiver, AudioOutput, AudioState};
 use crate::playback::data_source::{AudioDataReader, LocalReader};
 use crate::playback::progress::{emit_progress, PlaybackProgress, PreviewState};
-use crate::playback::service::{
-    default_audio_output, dispatch_command, log_streaming_decode_failure, setup_audio_stream,
-    teardown_decoder_for_seek, PlaybackCommand,
-};
-use crate::playback::source;
+use crate::playback::service::{default_audio_output, dispatch_command, PlaybackCommand};
 use crate::playback::source::TrackFmt;
 use crate::playback::sparse_buffer::{create_sparse_buffer, SharedSparseBuffer};
-use crate::playback::track_stream::create_track_stream_pair;
-use std::sync::{Arc, Mutex};
+use crate::playback::stream_pipeline::{
+    log_stream_diagnostic, report_dropped_audio_events, start_stream_pipeline, DecodeFailureReport,
+    SegmentDecodeParams, StreamDecodeParams, StreamPipeline, StreamPipelineStart,
+};
 use std::time::Duration;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 /// A second audio player dedicated to previewing a local file. Holds all preview
 /// state; the main player coordinates pause/resume around it but never reaches
@@ -40,28 +39,28 @@ pub(crate) struct PreviewPlayer {
     command_tx: tokio_mpsc::UnboundedSender<PlaybackCommand>,
     /// How often (ms) the audio callback emits position updates to the UI.
     position_update_interval_ms: u32,
-    /// Separate audio output for preview (lazily created on first play).
+    /// Separate audio output for preview (lazily created on first play, retained
+    /// across plays). Preview's play/pause authority is this output's state
+    /// atomic — its own truth, distinct from the main player's slot.
     audio_output: Option<Box<dyn AudioOutput>>,
-    /// Stream for preview playback.
-    stream: Option<Box<dyn AudioStream>>,
-    /// Streaming source for preview (to cancel on stop). Wrapped in a
-    /// single-track `PlaybackSource` (preview never chains) to share the audio
-    /// output's stream interface.
-    playback_source: Option<Arc<Mutex<source::PlaybackSource>>>,
-    /// Path of the file currently being previewed.
-    path: Option<String>,
-    /// Last known duration for the preview file.
+    /// The currently-loaded preview, if any.
+    active: Option<ActivePreview>,
+}
+
+/// One loaded preview: its file identity + format, the retained buffer (kept
+/// across seeks so the reader isn't restarted), the event-listener task, and the
+/// live streaming pipeline.
+struct ActivePreview {
+    path: String,
     duration: Duration,
-    /// Abort handles for preview event listener tasks.
-    listener_handle: Option<JoinHandle<()>>,
-    /// Sparse buffer for the current preview (retained across seeks).
-    buffer: Option<SharedSparseBuffer>,
-    /// JoinHandle for the preview decoder thread (needed for seek cancellation).
-    decoder_handle: Option<std::thread::JoinHandle<()>>,
-    /// Token for the active preview decoder's AVIO reader.
-    decoder_cancel_token: Option<Arc<std::sync::atomic::AtomicBool>>,
     sample_rate: u32,
     channels: u32,
+    /// Sparse buffer for the current preview, retained across seeks; the owner
+    /// cancels it on stop.
+    buffer: SharedSparseBuffer,
+    /// The preview event-listener task (aborted on stop/seek).
+    listener_handle: JoinHandle<()>,
+    pipeline: StreamPipeline,
 }
 
 impl PreviewPlayer {
@@ -75,48 +74,26 @@ impl PreviewPlayer {
             command_tx,
             position_update_interval_ms,
             audio_output: None,
-            stream: None,
-            playback_source: None,
-            path: None,
-            duration: Duration::ZERO,
-            listener_handle: None,
-            buffer: None,
-            decoder_handle: None,
-            decoder_cancel_token: None,
-            sample_rate: 44100,
-            channels: 2,
+            active: None,
         }
     }
 
     /// Path of the file currently being previewed, if any.
     pub(crate) fn current_path(&self) -> Option<&str> {
-        self.path.as_deref()
+        self.active.as_ref().map(|a| a.path.as_str())
     }
 
-    /// Whether a preview file is loaded (playing, paused, or finished-but-shown).
+    /// Whether a preview file is loaded (playing or paused).
     pub(crate) fn is_active(&self) -> bool {
-        self.path.is_some()
-    }
-
-    /// Whether the active preview reached its end (stream and source torn down)
-    /// but is still shown on the bar.
-    pub(crate) fn is_finished(&self) -> bool {
-        self.stream.is_none() && self.playback_source.is_none()
-    }
-
-    /// Drop a finished preview's lingering listeners and path so a fresh play of
-    /// the same file starts clean.
-    pub(crate) fn clear_finished(&mut self) {
-        self.abort_listeners();
-        self.path = None;
+        self.active.is_some()
     }
 
     /// Start a fresh preview of `path`. Switches off any currently-loaded
     /// preview first. Returns true if playback started.
     pub(crate) async fn play(&mut self, path: String) -> bool {
-        // A different preview is still active: stop it first (without resuming
-        // main — the new preview keeps main paused).
-        if self.path.is_some() {
+        // A preview is still active: stop it first (without resuming main — the
+        // new preview keeps main paused).
+        if self.active.is_some() {
             self.stop();
         }
 
@@ -128,29 +105,22 @@ impl PreviewPlayer {
             }
         };
 
-        // Probe duration and sample rate from file
+        // Probe duration and sample rate from file.
         let Some(probe) = probe_preview_audio(&path).await else {
             return false;
         };
-        let probed_duration = probe.duration;
-        let sample_rate = probe.sample_rate;
-        let channels = probe.channels;
 
-        // Create sparse buffer and start local file reader
+        // Create sparse buffer and start local file reader.
         let buffer = create_sparse_buffer(source_size);
         let reader: Box<dyn AudioDataReader> = Box::new(LocalReader::new(path.clone()));
         reader.start_reading(buffer.clone(), self.progress_tx.clone());
 
-        self.buffer = Some(buffer.clone());
-        self.sample_rate = sample_rate;
-        self.channels = channels;
-
         let started = self
-            .start_decode(
+            .start_streaming(
                 path.clone(),
-                probed_duration,
-                sample_rate,
-                channels,
+                probe.duration,
+                probe.sample_rate,
+                probe.channels,
                 buffer,
                 None,
                 false,
@@ -164,69 +134,76 @@ impl PreviewPlayer {
 
     /// Seek by slider ratio (0.0–1.0) within the active preview.
     pub(crate) async fn seek_by_ratio(&mut self, ratio: f64) {
-        let duration_ms = self.duration.as_millis() as u64;
+        let Some(active) = self.active.as_ref() else {
+            return;
+        };
+        let duration_ms = active.duration.as_millis() as u64;
         let position_ms = (ratio.clamp(0.0, 1.0) * duration_ms as f64) as u64;
         self.seek(Duration::from_millis(position_ms)).await;
     }
 
-    /// Seek within the active preview.
+    /// Seek within the active preview. Tears down the current pipeline (retaining
+    /// the buffer) and rebuilds a fresh one seeked to `position`.
     pub(crate) async fn seek(&mut self, position: Duration) {
-        let buffer = match &self.buffer {
-            Some(buf) => buf.clone(),
-            None => return,
+        let Some(active) = self.active.as_ref() else {
+            return;
         };
-        if self.path.is_none() {
+        if active.duration.is_zero() {
             return;
         }
-        let duration = self.duration;
-        if duration.is_zero() {
-            return;
-        }
+
+        let buffer = active.buffer.clone();
+        let path = active.path.clone();
+        let duration = active.duration;
+        let sample_rate = active.sample_rate;
+        let channels = active.channels;
 
         let was_paused = self
             .audio_output
             .as_ref()
-            .map(|o| o.get_state() == crate::playback::audio_output::AudioState::Paused)
+            .map(|o| o.get_state() == AudioState::Paused)
             .unwrap_or(false);
 
-        // Abort old listeners immediately to prevent stale position ticks
-        self.abort_listeners();
-        if let Some(stream) = self.stream.take() {
-            drop(stream);
+        // Take the active preview out, abort its listener, and shut the pipeline
+        // down — cancelling the old decoder and joining it so the fresh decoder
+        // can reuse the retained buffer.
+        let active = self.active.take().unwrap();
+        active.listener_handle.abort();
+        active
+            .pipeline
+            .shutdown_for_seek(std::slice::from_ref(&buffer))
+            .await;
+
+        let started = self
+            .start_streaming(
+                path,
+                duration,
+                sample_rate,
+                channels,
+                buffer,
+                Some(position),
+                was_paused,
+            )
+            .await;
+
+        // The rebuild failed: the old pipeline is already torn down and
+        // `start_streaming` cancelled the buffer, so the preview is simply gone
+        // (no zombie left behind). Surface Idle so the UI stops showing a preview
+        // that no longer exists, instead of freezing on the pre-seek state.
+        if !started {
+            if let Some(preview_output) = &self.audio_output {
+                preview_output.set_state(AudioState::Stopped);
+            }
+            emit_progress(
+                &self.progress_tx,
+                PlaybackProgress::PreviewStateChanged(PreviewState::Idle),
+            );
+            return;
         }
 
-        // Tear down old decoder, preserve buffer
-        let preview_cancel = self
-            .decoder_cancel_token
-            .take()
-            .expect("active preview decoder has a cancel token");
-        teardown_decoder_for_seek(
-            &mut self.playback_source,
-            std::slice::from_ref(&buffer),
-            &preview_cancel,
-            &mut self.decoder_handle,
-        )
-        .await;
-
-        // Start new decoder on the same buffer with seek_to
-        let path = self.path.clone().unwrap();
-        let sample_rate = self.sample_rate;
-        let channels = self.channels;
-        self.start_decode(
-            path,
-            duration,
-            sample_rate,
-            channels,
-            buffer,
-            Some(position),
-            was_paused,
-        )
-        .await;
-
-        // When seeking while paused, no tick will fire to carry the new
-        // position — emit explicitly so the NSView updates. When seeking
-        // while playing, the event listener task picks up from the new
-        // offset on its next tick, so no explicit emit is needed.
+        // When seeking while paused, no tick will fire to carry the new position —
+        // emit explicitly so the NSView updates. When seeking while playing, the
+        // event listener picks up from the new offset on its next tick.
         if was_paused {
             let pos_ms = position.as_millis() as u64;
             let dur_ms = duration.as_millis() as u64;
@@ -240,21 +217,21 @@ impl PreviewPlayer {
         }
     }
 
-    /// Toggle pause/resume on the active (non-finished) preview.
+    /// Toggle pause/resume on the active preview.
     pub(crate) fn toggle_pause(&mut self) {
-        let Some(path) = self.path.clone() else {
+        let Some(active) = self.active.as_ref() else {
             return;
         };
+        let path = active.path.clone();
+        let dur_ms = active.duration.as_millis() as u64;
 
         let Some(preview_output) = &self.audio_output else {
             return;
         };
 
-        let dur_ms = self.duration.as_millis() as u64;
         match preview_output.get_state() {
-            crate::playback::audio_output::AudioState::Playing => {
-                preview_output.set_state(crate::playback::audio_output::AudioState::Paused);
-
+            AudioState::Playing => {
+                preview_output.set_state(AudioState::Paused);
                 emit_progress(
                     &self.progress_tx,
                     PlaybackProgress::PreviewStateChanged(PreviewState::Paused {
@@ -263,9 +240,8 @@ impl PreviewPlayer {
                     }),
                 );
             }
-            crate::playback::audio_output::AudioState::Paused => {
-                preview_output.set_state(crate::playback::audio_output::AudioState::Playing);
-
+            AudioState::Paused => {
+                preview_output.set_state(AudioState::Playing);
                 emit_progress(
                     &self.progress_tx,
                     PlaybackProgress::PreviewStateChanged(PreviewState::Playing {
@@ -281,15 +257,19 @@ impl PreviewPlayer {
     /// Stop preview playback and tear down its pipeline. Does not touch the main
     /// player — the caller decides whether to resume it.
     pub(crate) fn stop(&mut self) {
-        self.teardown_decoder();
-
-        if let Some(preview_output) = &self.audio_output {
-            preview_output.set_state(crate::playback::audio_output::AudioState::Stopped);
+        let was_previewing = self.active.is_some();
+        if let Some(active) = self.active.take() {
+            active.listener_handle.abort();
+            // Cancel the source + decoder token and drop the stream; then cancel
+            // the buffer so the local reader stops and any blocked decoder read
+            // exits.
+            active.pipeline.cancel();
+            active.buffer.cancel();
         }
 
-        let was_previewing = self.path.is_some();
-        self.path = None;
-        self.duration = Duration::ZERO;
+        if let Some(preview_output) = &self.audio_output {
+            preview_output.set_state(AudioState::Stopped);
+        }
 
         if was_previewing {
             info!("Preview stopped");
@@ -300,40 +280,10 @@ impl PreviewPlayer {
         }
     }
 
-    fn teardown_decoder(&mut self) {
-        if let Some(source) = self.playback_source.take() {
-            if let Ok(guard) = source.lock() {
-                guard.cancel();
-            }
-        }
-
-        // Cancel the token and buffer so any blocked decoder read exits.
-        if let Some(cancel_token) = self.decoder_cancel_token.take() {
-            cancel_token.store(true, std::sync::atomic::Ordering::Release);
-        }
-        if let Some(buf) = &self.buffer {
-            buf.cancel();
-        }
-        self.buffer = None;
-        self.decoder_handle = None;
-
-        if let Some(stream) = self.stream.take() {
-            drop(stream);
-        }
-
-        self.abort_listeners();
-    }
-
-    /// Abort preview event listener tasks.
-    fn abort_listeners(&mut self) {
-        if let Some(handle) = self.listener_handle.take() {
-            handle.abort();
-        }
-    }
-
-    /// Start decoding and streaming for preview playback. Shared by `play`
-    /// (`seek_to=None`) and `seek`. Returns true on success.
-    async fn start_decode(
+    /// Build and start the shared streaming pipeline for a preview. Shared by
+    /// `play` (`seek_to=None`) and `seek`. On success installs the `ActivePreview`
+    /// and returns true; on failure cancels the buffer and returns false.
+    async fn start_streaming(
         &mut self,
         path: String,
         duration: Duration,
@@ -343,88 +293,75 @@ impl PreviewPlayer {
         seek_to: Option<Duration>,
         paused: bool,
     ) -> bool {
-        let (mut sink, source, _) = create_track_stream_pair(sample_rate, channels);
-
-        let decoder_buffer = buffer.clone();
-        let preview_cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let decoder_cancel_token = preview_cancel.clone();
-        let seek_to_sample = seek_to.map(|d| (d.as_secs_f64() * sample_rate as f64) as u64);
-        let decoder_handle = std::thread::spawn(move || {
-            if let Err(e) = crate::audio_codec::decode_audio_streaming(
-                decoder_buffer,
-                &mut sink,
-                None,
-                seek_to_sample,
-                None,
-                None,
-                None, // preview auditions the whole file
-                preview_cancel,
-            ) {
-                let _ = log_streaming_decode_failure("Preview decode", e);
-            }
-        });
-
-        self.decoder_handle = Some(decoder_handle);
-        self.decoder_cancel_token = Some(decoder_cancel_token);
-
-        // Preview never chains; the fmt's values are read from the audio
-        // event stream by the listener.
-        let preview_fmt = TrackFmt {
-            track_id: path.clone(),
-            duration_ms: duration.as_millis() as u64,
-            pregap_ms: None,
-            position_offset: seek_to.unwrap_or(Duration::ZERO),
-            // Preview plays an unimported file (no stored measurements) at unity.
-            replay_gain_linear: 1.0,
-        };
-        let source = Arc::new(Mutex::new(source::PlaybackSource::new(source, preview_fmt)));
-
         if self.audio_output.is_none() {
             match default_audio_output() {
                 Ok(output) => self.audio_output = Some(output),
                 Err(e) => {
                     error!("Failed to create preview audio output: {:?}", e);
-                    self.teardown_decoder();
+                    buffer.cancel();
                     return false;
                 }
             }
         }
-        if let Some(stream) = self.stream.take() {
-            drop(stream);
-        }
 
-        let setup = match setup_audio_stream(
+        // Preview is a single whole-file window. `target_sample` trims the first
+        // output sample exactly at the seek target (0 for a fresh play).
+        let target_sample = seek_to
+            .map(|d| (d.as_secs_f64() * sample_rate as f64) as u64)
+            .unwrap_or(0);
+        let decode = StreamDecodeParams {
+            segments: vec![SegmentDecodeParams {
+                buffer: buffer.clone(),
+                seek_to_byte: None,
+                target_sample,
+                stop_at_sample: None,
+                end_byte: None, // preview auditions the whole file
+            }],
+            leading_silence_frames: 0,
+        };
+
+        // Preview never chains and plays an unimported file (no stored loudness
+        // measurements) at unity gain; the listener reads position from the event
+        // stream's fmt.
+        let fmt = TrackFmt {
+            track_id: path.clone(),
+            duration_ms: duration.as_millis() as u64,
+            pregap_ms: None,
+            position_offset: seek_to.unwrap_or(Duration::ZERO),
+            replay_gain_linear: 1.0,
+        };
+
+        let StreamPipelineStart {
+            pipeline,
+            audio_events,
+            ready: _,
+        } = match start_stream_pipeline(
             self.audio_output.as_deref_mut().unwrap(),
-            source.clone(),
+            decode,
+            fmt,
+            sample_rate,
+            channels,
             self.position_update_interval_ms,
+            "Preview decode",
+            DecodeFailureReport::LogOnly,
         )
         .await
         {
-            Ok(s) => s,
+            Ok(start) => start,
             Err(e) => {
-                error!("Failed to create preview audio stream: {:?}", e);
-                self.teardown_decoder();
+                error!("Failed to start preview stream: {:?}", e);
+                buffer.cancel();
                 return false;
             }
         };
 
-        if let Err(e) = setup.stream.play() {
-            error!("Failed to start preview playback: {:?}", e);
-            self.teardown_decoder();
-            return false;
-        }
-
+        // Preview's play/pause authority is its own audio-output state atomic.
         let preview_output = self.audio_output.as_ref().unwrap();
-        if paused {
-            preview_output.set_state(crate::playback::audio_output::AudioState::Paused);
+        preview_output.set_state(if paused {
+            AudioState::Paused
         } else {
-            preview_output.set_state(crate::playback::audio_output::AudioState::Playing);
-        }
-
-        self.stream = Some(setup.stream);
-        self.playback_source = Some(source.clone());
-        self.path = Some(path.clone());
-        self.duration = duration;
+            AudioState::Playing
+        });
 
         let dur_ms = duration.as_millis() as u64;
         let preview_state = if paused {
@@ -438,17 +375,33 @@ impl PreviewPlayer {
                 duration_ms: dur_ms,
             }
         };
-
         emit_progress(
             &self.progress_tx,
             PlaybackProgress::PreviewStateChanged(preview_state),
         );
 
+        let listener_handle = self.spawn_listener(audio_events);
+
+        self.active = Some(ActivePreview {
+            path,
+            duration,
+            sample_rate,
+            channels,
+            buffer,
+            listener_handle,
+            pipeline,
+        });
+        true
+    }
+
+    /// Spawn the preview event-listener task. Keeps the preview-specific arms
+    /// (Position → `PreviewPositionUpdate`, Completion → `PreviewCompleted`) and
+    /// delegates the diagnostics and dropped-event accounting to the shared unit.
+    fn spawn_listener(&self, mut audio_events: AudioEventReceiver) -> JoinHandle<()> {
         let progress_tx = self.progress_tx.clone();
         let command_tx = self.command_tx.clone();
-        let mut audio_events = setup.audio_events;
 
-        let h3 = tokio::spawn(async move {
+        tokio::spawn(async move {
             let mut event_tick = tokio::time::interval(Duration::from_millis(10));
             event_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
@@ -456,10 +409,9 @@ impl PreviewPlayer {
                 let mut completed = false;
                 while let Some(event) = audio_events.pop() {
                     match event {
-                        // Preview is single-track; the audio callback tags
-                        // every tick with the same fmt we built above. Read
-                        // its fields directly so the listener doesn't carry
-                        // parallel copies.
+                        // Preview is single-track; the audio callback tags every
+                        // tick with the same fmt built above. Read its fields
+                        // directly so the listener carries no parallel copies.
                         AudioEvent::Position((fmt, pos)) => {
                             let actual_pos_ms = (fmt.position_offset + pos).as_millis() as u64;
                             emit_progress(
@@ -474,73 +426,24 @@ impl PreviewPlayer {
                                 },
                             );
                         }
-                        AudioEvent::Completion((_fmt, _error_count, _samples_decoded)) => {
+                        AudioEvent::Completion(_) => {
                             // Preview doesn't track decode stats — it is not a
                             // library track. The stats carried by the uniform
                             // event are dropped here by design.
                             dispatch_command(&command_tx, PlaybackCommand::PreviewCompleted);
                             completed = true;
                         }
-                        AudioEvent::TrackCrossing(_) => {}
-                        AudioEvent::SourceLockMissed { missed_ms } => {
-                            warn!(
-                                missed_ms,
-                                "preview audio callback could not lock playback source while playing"
-                            );
-                        }
-                        AudioEvent::SourceLockReacquired { missed_ms } => {
-                            debug!(
-                                missed_ms,
-                                "preview audio callback reacquired playback source lock"
-                            );
-                        }
-                        AudioEvent::Starved {
-                            fmt,
-                            starved_ms,
-                            position_ms,
-                            producer_finished,
-                            samples_decoded,
-                            decode_errors,
-                            has_next,
-                        } => {
-                            warn!(
-                                track_id = %fmt.track_id,
-                                starved_ms,
-                                position_ms,
-                                producer_finished,
-                                samples_decoded,
-                                decode_errors,
-                                has_next,
-                                "preview playback source has no decoded samples while current track is not finished"
-                            );
-                        }
-                        AudioEvent::StarvationEnded {
-                            fmt,
-                            starved_ms,
-                            position_ms,
-                            samples_decoded,
-                            decode_errors,
-                        } => {
-                            debug!(
-                                track_id = %fmt.track_id,
-                                starved_ms,
-                                position_ms,
-                                samples_decoded,
-                                decode_errors,
-                                "preview playback source resumed after decoded sample starvation"
-                            );
+                        // Diagnostics (and the never-relevant TrackCrossing) go to
+                        // the shared logger.
+                        other => {
+                            log_stream_diagnostic("preview", &other);
                         }
                     }
                     if completed {
                         break;
                     }
                 }
-                let dropped_required = audio_events.take_dropped_required_count();
-                if dropped_required > 0 {
-                    error!(
-                        dropped_required,
-                        "preview audio callback event queue dropped required events"
-                    );
+                if report_dropped_audio_events(&audio_events, "preview") {
                     emit_progress(
                         &progress_tx,
                         PlaybackProgress::PlaybackError {
@@ -551,19 +454,11 @@ impl PreviewPlayer {
                     );
                     break;
                 }
-                let dropped = audio_events.take_dropped_count();
-                if dropped > 0 {
-                    warn!(dropped, "preview audio callback event queue dropped events");
-                }
                 if completed {
                     break;
                 }
             }
-        });
-
-        self.listener_handle = Some(h3);
-
-        true
+        })
     }
 }
 
@@ -599,41 +494,35 @@ fn resolve_preview_probe(
     }
 }
 
+#[cfg(test)]
+impl PreviewPlayer {
+    /// Inject an active preview over a caller-built pipeline so service-level
+    /// tests can exercise the completion/stop teardown seam without real audio.
+    pub(crate) fn set_active_for_test(
+        &mut self,
+        path: String,
+        pipeline: StreamPipeline,
+        buffer: SharedSparseBuffer,
+    ) {
+        self.active = Some(ActivePreview {
+            path,
+            duration: Duration::from_secs(1),
+            sample_rate: 44_100,
+            channels: 2,
+            buffer,
+            listener_handle: tokio::spawn(async {}),
+            pipeline,
+        });
+    }
+}
+
 #[cfg(all(test, feature = "test-utils"))]
 mod tests {
     use super::*;
     use crate::playback::audio_output::{
-        AudioError, AudioEventSender, AudioState, CaptureAudioOutput,
+        audio_event_channel, CaptureAudioOutput, FailingAudioOutput,
     };
-
-    struct FailingAudioOutput;
-
-    impl AudioOutput for FailingAudioOutput {
-        fn create_stream(
-            &mut self,
-            _source: Arc<Mutex<source::PlaybackSource>>,
-            _source_sample_rate: u32,
-            _source_channels: u32,
-            _audio_events: AudioEventSender,
-            _position_update_interval_ms: u32,
-        ) -> Result<Box<dyn AudioStream>, AudioError> {
-            Err(AudioError::StreamBuildError(
-                "preview test failure".to_string(),
-            ))
-        }
-
-        fn set_state(&self, _state: AudioState) {}
-
-        fn get_state(&self) -> AudioState {
-            AudioState::Stopped
-        }
-
-        fn set_volume(&self, _volume: f32) {}
-
-        fn get_volume(&self) -> f32 {
-            1.0
-        }
-    }
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn preview_play_rejects_unprobeable_file() {
@@ -654,17 +543,20 @@ mod tests {
         assert!(!started);
     }
 
+    /// A failed stream start leaves no active preview and cancels the buffer — the
+    /// preview side of the shared unit's failure contract (the unit cancels the
+    /// decoder; the owner cancels the buffer). A subsequent start over a working
+    /// output leaves `active` populated with the file as the current path.
     #[tokio::test]
-    async fn failed_preview_stream_start_clears_decoder_state() {
+    async fn failed_preview_stream_start_leaves_no_active_preview() {
         let (progress_tx, _progress_rx) = tokio_mpsc::unbounded_channel();
         let (command_tx, _command_rx) = tokio_mpsc::unbounded_channel();
         let mut player = PreviewPlayer::new(progress_tx, command_tx, 50);
         let buffer = create_sparse_buffer(0);
-        player.buffer = Some(buffer.clone());
         player.audio_output = Some(Box::new(FailingAudioOutput));
 
         let started = player
-            .start_decode(
+            .start_streaming(
                 "preview.wav".to_string(),
                 Duration::from_secs(1),
                 44_100,
@@ -676,23 +568,20 @@ mod tests {
             .await;
 
         assert!(!started);
-        assert!(player.buffer.is_none());
-        assert!(player.decoder_handle.is_none());
-        assert!(player.decoder_cancel_token.is_none());
+        assert!(player.active.is_none());
         assert!(buffer.is_cancelled());
 
         let (output, _capture_rx) = CaptureAudioOutput::new();
         let next_buffer = create_sparse_buffer(0);
-        player.buffer = Some(next_buffer);
         player.audio_output = Some(Box::new(output));
 
         let started = player
-            .start_decode(
+            .start_streaming(
                 "preview.wav".to_string(),
                 Duration::from_secs(1),
                 44_100,
                 2,
-                player.buffer.as_ref().unwrap().clone(),
+                next_buffer,
                 None,
                 false,
             )
@@ -701,6 +590,88 @@ mod tests {
         assert!(started);
         assert_eq!(player.current_path(), Some("preview.wav"));
         player.stop();
+    }
+
+    /// The preview listener maps a natural-completion audio event to a
+    /// `PreviewCompleted` command — the seam the service turns into teardown.
+    #[tokio::test]
+    async fn preview_listener_maps_completion_to_preview_completed() {
+        let (progress_tx, _progress_rx) = tokio_mpsc::unbounded_channel();
+        let (command_tx, mut command_rx) = tokio_mpsc::unbounded_channel();
+        let player = PreviewPlayer::new(progress_tx, command_tx, 50);
+
+        let (mut audio_tx, audio_rx) = audio_event_channel();
+        let handle = player.spawn_listener(audio_rx);
+
+        audio_tx.push_required(AudioEvent::Completion((
+            Arc::new(TrackFmt {
+                track_id: "preview.wav".to_string(),
+                duration_ms: 1_000,
+                pregap_ms: None,
+                position_offset: Duration::ZERO,
+                replay_gain_linear: 1.0,
+            }),
+            0,
+            0,
+        )));
+
+        let cmd = tokio::time::timeout(Duration::from_secs(1), command_rx.recv())
+            .await
+            .expect("the listener dispatches within the timeout")
+            .expect("a command is sent");
+        assert!(matches!(cmd, PlaybackCommand::PreviewCompleted));
+        handle.abort();
+    }
+
+    /// A preview seek whose stream rebuild fails tears the preview down outright
+    /// (no zombie) and surfaces `PreviewState::Idle` so the UI stops showing it.
+    #[tokio::test]
+    async fn failed_preview_seek_surfaces_idle() {
+        let (progress_tx, mut progress_rx) = tokio_mpsc::unbounded_channel();
+        let (command_tx, _command_rx) = tokio_mpsc::unbounded_channel();
+        let mut player = PreviewPlayer::new(progress_tx, command_tx, 50);
+
+        // Set up an active preview over a working capture output.
+        let (output, _capture_rx) = CaptureAudioOutput::new();
+        player.audio_output = Some(Box::new(output));
+        let buffer = create_sparse_buffer(0);
+        assert!(
+            player
+                .start_streaming(
+                    "preview.wav".to_string(),
+                    Duration::from_secs(1),
+                    44_100,
+                    2,
+                    buffer,
+                    None,
+                    false,
+                )
+                .await
+        );
+        assert!(player.is_active());
+
+        // The rebuild output now fails; seeking must tear the preview down and
+        // notify the UI rather than leaving a torn-down zombie.
+        player.audio_output = Some(Box::new(FailingAudioOutput));
+        player.seek(Duration::from_millis(500)).await;
+
+        assert!(
+            !player.is_active(),
+            "a failed seek leaves no active preview"
+        );
+        let mut saw_idle = false;
+        while let Ok(progress) = progress_rx.try_recv() {
+            if matches!(
+                progress,
+                PlaybackProgress::PreviewStateChanged(PreviewState::Idle)
+            ) {
+                saw_idle = true;
+            }
+        }
+        assert!(
+            saw_idle,
+            "a failed preview seek surfaces PreviewState::Idle to the UI"
+        );
     }
 
     #[tokio::test]

--- a/bae-core/src/playback/service/advance.rs
+++ b/bae-core/src/playback/service/advance.rs
@@ -66,14 +66,11 @@ impl PlaybackService {
             }
         };
 
-        // Create decoder sink/source and start decoder eagerly for gapless playback
-        let decoder_buffer = prepared
-            .segments
-            .first()
-            .expect("prepared track has at least one segment")
-            .buffer
-            .clone();
-        let cancel_token = prepared.cancel_token.clone();
+        // A preload has no stream — it is not a pipeline yet. Mint its decoder's
+        // cancel token here (where the decoder is spawned) and carry it in
+        // `PreloadedNext` so promotion hands it to the pipeline that adopts this
+        // decoder.
+        let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         // Preload params (natural transition: no pregap skip): seek to the
         // track's first sample, trim there, stop at its end.
@@ -81,11 +78,14 @@ impl PlaybackService {
         let (mut sink, source, _ready) =
             create_track_stream_pair(prepared.sample_rate, prepared.channels);
 
-        let decoder_handle = std::thread::spawn(move || {
-            if let Err(e) = decode.run_decoder(decoder_buffer, &mut sink, cancel_token) {
-                let _ = log_streaming_decode_failure("Preload streaming decode", e);
-            }
-        });
+        let decoder_handle = {
+            let decoder_cancel = cancel_token.clone();
+            std::thread::spawn(move || {
+                if let Err(e) = decode.run_decoder(&mut sink, decoder_cancel) {
+                    let _ = log_streaming_decode_failure("Preload streaming decode", e);
+                }
+            })
+        };
 
         // Store preloaded state. If the next track shares the live stream's
         // format, stage it into the PlaybackSource so the audio callback can
@@ -100,7 +100,7 @@ impl PlaybackService {
                     && self.playback_queue.repeat_mode() != RepeatMode::Track
                     && !self.should_hold_for_side_pause(&cur.prepared, &prepared) =>
             {
-                Some(cur.source.clone())
+                Some(cur.pipeline.source().clone())
             }
             _ => None,
         };
@@ -116,6 +116,7 @@ impl PlaybackService {
             self.preloaded_next = Some(PreloadedNext {
                 prepared,
                 decoder_handle,
+                cancel_token,
                 source: PreloadedNextSource::Staged,
             });
         } else {
@@ -126,6 +127,7 @@ impl PlaybackService {
             self.preloaded_next = Some(PreloadedNext {
                 prepared,
                 decoder_handle,
+                cancel_token,
                 source: PreloadedNextSource::Held(source),
             });
         }
@@ -312,7 +314,7 @@ impl PlaybackService {
     /// The current track's playback source, if a track is active.
     pub(super) fn current_source(&self) -> Option<&Arc<Mutex<source::PlaybackSource>>> {
         match &self.slot {
-            PlaybackSlot::Active(cur) => Some(&cur.source),
+            PlaybackSlot::Active(cur) => Some(cur.pipeline.source()),
             _ => None,
         }
     }
@@ -375,6 +377,7 @@ impl PlaybackService {
         let PreloadedNext {
             prepared: next_prepared,
             decoder_handle,
+            cancel_token,
             ..
         } = preloaded;
         let track_id = crossing.incoming_fmt.track_id.clone();
@@ -397,7 +400,8 @@ impl PlaybackService {
         cur.prepared
             .release_buffers_not_used_by(&next_prepared, &mut self.shared_file_buffers);
         cur.prepared = next_prepared;
-        cur.decoder_handle = decoder_handle;
+        cur.pipeline
+            .adopt_crossed_decoder(decoder_handle, cancel_token);
 
         // The crossed-into track is now playing: hand its reader fetch priority
         // over the track preloaded below.
@@ -478,6 +482,7 @@ impl PlaybackService {
         let PreloadedNext {
             prepared: next_prepared,
             decoder_handle,
+            cancel_token,
             source: preloaded_source,
         } = preloaded;
 
@@ -489,10 +494,11 @@ impl PlaybackService {
         // Fall back to play_track which handles pregap at decoder start.
         if !is_natural_transition && pregap_ms.is_some_and(|p| p > 0) {
             info!("Pregap skip needed for preloaded track - falling back to play_track");
-            next_prepared.cancel_unshared_buffers();
-            if let Some(source) = detach_preloaded_source(self.current_source(), preloaded_source) {
-                source.cancel();
-            }
+            // This preload was staged for a natural start (byte 0); a pregap-skip
+            // direct selection can't use it, so discard its decoder and re-decode
+            // through play_track.
+            let detached = detach_preloaded_source(self.current_source(), preloaded_source);
+            discard_preloaded_decoder(&next_prepared, detached, &cancel_token);
             self.play_track(
                 &track_id,
                 TrackStart::from_natural_transition(is_natural_transition),
@@ -502,9 +508,9 @@ impl PlaybackService {
             return;
         }
 
-        // Recover the preloaded next source (staged in the gapless chain or held
-        // for the rebuild path) BEFORE tearing down the current stream.
-        let source = detach_preloaded_source(self.current_source(), preloaded_source)
+        // Recover the preloaded next track stream (staged in the gapless chain or
+        // held for the rebuild path) BEFORE tearing down the current stream.
+        let track_stream = detach_preloaded_source(self.current_source(), preloaded_source)
             .expect("Preloaded track has no streaming source");
 
         // Tear down the current track. Cancel its source so the callback goes
@@ -512,21 +518,33 @@ impl PlaybackService {
         // track). The preloaded track's already-running decoder becomes current.
         if let PlaybackSlot::Active(cur) = std::mem::replace(&mut self.slot, PlaybackSlot::Stopped)
         {
-            if let Ok(guard) = cur.source.lock() {
+            if let Ok(guard) = cur.pipeline.source().lock() {
                 guard.cancel();
             }
             cur.prepared
                 .release_buffers_not_used_by(&next_prepared, &mut self.shared_file_buffers);
-            // Dropping `cur` drops the old stream/events and detaches its decoder.
+            // Dropping `cur` drops the old pipeline (stream + source, detaching the
+            // decoder) and the old audio-events receiver.
         }
 
         // Natural transition: start at position 0 (INDEX 00, pregap plays).
         let fmt = next_prepared.track_fmt(std::time::Duration::ZERO);
+        let position_update_interval_ms = self.position_update_interval_ms;
 
-        // Initialize streaming with the preloaded source. On failure the caller
-        // owns the failure path: surface a PlaybackError, then stop() to resolve
-        // the transition to Stopped (as play_track does when audio can't start).
-        let parts = match self.init_streaming(source, fmt).await {
+        // Adopt the preloaded track's already-running decoder onto a fresh stream.
+        // On failure the caller owns the failure path: surface a PlaybackError,
+        // then stop() to resolve the transition to Stopped (as play_track does when
+        // audio can't start).
+        let (pipeline, audio_events) = match StreamPipeline::attach_preloaded(
+            &mut *self.audio_output,
+            track_stream,
+            fmt,
+            decoder_handle,
+            cancel_token,
+            position_update_interval_ms,
+        )
+        .await
+        {
             Ok(parts) => parts,
             Err(_) => {
                 emit_progress(
@@ -542,12 +560,15 @@ impl PlaybackService {
             }
         };
 
-        // The preloaded track's already-running decoder becomes current.
-        let started = StartedStream {
-            parts,
-            decoder_handle,
-        };
-        self.install_active_track(next_prepared, started, target.into_track_phase());
+        // The gapless natural transition begins at position 0.
+        *self.current_position_shared.lock().unwrap() = Some(std::time::Duration::ZERO);
+
+        self.install_active_track(
+            next_prepared,
+            pipeline,
+            audio_events,
+            target.into_track_phase(),
+        );
         self.emit_state();
 
         self.preload_queue_front().await;

--- a/bae-core/src/playback/service/mod.rs
+++ b/bae-core/src/playback/service/mod.rs
@@ -31,9 +31,7 @@ use crate::db::{DbAudioSegmentRole, DbPlaybackContext, DbPlaybackState};
 use crate::library::LibraryEvent;
 use crate::library::LibraryManager;
 use crate::library::ResolvedTrackAudio;
-use crate::playback::audio_output::{
-    audio_event_channel, AudioEvent, AudioEventReceiver, AudioOutput, AudioStream,
-};
+use crate::playback::audio_output::{AudioEvent, AudioEventReceiver, AudioOutput};
 use crate::playback::data_source::{create_audio_reader, FetchArbiter};
 use crate::playback::error::PlaybackError;
 use crate::playback::progress::emit_progress;
@@ -62,7 +60,10 @@ mod seek;
 mod slot;
 mod state;
 
-use pipeline::StartedStream;
+use crate::playback::stream_pipeline::{
+    log_stream_diagnostic, report_dropped_audio_events, start_stream_pipeline, DecodeFailureReport,
+    SegmentDecodeParams, StreamDecodeParams, StreamPipeline,
+};
 use slot::{
     CurrentTrack, LoadGeneration, PausePhase, PlayIntent, PlayTarget, PlaybackSlot, TrackPhase,
 };
@@ -614,9 +615,6 @@ struct PreparedAudioSegment {
 struct PlaybackPreparedTrack {
     track_info: PlaybackTrackInfo,
     segments: Vec<PreparedAudioSegment>,
-    /// Per-decoder cancellation token. Set to true to stop the AVIO read callback
-    /// without affecting other decoders on the same buffer.
-    cancel_token: Arc<std::sync::atomic::AtomicBool>,
     /// Sample rate in Hz for time-to-sample conversion
     sample_rate: u32,
     channels: u32,
@@ -640,6 +638,10 @@ struct PlaybackPreparedTrack {
 struct PreloadedNext {
     prepared: PlaybackPreparedTrack,
     decoder_handle: std::thread::JoinHandle<()>,
+    /// The preload decoder's AVIO cancel flag, minted where the decoder is
+    /// spawned. Handed to `attach_preloaded` / `adopt_crossed_decoder` when the
+    /// preload is promoted to current, so the pipeline owns exactly one token.
+    cancel_token: Arc<std::sync::atomic::AtomicBool>,
     source: PreloadedNextSource,
 }
 
@@ -692,12 +694,36 @@ fn clear_preloaded_next(
     };
 
     let PreloadedNext {
-        prepared, source, ..
+        prepared,
+        source,
+        cancel_token,
+        ..
     } = preloaded;
 
-    if let Some(source) = detach_preloaded_source(current_playback_source, source) {
+    let detached = detach_preloaded_source(current_playback_source, source);
+    discard_preloaded_decoder(&prepared, detached, &cancel_token);
+}
+
+/// Stop a preloaded (not-yet-promoted) decoder and free its byte buffers. Three
+/// mechanisms, one per place the decoder can be blocked:
+/// - cancel the output source: sets the sink's cancel flag and unparks the
+///   decoder, so one blocked writing a full ring exits;
+/// - set the per-decoder token: stops a decoder blocked reading a *shared* buffer
+///   — `cancel_unshared_buffers` deliberately spares shared buffers (cancelling
+///   one would kill the other decoder still reading it), and `source.cancel()`
+///   only reaches the sink/write side, so the token is that decoder's only
+///   read-side stop;
+/// - cancel the unshared byte buffers: stops their reader and wakes a decoder
+///   blocked reading one.
+fn discard_preloaded_decoder(
+    prepared: &PlaybackPreparedTrack,
+    detached_source: Option<TrackStream>,
+    cancel_token: &Arc<std::sync::atomic::AtomicBool>,
+) {
+    if let Some(source) = detached_source {
         source.cancel();
     }
+    cancel_token.store(true, std::sync::atomic::Ordering::Release);
     prepared.cancel_unshared_buffers();
 }
 
@@ -740,7 +766,6 @@ fn finalize_playback_track(
     PlaybackPreparedTrack {
         track_info,
         segments,
-        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         sample_rate: resolved.sample_rate,
         channels: resolved.channels,
         pregap_ms: resolved.pregap_ms,
@@ -992,57 +1017,6 @@ impl PlaybackService {
         self.sync_audio_state();
     }
 
-    fn log_audio_diagnostic(&self, event: AudioEvent) {
-        match event {
-            AudioEvent::SourceLockMissed { missed_ms } => {
-                warn!(
-                    missed_ms,
-                    "audio callback could not lock playback source while playing"
-                );
-            }
-            AudioEvent::SourceLockReacquired { missed_ms } => {
-                debug!(missed_ms, "audio callback reacquired playback source lock");
-            }
-            AudioEvent::Starved {
-                fmt,
-                starved_ms,
-                position_ms,
-                producer_finished,
-                samples_decoded,
-                decode_errors,
-                has_next,
-            } => {
-                warn!(
-                    track_id = %fmt.track_id,
-                    starved_ms,
-                    position_ms,
-                    producer_finished,
-                    samples_decoded,
-                    decode_errors,
-                    has_next,
-                    "playback source has no decoded samples while current track is not finished"
-                );
-            }
-            AudioEvent::StarvationEnded {
-                fmt,
-                starved_ms,
-                position_ms,
-                samples_decoded,
-                decode_errors,
-            } => {
-                debug!(
-                    track_id = %fmt.track_id,
-                    starved_ms,
-                    position_ms,
-                    samples_decoded,
-                    decode_errors,
-                    "playback source resumed after decoded sample starvation"
-                );
-            }
-            AudioEvent::Position(_) | AudioEvent::Completion(_) | AudioEvent::TrackCrossing(_) => {}
-        }
-    }
-
     async fn handle_audio_event(&mut self, event: AudioEvent) {
         match event {
             AudioEvent::Position((fmt, pos)) => self.handle_position_event(fmt, pos),
@@ -1050,7 +1024,9 @@ impl PlaybackService {
                 self.handle_completion_event(fmt, error_count, samples_decoded);
             }
             AudioEvent::TrackCrossing(crossing) => self.handle_track_crossed(crossing).await,
-            event => self.log_audio_diagnostic(event),
+            event => {
+                log_stream_diagnostic("playback", &event);
+            }
         }
     }
 
@@ -1066,13 +1042,9 @@ impl PlaybackService {
         let dropped_required = self
             .slot
             .pollable_audio_events_ref()
-            .map(AudioEventReceiver::take_dropped_required_count)
-            .unwrap_or(0);
-        if dropped_required > 0 {
-            error!(
-                dropped_required,
-                "audio callback event queue dropped required events"
-            );
+            .map(|events| report_dropped_audio_events(events, "playback"))
+            .unwrap_or(false);
+        if dropped_required {
             emit_progress(
                 &self.progress_tx,
                 PlaybackProgress::PlaybackError {
@@ -1082,14 +1054,6 @@ impl PlaybackService {
                 },
             );
             self.stop().await;
-            return;
-        }
-
-        if let Some(events) = self.slot.pollable_audio_events_ref() {
-            let dropped = events.take_dropped_count();
-            if dropped > 0 {
-                warn!(dropped, "audio callback event queue dropped events");
-            }
         }
     }
 }
@@ -1138,147 +1102,6 @@ pub(crate) fn default_audio_output(
     Ok(Box::new(
         crate::playback::aaudio_output::AAudioOutput::new()?
     ))
-}
-
-pub(crate) struct StreamSetup {
-    pub(crate) stream: Box<dyn AudioStream>,
-    pub(crate) audio_events: AudioEventReceiver,
-}
-
-pub(crate) async fn setup_audio_stream(
-    audio_output: &mut dyn AudioOutput,
-    source: Arc<Mutex<source::PlaybackSource>>,
-    position_update_interval_ms: u32,
-) -> Result<StreamSetup, PlaybackError> {
-    let (source_sample_rate, source_channels) = {
-        let guard = source.lock().unwrap();
-        (guard.sample_rate(), guard.channels())
-    };
-
-    let (audio_event_tx, audio_events) = audio_event_channel();
-
-    let stream = match audio_output.create_stream(
-        source,
-        source_sample_rate,
-        source_channels,
-        audio_event_tx,
-        position_update_interval_ms,
-    ) {
-        Ok(stream) => stream,
-        Err(e) => {
-            return Err(PlaybackError::task(format!("Audio stream: {:?}", e)));
-        }
-    };
-
-    Ok(StreamSetup {
-        stream,
-        audio_events,
-    })
-}
-
-/// Tear down the decoded-audio pipeline for a seek.
-///
-/// Cancels this decoder's token to unblock the old decoder while the data
-/// reader keeps filling the buffer. After this, the buffer is ready for a new
-/// decoder to read from position 0. Shared by the main player's seek and the
-/// preview player's seek.
-pub(crate) async fn teardown_decoder_for_seek(
-    source: &mut Option<Arc<Mutex<source::PlaybackSource>>>,
-    buffers: &[SharedSparseBuffer],
-    cancel_token: &Arc<std::sync::atomic::AtomicBool>,
-    decoder_handle: &mut Option<std::thread::JoinHandle<()>>,
-) {
-    // Cancel streaming source (cpal callback outputs silence)
-    if let Some(src) = source.take() {
-        if let Ok(guard) = src.lock() {
-            guard.cancel();
-        }
-    }
-
-    // Cancel this decoder's AVIO reads via its token.
-    cancel_token.store(true, std::sync::atomic::Ordering::Release);
-
-    // Wake any readers blocked on the condvar so they can check the token.
-    for buffer in buffers {
-        buffer.wake_readers();
-    }
-
-    // Wait for decoder thread to exit. Surface a thread panic as an error
-    // (decoder bug, real signal); tokio join failures (panic in the
-    // spawn_blocking wrapper itself, runtime shutdown) get a warn.
-    if let Some(handle) = decoder_handle.take() {
-        match tokio::task::spawn_blocking(move || handle.join()).await {
-            Ok(Ok(())) => {}
-            Ok(Err(panic)) => {
-                error!("Decoder thread panicked during seek teardown: {:?}", panic);
-            }
-            Err(e) => {
-                warn!("spawn_blocking failed while joining decoder thread: {e}");
-            }
-        }
-    }
-}
-
-/// The decoder window for one stream. `target_sample` is where FFmpeg trims
-/// lead-in (the track's start plus any pregap/seek offset). The seek to it is
-/// either a by-byte jump (`seek_to_byte`, a lossless track's natural start) or a
-/// sample seek (APE, or a mid-track seek); the `target_sample` trim makes the
-/// first output sample exact either way. `stop_at_sample` ends output at the
-/// track's end (`None` = to EOF).
-struct StreamDecodeParams {
-    segments: Vec<SegmentDecodeParams>,
-    leading_silence_frames: u64,
-}
-
-struct SegmentDecodeParams {
-    buffer: SharedSparseBuffer,
-    seek_to_byte: Option<u64>,
-    target_sample: u64,
-    stop_at_sample: Option<u64>,
-    /// The track's end byte offset -- the read-ahead ceiling. `None` = whole file.
-    end_byte: Option<u64>,
-}
-
-impl StreamDecodeParams {
-    /// Run the streaming decoder for this window: FFmpeg seeks (by byte or by
-    /// sample), trims lead-in at `target_sample`, and stops at `stop_at_sample`.
-    /// Shared by the play/seek and preload paths so they can't drift on the
-    /// seek/trim mapping.
-    fn run_decoder(
-        &self,
-        _buffer: SharedSparseBuffer,
-        sink: &mut crate::playback::track_stream::TrackSink,
-        cancel: Arc<std::sync::atomic::AtomicBool>,
-    ) -> Result<(), StreamingDecodeError> {
-        if self.leading_silence_frames > 0 {
-            sink.push_silence_frames_blocking(self.leading_silence_frames);
-            if cancel.load(std::sync::atomic::Ordering::Relaxed) || sink.is_cancelled() {
-                return Err(StreamingDecodeError::InputCancelled);
-            }
-        }
-
-        for segment in &self.segments {
-            let seek_to_sample = if segment.seek_to_byte.is_some() {
-                None
-            } else {
-                Some(segment.target_sample)
-            };
-            crate::audio_codec::decode_audio_streaming(
-                segment.buffer.clone(),
-                sink,
-                segment.seek_to_byte,
-                seek_to_sample,
-                Some(segment.target_sample),
-                segment.stop_at_sample,
-                segment.end_byte,
-                cancel.clone(),
-            )?;
-            if cancel.load(std::sync::atomic::Ordering::Relaxed) || sink.is_cancelled() {
-                return Err(StreamingDecodeError::InputCancelled);
-            }
-        }
-        Ok(())
-    }
 }
 
 impl PlaybackService {
@@ -1803,7 +1626,7 @@ impl PlaybackService {
                     self.preview_stop();
                 }
                 PlaybackCommand::PreviewTogglePause => {
-                    self.preview_toggle_pause().await;
+                    self.preview_toggle_pause();
                 }
                 PlaybackCommand::PreviewSeekByRatio(ratio) => {
                     self.preview.seek_by_ratio(ratio).await;

--- a/bae-core/src/playback/service/pipeline.rs
+++ b/bae-core/src/playback/service/pipeline.rs
@@ -1,28 +1,11 @@
 use super::*;
 
-/// A built, playing cpal (or test) stream over a decoded `TrackStream`: the
-/// `StreamSetup` (stream + its audio-events receiver) plus the wrapped source.
-/// `start_decoder_and_watch` pairs this with the decoder handle it spawned; the
-/// preload-advance paths pair it with the already-running preloaded decoder.
-pub(super) struct StreamParts {
-    pub(super) setup: StreamSetup,
-    pub(super) source: Arc<Mutex<source::PlaybackSource>>,
-}
-
-/// Everything a fresh decoder load assembles: the stream parts plus the decoder
-/// thread the caller stores in the `CurrentTrack`. Returned by
-/// `start_decoder_and_watch` so the caller assigns the slot as one whole value.
-pub(super) struct StartedStream {
-    pub(super) parts: StreamParts,
-    pub(super) decoder_handle: std::thread::JoinHandle<()>,
-}
-
 impl PlaybackService {
     /// Tear down the current track, whatever phase it is in, leaving the slot
-    /// Stopped. Cancels the playback source so the callback goes silent, signals
-    /// the decoder cancel token and cancels its unshared buffers (so the decoder
-    /// thread exits its park loop and the data reader stops fetching), and drops
-    /// the stream, audio-events receiver, and (detaching) the decoder handle.
+    /// Stopped. The pipeline's `cancel()` silences the audio callback, signals the
+    /// decoder token, and drops the stream; cancelling the prepared track's
+    /// unshared buffers stops the data reader and lets the decoder thread exit its
+    /// park loop.
     ///
     /// A shared buffer is spared (the same-source reuse path appends into it via
     /// `uncancel`); `stop()` drops the shared-buffer cache wholesale instead. The
@@ -32,19 +15,9 @@ impl PlaybackService {
     pub(super) fn teardown_current_track(&mut self) {
         if let PlaybackSlot::Active(cur) = std::mem::replace(&mut self.slot, PlaybackSlot::Stopped)
         {
-            match cur.source.lock() {
-                Ok(guard) => guard.cancel(),
-                // A poisoned lock means the cpal callback thread panicked while
-                // holding it. The source is being dropped here anyway, so the
-                // cancel it would have requested is moot — log and move on.
-                Err(_) => warn!("playback source lock poisoned during teardown; skipping cancel"),
-            }
-            cur.prepared
-                .cancel_token
-                .store(true, std::sync::atomic::Ordering::Release);
+            cur.pipeline.cancel();
             cur.prepared.cancel_unshared_buffers();
-            // Dropping `cur` drops the stream and audio-events receiver and
-            // detaches the decoder thread.
+            // Dropping `cur` drops the audio-events receiver.
         }
     }
 
@@ -56,147 +29,84 @@ impl PlaybackService {
     pub(super) fn install_active_track(
         &mut self,
         prepared: PlaybackPreparedTrack,
-        started: StartedStream,
+        pipeline: StreamPipeline,
+        audio_events: AudioEventReceiver,
         phase: TrackPhase,
     ) {
         self.slot = PlaybackSlot::Active(CurrentTrack {
             prepared,
-            stream: started.parts.setup.stream,
-            source: started.parts.source,
-            decoder_handle: started.decoder_handle,
-            audio_events: started.parts.setup.audio_events,
+            pipeline,
+            audio_events,
             phase,
         });
         self.mark_current_foreground();
         self.sync_audio_state();
     }
 
-    /// Build the cpal (or test) stream over a decoded `TrackStream`, start it,
-    /// and return the parts. Sets the shared position to the stream's start
-    /// offset. Does not touch the slot or the audio-state atomic — the caller
-    /// assembles the slot and calls `sync_audio_state`.
-    pub(super) async fn init_streaming(
-        &mut self,
-        source: TrackStream,
-        fmt: TrackFmt,
-    ) -> Result<StreamParts, PlaybackError> {
-        // fmt is the per-stream formatting envelope; the caller built it from its
-        // prepared track (see `PlaybackPreparedTrack::track_fmt`). The audio
-        // callback tags every position/completion emit with it; at a gapless
-        // boundary the callback swaps to the staged next track's fmt.
-        let position_offset = fmt.position_offset;
-
-        // Wrap the track source in a PlaybackSource so the audio callback can
-        // advance to a pre-staged next track without rebuilding the stream.
-        let gapless = Arc::new(Mutex::new(source::PlaybackSource::new(source, fmt)));
-
-        let setup = setup_audio_stream(
-            &mut *self.audio_output,
-            gapless.clone(),
-            self.position_update_interval_ms,
-        )
-        .await?;
-
-        if let Err(e) = setup.stream.play() {
-            return Err(PlaybackError::task(format!(
-                "Failed to start streaming playback: {e:?}"
-            )));
-        }
-
-        *self.current_position_shared.lock().unwrap() = Some(position_offset);
-
-        Ok(StreamParts {
-            setup,
-            source: gapless,
-        })
-    }
-
-    /// Spawn the in-core decoder for `prepared`, build the audio stream, and arm
-    /// the ready-watcher — the shared tail of the play and seek paths. The
-    /// decoder reads `prepared`'s buffer and cancel token, so the watcher's
-    /// `TrackReady` carries this load's `generation` and the handler ignores a
-    /// stale signal. Audio doesn't flow until the ring fills, so the caller may
-    /// set the phase target after this returns without racing the watcher.
+    /// Spawn the in-core decoder for `prepared`, build the audio stream through
+    /// the shared `StreamPipeline`, and arm the ready-watcher — the shared tail of
+    /// the play and seek paths. The watcher's `TrackReady` carries this load's
+    /// `generation` so the handler ignores a stale signal. Audio doesn't flow
+    /// until the ring fills, so the caller may set the phase target after this
+    /// returns without racing the watcher.
     ///
-    /// On stream-build failure the just-spawned decoder is cancelled (it would
-    /// otherwise fill a ring nobody pulls) and the error is returned; the caller
-    /// owns the rest of the failure path.
+    /// On stream-build failure `start_stream_pipeline` has already cancelled the
+    /// just-spawned decoder; here we cancel the prepared track's unshared buffers
+    /// and wake their readers (so a read-blocked decoder sees the token), then
+    /// return the error for the caller to resolve.
     pub(super) async fn start_decoder_and_watch(
         &mut self,
         prepared: &PlaybackPreparedTrack,
         decode: StreamDecodeParams,
         fmt: TrackFmt,
         generation: LoadGeneration,
-    ) -> Result<StartedStream, PlaybackError> {
-        let decoder_buffer = prepared
-            .segments
-            .first()
-            .expect("prepared track has at least one segment")
-            .buffer
-            .clone();
-        let cancel_token = prepared.cancel_token.clone();
-        let sample_rate = prepared.sample_rate;
-        let channels = prepared.channels;
+    ) -> Result<(StreamPipeline, AudioEventReceiver), PlaybackError> {
+        let position_offset = fmt.position_offset;
         let track_id = prepared.track_info.track_id.clone();
 
-        // Create decoder sink/source with the track's sample rate and spawn the
-        // in-core FFmpeg decoder thread that fills the sink's ring buffer.
-        let (mut sink, source, ready_rx) = create_track_stream_pair(sample_rate, channels);
-
-        let decoder_handle = {
-            let decoder_cancel = cancel_token.clone();
-            // Kept to tell a genuine decode failure from normal teardown (seek /
-            // stop / track change all cancel the token before the decoder exits).
-            let teardown_check = cancel_token.clone();
-            let error_tx = self.progress_tx.clone();
-            std::thread::spawn(move || {
-                if let Err(e) = decode.run_decoder(decoder_buffer, &mut sink, decoder_cancel) {
-                    if let Some(message) = log_streaming_decode_failure("Streaming decode", e) {
-                        if !teardown_check.load(std::sync::atomic::Ordering::Relaxed) {
-                            emit_progress(
-                                &error_tx,
-                                PlaybackProgress::PlaybackError {
-                                    reason: crate::ui::PlaybackErrorReason::internal(format!(
-                                        "Playback decode failed: {message}"
-                                    )),
-                                },
-                            );
-                        }
-                    }
-                }
-            })
-        };
-
-        let parts = match self.init_streaming(source, fmt).await {
-            Ok(parts) => parts,
+        let start = match start_stream_pipeline(
+            &mut *self.audio_output,
+            decode,
+            fmt,
+            prepared.sample_rate,
+            prepared.channels,
+            self.position_update_interval_ms,
+            "Streaming decode",
+            DecodeFailureReport::EmitPlaybackError {
+                progress_tx: self.progress_tx.clone(),
+            },
+        )
+        .await
+        {
+            Ok(start) => start,
             Err(e) => {
-                error!("Failed to create streaming audio stream: {:?}", e);
-                // The decoder is spawned but no stream will pull from it. Cancel
-                // it so it exits instead of parking on a ring nobody reads, then
-                // detach — joining would block the command loop.
-                cancel_token.store(true, std::sync::atomic::Ordering::Release);
                 prepared.cancel_unshared_buffers();
                 for segment in &prepared.segments {
                     segment.buffer.wake_readers();
                 }
-                drop(decoder_handle);
                 return Err(e);
             }
         };
 
+        // The stream's start offset is the in-track time it begins at (non-zero
+        // only on seek). Set here rather than inside the shared unit — preview has
+        // no shared position cell.
+        *self.current_position_shared.lock().unwrap() = Some(position_offset);
+
         // Hold the phase in Loading until audio is actually flowing. The in-core
-        // decoder signals `ready_rx` when the ring buffer fills to the play
-        // threshold (or hits EOF for a short track); a watcher task turns that
-        // into a `TrackReady` command so the command loop stays responsive to
-        // Stop/Pause during a slow cloud load. Awaiting inline would wedge the loop.
+        // decoder signals `ready` when the ring buffer fills to the play threshold
+        // (or hits EOF for a short track); a watcher task turns that into a
+        // `TrackReady` command so the command loop stays responsive to Stop/Pause
+        // during a slow cloud load. Awaiting inline would wedge the loop.
         let command_tx = self.command_tx.clone();
+        let ready = start.ready;
         tokio::spawn(async move {
             // Err means the decoder dropped its sink before signalling ready (it
             // died or was cancelled). The decode-failure path drives playback to
             // Stopped, and a cancelled load's generation no longer matches so
             // TrackReady would be ignored anyway — the error path owns recovery,
             // so just record the dropped watcher.
-            match ready_rx.await {
+            match ready.await {
                 Ok(()) => dispatch_command(
                     &command_tx,
                     PlaybackCommand::TrackReady {
@@ -210,10 +120,7 @@ impl PlaybackService {
             }
         });
 
-        Ok(StartedStream {
-            parts,
-            decoder_handle,
-        })
+        Ok((start.pipeline, start.audio_events))
     }
 
     /// Play a track.
@@ -289,11 +196,11 @@ impl PlaybackService {
         let fmt = prepared.track_fmt(start_position);
         let generation = self.next_load_generation();
 
-        let started = match self
+        let (pipeline, audio_events) = match self
             .start_decoder_and_watch(&prepared, decode, fmt, generation)
             .await
         {
-            Ok(started) => started,
+            Ok(parts) => parts,
             Err(_) => {
                 emit_progress(
                     &self.progress_tx,
@@ -315,7 +222,8 @@ impl PlaybackService {
         // onto the atomic so the callback outputs samples/silence as intended.
         self.install_active_track(
             prepared,
-            started,
+            pipeline,
+            audio_events,
             TrackPhase::Loading { generation, target },
         );
 

--- a/bae-core/src/playback/service/preview.rs
+++ b/bae-core/src/playback/service/preview.rs
@@ -55,15 +55,10 @@ impl PlaybackService {
     /// Preview a local file. Same path toggles off (and resumes main); a
     /// different path switches; a fresh path starts and pauses the main player.
     pub(super) async fn preview_play(&mut self, path: String) {
-        // Same path: dismiss if playing/paused (and resume main); if finished,
-        // clear it and replay from the top.
+        // Same path: dismiss (and resume main).
         if self.preview.current_path() == Some(path.as_str()) {
-            if self.preview.is_finished() {
-                self.preview.clear_finished();
-            } else {
-                self.preview_stop();
-                return;
-            }
+            self.preview_stop();
+            return;
         }
 
         // Pause the main player only once the preview has actually started, so a
@@ -86,16 +81,8 @@ impl PlaybackService {
         self.maybe_resume_main_player();
     }
 
-    /// Toggle pause/resume on the active preview. A finished preview restarts
-    /// from the top (which re-pauses the main player).
-    pub(super) async fn preview_toggle_pause(&mut self) {
-        let Some(path) = self.preview.current_path().map(str::to_string) else {
-            return;
-        };
-        if self.preview.is_finished() {
-            self.preview_play(path).await;
-            return;
-        }
+    /// Toggle pause/resume on the active preview.
+    pub(super) fn preview_toggle_pause(&mut self) {
         self.preview.toggle_pause();
     }
 }

--- a/bae-core/src/playback/service/seek.rs
+++ b/bae-core/src/playback/service/seek.rs
@@ -42,10 +42,8 @@ impl PlaybackService {
 
         let generation = self.next_load_generation();
         let CurrentTrack {
-            mut prepared,
-            stream,
-            source,
-            decoder_handle,
+            prepared,
+            pipeline,
             audio_events,
             phase,
         } = cur;
@@ -59,40 +57,31 @@ impl PlaybackService {
             TrackPhase::Loading { target, .. } => target,
         };
 
-        // Drop the old stream and its event receiver — the rebuild replaces them.
-        drop(stream);
+        // Drop the old event receiver — the rebuild replaces it.
         drop(audio_events);
 
-        let old_cancel_token = prepared.cancel_token.clone();
         let old_buffers: Vec<_> = prepared
             .segments
             .iter()
             .map(|segment| segment.buffer.clone())
             .collect();
-        // Mint a fresh cancel token for the seek's decoder so cancelling the old
-        // decoder below doesn't cancel the new one; staleness is decided by
-        // generation, not by this token.
-        prepared.cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         // Preserve any staged gapless next track across the rebuild so playback
         // stays gapless after the seek. Removing it from the old chain keeps the
         // teardown below from cancelling its (still-running) decoder; its source +
         // fmt are re-staged into the new stream once it's built.
-        let staged_next: Option<(TrackStream, TrackFmt)> = source
+        let staged_next: Option<(TrackStream, TrackFmt)> = pipeline
+            .source()
             .lock()
             .unwrap()
             .take_next()
             .map(|(s, fmt)| (s, (*fmt).clone()));
 
-        let mut source_opt = Some(source);
-        let mut decoder_opt = Some(decoder_handle);
-        teardown_decoder_for_seek(
-            &mut source_opt,
-            &old_buffers,
-            &old_cancel_token,
-            &mut decoder_opt,
-        )
-        .await;
+        // Cancel the old decoder + source, wake the retained buffers, and join the
+        // old decoder so a fresh one can reuse the same buffers. The seek's fresh
+        // decoder mints its own token inside the shared unit, so cancelling the old
+        // one here can't touch it.
+        pipeline.shutdown_for_seek(&old_buffers).await;
 
         // Show buffering at the target immediately (the same Loading→ready arc the
         // play path uses): the bar jumps to the seek position via Seeked below,
@@ -112,11 +101,11 @@ impl PlaybackService {
         let fmt = prepared.track_fmt(position);
         info!("Seek: position {:?}", position);
 
-        let started = match self
+        let (pipeline, audio_events) = match self
             .start_decoder_and_watch(&prepared, decode, fmt, generation)
             .await
         {
-            Ok(started) => started,
+            Ok(parts) => parts,
             Err(_) => {
                 // The rebuilt stream failed. The preserved next track was taken
                 // out of the old chain, so stop()'s teardown can't reach it —
@@ -144,9 +133,8 @@ impl PlaybackService {
         // source before it becomes current, so post-seek auto-advance stays
         // gapless without re-decoding.
         if let Some((next_source, next_fmt)) = staged_next {
-            started
-                .parts
-                .source
+            pipeline
+                .source()
                 .lock()
                 .unwrap()
                 .stage_next(next_source, next_fmt);
@@ -156,7 +144,8 @@ impl PlaybackService {
         // generation and target) until the ready-watcher's TrackReady resolves it.
         self.install_active_track(
             prepared,
-            started,
+            pipeline,
+            audio_events,
             TrackPhase::Loading { generation, target },
         );
 

--- a/bae-core/src/playback/service/slot.rs
+++ b/bae-core/src/playback/service/slot.rs
@@ -105,12 +105,14 @@ impl TrackPhase {
 }
 
 /// Everything that exists exactly when a track is current, held as one
-/// always-consistent whole.
+/// always-consistent whole. The stream + source + decoder are the shared
+/// `StreamPipeline`; the audio-events receiver stays a `CurrentTrack` field
+/// (not inside the pipeline) because the service drains it on its select tick,
+/// while preview moves its receiver into a spawned task — that asymmetry lives
+/// at the owner, not in the shared unit.
 pub(super) struct CurrentTrack {
     pub(super) prepared: PlaybackPreparedTrack,
-    pub(super) stream: Box<dyn AudioStream>,
-    pub(super) source: Arc<Mutex<source::PlaybackSource>>,
-    pub(super) decoder_handle: std::thread::JoinHandle<()>,
+    pub(super) pipeline: StreamPipeline,
     pub(super) audio_events: AudioEventReceiver,
     pub(super) phase: TrackPhase,
 }

--- a/bae-core/src/playback/service/tests.rs
+++ b/bae-core/src/playback/service/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::playback::audio_output::{
-    audio_event_channel, AudioError, AudioEvent, AudioEventSender, AudioState,
+    audio_event_channel, AudioError, AudioEvent, AudioEventSender, AudioState, AudioStream,
 };
 use tempfile::TempDir;
 
@@ -114,18 +114,26 @@ async fn test_playback_service() -> (
     (home, service, progress_rx)
 }
 
-/// Build an `Active` slot from a prepared track, wrapping a fresh test stream
-/// source and audio-events channel. Tests that need a specific source or
-/// pending audio event build the slot inline instead.
-fn active_slot(prepared: PlaybackPreparedTrack, phase: TrackPhase) -> PlaybackSlot {
+/// Build a `StreamPipeline` over a fresh source for the prepared track's fmt —
+/// the shared unit a `CurrentTrack` holds. The stub stream/decoder/token come
+/// from `new_for_test`.
+fn test_pipeline(prepared: &PlaybackPreparedTrack) -> StreamPipeline {
     let (_sink, source, _ready) = create_track_stream_pair(prepared.sample_rate, prepared.channels);
     let track_fmt = prepared.track_fmt(std::time::Duration::ZERO);
+    StreamPipeline::new_for_test(Arc::new(Mutex::new(source::PlaybackSource::new(
+        source, track_fmt,
+    ))))
+}
+
+/// Build an `Active` slot from a prepared track, wrapping a fresh test pipeline
+/// and audio-events channel. Tests that need a specific source or pending audio
+/// event build the slot inline instead.
+fn active_slot(prepared: PlaybackPreparedTrack, phase: TrackPhase) -> PlaybackSlot {
+    let pipeline = test_pipeline(&prepared);
     let (_tx, audio_events) = audio_event_channel();
     PlaybackSlot::Active(CurrentTrack {
         prepared,
-        stream: Box::new(TestAudioStream),
-        source: Arc::new(Mutex::new(source::PlaybackSource::new(source, track_fmt))),
-        decoder_handle: finished_decoder_handle(),
+        pipeline,
         audio_events,
         phase,
     })
@@ -171,7 +179,6 @@ fn test_prepared_track_with_file(
             start_byte: None,
             end_byte: None,
         }],
-        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         sample_rate: 44_100,
         channels: 2,
         pregap_ms: None,
@@ -228,6 +235,7 @@ fn clear_preloaded_next_cancels_held_unshared_buffer() {
     let mut preloaded = Some(PreloadedNext {
         prepared: test_prepared_track("next-track", buffer.clone(), false),
         decoder_handle: finished_decoder_handle(),
+        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         source: PreloadedNextSource::Held(source),
     });
 
@@ -254,6 +262,7 @@ fn clear_preloaded_next_removes_staged_source() {
     let mut preloaded = Some(PreloadedNext {
         prepared: test_prepared_track("next-track", buffer.clone(), false),
         decoder_handle: finished_decoder_handle(),
+        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         source: PreloadedNextSource::Staged,
     });
 
@@ -283,14 +292,13 @@ async fn seek_drains_pending_gapless_crossing_before_reading_current_track() {
         incoming_fmt: Arc::new(test_track_fmt("incoming-track")),
     }));
     let (_sink, source, _ready) = create_track_stream_pair(44_100, 2);
+    let pipeline = StreamPipeline::new_for_test(Arc::new(Mutex::new(source::PlaybackSource::new(
+        source,
+        test_track_fmt("finished-track"),
+    ))));
     service.slot = PlaybackSlot::Active(CurrentTrack {
         prepared: test_prepared_track("finished-track", finished_buffer.clone(), false),
-        stream: Box::new(TestAudioStream),
-        source: Arc::new(Mutex::new(source::PlaybackSource::new(
-            source,
-            test_track_fmt("finished-track"),
-        ))),
-        decoder_handle: finished_decoder_handle(),
+        pipeline,
         audio_events: audio_rx,
         phase: TrackPhase::Playing,
     });
@@ -299,6 +307,7 @@ async fn seek_drains_pending_gapless_crossing_before_reading_current_track() {
     service.preloaded_next = Some(PreloadedNext {
         prepared: test_prepared_track("incoming-track", incoming_buffer, false),
         decoder_handle: finished_decoder_handle(),
+        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         source: PreloadedNextSource::Staged,
     });
 
@@ -389,6 +398,7 @@ async fn next_after_natural_completion_resumes_audibly() {
     service.preloaded_next = Some(PreloadedNext {
         prepared: test_prepared_track("next-track", next_buffer, false),
         decoder_handle: finished_decoder_handle(),
+        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         source: PreloadedNextSource::Held(next_source),
     });
 
@@ -444,6 +454,7 @@ async fn gapless_crossing_evicts_finished_track_file_buffer() {
             false,
         ),
         decoder_handle: finished_decoder_handle(),
+        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         source: PreloadedNextSource::Staged,
     });
 
@@ -491,6 +502,7 @@ async fn gapless_crossing_keeps_file_buffer_used_by_incoming_track() {
             true,
         ),
         decoder_handle: finished_decoder_handle(),
+        cancel_token: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         source: PreloadedNextSource::Staged,
     });
 
@@ -598,6 +610,44 @@ async fn halt_on_error_noops_when_stopped() {
         progress_rx.try_recv().is_err(),
         "halting an already-stopped slot must emit nothing"
     );
+}
+
+/// Natural preview completion (a `PreviewCompleted` command) tears the preview
+/// pipeline down and emits `PreviewState::Idle`. This pins the service-side
+/// contract the preview listener's Completion arm feeds into: PreviewCompleted →
+/// stop() → Idle, with the pipeline gone.
+#[tokio::test]
+async fn preview_completed_tears_down_and_emits_idle() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+
+    let buffer = create_sparse_buffer(1_024);
+    let prepared = test_prepared_track("preview-file", buffer.clone(), false);
+    let pipeline = test_pipeline(&prepared);
+    service
+        .preview
+        .set_active_for_test("preview-file".to_string(), pipeline, buffer.clone());
+    assert!(service.preview.is_active());
+
+    service.preview_completed();
+
+    assert!(
+        !service.preview.is_active(),
+        "completion tears the active preview down"
+    );
+    assert!(
+        buffer.is_cancelled(),
+        "completion cancels the preview buffer"
+    );
+    let mut saw_idle = false;
+    while let Ok(progress) = progress_rx.try_recv() {
+        if matches!(
+            progress,
+            PlaybackProgress::PreviewStateChanged(crate::playback::PreviewState::Idle)
+        ) {
+            saw_idle = true;
+        }
+    }
+    assert!(saw_idle, "completion emits PreviewState::Idle");
 }
 
 /// Table-drive `playback_state()` over each slot/phase.

--- a/bae-core/src/playback/stream_pipeline.rs
+++ b/bae-core/src/playback/stream_pipeline.rs
@@ -1,0 +1,584 @@
+//! One live decoded-audio pipeline, shared by both players.
+//!
+//! A `StreamPipeline` is the decoder thread + `PlaybackSource` + output
+//! `AudioStream` trio with one construction path and one teardown path. Both the
+//! main current track (`service::CurrentTrack`) and the preview player
+//! (`preview_player::ActivePreview`) run exactly one of these at a time, so the
+//! buffer+decoder+stream startup, the seek teardown, and the diagnostic event
+//! logging live here once instead of being mirrored in both players.
+
+use crate::audio_codec::StreamingDecodeError;
+use crate::playback::audio_output::{
+    audio_event_channel, AudioEvent, AudioEventReceiver, AudioOutput, AudioStream,
+};
+use crate::playback::error::PlaybackError;
+use crate::playback::progress::{emit_progress, PlaybackProgress};
+use crate::playback::service::log_streaming_decode_failure;
+use crate::playback::source::{PlaybackSource, TrackFmt};
+use crate::playback::sparse_buffer::SharedSparseBuffer;
+use crate::playback::track_stream::{
+    create_track_stream_pair, ReadyReceiver, TrackSink, TrackStream,
+};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc as tokio_mpsc;
+use tracing::{debug, error, warn};
+
+/// One live decoded-audio pipeline: a decoder thread filling a ring, wrapped in
+/// a `PlaybackSource`, attached to an output stream.
+pub(crate) struct StreamPipeline {
+    stream: Box<dyn AudioStream>,
+    source: Arc<Mutex<PlaybackSource>>,
+    decoder_handle: std::thread::JoinHandle<()>,
+    /// This decoder's AVIO cancel flag — owned here, not by the prepared track.
+    cancel_token: Arc<AtomicBool>,
+}
+
+/// What a decode failure does beyond the shared log: the main player surfaces it
+/// to the UI as a `PlaybackError`; preview only logs.
+pub(crate) enum DecodeFailureReport {
+    EmitPlaybackError {
+        progress_tx: tokio_mpsc::UnboundedSender<PlaybackProgress>,
+    },
+    LogOnly,
+}
+
+/// The assembled pipeline plus the two channels the owner consumes: the
+/// audio-events receiver (drained on the service's select tick, or moved into
+/// preview's listener task) and the ready receiver (the main player arms its
+/// `TrackReady` watcher on it; preview drops it — it has no Loading state).
+pub(crate) struct StreamPipelineStart {
+    pub(crate) pipeline: StreamPipeline,
+    pub(crate) audio_events: AudioEventReceiver,
+    pub(crate) ready: ReadyReceiver,
+}
+
+/// The decoder window for one stream. `target_sample` is where FFmpeg trims
+/// lead-in (the track's start plus any pregap/seek offset). The seek to it is
+/// either a by-byte jump (`seek_to_byte`, a lossless track's natural start) or a
+/// sample seek (APE, or a mid-track seek); the `target_sample` trim makes the
+/// first output sample exact either way. `stop_at_sample` ends output at the
+/// track's end (`None` = to EOF).
+pub(crate) struct StreamDecodeParams {
+    pub(crate) segments: Vec<SegmentDecodeParams>,
+    pub(crate) leading_silence_frames: u64,
+}
+
+pub(crate) struct SegmentDecodeParams {
+    pub(crate) buffer: SharedSparseBuffer,
+    pub(crate) seek_to_byte: Option<u64>,
+    pub(crate) target_sample: u64,
+    pub(crate) stop_at_sample: Option<u64>,
+    /// The track's end byte offset -- the read-ahead ceiling. `None` = whole file.
+    pub(crate) end_byte: Option<u64>,
+}
+
+impl StreamDecodeParams {
+    /// Run the streaming decoder for this window: FFmpeg seeks (by byte or by
+    /// sample), trims lead-in at `target_sample`, and stops at `stop_at_sample`.
+    /// Shared by the play/seek, preload, and preview paths so they can't drift on
+    /// the seek/trim mapping.
+    pub(crate) fn run_decoder(
+        &self,
+        sink: &mut TrackSink,
+        cancel: Arc<AtomicBool>,
+    ) -> Result<(), StreamingDecodeError> {
+        if self.leading_silence_frames > 0 {
+            sink.push_silence_frames_blocking(self.leading_silence_frames);
+            if cancel.load(Ordering::Relaxed) || sink.is_cancelled() {
+                return Err(StreamingDecodeError::InputCancelled);
+            }
+        }
+
+        for segment in &self.segments {
+            let seek_to_sample = if segment.seek_to_byte.is_some() {
+                None
+            } else {
+                Some(segment.target_sample)
+            };
+            crate::audio_codec::decode_audio_streaming(
+                segment.buffer.clone(),
+                sink,
+                segment.seek_to_byte,
+                seek_to_sample,
+                Some(segment.target_sample),
+                segment.stop_at_sample,
+                segment.end_byte,
+                cancel.clone(),
+            )?;
+            if cancel.load(Ordering::Relaxed) || sink.is_cancelled() {
+                return Err(StreamingDecodeError::InputCancelled);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Spawn the decoder for `decode`, build the audio stream on `audio_output`,
+/// start it, and return the assembled pipeline plus its event/ready channels. On
+/// any stream-build failure the spawned decoder is cancelled and its handle
+/// dropped before returning `Err`, so no half-built pipeline escapes. Cancelling
+/// the source's byte buffers (stopping the data reader) stays with the buffer's
+/// owner — this cancels only the decoder it spawned.
+pub(crate) async fn start_stream_pipeline(
+    audio_output: &mut dyn AudioOutput,
+    decode: StreamDecodeParams,
+    fmt: TrackFmt,
+    sample_rate: u32,
+    channels: u32,
+    position_update_interval_ms: u32,
+    log_context: &'static str,
+    on_decode_failure: DecodeFailureReport,
+) -> Result<StreamPipelineStart, PlaybackError> {
+    let cancel_token = Arc::new(AtomicBool::new(false));
+    let (mut sink, track_source, ready) = create_track_stream_pair(sample_rate, channels);
+
+    let decoder_handle = {
+        let decoder_cancel = cancel_token.clone();
+        // Kept to tell a genuine decode failure from normal teardown (seek /
+        // stop / track change all cancel the token before the decoder exits).
+        let teardown_check = cancel_token.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = decode.run_decoder(&mut sink, decoder_cancel) {
+                if let Some(message) = log_streaming_decode_failure(log_context, e) {
+                    if let DecodeFailureReport::EmitPlaybackError { progress_tx } =
+                        &on_decode_failure
+                    {
+                        if !teardown_check.load(Ordering::Relaxed) {
+                            emit_progress(
+                                progress_tx,
+                                PlaybackProgress::PlaybackError {
+                                    reason: crate::ui::PlaybackErrorReason::internal(format!(
+                                        "Playback decode failed: {message}"
+                                    )),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        })
+    };
+
+    let (stream, source, audio_events) =
+        match build_and_play_stream(audio_output, track_source, fmt, position_update_interval_ms)
+            .await
+        {
+            Ok(parts) => parts,
+            Err(e) => {
+                error!("Failed to create streaming audio stream: {:?}", e);
+                // The decoder is spawned but no stream will pull from it. Cancel
+                // it so it exits instead of parking on a ring nobody reads, then
+                // detach — joining would block the caller's command loop. Waking
+                // its byte buffers (so a read-blocked decoder sees the token) is
+                // the owner's job on the returned `Err`.
+                cancel_token.store(true, Ordering::Release);
+                drop(decoder_handle);
+                return Err(e);
+            }
+        };
+
+    Ok(StreamPipelineStart {
+        pipeline: StreamPipeline {
+            stream,
+            source,
+            decoder_handle,
+            cancel_token,
+        },
+        audio_events,
+        ready,
+    })
+}
+
+/// Wrap `track_source` in a `PlaybackSource`, build the output stream over it,
+/// and start it. The single stream-construction path both `start_stream_pipeline`
+/// (fresh decoder) and `StreamPipeline::attach_preloaded` (already-running
+/// decoder) run through.
+async fn build_and_play_stream(
+    audio_output: &mut dyn AudioOutput,
+    track_source: TrackStream,
+    fmt: TrackFmt,
+    position_update_interval_ms: u32,
+) -> Result<
+    (
+        Box<dyn AudioStream>,
+        Arc<Mutex<PlaybackSource>>,
+        AudioEventReceiver,
+    ),
+    PlaybackError,
+> {
+    // Wrap the track source in a PlaybackSource so the audio callback can advance
+    // to a pre-staged next track without rebuilding the stream. The audio
+    // callback tags every position/completion emit with `fmt`; at a gapless
+    // boundary it swaps to the staged next track's fmt.
+    let source = Arc::new(Mutex::new(PlaybackSource::new(track_source, fmt)));
+
+    let (source_sample_rate, source_channels) = {
+        let guard = source.lock().unwrap();
+        (guard.sample_rate(), guard.channels())
+    };
+
+    let (audio_event_tx, audio_events) = audio_event_channel();
+
+    let stream = match audio_output.create_stream(
+        source.clone(),
+        source_sample_rate,
+        source_channels,
+        audio_event_tx,
+        position_update_interval_ms,
+    ) {
+        Ok(stream) => stream,
+        Err(e) => {
+            // The decoder is already filling this source's ring, but no output
+            // will ever drain it. Cancel the source: that sets the sink's cancel
+            // flag and unparks the decoder, so a decoder blocked writing a full
+            // ring exits instead of parking on it until the process ends.
+            source.lock().unwrap().cancel();
+            return Err(PlaybackError::task(format!("Audio stream: {:?}", e)));
+        }
+    };
+
+    if let Err(e) = stream.play() {
+        source.lock().unwrap().cancel();
+        return Err(PlaybackError::task(format!(
+            "Failed to start streaming playback: {e:?}"
+        )));
+    }
+
+    Ok((stream, source, audio_events))
+}
+
+impl StreamPipeline {
+    /// Adopt an already-running preloaded decoder onto a fresh stream (the main
+    /// player's gapless-rebuild advance path). The decoder + token were minted at
+    /// preload time; this only builds and starts the output stream over the
+    /// preloaded track source.
+    pub(crate) async fn attach_preloaded(
+        audio_output: &mut dyn AudioOutput,
+        track_stream: TrackStream,
+        fmt: TrackFmt,
+        decoder_handle: std::thread::JoinHandle<()>,
+        cancel_token: Arc<AtomicBool>,
+        position_update_interval_ms: u32,
+    ) -> Result<(Self, AudioEventReceiver), PlaybackError> {
+        let (stream, source, audio_events) =
+            build_and_play_stream(audio_output, track_stream, fmt, position_update_interval_ms)
+                .await?;
+        Ok((
+            StreamPipeline {
+                stream,
+                source,
+                decoder_handle,
+                cancel_token,
+            },
+            audio_events,
+        ))
+    }
+
+    pub(crate) fn source(&self) -> &Arc<Mutex<PlaybackSource>> {
+        &self.source
+    }
+
+    /// Swap in the crossed-into track's decoder at a gapless boundary. The stream
+    /// and source stay live (the `PlaybackSource` already advanced to the staged
+    /// next track within the same stream); only the decoder thread + token the
+    /// pipeline owns are replaced.
+    pub(crate) fn adopt_crossed_decoder(
+        &mut self,
+        decoder_handle: std::thread::JoinHandle<()>,
+        cancel_token: Arc<AtomicBool>,
+    ) {
+        // The finishing track's decoder already exited (the crossing fired), so
+        // dropping its handle detaches nothing live.
+        self.decoder_handle = decoder_handle;
+        self.cancel_token = cancel_token;
+    }
+
+    /// Immediate teardown: cancel the source (the audio callback goes silent),
+    /// cancel the decoder token, drop the stream, and detach the decoder. Does NOT
+    /// join the decoder — the token plus the owner's buffer cancellation make it
+    /// exit, and joining would block the command loop. Buffer cancellation stays
+    /// with the buffer's owner.
+    pub(crate) fn cancel(self) {
+        match self.source.lock() {
+            Ok(guard) => guard.cancel(),
+            // A poisoned lock means the audio callback thread panicked while
+            // holding it. The source is being dropped here anyway, so the cancel
+            // it would have requested is moot — log and move on.
+            Err(_) => warn!("playback source lock poisoned during teardown; skipping cancel"),
+        }
+        self.cancel_token.store(true, Ordering::Release);
+        // Dropping `self` drops the stream and detaches the decoder thread.
+    }
+
+    /// Seek teardown: cancel the source, cancel the decoder token, wake the given
+    /// buffers so a read-blocked decoder sees the token, and join the decoder — so
+    /// a new pipeline can reuse the same buffers with the old decoder guaranteed
+    /// gone. The buffers themselves are left uncancelled (the owner retains them
+    /// across the seek).
+    pub(crate) async fn shutdown_for_seek(self, buffers: &[SharedSparseBuffer]) {
+        // Drop the stream first so the audio callback stops pulling.
+        drop(self.stream);
+
+        match self.source.lock() {
+            Ok(guard) => guard.cancel(),
+            Err(_) => warn!("playback source lock poisoned during seek teardown; skipping cancel"),
+        }
+
+        // Cancel this decoder's AVIO reads via its token.
+        self.cancel_token.store(true, Ordering::Release);
+
+        // Wake any readers blocked on the condvar so they can check the token.
+        for buffer in buffers {
+            buffer.wake_readers();
+        }
+
+        // Wait for the decoder thread to exit. Surface a thread panic as an error
+        // (decoder bug, real signal); tokio join failures (panic in the
+        // spawn_blocking wrapper itself, runtime shutdown) get a warn.
+        let handle = self.decoder_handle;
+        match tokio::task::spawn_blocking(move || handle.join()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(panic)) => {
+                error!("Decoder thread panicked during seek teardown: {:?}", panic);
+            }
+            Err(e) => {
+                warn!("spawn_blocking failed while joining decoder thread: {e}");
+            }
+        }
+    }
+
+    /// Build a pipeline over a caller-supplied `source` with stub parts (a no-op
+    /// stream, an already-exited decoder, a fresh token) so slot-shaped tests only
+    /// specify the one value they vary.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(source: Arc<Mutex<PlaybackSource>>) -> Self {
+        StreamPipeline {
+            stream: Box::new(StubStream),
+            source,
+            decoder_handle: std::thread::spawn(|| {}),
+            cancel_token: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+/// A no-op output stream for `StreamPipeline::new_for_test`.
+#[cfg(test)]
+struct StubStream;
+
+#[cfg(test)]
+impl AudioStream for StubStream {
+    fn play(&self) -> Result<(), crate::playback::audio_output::AudioError> {
+        Ok(())
+    }
+}
+
+/// Log the diagnostics both players log identically for Starved / StarvationEnded
+/// / SourceLockMissed / SourceLockReacquired. Position / Completion / TrackCrossing
+/// are the caller's to handle and are ignored here — both callers match those arms
+/// before falling through to this.
+pub(crate) fn log_stream_diagnostic(context: &'static str, event: &AudioEvent) {
+    match event {
+        AudioEvent::SourceLockMissed { missed_ms } => {
+            warn!(
+                context,
+                missed_ms, "audio callback could not lock playback source while playing"
+            );
+        }
+        AudioEvent::SourceLockReacquired { missed_ms } => {
+            debug!(
+                context,
+                missed_ms, "audio callback reacquired playback source lock"
+            );
+        }
+        AudioEvent::Starved {
+            fmt,
+            starved_ms,
+            position_ms,
+            producer_finished,
+            samples_decoded,
+            decode_errors,
+            has_next,
+        } => {
+            warn!(
+                context,
+                track_id = %fmt.track_id,
+                starved_ms,
+                position_ms,
+                producer_finished,
+                samples_decoded,
+                decode_errors,
+                has_next,
+                "playback source has no decoded samples while current track is not finished"
+            );
+        }
+        AudioEvent::StarvationEnded {
+            fmt,
+            starved_ms,
+            position_ms,
+            samples_decoded,
+            decode_errors,
+        } => {
+            debug!(
+                context,
+                track_id = %fmt.track_id,
+                starved_ms,
+                position_ms,
+                samples_decoded,
+                decode_errors,
+                "playback source resumed after decoded sample starvation"
+            );
+        }
+        AudioEvent::Position(_) | AudioEvent::Completion(_) | AudioEvent::TrackCrossing(_) => {}
+    }
+}
+
+/// Shared dropped-events accounting: logs the dropped counts and returns `true`
+/// when a REQUIRED event was dropped (both callers then emit a `PlaybackError`
+/// and halt).
+pub(crate) fn report_dropped_audio_events(
+    events: &AudioEventReceiver,
+    context: &'static str,
+) -> bool {
+    let dropped_required = events.take_dropped_required_count();
+    if dropped_required > 0 {
+        error!(
+            context,
+            dropped_required, "audio callback event queue dropped required events"
+        );
+        return true;
+    }
+    let dropped = events.take_dropped_count();
+    if dropped > 0 {
+        warn!(
+            context,
+            dropped, "audio callback event queue dropped events"
+        );
+    }
+    false
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod tests {
+    use super::*;
+    use crate::playback::audio_output::{CaptureAudioOutput, FailingAudioOutput};
+    use crate::playback::sparse_buffer::create_sparse_buffer;
+
+    fn one_segment_decode(buffer: SharedSparseBuffer) -> StreamDecodeParams {
+        StreamDecodeParams {
+            segments: vec![SegmentDecodeParams {
+                buffer,
+                seek_to_byte: None,
+                target_sample: 0,
+                stop_at_sample: None,
+                end_byte: None,
+            }],
+            leading_silence_frames: 0,
+        }
+    }
+
+    fn test_fmt() -> TrackFmt {
+        TrackFmt {
+            track_id: "unit".to_string(),
+            duration_ms: 1_000,
+            pregap_ms: None,
+            position_offset: std::time::Duration::ZERO,
+            replay_gain_linear: 1.0,
+        }
+    }
+
+    /// A stream-build failure cancels the just-spawned decoder and returns `Err`
+    /// rather than leaking a half-built pipeline. This exercises the real shared
+    /// unit both players run through.
+    #[tokio::test]
+    async fn start_stream_pipeline_failure_returns_err_and_cancels_decoder() {
+        let buffer = create_sparse_buffer(0);
+        let mut output = FailingAudioOutput;
+
+        let result = start_stream_pipeline(
+            &mut output,
+            one_segment_decode(buffer.clone()),
+            test_fmt(),
+            44_100,
+            2,
+            50,
+            "unit decode",
+            DecodeFailureReport::LogOnly,
+        )
+        .await;
+
+        assert!(result.is_err(), "a failed stream build returns Err");
+        // The owner cancels the buffer on Err; doing so here proves the spawned
+        // decoder unwinds (its read unblocks and it exits) rather than parking
+        // forever on a ring nobody drains.
+        buffer.cancel();
+        assert!(buffer.is_cancelled());
+    }
+
+    /// The happy path assembles a live pipeline over a working output and hands
+    /// back the audio-events and ready channels.
+    #[tokio::test]
+    async fn start_stream_pipeline_success_builds_pipeline() {
+        let buffer = create_sparse_buffer(0);
+        let (mut output, _capture_rx) = CaptureAudioOutput::new();
+
+        let start = start_stream_pipeline(
+            &mut output,
+            one_segment_decode(buffer),
+            test_fmt(),
+            44_100,
+            2,
+            50,
+            "unit decode",
+            DecodeFailureReport::LogOnly,
+        )
+        .await
+        .expect("stream builds over a working output");
+
+        // Teardown drops the stream and detaches the decoder; nothing left to poll.
+        start.pipeline.cancel();
+    }
+
+    /// When `attach_preloaded`'s stream build fails, the already-running preloaded
+    /// decoder must be stopped, not left parked filling a ring with no consumer.
+    /// A decoder that pushes until its sink is cancelled exits promptly, proving
+    /// the failure path cancelled the source.
+    #[tokio::test]
+    async fn attach_preloaded_failure_stops_the_preloaded_decoder() {
+        let (mut sink, track_stream, _ready) = create_track_stream_pair(44_100, 2);
+        let exited = Arc::new(AtomicBool::new(false));
+        let exited_in_thread = exited.clone();
+        // Stands in for a preloaded decoder: push forever until the sink cancels.
+        let decoder_handle = std::thread::spawn(move || {
+            let chunk = vec![0.0f32; 4096];
+            while !sink.is_cancelled() {
+                sink.push_samples_blocking(&chunk);
+            }
+            exited_in_thread.store(true, Ordering::Release);
+        });
+        let cancel_token = Arc::new(AtomicBool::new(false));
+
+        let mut output = FailingAudioOutput;
+        let result = StreamPipeline::attach_preloaded(
+            &mut output,
+            track_stream,
+            test_fmt(),
+            decoder_handle,
+            cancel_token,
+            50,
+        )
+        .await;
+        assert!(result.is_err(), "a failed attach returns Err");
+
+        // The failure path cancelled the source, so the decoder's sink is
+        // cancelled and the thread exits rather than parking on a full ring.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !exited.load(Ordering::Acquire) && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            exited.load(Ordering::Acquire),
+            "the preloaded decoder must exit when attach_preloaded fails"
+        );
+    }
+}


### PR DESCRIPTION
The preview player was a near-line-for-line second copy of the main playback pipeline: it re-implemented the buffer + decoder + stream startup, the seek teardown, and the four diagnostic audio-event arms (Starved / StarvationEnded / SourceLockMissed / SourceLockReacquired), plus the dropped-events accounting. Two independent copies of a real-time audio pipeline are two places to drift, and they had already begun to (the preview copies differed from the originals only by a `"preview "` log prefix).

This promotes the shared trio — the decoder thread, the `PlaybackSource`, and the output `AudioStream` — into one `StreamPipeline` type in a new `stream_pipeline` module. It has a single construction path (`start_stream_pipeline`, plus `attach_preloaded` for the gapless-advance case), a single immediate teardown (`cancel`), and a single seek teardown (`shutdown_for_seek`). Both the main current track and the preview player now hold and run exactly one of these. The per-decoder AVIO cancel token moves onto the pipeline — minted where the decoder is actually spawned (inside `start_stream_pipeline`, and on a preloaded-next until it is promoted) — instead of riding on the prepared track, so every decoder has exactly one owner and there is no dual-Arc bookkeeping. The stream-build failure contract is split cleanly along ownership: the unit cancels the decoder it spawned; the caller cancels the byte buffers it owns. The diagnostics and dropped-event accounting collapse to `log_stream_diagnostic` and `report_dropped_audio_events`, taking a context string rather than a copied prefix.

What deliberately stays different lives at the owner, not behind a flag or trait: the main player arms a `TrackReady` watcher on the ready receiver while preview drops it; the service drains the audio-events receiver on its select tick while preview moves it into a listener task (so the receiver stays a `CurrentTrack`/`ActivePreview` field, outside the pipeline); a decode failure surfaces a UI `PlaybackError` for the library player but only logs for an audition (a `DecodeFailureReport` param). Two behavior consequences, both toward the main path's existing semantics: preview seeks are now sample-exact because the shared decoder trims at the seek target, and a fresh preview play seeks to sample 0 — both are decoder inputs the main path already exercises.

## Behavior changes to preview teardown

The preview player's finished-but-shown state was dropped rather than ported. Natural completion already routes through `stop()` to `PreviewState::Idle` (there is no UI event for a lingering finished preview), so the `is_finished` / `clear_finished` machinery it fed was unreachable; keeping a `PreviewPhase::Finished` variant nothing constructs would be dead code.

A preview **seek whose stream rebuild fails** now drops the preview outright and emits `PreviewState::Idle`, instead of the old behavior. Previously the failure left `path` set with the stream/source torn down — an `is_finished()==true` zombie that `preview_toggle_pause` would detect and resurrect by restarting the preview. That hidden-broken-state-plus-recovery-branch is exactly the shape this codebase's no-self-heal rule bans; the new pipeline is fully-active-or-absent by construction, so on a failed seek the preview is simply gone, and the service surfaces `Idle` so the UI stops showing a preview that no longer exists. (Both paths — old zombie and new drop — leave the main player where it was; seek was never a main-resume trigger.)

## Test plan
- `cargo test -p bae-core --features test-utils` green (166 playback lib unit tests, 61 `test_playback_behavior` integration tests including `test_preview_seek_while_paused_emits_position_update`, and the full crate suite).
- `cargo clippy -p bae-core --features test-utils --all-targets` clean.
- New tests:
  - `stream_pipeline::start_stream_pipeline_failure_returns_err_and_cancels_decoder` and `..._success_builds_pipeline` — the shared unit's failure/happy paths.
  - `preview_player::failed_preview_stream_start_leaves_no_active_preview` — a failed start leaves no active preview and cancels the buffer.
  - `preview_player::preview_listener_maps_completion_to_preview_completed` — the listener maps `AudioEvent::Completion` to a `PreviewCompleted` command.
  - `preview_player::failed_preview_seek_surfaces_idle` — a failed seek rebuild drops the preview and emits `PreviewState::Idle`.
  - `service::tests::preview_completed_tears_down_and_emits_idle` — the service-side contract: `PreviewCompleted` → pipeline torn down, buffer cancelled, `PreviewState::Idle` emitted.
- The whole existing `test_playback_behavior` suite (play / seek / gapless / side-pause / restore / halt) passes unchanged, locking the main-path behavior across the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EH8tSJH1vng8zBtCAYaxe