### PR TITLE
Fix DispatcherQueue ambiguity breaking the Windows build

### DIFF
--- a/bae-windows/Views/SettingsDialog.cs
+++ b/bae-windows/Views/SettingsDialog.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using uniffi.bae_bridge;
 using Windows.System;
+// `Windows.System` (needed for VirtualKey) also declares a DispatcherQueue;
+// alias the WinUI one so the unqualified name stays unambiguous (CS0104).
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 
 namespace Bae.Windows;
 


### PR DESCRIPTION
PR #305's SettingsDialog imports both `Microsoft.UI.Dispatching` (for DispatcherQueue) and `Windows.System` (for VirtualKey); both namespaces declare a `DispatcherQueue`, so the unqualified references fail with CS0104 and every Windows CI run on main fails at the WinUI compile. Alias the WinUI type.

## Test plan
- [ ] Windows CI build (the failing step; C# compiles only there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)