### PR TITLE
Type the import pipeline's errors

### DIFF
--- a/bae-automation/src/lib.rs
+++ b/bae-automation/src/lib.rs
@@ -11,8 +11,8 @@ use bae_core::import::release_group::ReleaseGroup;
 use bae_core::import::search::{ImportSearchReleaseDetail, MetadataResult, ReleaseTrack};
 use bae_core::import::{
     shape_user_edit_from_search_detail, CoverSelection, GroupedSearchResults, IdentityChoice,
-    ImportEvent, ImportProgress, MetadataRef, MetadataSource, PressingEdit, ScanEvent, SearchQuery,
-    StorageMode, TrackUserEdit,
+    ImportError, ImportEvent, ImportProgress, MetadataRef, MetadataSource, PressingEdit, ScanEvent,
+    SearchQuery, StorageMode, TrackUserEdit,
 };
 use bae_core::library::{AppServices, LibraryError};
 use schemars::JsonSchema;
@@ -366,7 +366,6 @@ pub enum AutomationImportProgress {
         album_id: String,
     },
     Failed {
-        id: String,
         error: String,
         import_id: String,
     },
@@ -687,6 +686,15 @@ impl From<LibraryError> for AutomationError {
     }
 }
 
+impl From<ImportError> for AutomationError {
+    /// The automation surface reports import failures as an opaque `import`
+    /// error with the typed error's Display as the message — the same
+    /// stringification every import call site used before, now in one place.
+    fn from(value: ImportError) -> Self {
+        Self::Import(value.to_string())
+    }
+}
+
 struct AutomationState {
     candidates: RwLock<HashMap<String, AutomationCandidate>>,
     event_indexing: RwLock<AutomationEventIndexing>,
@@ -942,10 +950,7 @@ impl Automation {
         &self,
         path: String,
     ) -> Result<Vec<AutomationWatchedFolder>, AutomationError> {
-        self.services
-            .import()
-            .add_watched_folder(path)
-            .map_err(AutomationError::import)?;
+        self.services.import().add_watched_folder(path)?;
         Ok(self.watched_folders())
     }
 
@@ -953,10 +958,7 @@ impl Automation {
         &self,
         path: String,
     ) -> Result<Vec<AutomationWatchedFolder>, AutomationError> {
-        self.services
-            .import()
-            .remove_watched_folder(path)
-            .map_err(AutomationError::import)?;
+        self.services.import().remove_watched_folder(path)?;
         Ok(self.watched_folders())
     }
 
@@ -966,17 +968,11 @@ impl Automation {
     ) -> Result<AutomationScanResult, AutomationError> {
         match wait {
             ScanWait::NoWait => {
-                self.services
-                    .import()
-                    .scan_watched_folders()
-                    .map_err(AutomationError::import)?;
+                self.services.import().scan_watched_folders()?;
             }
             ScanWait::UntilFinished { timeout_ms } => {
                 let mut rx = self.services.import().subscribe_folder_scan_events();
-                self.services
-                    .import()
-                    .scan_watched_folders()
-                    .map_err(AutomationError::import)?;
+                self.services.import().scan_watched_folders()?;
                 let wait_for_finish = async {
                     while let Some(event) = rx.recv().await {
                         match event {
@@ -1033,8 +1029,8 @@ impl Automation {
     ) -> Result<(), AutomationError> {
         self.services
             .import()
-            .set_candidate_skipped(candidate_key, skipped)
-            .map_err(AutomationError::import)
+            .set_candidate_skipped(candidate_key, skipped)?;
+        Ok(())
     }
 
     pub async fn search_imports(
@@ -1045,8 +1041,7 @@ impl Automation {
             .services
             .import()
             .search_with_status(search_query(query))
-            .await
-            .map_err(AutomationError::import)?;
+            .await?;
         Ok(automation_search_results(results))
     }
 
@@ -1055,24 +1050,24 @@ impl Automation {
         source: AutomationMetadataSource,
         release_id: String,
     ) -> Result<AutomationReleaseDetail, AutomationError> {
-        self.services
+        let detail = self
+            .services
             .import()
             .prefetch_release(&release_id, source.into())
-            .await
-            .map(automation_release_detail)
-            .map_err(AutomationError::import)
+            .await?;
+        Ok(automation_release_detail(detail))
     }
 
     pub async fn preview_file_tags(
         &self,
         folder: String,
     ) -> Result<AutomationReleaseUserEdit, AutomationError> {
-        self.services
+        let edit = self
+            .services
             .import()
             .preview_file_tags_for_folder(PathBuf::from(folder))
-            .await
-            .map(automation_release_user_edit)
-            .map_err(AutomationError::import)
+            .await?;
+        Ok(automation_release_user_edit(edit))
     }
 
     pub async fn shape_release_edit(
@@ -1091,19 +1086,15 @@ impl Automation {
         &self,
         request: AutomationStartImport,
     ) -> Result<AutomationImportStarted, AutomationError> {
-        let import_id = self
-            .services
-            .import()
-            .start_import(
-                &request.candidate_key,
-                PathBuf::from(request.folder),
-                request.selected_cover.map(cover_selection),
-                storage_mode(request.storage_mode),
-                request.pin,
-                identity_choice(request.identity_choice),
-                request.user_edit.map(release_user_edit),
-            )
-            .map_err(AutomationError::import)?;
+        let import_id = self.services.import().start_import(
+            &request.candidate_key,
+            PathBuf::from(request.folder),
+            request.selected_cover.map(cover_selection),
+            storage_mode(request.storage_mode),
+            request.pin,
+            identity_choice(request.identity_choice),
+            request.user_edit.map(release_user_edit),
+        )?;
         Ok(AutomationImportStarted { import_id })
     }
 
@@ -1959,15 +1950,9 @@ fn automation_import_progress(progress: ImportProgress) -> AutomationImportProgr
             import_id,
             album_id,
         },
-        ImportProgress::Failed {
-            id,
-            error,
-            import_id,
-        } => AutomationImportProgress::Failed {
-            id,
-            error,
-            import_id,
-        },
+        ImportProgress::Failed { error, import_id } => {
+            AutomationImportProgress::Failed { error, import_id }
+        }
     }
 }
 

--- a/bae-core/src/identify/barcode.rs
+++ b/bae-core/src/identify/barcode.rs
@@ -24,7 +24,8 @@ pub async fn lookup_barcode(
             ..Default::default()
         },
     )
-    .await?;
+    .await
+    .map_err(|e| e.to_string())?;
 
     let discogs = discogs_barcode_lookup(discogs_client, barcode).await;
 

--- a/bae-core/src/import/commit.rs
+++ b/bae-core/src/import/commit.rs
@@ -6,7 +6,6 @@
 
 use tracing::warn;
 
-use crate::discogs::client::DiscogsError;
 use crate::discogs::DiscogsClient;
 use crate::musicbrainz;
 use coven::Clock;
@@ -14,24 +13,7 @@ use coven::IdProvider;
 
 use super::discogs_mapper;
 use super::types::MetadataSource;
-use super::ParsedAlbum;
-
-/// Error from import commit operations.
-/// Preserves the typed `DiscogsError` through `?` rather than flattening to a
-/// string.
-#[derive(Debug, thiserror::Error)]
-pub enum CommitError {
-    #[error("{0}")]
-    Discogs(#[from] DiscogsError),
-    #[error("{0}")]
-    Other(String),
-}
-
-impl From<String> for CommitError {
-    fn from(s: String) -> Self {
-        CommitError::Other(s)
-    }
-}
+use super::{ImportError, ParsedAlbum};
 
 /// Fetch a Discogs release plus its master, without any MB cross-ref.
 /// Pure Discogs: no MB API calls. Returns the parsed release, the master
@@ -50,7 +32,7 @@ pub async fn fetch_discogs_release(
         Option<u32>,
         Vec<(String, String)>,
     ),
-    CommitError,
+    ImportError,
 > {
     let (discogs_release, raw_json) = client.get_release(release_id).await?;
 
@@ -83,7 +65,7 @@ pub async fn fetch_and_map_discogs(
     release_id: &str,
     clock: &dyn Clock,
     ids: &dyn IdProvider,
-) -> Result<(ParsedAlbum, Vec<(String, String)>), CommitError> {
+) -> Result<(ParsedAlbum, Vec<(String, String)>), ImportError> {
     let (discogs_release, master_year, mut metadata) =
         fetch_discogs_release(client, release_id).await?;
     let mb_xref = match musicbrainz::fetch_mb_xref(release_id).await {
@@ -99,7 +81,6 @@ pub async fn fetch_and_map_discogs(
         mb_xref.as_ref(),
         clock,
         ids,
-    )
-    .map_err(|e| format!("Failed to map release: {e}"))?;
+    )?;
     Ok((parsed, metadata))
 }

--- a/bae-core/src/import/cover_art.rs
+++ b/bae-core/src/import/cover_art.rs
@@ -1,4 +1,4 @@
-use crate::import::MetadataSource;
+use crate::import::{ImportError, MetadataSource};
 use crate::network::upgrade_to_https;
 use crate::util::content_type::ContentType;
 use lru::LruCache;
@@ -52,7 +52,10 @@ fn cover_bytes_cache() -> &'static Mutex<LruCache<String, CoverCacheValue>> {
     })
 }
 
-fn image_download_client() -> Result<reqwest::Client, String> {
+fn image_download_client() -> Result<reqwest::Client, ImportError> {
+    // The build error is cached as a String because `reqwest::Client`'s builder
+    // error is not `Clone` and the cell is cloned on every read; the typed
+    // `CoverArt` wrapper is applied at each call.
     static CLIENT: OnceLock<Result<reqwest::Client, String>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
@@ -61,6 +64,7 @@ fn image_download_client() -> Result<reqwest::Client, String> {
                 .map_err(|e| format!("Failed to create HTTP client: {}", e))
         })
         .clone()
+        .map_err(|detail| ImportError::CoverArt { detail })
 }
 
 /// Cover Art Archive lookup client for release/release-group cover selection.
@@ -158,22 +162,23 @@ fn is_transient_status(status: reqwest::StatusCode) -> bool {
     status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
 }
 
-enum ClassifiedAttempt<T> {
+enum ClassifiedAttempt<T, E> {
     Done(T),
-    Retry(String),
-    Permanent(String),
+    Retry(E),
+    Permanent(E),
 }
 
-async fn retry_classified<T, F, Fut>(
+async fn retry_classified<T, E, F, Fut>(
     operation: &str,
     base_delay: Duration,
     mut attempt: F,
-) -> Result<T, String>
+) -> Result<T, E>
 where
+    E: std::fmt::Display,
     F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = ClassifiedAttempt<T>>,
+    Fut: std::future::Future<Output = ClassifiedAttempt<T, E>>,
 {
-    let mut last_error = String::new();
+    let mut last_error: Option<E> = None;
     for attempt_index in 0..=MAX_RETRIES {
         if attempt_index > 0 {
             let delay = base_delay * 2u32.pow(attempt_index - 1);
@@ -183,7 +188,9 @@ where
                 operation,
                 attempt_index,
                 MAX_RETRIES + 1,
-                last_error,
+                last_error
+                    .as_ref()
+                    .expect("a retry set last_error before this attempt"),
                 delay
             );
 
@@ -194,11 +201,12 @@ where
             ClassifiedAttempt::Done(value) => return Ok(value),
             ClassifiedAttempt::Permanent(error) => return Err(error),
             ClassifiedAttempt::Retry(error) => {
-                last_error = error;
+                last_error = Some(error);
             }
         }
     }
 
+    let last_error = last_error.expect("the retry loop ran at least once and never succeeded");
     warn!(
         "{} failed after {} attempts: {}",
         operation,
@@ -450,14 +458,14 @@ fn find_url_in<'a>(value: &serde_json::Value, keys: &'a [&'a str]) -> Option<(&'
 /// session.
 pub async fn download_cover_art_bytes(
     cover_art_url: &str,
-) -> Result<(Vec<u8>, ContentType), String> {
+) -> Result<(Vec<u8>, ContentType), ImportError> {
     download_cover_art_bytes_with_backoff(cover_art_url, RETRY_BASE_DELAY).await
 }
 
 async fn download_cover_art_bytes_with_backoff(
     cover_art_url: &str,
     base_delay: Duration,
-) -> Result<(Vec<u8>, ContentType), String> {
+) -> Result<(Vec<u8>, ContentType), ImportError> {
     if let Some(hit) = cover_bytes_cache()
         .lock()
         .expect("cover bytes cache mutex poisoned")
@@ -483,7 +491,7 @@ async fn download_cover_art_bytes_with_backoff(
 pub(crate) async fn download_image_bytes(
     image_url: &str,
     operation: &str,
-) -> Result<(Vec<u8>, ContentType), String> {
+) -> Result<(Vec<u8>, ContentType), ImportError> {
     download_image_bytes_with_backoff(image_url, operation, RETRY_BASE_DELAY).await
 }
 
@@ -491,7 +499,7 @@ async fn download_image_bytes_with_backoff(
     image_url: &str,
     operation: &str,
     base_delay: Duration,
-) -> Result<(Vec<u8>, ContentType), String> {
+) -> Result<(Vec<u8>, ContentType), ImportError> {
     let client = image_download_client()?;
     retry_classified(operation, base_delay, || async {
         let response = match client.get(image_url).send().await {
@@ -501,10 +509,14 @@ async fn download_image_bytes_with_backoff(
                 // redirect-loop bottoming out — same failure every
                 // attempt. Don't burn 1+2+4s of backoff on a
                 // deterministic error.
-                return ClassifiedAttempt::Permanent(format!("Failed to fetch image: {}", e));
+                return ClassifiedAttempt::Permanent(ImportError::CoverArt {
+                    detail: format!("Failed to fetch image: {}", e),
+                });
             }
             Err(e) => {
-                return ClassifiedAttempt::Retry(format!("Failed to fetch image: {}", e));
+                return ClassifiedAttempt::Retry(ImportError::CoverArt {
+                    detail: format!("Failed to fetch image: {}", e),
+                });
             }
         };
 
@@ -514,16 +526,14 @@ async fn download_image_bytes_with_backoff(
                 Err(e) => ClassifiedAttempt::Permanent(e),
             }
         } else if is_transient_status(response.status()) {
-            ClassifiedAttempt::Retry(format!(
-                "Image download failed with status {}",
-                response.status()
-            ))
+            ClassifiedAttempt::Retry(ImportError::CoverArt {
+                detail: format!("Image download failed with status {}", response.status()),
+            })
         } else {
             // Non-transient error — don't retry
-            ClassifiedAttempt::Permanent(format!(
-                "Image download failed with status {}",
-                response.status()
-            ))
+            ClassifiedAttempt::Permanent(ImportError::CoverArt {
+                detail: format!("Image download failed with status {}", response.status()),
+            })
         }
     })
     .await
@@ -540,15 +550,19 @@ fn is_permanent_request_error(e: &reqwest::Error) -> bool {
 async fn read_image_response(
     response: reqwest::Response,
     image_url: &str,
-) -> Result<(Vec<u8>, ContentType), String> {
+) -> Result<(Vec<u8>, ContentType), ImportError> {
     let content_type =
         super::image_response::image_content_type_from_response(response.headers(), image_url);
 
     let bytes = crate::util::http::read_body_capped(response, crate::util::http::MAX_IMAGE_BYTES)
         .await
-        .map_err(|e| format!("Failed to read image response: {}", e))?;
+        .map_err(|e| ImportError::CoverArt {
+            detail: format!("Failed to read image response: {}", e),
+        })?;
     if bytes.len() < 100 {
-        return Err("Downloaded file too small to be a valid image".to_string());
+        return Err(ImportError::CoverArt {
+            detail: "Downloaded file too small to be a valid image".to_string(),
+        });
     }
 
     info!("Downloaded cover art ({} bytes)", bytes.len());
@@ -943,7 +957,10 @@ mod tests {
     async fn download_rejects_too_small_response() {
         let url = start_mock(vec![(200, vec![0u8; 50])]).await; // under the 100-byte floor
         let err = download_cover_art_bytes(&url).await.unwrap_err();
-        assert!(err.contains("too small"), "got: {err}");
+        assert!(
+            matches!(&err, ImportError::CoverArt { detail } if detail.contains("too small")),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]
@@ -956,7 +973,10 @@ mod tests {
         .await
         .expect("oversized response should fail before reading the body");
         let err = result.unwrap_err();
-        assert!(err.contains("too large"), "got: {err}");
+        assert!(
+            matches!(&err, ImportError::CoverArt { detail } if detail.contains("too large")),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/bae-core/src/import/discogs_mapper.rs
+++ b/bae-core/src/import/discogs_mapper.rs
@@ -6,7 +6,7 @@ use super::ParsedAlbum;
 use crate::db::{is_various_artists, Pressing, ReleaseMetadataSource};
 use crate::discogs::{DiscogsArtist, DiscogsRelease, DiscogsRoleArtist};
 use crate::import::types::ReleaseIdentity;
-use crate::import::MetadataSource;
+use crate::import::{ImportError, MetadataSource};
 use crate::musicbrainz::MbReleaseResponse;
 use coven::Clock;
 use coven::IdProvider;
@@ -79,17 +79,18 @@ pub fn map_discogs_to_db(
     mb_xref: Option<&MbReleaseResponse>,
     clock: &dyn Clock,
     ids: &dyn IdProvider,
-) -> Result<ParsedAlbum, String> {
+) -> Result<ParsedAlbum, ImportError> {
     // Release artists → the artist pool. With no artists list, fall back to
     // the artist half of the "Artist - Album" title split.
     let mut release_refs: Vec<ArtistRef> = if release.artists.is_empty() {
         let artist_name = crate::discogs::split_title(&release.title)
             .and_then(|(artist, _)| artist)
-            .ok_or_else(|| {
-                format!(
+            .ok_or_else(|| ImportError::SourceData {
+                metadata_source: MetadataSource::Discogs,
+                detail: format!(
                     "Discogs release {} has no release artist in artists list or title",
                     release.id
-                )
+                ),
             })?
             .to_string();
         vec![ArtistRef {
@@ -182,7 +183,10 @@ pub fn map_discogs_to_db(
         let rg = mb
             .release_group
             .as_ref()
-            .ok_or_else(|| format!("MusicBrainz release {} missing release_group", mb.id))?;
+            .ok_or_else(|| ImportError::SourceData {
+                metadata_source: MetadataSource::MusicBrainz,
+                detail: format!("MusicBrainz release {} missing release_group", mb.id),
+            })?;
         identities.push(ReleaseIdentity {
             source: MetadataSource::MusicBrainz,
             source_group_id: rg.id.clone(),
@@ -470,7 +474,7 @@ mod tests {
         release: &DiscogsRelease,
         master_year: Option<u32>,
         mb_xref: Option<&MbReleaseResponse>,
-    ) -> Result<ParsedAlbum, String> {
+    ) -> Result<ParsedAlbum, ImportError> {
         let clock = FixedClock(
             chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
                 .unwrap()
@@ -558,7 +562,7 @@ mod tests {
                 .expect_err(&format!("expected error for unattributed title {title:?}"));
 
             assert!(
-                err.contains("has no release artist"),
+                matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("has no release artist")),
                 "unexpected error message for {title:?}: {err}"
             );
         }
@@ -973,7 +977,7 @@ mod tests {
             .expect_err("expected missing MB release group to return an error");
 
         assert!(
-            err.contains("missing release_group"),
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("missing release_group")),
             "unexpected error message: {err}"
         );
     }

--- a/bae-core/src/import/error.rs
+++ b/bae-core/src/import/error.rs
@@ -1,0 +1,138 @@
+//! The typed error the import pipeline threads through every fallible step.
+//!
+//! Every function under `import/` returns `Result<_, ImportError>` (or one of
+//! the narrower typed errors that `#[from]`-convert into it). Wire-level source
+//! errors (`MusicBrainzError`, `DiscogsError`) are preserved structurally rather
+//! than flattened to a string, so a consumer that needs to know a MusicBrainz
+//! timeout from a malformed-payload failure can read it from the chain. The
+//! terminal consumer, `do_import`, is the only place that turns this back into a
+//! string, for the user-facing `ImportProgress::Failed { error }` event.
+
+use crate::import::MetadataSource;
+
+/// Why an import failed. One class per distinguishable failure the pipeline
+/// actually produces.
+#[derive(Debug, thiserror::Error)]
+pub enum ImportError {
+    /// Walking the candidate folder failed (I/O during the tree walk).
+    #[error("folder scan failed: {0}")]
+    Scan(#[from] crate::import::folder_scanner::FolderScanError),
+
+    /// The folder is structurally unimportable (corrupt/zero-byte audio,
+    /// CUE referencing missing audio, no valid audio). Typed reason reused
+    /// from the scanner.
+    #[error("folder cannot be imported: {0}")]
+    InvalidFolder(#[from] crate::import::folder_scanner::InvalidReason),
+
+    /// A MusicBrainz request failed. Network/Timeout/Provider{status}
+    /// distinctions preserved from the wire.
+    #[error("MusicBrainz request failed: {0}")]
+    MusicBrainz(#[from] crate::musicbrainz::MusicBrainzError),
+
+    /// A Discogs request failed. RateLimit/InvalidApiKey/NotFound preserved.
+    #[error("Discogs request failed: {0}")]
+    Discogs(#[from] crate::discogs::client::DiscogsError),
+
+    /// A Discogs operation was requested but no API key is configured.
+    #[error("Discogs API key not configured")]
+    DiscogsNotConfigured,
+
+    /// The source responded, but its payload can't be mapped to a release
+    /// (no artist credits, missing release_group, multi-side track with no
+    /// side letter, medium with no tracks, no track title, ...).
+    ///
+    /// The field is `metadata_source`, not `source`: thiserror reserves a
+    /// field literally named `source` for the error-chain source, which a
+    /// `MetadataSource` (not an `Error`) can't be.
+    #[error("{} release data cannot be mapped: {detail}", metadata_source.as_str())]
+    SourceData {
+        metadata_source: MetadataSource,
+        detail: String,
+    },
+
+    /// Local file-tag evidence can't seed an Unknown import (no audio files,
+    /// a file failed to open / parse, embedded-cover read failure).
+    #[error("file tags cannot be read: {detail}")]
+    FileTags { detail: String },
+
+    /// The release's tracks don't map onto the folder's audio files
+    /// (track count mismatch, no audio files found, CUE analysis/probe
+    /// failures, incompatible CUE segment formats, unusable audio format).
+    #[error("{detail}")]
+    TrackMapping { detail: String },
+
+    /// Cover art selection/fetch/decode failed (download after retries,
+    /// unrecognized image bytes, selected local cover missing, read/resize
+    /// failure).
+    #[error("cover art failed: {detail}")]
+    CoverArt { detail: String },
+
+    /// verify_decode_on_import found tracks that would import but not play.
+    #[error("decode verification failed for {} track(s): {}", broken.len(), broken.join("; "))]
+    DecodeVerification { broken: Vec<String> },
+
+    /// Per-pressing duplicate rejection: an Exact identity already in the
+    /// library. The Display text is a user-facing surface the UI renders and a
+    /// test asserts on, so it names the album verbatim.
+    #[error("This release is already in your library as \"{album_title}\"")]
+    AlreadyInLibrary { album_title: String },
+
+    /// The user-edit overlay is invalid (reuses the editor's typed error).
+    #[error(transparent)]
+    Edit(#[from] crate::import::EditValidationError),
+
+    /// A library/DB operation failed (insert_import, finalize_import_atomic,
+    /// resolve_artists_for_import, replacement plans, coven_make_remote).
+    #[error(transparent)]
+    Db(#[from] crate::library::LibraryError),
+
+    /// The watched-folder registry could not persist (YAML serialize / fs write).
+    #[error("watched-folder registry: {detail}")]
+    Registry { detail: String },
+
+    /// Config/keyring plumbing failed (Discogs key store/read).
+    #[error("configuration error: {detail}")]
+    Config { detail: String },
+
+    /// A broken invariant, not a user condition: artist-id remap miss,
+    /// non-UTF-8 path, spawn_blocking join failure, closed command channel,
+    /// missing library-status row.
+    #[error("internal import error: {detail}")]
+    Internal { detail: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::musicbrainz::MusicBrainzError;
+
+    /// Wire-level source errors reach a consumer structurally, not flattened to
+    /// a string. A MusicBrainz timeout that a producer raises with `?` arrives
+    /// at the terminal consumer as a matchable `MusicBrainz(Timeout)` — a retry
+    /// policy can read the retryability straight off the variant.
+    #[test]
+    fn musicbrainz_error_is_preserved_unflattened() {
+        let err: ImportError = MusicBrainzError::Timeout.into();
+        assert!(matches!(
+            err,
+            ImportError::MusicBrainz(MusicBrainzError::Timeout)
+        ));
+
+        let err: ImportError = MusicBrainzError::Provider { status: Some(503) }.into();
+        assert!(matches!(
+            err,
+            ImportError::MusicBrainz(MusicBrainzError::Provider { status: Some(503) })
+        ));
+    }
+
+    /// A Discogs rate-limit likewise survives the conversion so a retry policy
+    /// can distinguish it from a hard failure.
+    #[test]
+    fn discogs_error_is_preserved_unflattened() {
+        let err: ImportError = crate::discogs::client::DiscogsError::RateLimit.into();
+        assert!(matches!(
+            err,
+            ImportError::Discogs(crate::discogs::client::DiscogsError::RateLimit)
+        ));
+    }
+}

--- a/bae-core/src/import/file_tag_mapper.rs
+++ b/bae-core/src/import/file_tag_mapper.rs
@@ -27,6 +27,7 @@ use super::ParsedAlbum;
 use crate::cue_flac::CueSheet;
 use crate::db::{Pressing, ReleaseMetadataSource};
 use crate::import::folder_scanner::{AudioContent, CategorizedFiles};
+use crate::import::ImportError;
 use crate::util::content_type::ContentType;
 use coven::Clock;
 use coven::IdProvider;
@@ -74,9 +75,11 @@ pub fn map_file_tags_to_db(
     folder_name: Option<&str>,
     clock: &dyn Clock,
     ids: &dyn IdProvider,
-) -> Result<ParsedAlbum, String> {
+) -> Result<ParsedAlbum, ImportError> {
     if audio_files.is_empty() {
-        return Err("file-tag seeding requires at least one audio file".to_string());
+        return Err(ImportError::FileTags {
+            detail: "file-tag seeding requires at least one audio file".to_string(),
+        });
     }
 
     let extracted: Vec<FileTags> = audio_files
@@ -250,7 +253,7 @@ pub fn map_unknown_candidate_to_db(
     folder_name: Option<&str>,
     clock: &dyn Clock,
     ids: &dyn IdProvider,
-) -> Result<ParsedAlbum, String> {
+) -> Result<ParsedAlbum, ImportError> {
     match &categorized.audio {
         AudioContent::CueFlacPairs { pairs, .. } => {
             let mut sorted = pairs.iter().collect::<Vec<_>>();
@@ -285,9 +288,11 @@ pub fn map_cue_sheets_to_db(
     folder_name: Option<&str>,
     clock: &dyn Clock,
     ids: &dyn IdProvider,
-) -> Result<ParsedAlbum, String> {
+) -> Result<ParsedAlbum, ImportError> {
     if sheets.is_empty() {
-        return Err("CUE seeding requires at least one sheet".to_string());
+        return Err(ImportError::FileTags {
+            detail: "CUE seeding requires at least one sheet".to_string(),
+        });
     }
 
     // Album title: a sheet TITLE if any carries one, else the rip's folder
@@ -386,24 +391,28 @@ fn probe_content_type(path: &Path) -> Option<ContentType> {
 /// read.
 pub fn read_embedded_cover(
     audio_files: &[PathBuf],
-) -> Result<Option<(Vec<u8>, ContentType)>, String> {
+) -> Result<Option<(Vec<u8>, ContentType)>, ImportError> {
     for path in audio_files {
         let probe = match Probe::open(path) {
             Ok(probe) => probe,
             Err(e) => {
-                return Err(format!(
-                    "failed to open {} for embedded cover read: {e}",
-                    path.display()
-                ));
+                return Err(ImportError::FileTags {
+                    detail: format!(
+                        "failed to open {} for embedded cover read: {e}",
+                        path.display()
+                    ),
+                });
             }
         };
         let tagged = match probe.read() {
             Ok(tagged) => tagged,
             Err(e) => {
-                return Err(format!(
-                    "failed to read embedded cover tags from {}: {e}",
-                    path.display()
-                ));
+                return Err(ImportError::FileTags {
+                    detail: format!(
+                        "failed to read embedded cover tags from {}: {e}",
+                        path.display()
+                    ),
+                });
             }
         };
         let Some(tag) = tagged.primary_tag().or_else(|| tagged.first_tag()) else {
@@ -453,12 +462,13 @@ fn image_content_type(mime: &lofty::picture::MimeType) -> Option<ContentType> {
 }
 
 /// Extract embedded tag values from a single audio file.
-fn read_tags(path: &Path) -> Result<FileTags, String> {
-    let probe =
-        Probe::open(path).map_err(|e| format!("failed to open {}: {}", path.display(), e))?;
-    let tagged = probe
-        .read()
-        .map_err(|e| format!("failed to read tags from {}: {}", path.display(), e))?;
+fn read_tags(path: &Path) -> Result<FileTags, ImportError> {
+    let probe = Probe::open(path).map_err(|e| ImportError::FileTags {
+        detail: format!("failed to open {}: {}", path.display(), e),
+    })?;
+    let tagged = probe.read().map_err(|e| ImportError::FileTags {
+        detail: format!("failed to read tags from {}: {}", path.display(), e),
+    })?;
 
     let content_type = probe_content_type(path);
 
@@ -552,14 +562,14 @@ mod tests {
 
     /// Run the mapper with deterministic fakes. Exercises the real
     /// `map_file_tags_to_db`; only the clock/id inputs are faked.
-    fn map_tags(audio_files: &[PathBuf]) -> Result<ParsedAlbum, String> {
+    fn map_tags(audio_files: &[PathBuf]) -> Result<ParsedAlbum, ImportError> {
         map_tags_with_folder(audio_files, None)
     }
 
     fn map_tags_with_folder(
         audio_files: &[PathBuf],
         folder_name: Option<&str>,
-    ) -> Result<ParsedAlbum, String> {
+    ) -> Result<ParsedAlbum, ImportError> {
         let clock = FixedClock(
             chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
                 .unwrap()
@@ -726,7 +736,10 @@ mod tests {
         let ids = SequentialIdProvider::new("cue");
         let err = map_cue_sheets_to_db(&[], &[], Some("Folder"), &clock, &ids)
             .expect_err("expected empty sheets to error");
-        assert!(err.contains("at least one sheet"), "got: {err}");
+        assert!(
+            matches!(&err, ImportError::FileTags { detail } if detail.contains("at least one sheet")),
+            "got: {err}"
+        );
     }
 
     /// Copy a fixture into `dest_dir/{name}` and stamp it with the given
@@ -1223,7 +1236,10 @@ mod tests {
     #[test]
     fn empty_input_returns_error() {
         let err = map_tags(&[]).unwrap_err();
-        assert!(err.contains("at least one"), "got: {err}");
+        assert!(
+            matches!(&err, ImportError::FileTags { detail } if detail.contains("at least one")),
+            "got: {err}"
+        );
     }
 
     /// Title falls back to the filename stem when the TITLE tag is
@@ -1506,9 +1522,10 @@ mod tests {
         let err = read_embedded_cover(std::slice::from_ref(&missing)).unwrap_err();
 
         assert!(
-            err.contains("failed to open")
-                && err.contains("for embedded cover read")
-                && err.contains(&missing.display().to_string()),
+            matches!(&err, ImportError::FileTags { detail }
+                if detail.contains("failed to open")
+                    && detail.contains("for embedded cover read")
+                    && detail.contains(&missing.display().to_string())),
             "expected embedded-cover open error, got {err:?}"
         );
     }
@@ -1523,8 +1540,9 @@ mod tests {
         let err = read_embedded_cover(std::slice::from_ref(&path)).unwrap_err();
 
         assert!(
-            err.contains("failed to read embedded cover tags")
-                && err.contains(&path.display().to_string()),
+            matches!(&err, ImportError::FileTags { detail }
+                if detail.contains("failed to read embedded cover tags")
+                    && detail.contains(&path.display().to_string())),
             "expected embedded-cover tag-read error, got {err:?}"
         );
     }
@@ -1656,6 +1674,9 @@ mod tests {
             .join("placeholder-dsd.dsf");
         let err = map_tags_with_folder(&[path], Some("Album Title"))
             .expect_err("lofty does not read DSF tags");
-        assert!(err.contains("failed to read tags"), "{err}");
+        assert!(
+            matches!(&err, ImportError::FileTags { detail } if detail.contains("failed to read tags")),
+            "{err}"
+        );
     }
 }

--- a/bae-core/src/import/folder_registry.rs
+++ b/bae-core/src/import/folder_registry.rs
@@ -94,10 +94,15 @@ impl ImportFolderRegistry {
         }
     }
 
-    fn save(&self, library_dir: &LibraryDir) -> Result<(), String> {
+    fn save(&self, library_dir: &LibraryDir) -> Result<(), crate::import::ImportError> {
         let path = Self::file_path(library_dir);
-        let yaml = serde_yaml::to_string(self).map_err(|e| e.to_string())?;
-        std::fs::write(&path, yaml).map_err(|e| format!("writing {}: {e}", path.display()))
+        let yaml =
+            serde_yaml::to_string(self).map_err(|e| crate::import::ImportError::Registry {
+                detail: e.to_string(),
+            })?;
+        std::fs::write(&path, yaml).map_err(|e| crate::import::ImportError::Registry {
+            detail: format!("writing {}: {e}", path.display()),
+        })
     }
 
     /// The watched folders, in add order, as the list the UI renders as group
@@ -113,7 +118,11 @@ impl ImportFolderRegistry {
     /// Add `path` if not already watched, persisting on change. Returns `true`
     /// when it was newly added (the caller then scans it), `false` if it was
     /// already present.
-    pub fn add(&mut self, library_dir: &LibraryDir, path: String) -> Result<bool, String> {
+    pub fn add(
+        &mut self,
+        library_dir: &LibraryDir,
+        path: String,
+    ) -> Result<bool, crate::import::ImportError> {
         if self.folders.contains(&path) {
             return Ok(false);
         }
@@ -123,7 +132,11 @@ impl ImportFolderRegistry {
     }
 
     /// Remove `path`, persisting on change. Returns `true` when it was present.
-    pub fn remove(&mut self, library_dir: &LibraryDir, path: &str) -> Result<bool, String> {
+    pub fn remove(
+        &mut self,
+        library_dir: &LibraryDir,
+        path: &str,
+    ) -> Result<bool, crate::import::ImportError> {
         let before = self.folders.len();
         self.folders.retain(|p| p != path);
         if self.folders.len() == before {
@@ -146,7 +159,7 @@ impl ImportFolderRegistry {
         library_dir: &LibraryDir,
         path: String,
         skipped: bool,
-    ) -> Result<bool, String> {
+    ) -> Result<bool, crate::import::ImportError> {
         let changed = if skipped {
             if self.skipped.contains(&path) {
                 false

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -11,7 +11,6 @@ use crate::cue_flac::CueFlacProcessor;
 use crate::util::content_type_hint::ContentTypeHint;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -290,9 +289,15 @@ pub struct FileTree {
     dirs: BTreeMap<PathBuf, DirEntry>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum FolderScanError {
-    Io { path: PathBuf, source: io::Error },
+    #[error("{}: {source}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("{0}")]
     Other(String),
 }
 
@@ -304,17 +309,6 @@ impl FolderScanError {
         }
     }
 }
-
-impl fmt::Display for FolderScanError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io { path, source } => write!(f, "{}: {source}", path.display()),
-            Self::Other(message) => f.write_str(message),
-        }
-    }
-}
-
-impl std::error::Error for FolderScanError {}
 
 #[derive(Debug, Default)]
 struct DirEntry {
@@ -498,10 +492,10 @@ enum CueCodecLabel {
 /// all). A readable file whose codec bae can't play (`Ok(Unsupported)`) or that
 /// FFmpeg can't probe (`Ok(Unprobeable)`) is not an error — each surfaces its
 /// folder as an invalid candidate without aborting the whole watched-root walk.
-fn cue_pair_codec_label(path: &Path) -> Result<CueCodecLabel, String> {
-    let path_str = path
-        .to_str()
-        .ok_or_else(|| format!("CUE audio path is not UTF-8: {}", path.display()))?;
+fn cue_pair_codec_label(path: &Path) -> Result<CueCodecLabel, FolderScanError> {
+    let path_str = path.to_str().ok_or_else(|| {
+        FolderScanError::Other(format!("CUE audio path is not UTF-8: {}", path.display()))
+    })?;
     let Some(probe) = crate::audio_codec::probe_audio_from_path(path_str) else {
         return Ok(CueCodecLabel::Unprobeable);
     };
@@ -746,8 +740,17 @@ struct DetectedCueAudioPair {
 }
 
 /// Shorthand for a failed-validation leaf carrying `reason`.
-fn invalid(reason: InvalidReason) -> Result<CategorizeOutcome, String> {
+fn invalid(reason: InvalidReason) -> Result<CategorizeOutcome, FolderScanError> {
     Ok(CategorizeOutcome::Invalid(reason))
+}
+
+/// The directory holding a CUE sheet, where its `FILE` references resolve. A
+/// CUE path with no parent is a filesystem impossibility for a scanned file,
+/// so it's a hard scan error, not an invalid-candidate reason.
+fn cue_parent_dir(cue_path: &Path) -> Result<&Path, FolderScanError> {
+    cue_path
+        .parent()
+        .ok_or_else(|| FolderScanError::Other(format!("CUE file has no parent: {:?}", cue_path)))
 }
 
 /// Categorize files from a FileTree for a given release root.
@@ -760,7 +763,7 @@ fn categorize_files_from_tree(
     tree: &FileTree,
     release_root: &Path,
     fs_root: &Path,
-) -> Result<CategorizeOutcome, String> {
+) -> Result<CategorizeOutcome, FolderScanError> {
     let mut all_audio: Vec<ScannedFile> = Vec::new();
     let mut all_cue: Vec<ScannedFile> = Vec::new();
     let mut artwork: Vec<ScannedFile> = Vec::new();
@@ -787,8 +790,11 @@ fn categorize_files_from_tree(
             // I/O fault (file vanished, permissions, flaky network mount) —
             // surface it rather than mis-label a system error as corruption
             // and silently drop the whole release.
-            let valid = file_validation::is_valid_audio(&absolute_path)
-                .map_err(|e| format!("Failed to validate audio file {absolute_path:?}: {e}"))?;
+            let valid = file_validation::is_valid_audio(&absolute_path).map_err(|e| {
+                FolderScanError::Other(format!(
+                    "Failed to validate audio file {absolute_path:?}: {e}"
+                ))
+            })?;
             if entry.size == 0 || !valid {
                 info!("Invalid candidate: corrupt or zero-byte audio file {relative_path}");
                 return invalid(InvalidReason::CorruptAudioFile {
@@ -810,8 +816,11 @@ fn categorize_files_from_tree(
         } else if is_image_file(&entry.path) {
             // As with audio: Ok(false) is corruption (skip), Err is a real
             // I/O fault that must surface rather than drop the release.
-            let valid = file_validation::is_valid_image(&absolute_path)
-                .map_err(|e| format!("Failed to validate image file {absolute_path:?}: {e}"))?;
+            let valid = file_validation::is_valid_image(&absolute_path).map_err(|e| {
+                FolderScanError::Other(format!(
+                    "Failed to validate image file {absolute_path:?}: {e}"
+                ))
+            })?;
             if entry.size == 0 || !valid {
                 info!("Invalid candidate: corrupt or zero-byte image {relative_path}");
                 return invalid(InvalidReason::CorruptImage {
@@ -868,10 +877,7 @@ fn categorize_files_from_tree(
             if file_references.is_empty() {
                 return Ok(None);
             }
-            let cue_dir = cue
-                .path
-                .parent()
-                .ok_or_else(|| format!("CUE file has no parent: {:?}", cue.path))?;
+            let cue_dir = cue_parent_dir(&cue.path)?;
             let first_audio_path = cue_dir.join(file_references[0]);
             Ok(audio_by_path
                 .get(&first_audio_path)
@@ -880,7 +886,7 @@ fn categorize_files_from_tree(
                     audio_index: *audio_index,
                 }))
         })
-        .collect::<Result<Vec<_>, String>>()?
+        .collect::<Result<Vec<_>, FolderScanError>>()?
         .into_iter()
         .flatten()
         .collect();
@@ -925,16 +931,15 @@ fn categorize_files_from_tree(
                 .remove(&cue_file.path)
                 .expect("detected CUE pair has a parsed CUE sheet");
 
-            let cue_dir = cue_file
-                .path
-                .parent()
-                .ok_or_else(|| format!("CUE file has no parent: {:?}", cue_file.path))?;
+            let cue_dir = cue_parent_dir(&cue_file.path)?;
             let mut audio_files = Vec::new();
             let mut seen = HashSet::new();
             for reference in cue_sheet.audio_file_references() {
                 let audio_path = cue_dir.join(reference);
                 let audio_index = audio_by_path.get(&audio_path).ok_or_else(|| {
-                    format!("CUE reference missing after validation: {reference}")
+                    FolderScanError::Other(format!(
+                        "CUE reference missing after validation: {reference}"
+                    ))
                 })?;
                 if seen.insert(*audio_index) {
                     audio_files.push(all_audio[*audio_index].clone());
@@ -1047,7 +1052,7 @@ fn scan_tree_recursive<F>(
     dir: &Path,
     fs_root: &Path,
     on_item: &mut F,
-) -> Result<(), String>
+) -> Result<(), FolderScanError>
 where
     F: FnMut(RawScanItem),
 {
@@ -1152,7 +1157,6 @@ where
             }));
         }
     })
-    .map_err(FolderScanError::Other)
 }
 
 /// Collect all files from a release directory and categorize them.
@@ -1160,13 +1164,15 @@ where
 /// This collects files recursively within a single release, preserving relative paths,
 /// and categorizes them into audio (CUE/FLAC pairs or track files), artwork, and documents.
 /// Unrecognized file types are ignored.
-pub fn collect_release_candidate_files(release_root: &Path) -> Result<CategorizedFiles, String> {
-    let tree = FileTree::from_filesystem(release_root).map_err(|e| e.to_string())?;
-    // An invalid folder can't be imported: surface its reason as the error so
-    // the import-commit caller fails with why the folder is unusable.
+pub fn collect_release_candidate_files(
+    release_root: &Path,
+) -> Result<CategorizedFiles, crate::import::ImportError> {
+    let tree = FileTree::from_filesystem(release_root)?;
+    // An invalid folder can't be imported: surface its typed reason so the
+    // import-commit caller fails with why the folder is unusable.
     match categorize_files_from_tree(&tree, &PathBuf::new(), release_root)? {
         CategorizeOutcome::Valid(files) => Ok(files),
-        CategorizeOutcome::Invalid(reason) => Err(reason.to_string()),
+        CategorizeOutcome::Invalid(reason) => Err(reason.into()),
     }
 }
 

--- a/bae-core/src/import/folder_scanner/tests.rs
+++ b/bae-core/src/import/folder_scanner/tests.rs
@@ -212,6 +212,29 @@ fn test_collect_release_candidate_files_skips_hidden_and_bae() {
     assert!(files.documents.is_empty());
 }
 
+/// A folder whose only audio is a zero-byte file can't be imported:
+/// `collect_release_candidate_files` surfaces the typed
+/// `ImportError::InvalidFolder` (carrying the scanner's `InvalidReason`)
+/// rather than a stringly error, so the commit caller can distinguish an
+/// unimportable folder from an I/O fault.
+#[test]
+fn collect_release_candidate_files_on_invalid_folder_yields_invalid_folder() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+    // Zero-byte audio is corruption, not an I/O fault.
+    std::fs::write(root.join("track.flac"), []).unwrap();
+
+    let err = collect_release_candidate_files(root)
+        .expect_err("zero-byte audio makes the folder unimportable");
+    assert!(
+        matches!(
+            err,
+            crate::import::ImportError::InvalidFolder(InvalidReason::CorruptAudioFile { .. })
+        ),
+        "got: {err:?}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn unreadable_child_directory_fails_scan() {

--- a/bae-core/src/import/handle/import.rs
+++ b/bae-core/src/import/handle/import.rs
@@ -15,7 +15,7 @@ impl ImportServiceHandle {
     pub async fn preview_file_tags_for_folder(
         &self,
         folder: std::path::PathBuf,
-    ) -> Result<crate::import::ReleaseUserEdit, String> {
+    ) -> Result<crate::import::ReleaseUserEdit, crate::import::ImportError> {
         // Captured before `folder` moves into the scan — the album-title
         // fallback when no file carries an ALBUM tag.
         let folder_name = folder
@@ -27,7 +27,9 @@ impl ImportServiceHandle {
             crate::import::folder_scanner::collect_release_candidate_files(&folder)
         })
         .await
-        .map_err(|e| format!("folder scan task failed: {e}"))??;
+        .map_err(|e| crate::import::ImportError::Internal {
+            detail: format!("folder scan task failed: {e}"),
+        })??;
 
         let clock = self.library_manager.clock().clone();
         let ids = self.library_manager.ids().clone();
@@ -41,7 +43,9 @@ impl ImportServiceHandle {
             Ok(parsed_album_to_user_edit(&parsed))
         })
         .await
-        .map_err(|e| format!("unknown preview projection task failed: {e}"))?
+        .map_err(|e| crate::import::ImportError::Internal {
+            detail: format!("unknown preview projection task failed: {e}"),
+        })?
     }
 
     /// Build an import command and enqueue it. For Exact / Approximate
@@ -69,7 +73,7 @@ impl ImportServiceHandle {
         pin: bool,
         identity_choice: crate::import::types::IdentityChoice,
         user_edit: Option<crate::import::types::ReleaseUserEdit>,
-    ) -> Result<String, String> {
+    ) -> Result<String, crate::import::ImportError> {
         let import_id = self.library_manager.ids().new_id();
         let command = ImportCommand {
             import_id: import_id.clone(),
@@ -90,7 +94,10 @@ impl ImportServiceHandle {
     /// it isn't outright rejected. Validating first means a typo (401) never
     /// stores a bad key, while an offline/rate-limited save still stores the key
     /// optimistically so the user isn't blocked. See `DiscogsSaveOutcome`.
-    pub async fn save_discogs_token(&self, token: &str) -> Result<DiscogsSaveOutcome, String> {
+    pub async fn save_discogs_token(
+        &self,
+        token: &str,
+    ) -> Result<DiscogsSaveOutcome, crate::import::ImportError> {
         use crate::config::DiscogsValidation;
 
         let client = DiscogsClient::new(token.to_string());
@@ -113,13 +120,17 @@ impl ImportServiceHandle {
         &self,
         token: &str,
         validation: crate::config::DiscogsValidation,
-    ) -> Result<(), String> {
-        self.library_manager
-            .save_discogs_key(token)
-            .map_err(|e| e.to_string())?;
+    ) -> Result<(), crate::import::ImportError> {
+        self.library_manager.save_discogs_key(token).map_err(|e| {
+            crate::import::ImportError::Config {
+                detail: e.to_string(),
+            }
+        })?;
         self.library_manager
             .set_discogs_key_stored(validation)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| crate::import::ImportError::Config {
+                detail: e.to_string(),
+            })?;
         Ok(())
     }
 
@@ -127,13 +138,17 @@ impl ImportServiceHandle {
     /// settings-tab open). No-op when no key is stored or the key is already
     /// settled `Valid`/`Rejected`. A 401 marks it `Rejected`; success confirms
     /// it `Valid`; network/rate-limit leaves it `Unvalidated` to retry later.
-    pub async fn revalidate_discogs_token(&self) -> Result<(), String> {
+    pub async fn revalidate_discogs_token(&self) -> Result<(), crate::import::ImportError> {
         use crate::config::DiscogsValidation;
 
         if self.library_manager.discogs_validation() != Some(DiscogsValidation::Unvalidated) {
             return Ok(());
         }
-        let Some(client) = self.library_manager.discogs_client()? else {
+        let Some(client) = self
+            .library_manager
+            .discogs_client()
+            .map_err(|detail| crate::import::ImportError::Config { detail })?
+        else {
             // A stored `Unvalidated` key (the guard above) with no client means
             // the keyring entry and the config disagree — surface it rather than
             // silently leaving the key stuck unvalidated.
@@ -146,20 +161,26 @@ impl ImportServiceHandle {
             settled @ (DiscogsValidation::Valid | DiscogsValidation::Rejected) => self
                 .library_manager
                 .set_discogs_validation(settled)
-                .map_err(|e| e.to_string()),
+                .map_err(|e| crate::import::ImportError::Config {
+                    detail: e.to_string(),
+                }),
             DiscogsValidation::Unvalidated => Ok(()),
         }
     }
 
     /// Remove the Discogs API token from the OS keyring and clear the
     /// stored-key hint.
-    pub fn remove_discogs_token(&self) -> Result<(), String> {
-        self.library_manager
-            .delete_discogs_key()
-            .map_err(|e| e.to_string())?;
+    pub fn remove_discogs_token(&self) -> Result<(), crate::import::ImportError> {
+        self.library_manager.delete_discogs_key().map_err(|e| {
+            crate::import::ImportError::Config {
+                detail: e.to_string(),
+            }
+        })?;
         self.library_manager
             .clear_discogs_key_stored()
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| crate::import::ImportError::Config {
+                detail: e.to_string(),
+            })?;
         Ok(())
     }
 
@@ -167,11 +188,16 @@ impl ImportServiceHandle {
     ///
     /// All heavy work (metadata resolution, file discovery, track mapping,
     /// DB insertion) happens in the service worker. This returns immediately.
-    pub fn send_command(&self, command: ImportCommand) -> Result<String, String> {
+    pub fn send_command(
+        &self,
+        command: ImportCommand,
+    ) -> Result<String, crate::import::ImportError> {
         let import_id = command.import_id.clone();
         self.requests_tx
             .send(command)
-            .map_err(|_| "Failed to queue import command".to_string())?;
+            .map_err(|_| crate::import::ImportError::Internal {
+                detail: "Failed to queue import command".to_string(),
+            })?;
         Ok(import_id)
     }
 

--- a/bae-core/src/import/handle/mod.rs
+++ b/bae-core/src/import/handle/mod.rs
@@ -563,13 +563,15 @@ pub fn remap_artist_links<T: Clone>(
     label: &str,
     artist_id: impl Fn(&T) -> &str,
     assign_artist_id: impl Fn(&mut T, String),
-) -> Result<Vec<T>, String> {
+) -> Result<Vec<T>, crate::import::ImportError> {
     links
         .iter()
         .map(|link| {
             let parsed_artist_id = artist_id(link);
             let actual_id = artist_id_map.get(parsed_artist_id).ok_or_else(|| {
-                format!("{label} artist ID {parsed_artist_id} not found in artist map")
+                crate::import::ImportError::Internal {
+                    detail: format!("{label} artist ID {parsed_artist_id} not found in artist map"),
+                }
             })?;
             let mut remapped = link.clone();
             assign_artist_id(&mut remapped, actual_id.clone());
@@ -586,7 +588,7 @@ pub fn remap_artist_links<T: Clone>(
 pub fn remap_track_artists(
     track_artists: &[crate::db::DbTrackArtist],
     artist_id_map: &HashMap<String, String>,
-) -> Result<Vec<crate::db::DbTrackArtist>, String> {
+) -> Result<Vec<crate::db::DbTrackArtist>, crate::import::ImportError> {
     remap_artist_links(
         track_artists,
         artist_id_map,
@@ -600,7 +602,7 @@ pub fn remap_track_artists(
 pub fn remap_album_artists(
     album_artists: &[crate::db::DbAlbumArtist],
     artist_id_map: &HashMap<String, String>,
-) -> Result<Vec<crate::db::DbAlbumArtist>, String> {
+) -> Result<Vec<crate::db::DbAlbumArtist>, crate::import::ImportError> {
     remap_artist_links(
         album_artists,
         artist_id_map,

--- a/bae-core/src/import/handle/scan.rs
+++ b/bae-core/src/import/handle/scan.rs
@@ -5,7 +5,11 @@ impl ImportServiceHandle {
     /// and broadcasting it so the import view re-tabs the row (New ↔ Skipped).
     /// A no-op request (already in the requested state) persists nothing and
     /// emits no event.
-    pub fn set_candidate_skipped(&self, path: String, skipped: bool) -> Result<(), String> {
+    pub fn set_candidate_skipped(
+        &self,
+        path: String,
+        skipped: bool,
+    ) -> Result<(), crate::import::ImportError> {
         let library_dir = self.library_manager.library_dir();
         let mut registry = self.folder_registry.lock().unwrap();
         let changed = registry.set_skipped(&library_dir, path.clone(), skipped)?;

--- a/bae-core/src/import/handle/search.rs
+++ b/bae-core/src/import/handle/search.rs
@@ -86,20 +86,20 @@ impl ImportServiceHandle {
     /// back through the import command, but a session-wide LRU cache
     /// in `cover_art` keeps the URL's bytes warm so the commit
     /// worker's later download is a cache hit, not a re-fetch.
-    pub async fn fetch_cover_bytes(&self, url: String) -> Result<Vec<u8>, String> {
+    pub async fn fetch_cover_bytes(
+        &self,
+        url: String,
+    ) -> Result<Vec<u8>, crate::import::ImportError> {
         let (bytes, _content_type) =
             crate::import::cover_art::download_cover_art_bytes(&url).await?;
         Ok(bytes)
     }
 
-    fn discogs_client(&self) -> Result<DiscogsClient, String> {
+    fn discogs_client(&self) -> Result<DiscogsClient, crate::import::ImportError> {
         self.library_manager
-            .discogs_client()?
-            .ok_or_else(|| "Discogs API key not configured".to_string())
-    }
-
-    fn discogs_search_error(e: crate::discogs::client::DiscogsError) -> String {
-        format!("Discogs search failed: {e}")
+            .discogs_client()
+            .map_err(|detail| crate::import::ImportError::Config { detail })?
+            .ok_or(crate::import::ImportError::DiscogsNotConfigured)
     }
 
     /// Search for releases, check library status, and bundle the results into
@@ -107,7 +107,7 @@ impl ImportServiceHandle {
     pub async fn search_with_status(
         &self,
         query: SearchQuery,
-    ) -> Result<GroupedSearchResults, String> {
+    ) -> Result<GroupedSearchResults, crate::import::ImportError> {
         use crate::db::LibraryCheck;
 
         let results = match query.into_provider_params() {
@@ -116,9 +116,7 @@ impl ImportServiceHandle {
             }
             ProviderSearchParams::Discogs(params) => {
                 let client = self.discogs_client()?;
-                crate::import::search::search_discogs(&client, params)
-                    .await
-                    .map_err(Self::discogs_search_error)?
+                crate::import::search::search_discogs(&client, params).await?
             }
         };
 
@@ -127,8 +125,7 @@ impl ImportServiceHandle {
         let statuses = self
             .library_manager
             .check_releases_in_library(&checks)
-            .await
-            .map_err(|e| format!("Failed to check library status: {e}"))?;
+            .await?;
 
         let status_map: HashMap<String, crate::db::LibraryStatus> = statuses
             .into_iter()
@@ -141,10 +138,11 @@ impl ImportServiceHandle {
         // would silently misclassify a real failure.
         let mut statuses = Vec::with_capacity(results.len());
         for r in &results {
-            let status = status_map
-                .get(&r.release_id)
-                .cloned()
-                .ok_or_else(|| format!("library status missing for release {}", r.release_id))?;
+            let status = status_map.get(&r.release_id).cloned().ok_or_else(|| {
+                crate::import::ImportError::Internal {
+                    detail: format!("library status missing for release {}", r.release_id),
+                }
+            })?;
             statuses.push(status);
         }
 
@@ -161,14 +159,14 @@ impl ImportServiceHandle {
         album: String,
         year: Option<String>,
         label: Option<String>,
-    ) -> Result<Vec<crate::import::search::MetadataResult>, String> {
+    ) -> Result<Vec<crate::import::search::MetadataResult>, crate::import::ImportError> {
         let client = self.discogs_client()?;
         crate::import::search::search_discogs(
             &client,
             discogs_general_params(artist, album, year, label),
         )
         .await
-        .map_err(Self::discogs_search_error)
+        .map_err(Into::into)
     }
 
     pub async fn search_musicbrainz(
@@ -177,7 +175,7 @@ impl ImportServiceHandle {
         album: String,
         year: Option<String>,
         label: Option<String>,
-    ) -> Result<Vec<crate::import::search::MetadataResult>, String> {
+    ) -> Result<Vec<crate::import::search::MetadataResult>, crate::import::ImportError> {
         crate::import::search::search_mb(
             &self.cover_art_archive,
             mb_general_params(artist, album, year, label),
@@ -201,12 +199,11 @@ impl ImportServiceHandle {
     pub async fn fetch_remote_covers(
         &self,
         release_id: &str,
-    ) -> Result<Vec<crate::import::cover_art::RemoteCover>, String> {
+    ) -> Result<Vec<crate::import::cover_art::RemoteCover>, crate::import::ImportError> {
         let identities = self
             .library_manager
             .get_release_identities(release_id)
-            .await
-            .map_err(|e| format!("{e}"))?;
+            .await?;
 
         let mut covers = Vec::new();
 
@@ -284,7 +281,7 @@ impl ImportServiceHandle {
         &self,
         release_id: &str,
         source: MetadataSource,
-    ) -> Result<crate::import::search::ImportSearchReleaseDetail, String> {
+    ) -> Result<crate::import::search::ImportSearchReleaseDetail, crate::import::ImportError> {
         match source {
             MetadataSource::MusicBrainz => {
                 crate::import::search::prefetch_mb_release(&self.cover_art_archive, release_id)

--- a/bae-core/src/import/handle/tests.rs
+++ b/bae-core/src/import/handle/tests.rs
@@ -364,12 +364,8 @@ async fn test_exact_release_duplicate_rejected() {
 
     let err = result.expect_err("duplicate import should be rejected");
     assert!(
-        err.contains("already in your library"),
-        "Expected duplicate error, got: {err}",
-    );
-    assert!(
-        err.contains("Album Title"),
-        "Expected album title in error, got: {err}",
+        matches!(&err, crate::import::ImportError::AlreadyInLibrary { album_title } if album_title == "Album Title"),
+        "Expected duplicate error naming the album, got: {err}",
     );
 
     // Discogs side mirrors the same logic.
@@ -761,7 +757,7 @@ fn remap_track_artists_errors_on_unmapped_id() {
     let err = remap_track_artists(std::slice::from_ref(&ta), &std::collections::HashMap::new())
         .unwrap_err();
     assert!(
-        err.contains("orphan-track-artist"),
+        matches!(&err, crate::import::ImportError::Internal { detail } if detail.contains("orphan-track-artist")),
         "error should name the unmapped id: {err}"
     );
 }
@@ -785,7 +781,7 @@ fn remap_album_artists_errors_on_unmapped_id() {
     let err = remap_album_artists(std::slice::from_ref(&aa), &std::collections::HashMap::new())
         .unwrap_err();
     assert!(
-        err.contains("orphan-album-artist"),
+        matches!(&err, crate::import::ImportError::Internal { detail } if detail.contains("orphan-album-artist")),
         "error should name the unmapped id: {err}"
     );
 }

--- a/bae-core/src/import/handle/watch.rs
+++ b/bae-core/src/import/handle/watch.rs
@@ -8,10 +8,24 @@ impl ImportServiceHandle {
         self.folder_registry.lock().unwrap().watched_folders()
     }
 
+    /// Send a command to the filesystem watcher, turning a closed channel into
+    /// a typed `Internal` error naming the action that couldn't be started.
+    fn send_watcher_command(
+        &self,
+        command: WatcherCommand,
+        on_closed: &str,
+    ) -> Result<(), crate::import::ImportError> {
+        self.watcher_tx
+            .send(command)
+            .map_err(|_| crate::import::ImportError::Internal {
+                detail: on_closed.to_string(),
+            })
+    }
+
     /// Add a folder to watch for imports: persist it, broadcast the new list,
     /// and start watching + scanning it so its releases appear as candidates and
     /// later on-disk changes propagate. A folder already watched is left as-is.
-    pub fn add_watched_folder(&self, path: String) -> Result<(), String> {
+    pub fn add_watched_folder(&self, path: String) -> Result<(), crate::import::ImportError> {
         let library_dir = self.library_manager.library_dir();
         let mut registry = self.folder_registry.lock().unwrap();
         let added = registry.add(&library_dir, path.clone())?;
@@ -24,16 +38,17 @@ impl ImportServiceHandle {
             &self.event_tx,
             ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
         );
-        self.watcher_tx
-            .send(WatcherCommand::Watch(std::path::PathBuf::from(path)))
-            .map_err(|_| "Failed to start watching folder".to_string())
+        self.send_watcher_command(
+            WatcherCommand::Watch(std::path::PathBuf::from(path)),
+            "Failed to start watching folder",
+        )
     }
 
     /// Stop watching `path`: persist the removal, broadcast the new list, and
     /// stop the filesystem watcher for it. The reducer drops the folder's
     /// candidates by reconciling against the list, so no per-candidate removal
     /// events are needed here.
-    pub fn remove_watched_folder(&self, path: String) -> Result<(), String> {
+    pub fn remove_watched_folder(&self, path: String) -> Result<(), crate::import::ImportError> {
         let library_dir = self.library_manager.library_dir();
         let mut registry = self.folder_registry.lock().unwrap();
         let removed = registry.remove(&library_dir, &path)?;
@@ -48,9 +63,10 @@ impl ImportServiceHandle {
                 &self.event_tx,
                 ImportEvent::Scan(ScanEvent::WatchedFoldersChanged { folders }),
             );
-            self.watcher_tx
-                .send(WatcherCommand::Unwatch(std::path::PathBuf::from(path)))
-                .map_err(|_| "Failed to stop watching folder".to_string())?;
+            self.send_watcher_command(
+                WatcherCommand::Unwatch(std::path::PathBuf::from(path)),
+                "Failed to stop watching folder",
+            )?;
         }
         Ok(())
     }
@@ -58,12 +74,13 @@ impl ImportServiceHandle {
     /// Start watching + scanning every watched folder, emitting one
     /// `FolderCandidate` per release found and `CandidateRemoved` for any that
     /// have since vanished. The UI calls this when the import view appears.
-    pub fn scan_watched_folders(&self) -> Result<(), String> {
+    pub fn scan_watched_folders(&self) -> Result<(), crate::import::ImportError> {
         let folders = self.folder_registry.lock().unwrap().watched_folders();
         for folder in folders {
-            self.watcher_tx
-                .send(WatcherCommand::Watch(std::path::PathBuf::from(folder.path)))
-                .map_err(|_| "Failed to start watching folder".to_string())?;
+            self.send_watcher_command(
+                WatcherCommand::Watch(std::path::PathBuf::from(folder.path)),
+                "Failed to start watching folder",
+            )?;
         }
         Ok(())
     }

--- a/bae-core/src/import/mod.rs
+++ b/bae-core/src/import/mod.rs
@@ -5,6 +5,7 @@ pub mod cover_art;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub mod discid;
 pub mod discogs_mapper;
+mod error;
 pub mod file_tag_mapper;
 mod file_validation;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
@@ -73,6 +74,7 @@ pub struct ParsedAlbum {
     pub identities: Vec<crate::import::types::ReleaseIdentity>,
 }
 
+pub use error::ImportError;
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 pub use folder_registry::{ImportFolderRegistry, WatchedFolder};
 pub use folder_scanner::{

--- a/bae-core/src/import/musicbrainz_mapper.rs
+++ b/bae-core/src/import/musicbrainz_mapper.rs
@@ -21,7 +21,7 @@ use super::assemble::{
 use super::ParsedAlbum;
 use crate::db::{is_various_artists, Pressing, ReleaseMetadataSource};
 use crate::import::types::ReleaseIdentity;
-use crate::import::MetadataSource;
+use crate::import::{ImportError, MetadataSource};
 use crate::musicbrainz::{
     fetch_release_group_json, ExternalUrls, MbArtistRef, MbMedium, MbRelation, MbReleaseResponse,
     MbWork,
@@ -159,13 +159,12 @@ fn mb_work_ref(work: &MbWork, converted: &mut HashSet<String>) -> WorkGraphRef {
 /// prefetch's API discogs-free; only commit composes both.
 pub async fn fetch_mb_response(
     release_id: &str,
-) -> Result<(MbReleaseResponse, ExternalUrls, Vec<(String, String)>), String> {
+) -> Result<(MbReleaseResponse, ExternalUrls, Vec<(String, String)>), ImportError> {
     let (response, external_urls, raw_json) =
         crate::retry::retry_with_backoff(3, "MusicBrainz release fetch", || {
             crate::musicbrainz::lookup_release_by_id(release_id)
         })
-        .await
-        .map_err(|e| format!("Failed to fetch MusicBrainz release: {}", e))?;
+        .await?;
 
     let mut metadata_pairs = vec![(MetadataSource::MusicBrainz.as_str().to_string(), raw_json)];
 
@@ -207,12 +206,18 @@ pub(crate) struct MediumSides {
 /// Errors when the medium has no tracks, or when a multi-side track has no
 /// leading side letter: there is no correct side for it, and silently bucketing
 /// it onto side 0 would corrupt the numbering.
-pub(crate) fn medium_sides(release_id: &str, medium: &MbMedium) -> Result<MediumSides, String> {
+pub(crate) fn medium_sides(
+    release_id: &str,
+    medium: &MbMedium,
+) -> Result<MediumSides, ImportError> {
     if medium.tracks.is_empty() {
-        return Err(format!(
-            "MusicBrainz release {} has a medium with no tracks",
-            release_id
-        ));
+        return Err(ImportError::SourceData {
+            metadata_source: MetadataSource::MusicBrainz,
+            detail: format!(
+                "MusicBrainz release {} has a medium with no tracks",
+                release_id
+            ),
+        });
     }
 
     let is_multi_side = medium
@@ -245,13 +250,14 @@ pub(crate) fn medium_sides(release_id: &str, medium: &MbMedium) -> Result<Medium
             .as_deref()
             .and_then(|n| n.chars().next())
             .filter(|c| c.is_ascii_alphabetic())
-            .ok_or_else(|| {
-                format!(
+            .ok_or_else(|| ImportError::SourceData {
+                metadata_source: MetadataSource::MusicBrainz,
+                detail: format!(
                     "MusicBrainz multi-side medium track has no side letter: \
                      number={:?}, title={:?}",
                     track.number,
                     track.recording.as_ref().and_then(|r| r.title.as_ref()),
-                )
+                ),
             })?;
         offsets.push((side_letter.to_ascii_uppercase() as u32) - base_letter);
     }
@@ -276,7 +282,7 @@ pub fn map_mb_response_to_db(
     discogs_release: Option<crate::discogs::DiscogsRelease>,
     clock: &dyn Clock,
     ids: &dyn IdProvider,
-) -> Result<ParsedAlbum, String> {
+) -> Result<ParsedAlbum, ImportError> {
     // Release-level artist credits → `ArtistRef`s, keeping the credit-name
     // preference and the Discogs cross-ref `discogs_artist_id` name-match
     // enrichment.
@@ -284,10 +290,13 @@ pub fn map_mb_response_to_db(
     for credit in &response.artist_credit {
         if let Some(artist_obj) = &credit.artist {
             let artist_name = mb_artist_name(artist_obj, Some(&credit.name)).ok_or_else(|| {
-                format!(
-                    "MusicBrainz release {} artist credit {:?} has no artist name",
-                    response.id, artist_obj.id
-                )
+                ImportError::SourceData {
+                    metadata_source: MetadataSource::MusicBrainz,
+                    detail: format!(
+                        "MusicBrainz release {} artist credit {:?} has no artist name",
+                        response.id, artist_obj.id
+                    ),
+                }
             })?;
             let discogs_artist_id = discogs_release.as_ref().and_then(|dr| {
                 dr.artists
@@ -307,7 +316,10 @@ pub fn map_mb_response_to_db(
         let artist_name = response
             .artist_credit
             .first()
-            .ok_or_else(|| format!("MusicBrainz release {} has no artist credits", response.id))?
+            .ok_or_else(|| ImportError::SourceData {
+                metadata_source: MetadataSource::MusicBrainz,
+                detail: format!("MusicBrainz release {} has no artist credits", response.id),
+            })?
             .name
             .clone();
         release_refs.push(ArtistRef {
@@ -325,10 +337,14 @@ pub fn map_mb_response_to_db(
     // master attach to this album. Both are Exact: the user committed
     // against the MB pressing, and the cross-link names a specific
     // Discogs pressing.
-    let mb_release_group = response
-        .release_group
-        .as_ref()
-        .ok_or_else(|| format!("MusicBrainz release {} missing release_group", response.id))?;
+    let mb_release_group =
+        response
+            .release_group
+            .as_ref()
+            .ok_or_else(|| ImportError::SourceData {
+                metadata_source: MetadataSource::MusicBrainz,
+                detail: format!("MusicBrainz release {} missing release_group", response.id),
+            })?;
     let mut identities = vec![ReleaseIdentity {
         source: MetadataSource::MusicBrainz,
         source_group_id: mb_release_group.id.clone(),
@@ -400,11 +416,12 @@ pub fn map_mb_response_to_db(
                 .and_then(|r| r.title.as_deref())
                 .or(track.title.as_deref())
                 .filter(|title| !title.trim().is_empty())
-                .ok_or_else(|| {
-                    format!(
+                .ok_or_else(|| ImportError::SourceData {
+                    metadata_source: MetadataSource::MusicBrainz,
+                    detail: format!(
                         "MusicBrainz release {} track {:?} has no track title",
                         response.id, track.number
-                    )
+                    ),
                 })?
                 .to_string();
 
@@ -535,7 +552,7 @@ mod tests {
         response: &MbReleaseResponse,
         master_year: Option<u32>,
         discogs_release: Option<crate::discogs::DiscogsRelease>,
-    ) -> Result<ParsedAlbum, String> {
+    ) -> Result<ParsedAlbum, ImportError> {
         let clock = FixedClock(
             chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
                 .unwrap()
@@ -744,7 +761,7 @@ mod tests {
         let err = map(&response, Some(2024), None)
             .expect_err("expected error for vinyl track without side letter");
         assert!(
-            err.contains("no side letter"),
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("no side letter")),
             "unexpected error message: {}",
             err
         );
@@ -765,7 +782,7 @@ mod tests {
         let err = map(&response, Some(2024), None)
             .expect_err("expected error for vinyl track with numeric-only number");
         assert!(
-            err.contains("no side letter"),
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("no side letter")),
             "unexpected error message: {}",
             err
         );
@@ -779,8 +796,10 @@ mod tests {
         }]);
 
         let result = map(&response, Some(2024), None);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("no tracks"));
+        assert!(matches!(
+            result.unwrap_err(),
+            ImportError::SourceData { detail, .. } if detail.contains("no tracks")
+        ));
     }
 
     #[test]
@@ -830,7 +849,7 @@ mod tests {
             .expect_err("expected missing MusicBrainz track title to return an error");
 
         assert!(
-            err.contains("has no track title"),
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("has no track title")),
             "unexpected error message: {err}"
         );
     }
@@ -914,7 +933,7 @@ mod tests {
             .expect_err("expected missing artist credits to return an error");
 
         assert!(
-            err.contains("has no artist credits"),
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("has no artist credits")),
             "unexpected error message: {err}"
         );
     }
@@ -931,7 +950,7 @@ mod tests {
             .expect_err("expected missing release group to return an error");
 
         assert!(
-            err.contains("missing release_group"),
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("missing release_group")),
             "unexpected error message: {err}"
         );
     }

--- a/bae-core/src/import/progress/handle.rs
+++ b/bae-core/src/import/progress/handle.rs
@@ -23,7 +23,10 @@ impl SubscriptionFilter {
                 ImportProgress::Progress { id, .. } => id == release_id,
                 ImportProgress::Complete { id, .. } => id == release_id,
                 ImportProgress::RemoteUploadQueued { id, .. } => id == release_id,
-                ImportProgress::Failed { id, .. } => id == release_id,
+                // A failed import has no release row (it never reached the
+                // atomic finalize), so a release-filtered subscriber never
+                // sees Failed.
+                ImportProgress::Failed { .. } => false,
             },
             SubscriptionFilter::Import { import_id } => match progress {
                 ImportProgress::Preparing { import_id: iid, .. } => iid == import_id,
@@ -154,6 +157,12 @@ mod tests {
             album_title: "Test".to_string(),
             artist_name: "Artist".to_string(),
         },),);
+        // A failed import has no release row, so a release-filtered
+        // subscriber never sees Failed.
+        assert!(!filter.matches(&ImportProgress::Failed {
+            error: "error".to_string(),
+            import_id: "import-1".to_string(),
+        },),);
     }
     #[test]
     fn test_import_filter_matches_preparing_events() {
@@ -205,7 +214,6 @@ mod tests {
             album_id: "album-1".to_string(),
         },),);
         assert!(filter.matches(&ImportProgress::Failed {
-            id: "release-1".to_string(),
             error: "error".to_string(),
             import_id: "import-1".to_string(),
         },),);
@@ -252,7 +260,6 @@ mod tests {
             album_id: "album-1".to_string(),
         },),);
         assert!(filter.matches(&ImportProgress::Failed {
-            id: "release-1".to_string(),
             error: "error".to_string(),
             import_id: "import-4".to_string(),
         },),);

--- a/bae-core/src/import/search.rs
+++ b/bae-core/src/import/search.rs
@@ -11,6 +11,7 @@ use crate::discogs::client::{DiscogsClient, DiscogsError, DiscogsSearchParams};
 use crate::import::cover_art::{CoverArtArchiveClient, RemoteCover};
 use crate::import::parse_year;
 use crate::import::types::MetadataSource;
+use crate::import::ImportError;
 use crate::musicbrainz::{self, MbReleaseResponse, ReleaseSearchParams, SearchRelease};
 use crate::retry::retry_with_backoff;
 use crate::signals::LookupFailure;
@@ -220,12 +221,11 @@ async fn musicbrainz_releases_to_metadata(
 pub async fn search_mb(
     cover_art_archive: &CoverArtArchiveClient,
     params: ReleaseSearchParams,
-) -> Result<Vec<MetadataResult>, String> {
+) -> Result<Vec<MetadataResult>, ImportError> {
     let releases = retry_with_backoff(3, "MusicBrainz search", || {
         musicbrainz::search_releases_with_params(&params)
     })
-    .await
-    .map_err(|e| format!("MusicBrainz search failed: {e}"))?;
+    .await?;
 
     Ok(musicbrainz_releases_to_metadata(cover_art_archive, releases).await)
 }
@@ -324,7 +324,7 @@ fn build_mb_detail(
     release_id: &str,
     mb_response: &crate::musicbrainz::MbReleaseResponse,
     cover_art: Vec<RemoteCover>,
-) -> Result<ImportSearchReleaseDetail, String> {
+) -> Result<ImportSearchReleaseDetail, ImportError> {
     let year = parse_year(mb_response.date.as_deref());
 
     let mut side_base: u32 = 0;
@@ -393,7 +393,7 @@ fn build_mb_detail(
 pub async fn prefetch_mb_release(
     cover_art_archive: &CoverArtArchiveClient,
     release_id: &str,
-) -> Result<ImportSearchReleaseDetail, String> {
+) -> Result<ImportSearchReleaseDetail, ImportError> {
     let (response, _, _) = crate::import::musicbrainz_mapper::fetch_mb_response(release_id).await?;
     let release_group_id = response.release_group.as_ref().map(|rg| rg.id.as_str());
     let cover_art = cover_art_archive
@@ -410,7 +410,7 @@ pub async fn commit_mb_release(
     library_manager: &crate::library::LibraryManager,
     release_id: &str,
     discogs_client: Option<&DiscogsClient>,
-) -> Result<crate::import::folder_scanner::PreparedRelease, String> {
+) -> Result<crate::import::folder_scanner::PreparedRelease, ImportError> {
     let (response, external_urls, mut metadata_pairs) =
         crate::import::musicbrainz_mapper::fetch_mb_response(release_id).await?;
     let discogs_release = if let Some(client) = discogs_client {
@@ -518,11 +518,9 @@ fn build_discogs_detail(release: &crate::discogs::DiscogsRelease) -> ImportSearc
 pub async fn prefetch_discogs_release(
     client: &DiscogsClient,
     release_id: &str,
-) -> Result<ImportSearchReleaseDetail, String> {
+) -> Result<ImportSearchReleaseDetail, ImportError> {
     let (discogs_release, _master_year, _metadata_pairs) =
-        crate::import::commit::fetch_discogs_release(client, release_id)
-            .await
-            .map_err(|e| e.to_string())?;
+        crate::import::commit::fetch_discogs_release(client, release_id).await?;
     Ok(build_discogs_detail(&discogs_release))
 }
 
@@ -535,11 +533,9 @@ pub async fn commit_discogs_release(
     release_id: &str,
     clock: &dyn coven::Clock,
     ids: &dyn coven::IdProvider,
-) -> Result<crate::import::folder_scanner::PreparedRelease, String> {
+) -> Result<crate::import::folder_scanner::PreparedRelease, ImportError> {
     let (parsed, metadata_pairs) =
-        crate::import::commit::fetch_and_map_discogs(client, release_id, clock, ids)
-            .await
-            .map_err(|e| e.to_string())?;
+        crate::import::commit::fetch_and_map_discogs(client, release_id, clock, ids).await?;
     Ok(crate::import::folder_scanner::PreparedRelease {
         source: MetadataSource::Discogs,
         release_id: release_id.to_string(),
@@ -744,7 +740,11 @@ mod tests {
 
         let err = build_mb_detail("mb-release-1", &response, vec![])
             .expect_err("expected error for vinyl track without side letter");
-        assert!(err.contains("no side letter"), "unexpected error: {}", err);
+        assert!(
+            matches!(&err, ImportError::SourceData { detail, .. } if detail.contains("no side letter")),
+            "unexpected error: {}",
+            err
+        );
     }
 
     /// Assert the commit plane and the editor-seed plane assign identical

--- a/bae-core/src/import/service/cover_image.rs
+++ b/bae-core/src/import/service/cover_image.rs
@@ -21,8 +21,9 @@ impl ImportService {
         release_id: &str,
         discovered_files: &[DiscoveredFile],
         selected_cover_path: Option<&str>,
-    ) -> Result<Option<(crate::db::DbLibraryImage, Vec<u8>)>, String> {
+    ) -> Result<Option<(crate::db::DbLibraryImage, Vec<u8>)>, crate::import::ImportError> {
         use crate::db::{DbLibraryImage, LibraryImageType};
+        use crate::import::ImportError;
 
         let mut image_files: Vec<(&DiscoveredFile, &str)> = Vec::new();
         for f in discovered_files {
@@ -36,11 +37,11 @@ impl ImportService {
                 image_files
                     .iter()
                     .find(|(f, _)| f.relative_path == selected_path)
-                    .ok_or_else(|| {
-                        format!(
+                    .ok_or_else(|| ImportError::CoverArt {
+                        detail: format!(
                             "Selected cover {} not found among discovered images",
                             selected_path
-                        )
+                        ),
                     })?,
             )
         } else {
@@ -58,11 +59,11 @@ impl ImportService {
 
         // Read the cover bytes from the user's folder; the caller stores them in
         // coven's local store and writes the row.
-        let bytes = std::fs::read(&cover_file.path).map_err(|e| {
-            format!(
+        let bytes = std::fs::read(&cover_file.path).map_err(|e| ImportError::CoverArt {
+            detail: format!(
                 "Failed to read cover art {}: {e}",
                 cover_file.path.display()
-            )
+            ),
         })?;
 
         let now = self.library_manager.clock().now();

--- a/bae-core/src/import/service/format_prep.rs
+++ b/bae-core/src/import/service/format_prep.rs
@@ -11,6 +11,7 @@ use tracing::warn;
 
 use crate::db::{DbAudioFormat, DbAudioSegment, DbAudioSegmentRole};
 use crate::import::types::{CueAudioAnalysis, CueFlacAnalysis, TrackFile};
+use crate::import::ImportError;
 use crate::util::content_type::ContentType;
 use crate::util::content_type_hint::ContentTypeHint;
 
@@ -35,23 +36,43 @@ fn admitted_audio_content_type(content_type: &ContentType) -> bool {
 fn ensure_probe_audio_format(
     path: &Path,
     probe: &crate::audio_codec::ProbeResult,
-) -> Result<(), String> {
+) -> Result<(), ImportError> {
     if probe.sample_rate == 0 || probe.channels == 0 {
-        return Err(format!(
-            "unusable audio format in {}: sample_rate={}, channels={}",
-            path.display(),
-            probe.sample_rate,
-            probe.channels
-        ));
+        return Err(ImportError::TrackMapping {
+            detail: format!(
+                "unusable audio format in {}: sample_rate={}, channels={}",
+                path.display(),
+                probe.sample_rate,
+                probe.channels
+            ),
+        });
     }
     if !admitted_audio_content_type(&probe.content_type) {
-        return Err(format!(
-            "Unsupported audio codec {} in {}",
-            probe.content_type.display_name(),
-            path.display()
-        ));
+        return Err(ImportError::TrackMapping {
+            detail: format!(
+                "Unsupported audio codec {} in {}",
+                probe.content_type.display_name(),
+                path.display()
+            ),
+        });
     }
     Ok(())
+}
+
+/// Probe a file's audio format and validate it's admissible, returning the
+/// probe. The typed `TrackMapping` failure names a non-UTF-8 path, an
+/// unprobeable file, or an unusable/unsupported codec.
+fn probe_and_validate_audio(path: &Path) -> Result<crate::audio_codec::ProbeResult, ImportError> {
+    let path_str = path.to_str().ok_or_else(|| ImportError::TrackMapping {
+        detail: format!("Invalid path: {}", path.display()),
+    })?;
+    let probe = crate::audio_codec::probe_audio_from_path(path_str).ok_or_else(|| {
+        ImportError::TrackMapping {
+            detail: format!("Failed to probe audio file: {}", path.display()),
+        }
+    })?;
+    ensure_probe_audio_format(path, &probe)?;
+    Ok(probe)
 }
 
 /// Resolve the probe-verified `ContentType` for a discovered file.
@@ -62,21 +83,17 @@ fn ensure_probe_audio_format(
 /// that's an honest mapping for images (an extension on image bytes predicts
 /// the codec), text, and PDF. Anything the hint can't classify becomes
 /// `OctetStream`, which flows through the DB as-is.
-pub(super) fn resolve_file_content_type(path: &Path) -> Result<ContentType, String> {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .ok_or_else(|| format!("File has no extension: {:?}", path))?;
+pub(super) fn resolve_file_content_type(path: &Path) -> Result<ContentType, ImportError> {
+    let ext =
+        path.extension()
+            .and_then(|e| e.to_str())
+            .ok_or_else(|| ImportError::TrackMapping {
+                detail: format!("File has no extension: {:?}", path),
+            })?;
     let hint = ContentTypeHint::from_extension(ext);
 
     if hint.is_audio() {
-        let path_str = path
-            .to_str()
-            .ok_or_else(|| format!("Invalid path: {}", path.display()))?;
-        let probe = crate::audio_codec::probe_audio_from_path(path_str)
-            .ok_or_else(|| format!("Failed to probe audio file: {}", path.display()))?;
-        ensure_probe_audio_format(path, &probe)?;
-        return Ok(probe.content_type);
+        return Ok(probe_and_validate_audio(path)?.content_type);
     }
 
     Ok(match hint {
@@ -101,36 +118,42 @@ struct BuiltAudioFormat {
 fn cue_track_by_playable_index(
     cue_pair: &CueFlacAnalysis,
     cue_index: usize,
-) -> Result<&crate::cue_flac::CueTrack, String> {
+) -> Result<&crate::cue_flac::CueTrack, ImportError> {
     cue_pair
         .cue_sheet
         .playable_tracks()
         .nth(cue_index)
-        .ok_or_else(|| format!("CUE playable track index {cue_index} out of bounds"))
+        .ok_or_else(|| ImportError::TrackMapping {
+            detail: format!("CUE playable track index {cue_index} out of bounds"),
+        })
 }
 
 fn cue_file_analysis<'a>(
     cue_pair: &'a CueFlacAnalysis,
     file_reference: &str,
-) -> Result<&'a CueAudioAnalysis, String> {
+) -> Result<&'a CueAudioAnalysis, ImportError> {
     cue_pair
         .audio_files
         .iter()
         .find(|file| file.file_reference == file_reference)
         .map(|file| &file.analysis)
-        .ok_or_else(|| format!("CUE references unprobed audio file: {file_reference}"))
+        .ok_or_else(|| ImportError::Internal {
+            detail: format!("CUE references unprobed audio file: {file_reference}"),
+        })
 }
 
 fn cue_file_path<'a>(
     cue_pair: &'a CueFlacAnalysis,
     file_reference: &str,
-) -> Result<&'a Path, String> {
+) -> Result<&'a Path, ImportError> {
     cue_pair
         .audio_files
         .iter()
         .find(|file| file.file_reference == file_reference)
         .map(|file| file.path.as_path())
-        .ok_or_else(|| format!("CUE references unmapped audio file: {file_reference}"))
+        .ok_or_else(|| ImportError::Internal {
+            detail: format!("CUE references unmapped audio file: {file_reference}"),
+        })
 }
 
 /// Build track-level audio format metadata for a CUE-backed track.
@@ -140,7 +163,7 @@ fn cue_backed_audio_format(
     cue_index: usize,
     id: String,
     now: chrono::DateTime<chrono::Utc>,
-) -> Result<DbAudioFormat, String> {
+) -> Result<DbAudioFormat, ImportError> {
     let cue_track = cue_track_by_playable_index(cue_pair, cue_index)?;
     let cue_path = cue_file_path(cue_pair, &cue_track.file_reference)?;
 
@@ -187,13 +210,8 @@ fn standalone_probed_audio_format(
     file_path: &Path,
     id: String,
     now: chrono::DateTime<chrono::Utc>,
-) -> Result<crate::db::DbAudioFormat, String> {
-    let path_str = file_path
-        .to_str()
-        .ok_or_else(|| format!("Invalid path: {}", file_path.display()))?;
-    let probe = crate::audio_codec::probe_audio_from_path(path_str)
-        .ok_or_else(|| format!("Failed to probe audio file: {}", file_path.display()))?;
-    ensure_probe_audio_format(file_path, &probe)?;
+) -> Result<crate::db::DbAudioFormat, ImportError> {
+    let probe = probe_and_validate_audio(file_path)?;
 
     // A per-track file is its own whole-file source; the sample window lives in
     // its `audio_format_segments` row.
@@ -221,7 +239,7 @@ struct CueAnalysisFormat {
 fn cue_analysis_format(
     analysis: &CueAudioAnalysis,
     path: &Path,
-) -> Result<CueAnalysisFormat, String> {
+) -> Result<CueAnalysisFormat, ImportError> {
     let probe = &analysis.probe;
     ensure_probe_audio_format(path, probe)?;
     Ok(CueAnalysisFormat {
@@ -340,7 +358,7 @@ impl ImportService {
         byte_landings_by_file: &HashMap<PathBuf, Option<HashMap<u64, u64>>>,
         ids: &dyn coven::IdProvider,
         now: chrono::DateTime<chrono::Utc>,
-    ) -> Result<Vec<DbAudioSegment>, String> {
+    ) -> Result<Vec<DbAudioSegment>, ImportError> {
         let cue_track = cue_track_by_playable_index(cue_pair, cue_index)?;
         let main_path = cue_file_path(cue_pair, &cue_track.file_reference)?;
         let fmt = cue_analysis_format(
@@ -352,9 +370,14 @@ impl ImportService {
 
         if let crate::cue_flac::CuePregap::Audio(index) = &cue_track.pregap {
             let pregap_path = cue_file_path(cue_pair, &index.file_reference)?;
-            let pregap_file_id = file_ids.get(pregap_path).ok_or_else(|| {
-                format!("No DbFile registered for CUE pregap source {pregap_path:?}")
-            })?;
+            let pregap_file_id =
+                file_ids
+                    .get(pregap_path)
+                    .ok_or_else(|| ImportError::Internal {
+                        detail: format!(
+                            "No DbFile registered for CUE pregap source {pregap_path:?}"
+                        ),
+                    })?;
             let start_sample = index.frames * sample_rate / 75;
             let end_frames = if index.file_reference == cue_track.file_reference {
                 Some(cue_track.start_cue_frames)
@@ -383,7 +406,9 @@ impl ImportService {
 
         let main_file_id = file_ids
             .get(main_path)
-            .ok_or_else(|| format!("No DbFile registered for CUE source {main_path:?}"))?;
+            .ok_or_else(|| ImportError::Internal {
+                detail: format!("No DbFile registered for CUE source {main_path:?}"),
+            })?;
         let start_sample = cue_track.start_cue_frames * sample_rate / 75;
         let end_sample = cue_segment_end_frames(cue_pair, cue_index, &cue_track.file_reference)
             .map(|frames| frames * sample_rate / 75);
@@ -413,7 +438,7 @@ impl ImportService {
         file_ids: &HashMap<PathBuf, String>,
         clock: &dyn coven::Clock,
         ids: &dyn coven::IdProvider,
-    ) -> Result<BuiltAudioFormats, String> {
+    ) -> Result<BuiltAudioFormats, ImportError> {
         let now = clock.now();
         let mut audio_formats = Vec::with_capacity(tracks_to_files.len());
         let mut audio_segments = Vec::new();
@@ -457,9 +482,11 @@ impl ImportService {
                     db_track,
                     file_path,
                 } => {
-                    let file_id = file_ids.get(file_path).ok_or_else(|| {
-                        format!("No DbFile registered for track source {file_path:?}")
-                    })?;
+                    let file_id = file_ids
+                        .get(file_path)
+                        .ok_or_else(|| ImportError::Internal {
+                            detail: format!("No DbFile registered for track source {file_path:?}"),
+                        })?;
                     let af =
                         standalone_probed_audio_format(&db_track.id, file_path, ids.new_id(), now)?;
                     let segment = Self::audio_segment(
@@ -549,7 +576,10 @@ mod tests {
     #[test]
     fn resolve_file_content_type_errors_without_extension() {
         let error = resolve_file_content_type(Path::new("/x/README")).unwrap_err();
-        assert!(error.contains("no extension"), "got: {error}");
+        assert!(
+            matches!(&error, ImportError::TrackMapping { detail } if detail.contains("no extension")),
+            "got: {error}"
+        );
     }
 
     fn test_clock() -> coven::FixedClock {
@@ -759,7 +789,10 @@ FILE "Test Album.ape" WAVE
         let error = ensure_probe_audio_format(path, &probe_result(44_100, 0))
             .expect_err("zero channels should be rejected");
 
-        assert!(error.contains("unusable audio format"));
+        assert!(matches!(
+            &error,
+            ImportError::TrackMapping { detail } if detail.contains("unusable audio format")
+        ));
     }
 
     #[test]
@@ -769,7 +802,10 @@ FILE "Test Album.ape" WAVE
         let error = ensure_probe_audio_format(path, &probe_result(0, 2))
             .expect_err("zero sample rate should be rejected");
 
-        assert!(error.contains("unusable audio format"));
+        assert!(matches!(
+            &error,
+            ImportError::TrackMapping { detail } if detail.contains("unusable audio format")
+        ));
     }
 
     #[test]
@@ -808,7 +844,10 @@ FILE "test.flac" WAVE
             cue_backed_audio_format("track-id", &cue_pair, 0, "audio-format-id".to_string(), now)
                 .expect_err("zero-channel CUE audio format should fail");
 
-        assert!(error.contains("unusable audio format"));
+        assert!(matches!(
+            &error,
+            ImportError::TrackMapping { detail } if detail.contains("unusable audio format")
+        ));
     }
 
     #[test]

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -425,12 +425,16 @@ impl ImportService {
 
         if let Err(e) = result {
             error!("Import failed: {}", e);
+            // The typed error becomes a user-facing string only here, at the
+            // pipeline's terminal consumer. The variant Displays embed their
+            // `#[from]` source messages, so `to_string()` carries the chain.
+            let error = e.to_string();
 
             // No release to mark failed -- if import fails before the atomic
             // finalize, there's no release in the DB. Update the import record.
             if let Err(db_err) = self
                 .library_manager
-                .update_import_error(&import_id, &e)
+                .update_import_error(&import_id, &error)
                 .await
             {
                 error!("Failed to update import error: {}", db_err);
@@ -440,11 +444,7 @@ impl ImportService {
                 &self.event_tx,
                 crate::import::handle::ImportEvent::ImportProgress {
                     candidate_key,
-                    progress: ImportProgress::Failed {
-                        id: import_id.clone(),
-                        error: e,
-                        import_id,
-                    },
+                    progress: ImportProgress::Failed { error, import_id },
                 },
             );
         }
@@ -470,7 +470,7 @@ impl ImportService {
         pin: bool,
         identity_choice: crate::import::IdentityChoice,
         user_edit: Option<crate::import::ReleaseUserEdit>,
-    ) -> Result<(), String> {
+    ) -> Result<(), crate::import::ImportError> {
         let library_manager = &self.library_manager;
 
         let import_start = std::time::Instant::now();
@@ -487,15 +487,16 @@ impl ImportService {
             crate::import::folder_scanner::collect_release_candidate_files(&folder_buf)
         })
         .await
-        .map_err(|e| format!("Folder scan task failed: {e}"))??;
+        .map_err(|e| crate::import::ImportError::Internal {
+            detail: format!("Folder scan task failed: {e}"),
+        })??;
 
         // Content fingerprint of the folder tree. Used below to overwrite a
         // prior import of the same files, then stamped onto the new release row.
         let content_hash = categorized.content_hash();
         let replacement_plans = library_manager
             .import_replacement_plans_for_content_hash(&content_hash)
-            .await
-            .map_err(|e| format!("Failed to prepare prior import replacement: {e}"))?;
+            .await?;
         let replacement_release_ids: Vec<String> = replacement_plans
             .iter()
             .map(|plan| plan.db_delete.release_id.clone())
@@ -542,7 +543,9 @@ impl ImportService {
                     )
                 })
                 .await
-                .map_err(|e| format!("unknown-seed mapping task failed: {e}"))??;
+                .map_err(|e| crate::import::ImportError::Internal {
+                    detail: format!("unknown-seed mapping task failed: {e}"),
+                })??;
                 (parsed, Vec::new())
             }
         };
@@ -554,7 +557,9 @@ impl ImportService {
                 &import_id,
                 folder
                     .to_str()
-                    .ok_or_else(|| format!("Non-UTF-8 folder path: {:?}", folder))?,
+                    .ok_or_else(|| crate::import::ImportError::Internal {
+                        detail: format!("Non-UTF-8 folder path: {:?}", folder),
+                    })?,
                 &identity_choice,
                 user_edit,
                 &replacement_release_ids,
@@ -597,24 +602,25 @@ impl ImportService {
         // at cover-select time; if so this is a cache hit. The download
         // function returns the content type from the HTTP response,
         // so no magic-byte sniffing is required here.
-        let remote_cover_data =
-            if let Some(CoverSelection::Remote(ref url, source)) = selected_cover {
-                emit_preparing(PrepareStep::WritingCoverArt);
-                let (bytes, content_type) =
-                    crate::import::cover_art::download_cover_art_bytes(url).await?;
-                if matches!(
-                    content_type,
-                    crate::util::content_type::ContentType::OctetStream
-                ) {
-                    return Err(
-                        "Cover bytes aren't a recognized image format (PNG/JPEG/GIF/WebP/BMP)"
-                            .to_string(),
-                    );
-                }
-                Some((bytes, content_type, url.clone(), source))
-            } else {
-                None
-            };
+        let remote_cover_data = if let Some(CoverSelection::Remote(ref url, source)) =
+            selected_cover
+        {
+            emit_preparing(PrepareStep::WritingCoverArt);
+            let (bytes, content_type) =
+                crate::import::cover_art::download_cover_art_bytes(url).await?;
+            if matches!(
+                content_type,
+                crate::util::content_type::ContentType::OctetStream
+            ) {
+                return Err(crate::import::ImportError::CoverArt {
+                    detail: "Cover bytes aren't a recognized image format (PNG/JPEG/GIF/WebP/BMP)"
+                        .to_string(),
+                });
+            }
+            Some((bytes, content_type, url.clone(), source))
+        } else {
+            None
+        };
 
         step_times.push(("write_cover_art", last_step_start.elapsed()));
         last_step_start = std::time::Instant::now();
@@ -655,7 +661,9 @@ impl ImportService {
                 crate::import::file_tag_mapper::read_embedded_cover(&audio_paths)
             })
             .await
-            .map_err(|e| format!("embedded-cover read task failed: {e}"))??
+            .map_err(|e| crate::import::ImportError::Internal {
+                detail: format!("embedded-cover read task failed: {e}"),
+            })??
         } else {
             None
         };
@@ -806,7 +814,7 @@ impl ImportService {
         embedded_cover: Option<(Vec<u8>, crate::util::content_type::ContentType)>,
         db_metadata: &[DbReleaseMetadata],
         replacement_plans: &[crate::library::manager::ImportReplacementPlan],
-    ) -> Result<(), String> {
+    ) -> Result<(), crate::import::ImportError> {
         let library_manager = &self.library_manager;
         let total_files = discovered_files.len();
         let PreparedMetadata {
@@ -863,20 +871,26 @@ impl ImportService {
         let local_root = {
             let mut ancestor: Option<&Path> = None;
             for file in discovered_files.iter() {
-                let parent = file
-                    .path
-                    .parent()
-                    .ok_or_else(|| format!("File has no parent: {:?}", file.path))?;
+                let parent =
+                    file.path
+                        .parent()
+                        .ok_or_else(|| crate::import::ImportError::Internal {
+                            detail: format!("File has no parent: {:?}", file.path),
+                        })?;
                 ancestor = Some(match ancestor {
                     None => parent,
                     Some(a) => common_ancestor(a, parent),
                 });
             }
-            ancestor.ok_or_else(|| "No files to determine local path".to_string())?
+            ancestor.ok_or_else(|| crate::import::ImportError::Internal {
+                detail: "No files to determine local path".to_string(),
+            })?
         };
         let local_path = local_root
             .to_str()
-            .ok_or_else(|| format!("Cannot convert path to string: {:?}", local_root))?
+            .ok_or_else(|| crate::import::ImportError::Internal {
+                detail: format!("Cannot convert path to string: {:?}", local_root),
+            })?
             .to_string();
 
         // Per-track progress jumps to 100% immediately — files are referenced in
@@ -959,11 +973,9 @@ impl ImportService {
             if self.library_manager.get_config().verify_decode_on_import
                 && !loudness.broken.is_empty()
             {
-                return Err(format!(
-                    "decode verification failed for {} track(s): {}",
-                    loudness.broken.len(),
-                    loudness.broken.join("; ")
-                ));
+                return Err(crate::import::ImportError::DecodeVerification {
+                    broken: loudness.broken,
+                });
             }
         }
 
@@ -1003,7 +1015,8 @@ impl ImportService {
         // `finalize_import_atomic` derives from it must say JPEG too.
         let cover_winner = match cover_winner {
             Some((mut image, bytes)) => {
-                let bytes = crate::util::cover::resize_cover(&bytes)?;
+                let bytes = crate::util::cover::resize_cover(&bytes)
+                    .map_err(|detail| crate::import::ImportError::CoverArt { detail })?;
                 image.content_type = crate::util::content_type::ContentType::Jpeg;
                 image.file_size = bytes.len() as i64;
                 Some((image, bytes))
@@ -1061,8 +1074,7 @@ impl ImportService {
                 &local_path,
                 replacement_plans,
             )
-            .await
-            .map_err(|e| format!("Failed to finalize import: {}", e))?;
+            .await?;
 
         // A Remote import transitions to the cloud in the background — the same
         // flow the "Make Remote" action runs: coven uploads each file from its
@@ -1083,11 +1095,15 @@ impl ImportService {
                     .fail_import_and_delete_release(import_id, &db_release.id, &remote_error)
                     .await
                 {
-                    return Err(format!(
-                        "{remote_error}; removing release and marking import failed failed: {import_error}"
-                    ));
+                    return Err(crate::import::ImportError::Internal {
+                        detail: format!(
+                            "{remote_error}; removing release and marking import failed failed: {import_error}"
+                        ),
+                    });
                 }
-                return Err(remote_error);
+                return Err(crate::import::ImportError::Db(
+                    crate::library::LibraryError::Storage(remote_error),
+                ));
             }
         }
 
@@ -1220,18 +1236,20 @@ fn apply_user_edit_to_seed(
     track_artists: &mut Vec<crate::db::DbTrackArtist>,
     clock: &dyn coven::Clock,
     ids: &dyn coven::IdProvider,
-) -> Result<(), String> {
+) -> Result<(), crate::import::ImportError> {
     use crate::db::{DbAlbumArtist, DbArtist, DbTrackArtist};
 
     if edit.album_artist_names.is_empty() {
-        return Err("Album must have at least one artist".to_string());
+        return Err(crate::import::EditValidationError::NoAlbumArtist.into());
     }
     if edit.tracks.len() != db_tracks.len() {
-        return Err(format!(
-            "Track count mismatch: seed has {} tracks, edit supplies {}",
-            db_tracks.len(),
-            edit.tracks.len()
-        ));
+        return Err(crate::import::ImportError::Internal {
+            detail: format!(
+                "Track count mismatch: seed has {} tracks, edit supplies {}",
+                db_tracks.len(),
+                edit.tracks.len()
+            ),
+        });
     }
 
     let now = clock.now();
@@ -1267,7 +1285,9 @@ fn apply_user_edit_to_seed(
             .iter()
             .find(|a| a.id == db_album.artist_id)
             .map(|a| a.name.clone())
-            .ok_or_else(|| "primary album artist missing from artists vec".to_string())?;
+            .ok_or_else(|| crate::import::ImportError::Internal {
+                detail: "primary album artist missing from artists vec".to_string(),
+            })?;
         names.push(primary);
         let mut junction = album_artists.clone();
         junction.sort_by_key(|aa| aa.position);
@@ -1276,8 +1296,8 @@ fn apply_user_edit_to_seed(
                 .iter()
                 .find(|a| a.id == aa.artist_id)
                 .map(|a| a.name.clone())
-                .ok_or_else(|| {
-                    format!("album_artist references missing artist {}", aa.artist_id)
+                .ok_or_else(|| crate::import::ImportError::Internal {
+                    detail: format!("album_artist references missing artist {}", aa.artist_id),
                 })?;
             names.push(name);
         }
@@ -1336,8 +1356,8 @@ fn apply_user_edit_to_seed(
                     .iter()
                     .find(|a| a.id == ta.artist_id)
                     .map(|a| a.name.clone())
-                    .ok_or_else(|| {
-                        format!("track_artist references missing artist {}", ta.artist_id)
+                    .ok_or_else(|| crate::import::ImportError::Internal {
+                        detail: format!("track_artist references missing artist {}", ta.artist_id),
                     })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -1401,12 +1421,12 @@ pub(crate) fn common_ancestor<'a>(a: &'a Path, b: &Path) -> &'a Path {
 pub(crate) async fn prepare_release(
     library_manager: &LibraryManager,
     release_ref: &MetadataRef,
-) -> Result<crate::import::folder_scanner::PreparedRelease, String> {
+) -> Result<crate::import::folder_scanner::PreparedRelease, crate::import::ImportError> {
     match release_ref.source {
         MetadataSource::MusicBrainz => {
             let discogs_client = library_manager
                 .discogs_client()
-                .map_err(|e| format!("Failed to read Discogs key: {e}"))?;
+                .map_err(|detail| crate::import::ImportError::Config { detail })?;
             crate::import::search::commit_mb_release(
                 library_manager,
                 &release_ref.id,
@@ -1417,8 +1437,8 @@ pub(crate) async fn prepare_release(
         MetadataSource::Discogs => {
             let client = library_manager
                 .discogs_client()
-                .map_err(|e| format!("Failed to read Discogs key: {e}"))?
-                .ok_or_else(|| "Discogs API key not configured".to_string())?;
+                .map_err(|detail| crate::import::ImportError::Config { detail })?
+                .ok_or(crate::import::ImportError::DiscogsNotConfigured)?;
             crate::import::search::commit_discogs_release(
                 &client,
                 &release_ref.id,
@@ -1426,7 +1446,6 @@ pub(crate) async fn prepare_release(
                 library_manager.ids().as_ref(),
             )
             .await
-            .map_err(|e| format!("Failed to fetch Discogs release: {e}"))
         }
     }
 }

--- a/bae-core/src/import/service/reconcile.rs
+++ b/bae-core/src/import/service/reconcile.rs
@@ -65,7 +65,7 @@ impl ImportService {
         identity_choice: &crate::import::IdentityChoice,
         user_edit: Option<crate::import::ReleaseUserEdit>,
         replacement_release_ids: &[String],
-    ) -> Result<PreparedMetadata, String> {
+    ) -> Result<PreparedMetadata, crate::import::ImportError> {
         let library_manager = &self.library_manager;
 
         let crate::import::ParsedAlbum {
@@ -141,15 +141,9 @@ impl ImportService {
             source_path,
             library_manager.clock().now(),
         );
-        library_manager
-            .insert_import(&db_import)
-            .await
-            .map_err(|e| format!("Failed to create import record: {}", e))?;
+        library_manager.insert_import(&db_import).await?;
 
-        let resolved = library_manager
-            .resolve_artists_for_import(&artists)
-            .await
-            .map_err(|e| format!("Failed to resolve artists: {e}"))?;
+        let resolved = library_manager.resolve_artists_for_import(&artists).await?;
 
         let artist_id_map: HashMap<String, String> = artists
             .iter()
@@ -159,11 +153,11 @@ impl ImportService {
 
         let remapped_primary_artist_id = artist_id_map
             .get(&db_album.artist_id)
-            .ok_or_else(|| {
-                format!(
+            .ok_or_else(|| crate::import::ImportError::Internal {
+                detail: format!(
                     "Primary artist ID {} not found in artist map",
                     db_album.artist_id
-                )
+                ),
             })?
             .clone();
         db_album.artist_id = remapped_primary_artist_id;
@@ -198,7 +192,7 @@ impl ImportService {
 
         let discogs_client = library_manager
             .discogs_client()
-            .map_err(|e| format!("Failed to read Discogs key: {e}"))?;
+            .map_err(|detail| crate::import::ImportError::Config { detail })?;
         let artist_images = if let Some(ref discogs_client) = discogs_client {
             fetch_artist_images(library_manager, discogs_client, &artists, &artist_id_map).await
         } else {

--- a/bae-core/src/import/service/tests.rs
+++ b/bae-core/src/import/service/tests.rs
@@ -166,7 +166,7 @@ async fn explicit_local_cover_missing_from_discovered_images_is_an_error() {
         .unwrap_err();
 
     assert!(
-        err.contains("Selected cover") && err.contains("not found"),
+        matches!(&err, crate::import::ImportError::CoverArt { detail } if detail.contains("Selected cover") && detail.contains("not found")),
         "got: {err}"
     );
 }
@@ -180,7 +180,7 @@ async fn explicit_local_cover_with_no_discovered_images_is_an_error() {
         .unwrap_err();
 
     assert!(
-        err.contains("Selected cover") && err.contains("not found"),
+        matches!(&err, crate::import::ImportError::CoverArt { detail } if detail.contains("Selected cover") && detail.contains("not found")),
         "got: {err}"
     );
 }
@@ -212,7 +212,7 @@ async fn selected_local_cover_path_must_match_discovered_file() {
 
     let err = result.unwrap_err();
     assert!(
-        err.contains("Selected cover cover.bmp not found"),
+        matches!(&err, crate::import::ImportError::CoverArt { detail } if detail.contains("Selected cover cover.bmp not found")),
         "got: {err}"
     );
 }
@@ -297,7 +297,10 @@ async fn unreadable_selected_cover_is_an_error() {
 
     std::fs::set_permissions(&cover, std::fs::Permissions::from_mode(0o600)).unwrap();
     let err = result.unwrap_err();
-    assert!(err.contains("Failed to read cover art"), "got: {err}");
+    assert!(
+        matches!(&err, crate::import::ImportError::CoverArt { detail } if detail.contains("Failed to read cover art")),
+        "got: {err}"
+    );
 }
 
 async fn rescan_seeded_root(
@@ -756,7 +759,10 @@ fn user_edit_track_count_mismatch_is_an_error() {
         &SequentialIdProvider::new("seed"),
     )
     .unwrap_err();
-    assert!(err.contains("Track count mismatch"), "got: {err}");
+    assert!(
+        matches!(&err, crate::import::ImportError::Internal { detail } if detail.contains("Track count mismatch")),
+        "got: {err}"
+    );
 }
 
 /// Source-id linkage on artist rows (e.g. `musicbrainz_artist_id`)

--- a/bae-core/src/import/track_to_file_mapper.rs
+++ b/bae-core/src/import/track_to_file_mapper.rs
@@ -4,6 +4,7 @@ use crate::import::folder_scanner::{
     AudioContent, CategorizedFiles, ScannedCueFlacPair, ScannedFile,
 };
 use crate::import::types::{CueAnalyzedAudioFile, CueAudioAnalysis, CueFlacAnalysis, TrackFile};
+use crate::import::ImportError;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -21,7 +22,7 @@ use tracing::{debug, info, warn};
 pub fn map_tracks_to_files(
     tracks: Vec<DbTrack>,
     files: &CategorizedFiles,
-) -> Result<Vec<TrackFile>, String> {
+) -> Result<Vec<TrackFile>, ImportError> {
     info!("Mapping {} tracks using scan output", tracks.len());
     match &files.audio {
         AudioContent::CueFlacPairs { pairs, .. } => map_tracks_to_cue_flacs(tracks, pairs),
@@ -34,9 +35,11 @@ pub fn map_tracks_to_files(
 fn map_tracks_to_cue_flacs(
     tracks: Vec<DbTrack>,
     pairs: &[ScannedCueFlacPair],
-) -> Result<Vec<TrackFile>, String> {
+) -> Result<Vec<TrackFile>, ImportError> {
     if pairs.is_empty() {
-        return Err("CUE/FLAC import has no pairs".to_string());
+        return Err(ImportError::TrackMapping {
+            detail: "CUE/FLAC import has no pairs".to_string(),
+        });
     }
 
     // Natural-sort pairs by relative path: CD1, CD2, ... CD10, and Side A,
@@ -50,11 +53,13 @@ fn map_tracks_to_cue_flacs(
     let per_pair_counts: Vec<usize> = sheets.iter().map(|s| s.playable_track_count()).collect();
     let total_cue_tracks: usize = per_pair_counts.iter().sum();
     if total_cue_tracks != tracks.len() {
-        return Err(format!(
-            "Track count mismatch: CUE pairs contain {} tracks in total but release has {} tracks",
-            total_cue_tracks,
-            tracks.len(),
-        ));
+        return Err(ImportError::TrackMapping {
+            detail: format!(
+                "Track count mismatch: CUE pairs contain {} tracks in total but release has {} tracks",
+                total_cue_tracks,
+                tracks.len(),
+            ),
+        });
     }
 
     let mut track_files = Vec::with_capacity(tracks.len());
@@ -78,7 +83,7 @@ fn map_tracks_to_cue_flacs(
 fn map_tracks_to_cue_flac(
     pair: &ScannedCueFlacPair,
     tracks: Vec<DbTrack>,
-) -> Result<Vec<TrackFile>, String> {
+) -> Result<Vec<TrackFile>, ImportError> {
     let cue_sheet = pair.cue_sheet.clone();
     debug!(
         "Processing CUE/FLAC pair: {} + {} ({} tracks)",
@@ -87,10 +92,12 @@ fn map_tracks_to_cue_flac(
         cue_sheet.playable_track_count()
     );
     if cue_sheet.playable_track_count() == 0 {
-        return Err(format!(
-            "CUE sheet '{}' contains no playable audio tracks. Check CUE file format.",
-            pair.cue_file.path.display(),
-        ));
+        return Err(ImportError::TrackMapping {
+            detail: format!(
+                "CUE sheet '{}' contains no playable audio tracks. Check CUE file format.",
+                pair.cue_file.path.display(),
+            ),
+        });
     }
     // Caller pre-sliced `tracks` to match the CUE's track count, so the
     // zip-by-index below is always exact.
@@ -104,7 +111,9 @@ fn map_tracks_to_cue_flac(
         .cue_file
         .path
         .parent()
-        .ok_or_else(|| format!("CUE file has no parent: {:?}", pair.cue_file.path))?;
+        .ok_or_else(|| ImportError::TrackMapping {
+            detail: format!("CUE file has no parent: {:?}", pair.cue_file.path),
+        })?;
     let mut analyzed_files = Vec::new();
     for file_reference in cue_sheet.audio_file_references() {
         let path = cue_dir.join(file_reference);
@@ -162,7 +171,7 @@ fn main_file_analysis<'a>(
         .map(|file| &file.analysis)
 }
 
-fn ensure_cue_segment_formats_match(files: &[CueAnalyzedAudioFile]) -> Result<(), String> {
+fn ensure_cue_segment_formats_match(files: &[CueAnalyzedAudioFile]) -> Result<(), ImportError> {
     let Some(first) = files.first() else {
         return Ok(());
     };
@@ -174,7 +183,9 @@ fn ensure_cue_segment_formats_match(files: &[CueAnalyzedAudioFile]) -> Result<()
             || probe.bits_per_sample != baseline.bits_per_sample
             || probe.channels != baseline.channels
         {
-            return Err("CUE references audio files with incompatible formats".to_string());
+            return Err(ImportError::TrackMapping {
+                detail: "CUE references audio files with incompatible formats".to_string(),
+            });
         }
     }
     Ok(())
@@ -196,12 +207,19 @@ fn extract_duration_from_file(file_path: &std::path::Path) -> Option<i64> {
 }
 
 /// Probe a CUE-backed container through FFmpeg.
-pub(crate) fn analyze_cue_audio(audio_path: &std::path::Path) -> Result<CueAudioAnalysis, String> {
+pub(crate) fn analyze_cue_audio(
+    audio_path: &std::path::Path,
+) -> Result<CueAudioAnalysis, ImportError> {
     let path_str = audio_path
         .to_str()
-        .ok_or_else(|| format!("Non-UTF-8 audio path: {:?}", audio_path))?;
-    let probe = crate::audio_codec::probe_audio_from_path(path_str)
-        .ok_or_else(|| format!("Failed to probe CUE audio file: {:?}", audio_path))?;
+        .ok_or_else(|| ImportError::TrackMapping {
+            detail: format!("Non-UTF-8 audio path: {:?}", audio_path),
+        })?;
+    let probe = crate::audio_codec::probe_audio_from_path(path_str).ok_or_else(|| {
+        ImportError::TrackMapping {
+            detail: format!("Failed to probe CUE audio file: {:?}", audio_path),
+        }
+    })?;
     match probe.content_type {
         crate::util::content_type::ContentType::Flac
         | crate::util::content_type::ContentType::Ape
@@ -209,27 +227,33 @@ pub(crate) fn analyze_cue_audio(audio_path: &std::path::Path) -> Result<CueAudio
         | crate::util::content_type::ContentType::Pcm
         | crate::util::content_type::ContentType::WavPack
         | crate::util::content_type::ContentType::Dsd => Ok(CueAudioAnalysis { probe }),
-        other => Err(format!(
-            "CUE audio expects FLAC, APE, ALAC, PCM, WavPack, or DSD, got {} in {:?}",
-            other.display_name(),
-            audio_path
-        )),
+        other => Err(ImportError::TrackMapping {
+            detail: format!(
+                "CUE audio expects FLAC, APE, ALAC, PCM, WavPack, or DSD, got {} in {:?}",
+                other.display_name(),
+                audio_path
+            ),
+        }),
     }
 }
 
 fn map_tracks_to_individual_files(
     tracks: Vec<DbTrack>,
     audio_files: &[ScannedFile],
-) -> Result<Vec<TrackFile>, String> {
+) -> Result<Vec<TrackFile>, ImportError> {
     if audio_files.is_empty() {
-        return Err("No audio files found in discovered files".to_string());
+        return Err(ImportError::TrackMapping {
+            detail: "No audio files found in discovered files".to_string(),
+        });
     }
     if audio_files.len() != tracks.len() {
-        return Err(format!(
-            "Track count mismatch: found {} audio files but have {} tracks",
-            audio_files.len(),
-            tracks.len(),
-        ));
+        return Err(ImportError::TrackMapping {
+            detail: format!(
+                "Track count mismatch: found {} audio files but have {} tracks",
+                audio_files.len(),
+                tracks.len(),
+            ),
+        });
     }
     // Audio order within a release is already the scan's natural sort
     // (relative_path). The mapper preserves that order when zipping to
@@ -414,8 +438,10 @@ mod tests {
         let tracks = create_test_tracks(2);
         let files = categorized_track_files(Vec::new(), "FLAC");
         let result = map_tracks_to_files(tracks, &files);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("No audio files found"));
+        assert!(matches!(
+            result.unwrap_err(),
+            ImportError::TrackMapping { detail } if detail.contains("No audio files found")
+        ));
     }
     #[test]
     fn test_map_tracks_to_files_more_tracks_than_files() {
@@ -425,8 +451,10 @@ mod tests {
             "FLAC",
         );
         let result = map_tracks_to_files(tracks, &files);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Track count mismatch"));
+        assert!(matches!(
+            result.unwrap_err(),
+            ImportError::TrackMapping { detail } if detail.contains("Track count mismatch")
+        ));
     }
     #[test]
     fn test_map_tracks_to_files_more_files_than_tracks() {
@@ -441,8 +469,10 @@ mod tests {
             "FLAC",
         );
         let result = map_tracks_to_files(tracks, &files);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Track count mismatch"));
+        assert!(matches!(
+            result.unwrap_err(),
+            ImportError::TrackMapping { detail } if detail.contains("Track count mismatch")
+        ));
     }
     #[test]
     fn test_map_tracks_to_files_multi_disc_cue_flac() {
@@ -617,7 +647,10 @@ mod tests {
             ];
             let err = ensure_cue_segment_formats_match(&files)
                 .expect_err("divergent container formats must be rejected");
-            assert!(err.contains("incompatible formats"), "got: {err}");
+            assert!(
+                matches!(&err, ImportError::TrackMapping { detail } if detail.contains("incompatible formats")),
+                "got: {err}"
+            );
         }
     }
 

--- a/bae-core/src/import/types.rs
+++ b/bae-core/src/import/types.rs
@@ -511,7 +511,6 @@ pub enum ImportProgress {
         album_id: String,
     },
     Failed {
-        id: String,
         error: String,
         import_id: String,
     },

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -111,6 +111,17 @@ pub enum LibraryError {
     Playback(String),
 }
 
+impl From<crate::import::ImportError> for LibraryError {
+    /// The re-identify / reset-from-source paths run import mappers but report
+    /// through `LibraryError`; a mapper failure becomes an `Import` error with
+    /// the typed error's Display as the message. (`ImportError` carries
+    /// `Db(#[from] LibraryError)` for the other direction — the two are
+    /// distinct conversions.)
+    fn from(value: crate::import::ImportError) -> Self {
+        LibraryError::Import(value.to_string())
+    }
+}
+
 /// Current sync status for query callers. Event subscribers receive the same
 /// fields as transition events; this snapshot is the current value.
 #[derive(Debug, Clone)]

--- a/bae-core/src/library/manager/release.rs
+++ b/bae-core/src/library/manager/release.rs
@@ -48,7 +48,7 @@ impl LibraryManager {
     pub async fn find_existing_album_for_import(
         &self,
         identities: &[crate::import::ReleaseIdentity],
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, crate::import::ImportError> {
         self.find_existing_album_for_import_excluding(identities, &[])
             .await
     }
@@ -57,7 +57,7 @@ impl LibraryManager {
         &self,
         identities: &[crate::import::ReleaseIdentity],
         excluded_release_ids: &[String],
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<String>, crate::import::ImportError> {
         if identities.is_empty() {
             return Ok(None);
         }
@@ -68,12 +68,11 @@ impl LibraryManager {
             .database
             .find_album_by_identity_release_excluding(identities, excluded_release_ids)
             .await
-            .map_err(|e| format!("Database error: {e}"))?
+            .map_err(|e| crate::import::ImportError::Db(LibraryError::Database(e)))?
         {
-            return Err(format!(
-                "This release is already in your library as \"{}\"",
-                existing.title,
-            ));
+            return Err(crate::import::ImportError::AlreadyInLibrary {
+                album_title: existing.title,
+            });
         }
 
         // 2. Cross-source merge: any group identity matching a row already
@@ -82,7 +81,7 @@ impl LibraryManager {
             .database
             .find_album_by_identity_group_excluding_many(identities, excluded_release_ids)
             .await
-            .map_err(|e| format!("Database error: {e}"))?;
+            .map_err(|e| crate::import::ImportError::Db(LibraryError::Database(e)))?;
 
         Ok(album_id)
     }
@@ -238,9 +237,7 @@ impl LibraryManager {
 
         let (new_identities, metadata_pointer, metadata_pairs) = match &identity_choice {
             IdentityChoice::Exact { release_ref } | IdentityChoice::Approximate { release_ref } => {
-                let prepared = crate::import::service::prepare_release(self, release_ref)
-                    .await
-                    .map_err(LibraryError::Import)?;
+                let prepared = crate::import::service::prepare_release(self, release_ref).await?;
 
                 // Source pressing track count must match the local
                 // release's row count. The folder-import path enforces
@@ -856,7 +853,7 @@ async fn project_musicbrainz_from_cache(
         clock,
         ids,
     )
-    .map_err(LibraryError::Import)
+    .map_err(LibraryError::from)
 }
 
 /// Project cached Discogs `release_metadata` rows back into a
@@ -914,7 +911,7 @@ async fn project_discogs_from_cache(
         clock,
         ids,
     )
-    .map_err(LibraryError::Import)
+    .map_err(LibraryError::from)
 }
 
 /// Project the embedded tags of a release's local audio files into a
@@ -968,7 +965,7 @@ async fn project_file_tags(
     })
     .await
     .map_err(|e| LibraryError::Import(format!("file-tag mapping task failed: {e}")))?
-    .map_err(LibraryError::Import)
+    .map_err(LibraryError::from)
 }
 
 /// The cover [`ImageRef`] for one release from its `covers` row's `_updated_at`,


### PR DESCRIPTION
The import pipeline threaded every failure through `Result<_, String>`, wrapping the message with `format!` at each layer it crossed. By the time `do_import` received one, a retryable MusicBrainz timeout, a malformed Discogs payload, a finalize-transaction failure, and a decode-verification failure were all the same opaque string — the wire-level distinctions the MusicBrainz and Discogs clients already preserve were destroyed at the very first `map_err`, and no consumer could tell a transient network blip from a permanent bad-data condition.

This adds `ImportError`, one variant per distinguishable failure the pipeline actually produces. The wire-level source errors compose structurally through `#[from]` — `MusicBrainz(MusicBrainzError)`, `Discogs(DiscogsError)`, `Scan`, `InvalidFolder`, `Edit`, `Db` — so a MusicBrainz timeout arrives at the terminal consumer as a matchable `MusicBrainz(Timeout)`, retryability intact. The malformed-input classes (`SourceData`, `FileTags`, `TrackMapping`, `CoverArt`, `Registry`, `Config`, `Internal`) carry today's `format!` messages as a `detail` string under the typed umbrella: their *class* is the load-bearing distinction, and enumerating every malformed-input shape would be a taxonomy nothing dispatches on.

Every fallible function under `import/` now returns `Result<_, ImportError>` (or one of the narrower typed errors that convert into it), and the intra-layer `map_err(format!)` re-wraps are deleted — a plain `?` once producers are typed. The only place the error becomes a string is `do_import`'s terminal boundary, where it feeds the user-facing `ImportProgress::Failed { error }` event, which is unchanged.

Along the way: `CommitError` is removed (its Discogs and typed-mapper variants fold into `ImportError`); `FolderScanError` gains a `thiserror::Error` derive so `#[from]` and source chaining work; and the duplicate-vs-DB-error conflation is fixed where it originates — `find_existing_album_for_import` now yields a typed `AlreadyInLibrary` for a per-pressing duplicate versus `Db` for a real database fault, instead of packing both into one string.

`ImportProgress::Failed` drops its `id` field: it was a dead duplicate of `import_id` (a failed import never reached the atomic finalize, so it has no release row), and the sole release-filtered subscriber never matched it. The automation mirror and its serde-tagged JSON wire shape follow — no `bae-mcp` consumer read the field.

Two audit items are resolved explicitly rather than skipped: there is no cancellation path anywhere in the import pipeline (no cancel token reaches the worker, nothing string-matches "cancel"), so there is no `Cancelled` variant; and no `is_retryable()` method is added — the variant structure preserves exactly what a retry policy would read, but `do_import` has no retry loop, so a method with no consumer would be dead.

One deviation from the plan: the `SourceData` field is named `metadata_source`, not `source`. `thiserror` reserves a field literally named `source` for the error-chain source, which a `MetadataSource` (not an `Error`) can't be. The `cover_art` HTTP-client cache cell also stays `Result<_, String>` internally because `reqwest::Client`'s builder error isn't `Clone` and the cell is cloned on every read; the typed `CoverArt` wrapper is applied at each call.

## Test plan
- `cargo test -p bae-core --features test-utils` — all pass, including retargeted assertions (error-string checks became `matches!` on the variant plus a `detail`-contains where the message is the contract) and two new tests: `MusicBrainzError`/`DiscogsError` survive the `#[from]` conversion un-flattened, and `collect_release_candidate_files` on an invalid folder yields `InvalidFolder`.
- `cargo test -p bae-bridge` and `cargo test -p bae-automation` — pass (recompile + Failed-field-drop mirror).
- `cargo clippy` on `bae-core`, `bae-bridge`, `bae-automation` — clean.
- Pre-commit hook (fmt, clippy lib+tests, bae-bridge clippy, loc-gen) — passed. macOS build not exercised: no bridge or macOS files changed, and no `uniffi` type changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EH8tSJH1vng8zBtCAYaxe