### PR TITLE
Clear the queue pane when uploads finish; drop the Done state from the UI

### DIFF
--- a/BaeKit/Sources/BaeKit/BridgeUploadProgress+Derived.swift
+++ b/BaeKit/Sources/BaeKit/BridgeUploadProgress+Derived.swift
@@ -1,13 +1,6 @@
 import Foundation
 
 extension BridgeUploadProgress {
-    /// True when this slice of the queue holds no queued, active, or failed
-    /// work. Files already shipped (`done`) don't count — a fully-uploaded
-    /// release is idle even while its done row lingers in the queue pane.
-    public var isIdle: Bool {
-        queued == 0 && active == 0 && failed == 0
-    }
-
     /// Total queued + active + failed (i.e. anything not yet shipped). Drives
     /// the storage row's "Uploading (N)" badge.
     public var pending: UInt32 {
@@ -23,15 +16,13 @@ extension BridgeUploadProgress {
         return Double(bytesDone) / Double(bytesTotal)
     }
 
-    /// Byte progress for a queue row: "45.2 MB of 103.1 MB" while work
-    /// remains, or just the total once everything shipped.
+    /// Byte progress for a queue row: "45.2 MB of 103.1 MB", cumulative over
+    /// the queue burst.
     public var bytesText: String {
-        let total = Int64(bytesTotal).formatted(.byteCount(style: .file))
-        guard !isIdle else { return total }
-        return String(
+        String(
             format: QueueSummary.message("core.outbox.bytes_progress"),
             Int64(bytesDone).formatted(.byteCount(style: .file)),
-            total
+            Int64(bytesTotal).formatted(.byteCount(style: .file))
         )
     }
 }

--- a/BaeKit/Sources/BaeKit/Services/Store/OutboxStore.swift
+++ b/BaeKit/Sources/BaeKit/Services/Store/OutboxStore.swift
@@ -28,22 +28,18 @@ public class OutboxStore {
 
     /// Whether the release has upload work queued or in flight. Drives the
     /// storage row's "Cancel Upload" affordance and the suppression of other
-    /// storage actions while a transfer is mid-flight. A release whose files
-    /// all shipped stays in the per-release map (its done row lingers in the
-    /// pane until the queue idles) but has nothing left to cancel or wait for.
+    /// storage actions while a transfer is mid-flight. Releases with nothing
+    /// left to ship are absent from the per-release map, so presence is the
+    /// signal.
     public func isUploading(forRelease releaseId: String) -> Bool {
-        guard let progress = snapshot.perRelease[releaseId] else {
-            return false
-        }
-        return !progress.isIdle
+        snapshot.perRelease[releaseId] != nil
     }
 
     /// Whether any cloud writes are still queued or in flight — uploads or
     /// deletes that haven't reached the cloud home. Drives the extra
-    /// data-loss warning on the remove-library confirmation. Fully-uploaded
-    /// groups lingering as done rows carry no pending work.
+    /// data-loss warning on the remove-library confirmation.
     public var hasPendingCloudWork: Bool {
-        !snapshot.total.isIdle || snapshot.pendingDeletes > 0
+        !snapshot.uploadGroups.isEmpty || snapshot.pendingDeletes > 0
     }
 
     /// The idle (empty) queue. Seeds the store before the first snapshot read
@@ -57,7 +53,6 @@ public class OutboxStore {
                 queued: 0,
                 active: 0,
                 failed: 0,
-                done: 0,
                 bytesDone: 0,
                 bytesTotal: 0,
                 activity: nil,

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -1604,7 +1604,7 @@ impl crate::types::BridgeUploadReleaseGroup {
 }
 
 impl crate::types::BridgeUploadFileOp {
-    /// Flatten core's per-file `UploadState` into `activity` + `bytes_done` +
+    /// Flatten core's per-file `UploadState` into `state` + `bytes_done` +
     /// `last_error`, so the UI reads plain fields instead of switching on
     /// associated data.
     fn from_core(f: bae_core::library::UploadFileOp) -> Self {
@@ -1615,26 +1615,26 @@ impl crate::types::BridgeUploadFileOp {
             bytes_total,
             state,
         } = f;
-        let (activity, bytes_done, last_error) = match state {
-            UploadState::Queued => (crate::types::BridgeUploadActivity::Queued, 0, None),
+        let (state, bytes_done, last_error) = match state {
+            UploadState::Queued => (crate::types::BridgeUploadFileState::Queued, 0, None),
             UploadState::Active { bytes_done } => (
-                crate::types::BridgeUploadActivity::Uploading,
+                crate::types::BridgeUploadFileState::Uploading,
                 bytes_done,
                 None,
             ),
             UploadState::Failed { last_error } => (
-                crate::types::BridgeUploadActivity::Retrying,
+                crate::types::BridgeUploadFileState::Retrying,
                 0,
                 Some(last_error),
             ),
-            UploadState::Done => (crate::types::BridgeUploadActivity::Done, bytes_total, None),
+            UploadState::Done => (crate::types::BridgeUploadFileState::Done, bytes_total, None),
         };
         Self {
             file_id,
             display_name,
             bytes_done,
             bytes_total,
-            activity,
+            state,
             last_error,
         }
     }
@@ -1713,7 +1713,10 @@ impl crate::types::BridgeUploadProgress {
             queued,
             active,
             failed,
-            done,
+            // Completed files feed the cumulative byte fractions; the count
+            // itself has no UI consumer (finished releases aren't rendered,
+            // and pending groups list their done files individually).
+            done: _,
             bytes_done,
             bytes_total,
         } = p;
@@ -1721,7 +1724,6 @@ impl crate::types::BridgeUploadProgress {
             queued,
             active,
             failed,
-            done,
             bytes_done,
             bytes_total,
             activity,
@@ -1737,7 +1739,6 @@ impl crate::types::BridgeUploadActivity {
             UploadActivity::Uploading => BridgeUploadActivity::Uploading,
             UploadActivity::Retrying => BridgeUploadActivity::Retrying,
             UploadActivity::Queued => BridgeUploadActivity::Queued,
-            UploadActivity::Done => BridgeUploadActivity::Done,
         }
     }
 }
@@ -3245,7 +3246,7 @@ mod tests {
     /// failure message lands in `last_error` under `Retrying`.
     #[test]
     fn upload_file_op_flattens_state_into_fields() {
-        use crate::types::BridgeUploadActivity;
+        use crate::types::BridgeUploadFileState;
         use bae_core::library::{UploadFileOp, UploadState};
 
         let convert = |state: UploadState| {
@@ -3258,21 +3259,21 @@ mod tests {
         };
 
         let queued = convert(UploadState::Queued);
-        assert_eq!(queued.activity, BridgeUploadActivity::Queued);
+        assert_eq!(queued.state, BridgeUploadFileState::Queued);
         assert_eq!((queued.bytes_done, queued.last_error), (0, None));
 
         let active = convert(UploadState::Active { bytes_done: 400 });
-        assert_eq!(active.activity, BridgeUploadActivity::Uploading);
+        assert_eq!(active.state, BridgeUploadFileState::Uploading);
         assert_eq!(active.bytes_done, 400);
 
         let failed = convert(UploadState::Failed {
             last_error: "cloud write failed".into(),
         });
-        assert_eq!(failed.activity, BridgeUploadActivity::Retrying);
+        assert_eq!(failed.state, BridgeUploadFileState::Retrying);
         assert_eq!(failed.last_error.as_deref(), Some("cloud write failed"));
 
         let done = convert(UploadState::Done);
-        assert_eq!(done.activity, BridgeUploadActivity::Done);
+        assert_eq!(done.state, BridgeUploadFileState::Done);
         assert_eq!(done.bytes_done, 1000);
     }
 

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1663,13 +1663,24 @@ pub enum BridgeUiEvent {
 }
 
 /// The dominant activity of a slice of the upload queue (a release's uploads,
-/// a single file, or the whole queue), for the storage-row badge and the
-/// queue pane's per-file state. Mirror of bae-core's `UploadActivity`.
+/// or the whole queue), for the storage-row badge. Mirror of bae-core's
+/// `UploadActivity`. No terminal variant: a release with nothing left to ship
+/// stops being rendered at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum BridgeUploadActivity {
     Uploading,
     Retrying,
     Queued,
+}
+
+/// One file's state in the queue pane's per-file rows. Unlike the slice badge,
+/// a file inside a still-uploading release does render as `Done` — the row
+/// shows which files already shipped while the rest transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum BridgeUploadFileState {
+    Queued,
+    Uploading,
+    Retrying,
     Done,
 }
 
@@ -1685,19 +1696,18 @@ pub struct BridgeDeleteOp {
 /// Per-state counts, byte progress, and a derived badge `activity`. Used
 /// per-release (the storage-row badge reads `activity`; storage-action gates
 /// read the counts) and as the overall total (queue counts, ETA, summary band).
-/// Files completed during the current queue burst count in `done`,
-/// `bytes_done`, and `bytes_total`, so the fractions are cumulative.
+/// Files completed during the current queue burst count in `bytes_done` and
+/// `bytes_total`, so the fractions are cumulative over the burst.
 #[derive(Debug, Clone, Default, uniffi::Record)]
 pub struct BridgeUploadProgress {
     pub queued: u32,
     pub active: u32,
     pub failed: u32,
-    pub done: u32,
     pub bytes_done: u64,
     pub bytes_total: u64,
     /// The badge activity for this slice; `None` when idle. Per-release entries
-    /// are never idle, so theirs is always set; the overall total's is `None`
-    /// only when the whole queue is empty.
+    /// always have pending work (finished releases aren't rendered), so theirs
+    /// is always set.
     pub activity: Option<BridgeUploadActivity>,
 }
 
@@ -1815,7 +1825,7 @@ pub enum BridgeExportLocation {
 
 /// One file in a release's upload group: what the queue pane's per-file rows
 /// render. Mirror of bae-core's `UploadFileOp`, with the state flattened into
-/// `activity` + `bytes_done` + `last_error` so the UI doesn't switch on
+/// `state` + `bytes_done` + `last_error` so the UI doesn't switch on
 /// associated data: `bytes_done` is the live count while `Uploading`, equal to
 /// `bytes_total` when `Done`, and 0 otherwise; `last_error` is set only when
 /// `Retrying`.
@@ -1827,7 +1837,7 @@ pub struct BridgeUploadFileOp {
     pub display_name: String,
     pub bytes_done: u64,
     pub bytes_total: u64,
-    pub activity: BridgeUploadActivity,
+    pub state: BridgeUploadFileState,
     pub last_error: Option<String>,
 }
 

--- a/bae-core/src/db/client/blobs.rs
+++ b/bae-core/src/db/client/blobs.rs
@@ -406,40 +406,6 @@ impl Database {
         })
         .await
     }
-
-    /// Album titles for the given release ids. Backs the outbox snapshot's
-    /// fully-uploaded groups, whose rows are gone and so no longer carry the
-    /// title the `outbox_items` join supplies. A release that no longer exists
-    /// is simply absent from the map.
-    pub async fn album_titles_for_releases(
-        &self,
-        release_ids: &[String],
-    ) -> Result<HashMap<String, String>, DbError> {
-        let release_ids = release_ids.to_vec();
-        self.call(move |conn| {
-            let placeholders = (0..release_ids.len())
-                .map(|_| "?")
-                .collect::<Vec<_>>()
-                .join(",");
-            let sql = format!(
-                "SELECT r.id, a.title FROM releases r \
-                 JOIN albums a ON a.id = r.album_id \
-                 WHERE r.id IN ({placeholders})"
-            );
-            let mut stmt = conn.prepare(&sql)?;
-            let rows = stmt.query_map(
-                coven::rusqlite::params_from_iter(release_ids.iter()),
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-            )?;
-            let mut map = HashMap::new();
-            for row in rows {
-                let (id, title) = row?;
-                map.insert(id, title);
-            }
-            Ok(map)
-        })
-        .await
-    }
 }
 
 fn row_to_db_outbox_row(row: &Row<'_>) -> coven::rusqlite::Result<DbOutboxRow> {

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -1696,6 +1696,38 @@ async fn upload_observer_processes_transition_after_deleted_release() {
     );
 }
 
+/// A non-release root (covers, artist images) completing its make-remote must
+/// still push a fresh outbox snapshot: such a root often commits last in a
+/// burst, and without this emission the queue pane freezes on the previous
+/// snapshot instead of clearing.
+#[tokio::test]
+async fn non_release_root_completion_emits_outbox_changed() {
+    use coven::BlobTransitionObserver;
+
+    let (manager, _temp_dir) = setup_test_manager().await;
+    let mut events = manager.subscribe_events();
+
+    let observer = crate::sync::upload_observer::ReleaseUploadObserver::new(
+        manager.sync.outbox_in_flight(),
+        manager.sync.upload_sessions(),
+        manager.sync.upload_throughput(),
+        manager.sync.sync_paused(),
+        manager.event_tx.clone(),
+    );
+    observer.set_database(Arc::new(manager.database.clone()));
+
+    observer.on_root_made_remote("covers", "cover-1").await;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), events.recv())
+        .await
+        .expect("covers-root completion must emit an outbox snapshot")
+        .expect("event channel stays open");
+    assert!(
+        matches!(event, LibraryEvent::OutboxChanged { .. }),
+        "expected OutboxChanged, got {event:?}",
+    );
+}
+
 // ── Storage page tests ───────────────────────────────────────────
 
 /// Insert N albums each with one release; return `(albums, releases)`.
@@ -2637,16 +2669,15 @@ async fn observer_progress_advances_snapshot_bytes_done() {
     // non-zero before the file even finishes.
     assert!(manager.sync.upload_throughput().bytes_per_sec() > 0);
 
-    // Completion clears the in-flight entry and tallies the file as done;
-    // the row's still in the DB (this test drives only the observer, not
-    // coven's removal), but the snapshot keeps reporting the file as shipped
-    // with its bytes in the cumulative progress.
+    // Completion clears the in-flight entry and tallies the file as done; the
+    // row's still in the DB (this test drives only the observer, not coven's
+    // removal), but with its only file shipped the release has nothing left
+    // to render — the group leaves the snapshot.
     observer.on_blob_uploaded(&file.id).await;
     let snap = manager.outbox_snapshot().await.unwrap();
     assert_eq!(snap.total.active, 0);
-    assert_eq!(snap.upload_groups[0].progress.queued, 0);
-    assert_eq!(snap.upload_groups[0].progress.done, 1);
-    assert_eq!(snap.upload_groups[0].progress.bytes_done, 1000);
+    assert_eq!(snap.total.queued, 0);
+    assert!(snap.upload_groups.is_empty());
 }
 
 /// A file that finished uploading but whose outbox row hasn't been removed yet
@@ -2692,8 +2723,8 @@ async fn completed_upload_with_lingering_row_is_not_queued() {
     observer.on_blob_uploaded(&file.id).await;
 
     // The outbox row is still present — only coven's commit removes it — but
-    // the upload finished: nothing queued, nothing active, nothing failed,
-    // and the completed bytes stay in the release's cumulative progress.
+    // the upload finished: nothing pending anywhere, and the release (its
+    // only file shipped) is no longer rendered at all.
     let snap = manager.outbox_snapshot().await.unwrap();
     assert_eq!(
         snap.total.queued, 0,
@@ -2701,8 +2732,7 @@ async fn completed_upload_with_lingering_row_is_not_queued() {
     );
     assert_eq!(snap.total.active, 0);
     assert_eq!(snap.total.failed, 0);
-    assert_eq!(snap.total.bytes_done, 1000);
-    assert_eq!(snap.total.bytes_total, 1000);
+    assert!(snap.upload_groups.is_empty());
 }
 
 /// Insert a remote, not-pinned release with one file and return its id.

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -62,14 +62,15 @@ pub struct DeleteOp {
 /// The dominant activity of a slice of the upload queue (a release's uploads,
 /// or the whole queue), for the storage-row badge. A slice with any file
 /// uploading reads as `Uploading`; with none uploading but some failed and
-/// awaiting retry, `Retrying`; with work still waiting, `Queued`; with every
-/// file shipped, `Done`.
+/// awaiting retry, `Retrying`; otherwise `Queued`. There is no terminal
+/// variant: a release with nothing left to ship stops being rendered at all
+/// (its group leaves the snapshot and its storage row falls back to the
+/// resting state).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UploadActivity {
     Uploading,
     Retrying,
     Queued,
-    Done,
 }
 
 /// Upload progress as the UI cares about it: per-state counts plus
@@ -89,9 +90,16 @@ pub struct UploadProgress {
 }
 
 impl UploadProgress {
+    /// True when this slice still has unshipped work — queued, in flight, or
+    /// failed awaiting retry. Completed files don't count: a slice that's all
+    /// done has nothing left to render or wait for.
+    pub fn has_pending(&self) -> bool {
+        self.queued > 0 || self.active > 0 || self.failed > 0
+    }
+
     /// The badge activity for this slice: active uploads outrank failures
-    /// awaiting retry, which outrank items still only queued, which outrank
-    /// fully-shipped work. `None` when the slice holds nothing at all.
+    /// awaiting retry, which outrank items still only queued. `None` when
+    /// nothing is pending.
     pub fn activity(&self) -> Option<UploadActivity> {
         if self.active > 0 {
             Some(UploadActivity::Uploading)
@@ -99,8 +107,6 @@ impl UploadProgress {
             Some(UploadActivity::Retrying)
         } else if self.queued > 0 {
             Some(UploadActivity::Queued)
-        } else if self.done > 0 {
-            Some(UploadActivity::Done)
         } else {
             None
         }
@@ -164,10 +170,9 @@ pub struct UploadReleaseGroup {
 /// upload-related the UI renders.
 #[derive(Debug, Clone, Default)]
 pub struct OutboxSnapshot {
-    /// Uploads grouped by release — the rows the queue pane renders. Groups
-    /// whose files all completed stay listed (as done rows) until the whole
-    /// queue drains, so the master bar and the pane tell one coherent story
-    /// over the burst.
+    /// Uploads grouped by release — the rows the queue pane renders. Only
+    /// groups with unshipped work appear: a release whose files all completed
+    /// leaves the snapshot (and the pane hides once nothing pending remains).
     pub upload_groups: Vec<UploadReleaseGroup>,
     pub deletes: Vec<DeleteOp>,
     /// Sum across all uploads — drives the queue counts, ETA, the master
@@ -343,44 +348,30 @@ pub(crate) async fn build_outbox_snapshot(
         }
     }
 
-    // Resolve titles the rows didn't supply: a group whose files all completed
-    // has no rows left to carry the album title, so look it up by release id.
-    let unresolved: Vec<String> = groups
-        .iter()
-        .filter(|g| g.display_title.is_none())
-        .filter_map(|g| g.release_id.clone())
-        .collect();
-    let titles = if unresolved.is_empty() {
-        HashMap::new()
-    } else {
-        db.album_titles_for_releases(&unresolved).await?
-    };
-
     let upload_groups: Vec<UploadReleaseGroup> = groups
         .into_iter()
+        // A release with nothing left to ship stops being rendered: its group
+        // leaves the snapshot, its storage row falls back to the resting
+        // state, and the pane hides once no group (or delete) remains. The
+        // tally that fed its done files is dropped by the observer when the
+        // root completes; the idle clear above is the backstop.
+        .filter(|group| group.progress.has_pending())
         .map(|group| {
-            let display_title = group
-                .display_title
-                .or_else(|| {
-                    group
-                        .release_id
-                        .as_ref()
-                        .and_then(|id| titles.get(id).cloned())
-                })
-                .unwrap_or_else(|| {
-                    // No album to name the group by (the orphaned bucket, or a
-                    // release deleted mid-upload): label it by its first file,
-                    // matching the per-file orphan labelling above.
-                    debug!(
-                        release_id = ?group.release_id,
-                        "outbox upload group has no album title; labelling by file name"
-                    );
-                    group
-                        .files
-                        .first()
-                        .map(|f| f.display_name.clone())
-                        .unwrap_or_default()
-                });
+            // Every rendered group has at least one pending row, so the album
+            // title normally arrives via the row join; the fallback labels the
+            // orphaned bucket (no backing release) by its first file, matching
+            // the per-file orphan labelling above.
+            let display_title = group.display_title.unwrap_or_else(|| {
+                debug!(
+                    release_id = ?group.release_id,
+                    "outbox upload group has no album title; labelling by file name"
+                );
+                group
+                    .files
+                    .first()
+                    .map(|f| f.display_name.clone())
+                    .unwrap_or_default()
+            });
             UploadReleaseGroup {
                 release_id: group.release_id,
                 display_title,
@@ -447,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn activity_ranks_active_over_failed_over_queued_over_done() {
+    fn activity_ranks_active_over_failed_over_queued() {
         assert_eq!(progress(0, 0, 0, 0).activity(), None);
         assert_eq!(
             progress(3, 0, 0, 0).activity(),
@@ -467,8 +458,9 @@ mod tests {
             progress(5, 1, 2, 0).activity(),
             Some(UploadActivity::Uploading)
         );
-        // Fully-shipped work reads as done; any pending work outranks it.
-        assert_eq!(progress(0, 0, 0, 4).activity(), Some(UploadActivity::Done));
+        // Completed files never produce a badge of their own: a slice that's
+        // all done is idle (the group stops being rendered entirely).
+        assert_eq!(progress(0, 0, 0, 4).activity(), None);
         assert_eq!(
             progress(1, 0, 0, 4).activity(),
             Some(UploadActivity::Queued)
@@ -648,11 +640,11 @@ mod tests {
         assert_eq!(group.progress.bytes_total, 1100);
     }
 
-    /// A release whose rows all drained stays visible as a done group (title
-    /// re-resolved from the release) until the queue idles, so the master bar
-    /// stays cumulative over the whole burst.
+    /// A release with nothing left to ship stops being rendered: its group
+    /// leaves the snapshot while other releases keep uploading, and the totals
+    /// cover only the work still on screen.
     #[tokio::test]
-    async fn fully_done_group_stays_listed_while_queue_busy() {
+    async fn fully_done_group_is_dropped_while_queue_busy() {
         let (db, small, large, _tmp) = seed_two_queued_uploads().await;
 
         // Both of rel-1's files completed and their rows are gone; a second
@@ -687,18 +679,15 @@ mod tests {
         }
         let snapshot = build(&db, &HashMap::new(), &sessions).await;
 
-        assert_eq!(snapshot.upload_groups.len(), 2);
-        let done_group = &snapshot.upload_groups[0];
-        assert_eq!(done_group.release_id.as_deref(), Some("rel-1"));
-        // No rows left to carry the title; the batch lookup resolves it.
-        assert_eq!(done_group.display_title, "Album Title");
-        assert_eq!(done_group.progress.activity(), Some(UploadActivity::Done));
-        assert_eq!(done_group.progress.done, 2);
-        assert_eq!(done_group.progress.bytes_done, 1100);
-        // The master totals span the finished release and the busy one.
-        assert_eq!(snapshot.total.bytes_total, 1600);
-        assert_eq!(snapshot.total.bytes_done, 1100);
+        assert_eq!(snapshot.upload_groups.len(), 1);
+        let group = &snapshot.upload_groups[0];
+        assert_eq!(group.release_id.as_deref(), Some("rel-2"));
+        assert_eq!(snapshot.total.bytes_total, 500);
         assert_eq!(snapshot.total.queued, 1);
+        assert!(
+            !snapshot.per_release_progress().contains_key("rel-1"),
+            "a finished release must fall back to its resting storage badge"
+        );
     }
 
     /// An idle queue ends the burst: the tallies clear and the snapshot is

--- a/bae-core/src/sync/upload_observer.rs
+++ b/bae-core/src/sync/upload_observer.rs
@@ -275,31 +275,36 @@ impl coven::BlobTransitionObserver for ReleaseUploadObserver {
         self.sync_paused.load(std::sync::atomic::Ordering::SeqCst)
     }
 
-    /// coven finished making a release Remote (every blob uploaded, gate flipped,
-    /// source files dropped): emit `ReleaseUpdated` so the UI's storage state
-    /// flips, and refresh the outbox snapshot now that the queue is empty.
+    /// coven finished making a root Remote (every blob uploaded, gate flipped,
+    /// source files dropped). For a release, emit `ReleaseUpdated` so the UI's
+    /// storage state flips and drop its completed-upload tally (its queue rows
+    /// are gone, so nothing renders for it anymore). For *every* root, refresh
+    /// the outbox snapshot: a covers / artist-images root often commits last in
+    /// a burst, and skipping its emission would leave the queue pane frozen on
+    /// the previous snapshot instead of clearing.
     async fn on_root_made_remote(&self, root_table: &str, root_id: &str) {
-        if root_table != "releases" {
-            // bae declares only `releases` as a gated root, so any other root is
-            // unexpected — name it rather than silently dropping the completion.
-            debug!("on_root_made_remote for non-release root {root_table:?}/{root_id}; ignoring");
-            return;
+        if root_table == "releases" {
+            if let Err(e) = self.db().complete_import_for_release(root_id).await {
+                warn!("on_root_made_remote: marking import complete for {root_id}: {e}");
+            }
+            self.emit_release_updated(root_id).await;
+            self.sessions.clear_group(Some(root_id));
+        } else {
+            debug!("on_root_made_remote for non-release root {root_table:?}/{root_id}");
         }
-        if let Err(e) = self.db().complete_import_for_release(root_id).await {
-            warn!("on_root_made_remote: marking import complete for {root_id}: {e}");
-        }
-        self.emit_release_updated(root_id).await;
         self.emit_outbox_changed().await;
     }
 
-    /// coven finished making a release Local (blobs materialized to local files,
-    /// gate retracted, cloud blobs queued for tombstoning): emit `ReleaseUpdated`.
+    /// coven finished making a root Local (blobs materialized to local files,
+    /// gate retracted, cloud blobs queued for tombstoning): emit
+    /// `ReleaseUpdated` for a release, and refresh the outbox snapshot for
+    /// every root — the retraction changed the queue either way.
     async fn on_root_made_local(&self, root_table: &str, root_id: &str) {
-        if root_table != "releases" {
-            debug!("on_root_made_local for non-release root {root_table:?}/{root_id}; ignoring");
-            return;
+        if root_table == "releases" {
+            self.emit_release_updated(root_id).await;
+        } else {
+            debug!("on_root_made_local for non-release root {root_table:?}/{root_id}");
         }
-        self.emit_release_updated(root_id).await;
         self.emit_outbox_changed().await;
     }
 }

--- a/bae-macos/bae/bae/Views/AlbumDetailView.swift
+++ b/bae-macos/bae/bae/Views/AlbumDetailView.swift
@@ -1259,15 +1259,13 @@ private struct StorageStatusBand: View {
     @Environment(OutboxStore.self)
     private var outboxStore
 
-    /// Outbox progress for this release, if any work is in flight. Drives the
-    /// "uploading…" indicator and suppresses transfer actions — acting
+    /// Outbox progress for this release, if any work is in flight (releases
+    /// with nothing left to ship are absent from the per-release map). Drives
+    /// the "uploading…" indicator and suppresses transfer actions — acting
     /// mid-upload races the observer that completes the unmanaged → managed
     /// step.
     private var uploadProgress: BridgeUploadProgress? {
-        guard let p = outboxStore.progress(forRelease: release.summary.id),
-            !p.isIdle
-        else { return nil }
-        return p
+        outboxStore.progress(forRelease: release.summary.id)
     }
 
     var body: some View {

--- a/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportCandidateListContent.swift
@@ -450,9 +450,7 @@ struct CandidateRow: View {
             case .complete(_, let releaseId):
                 // Imported, but the cloud upload may still be draining — show
                 // the transfer until the release's queue empties.
-                if let progress = outboxStore.progress(forRelease: releaseId),
-                    !progress.isIdle
-                {
+                if outboxStore.progress(forRelease: releaseId) != nil {
                     icon("icloud.and.arrow.up", .secondary)
                 }
                 else {

--- a/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
+++ b/bae-macos/bae/bae/Views/Import/ImportConfirmationView.swift
@@ -79,11 +79,10 @@ struct ImportConfirmationView<
     /// durably queued — this surfaces the remaining transfer instead of
     /// presenting a cloud-only import as fully landed.
     private var uploadProgress: BridgeUploadProgress? {
-        guard case .complete(_, let releaseId) = importStatus,
-            let progress = outboxStore.progress(forRelease: releaseId),
-            !progress.isIdle
-        else { return nil }
-        return progress
+        guard case .complete(_, let releaseId) = importStatus else {
+            return nil
+        }
+        return outboxStore.progress(forRelease: releaseId)
     }
 
     /// `Import` stays disabled when the editor is in an invalid state

--- a/bae-macos/bae/bae/Views/StorageManagerView.swift
+++ b/bae-macos/bae/bae/Views/StorageManagerView.swift
@@ -765,9 +765,6 @@ private struct OutboxReleaseRow: View {
                 systemImage: "exclamationmark.triangle.fill"
             )
             .foregroundStyle(.red)
-        case .done:
-            Label("Done", systemImage: "checkmark.circle.fill")
-                .foregroundStyle(.green)
         case .none:
             EmptyView()
         }
@@ -793,7 +790,7 @@ private struct OutboxFileRow: View {
 
             Spacer()
 
-            if file.activity == .uploading {
+            if file.state == .uploading {
                 ProgressView(value: fraction)
                     .progressViewStyle(.linear)
                     .frame(width: 140)
@@ -812,7 +809,7 @@ private struct OutboxFileRow: View {
 
     @ViewBuilder
     private var stateIcon: some View {
-        switch file.activity {
+        switch file.state {
         case .queued:
             Image(systemName: "clock")
                 .foregroundStyle(.secondary)
@@ -844,7 +841,7 @@ private struct OutboxFileRow: View {
     /// "6.2 MB of 12.4 MB" while transferring; just the size otherwise.
     private var bytesText: String {
         let total = Int64(file.bytesTotal).formatted(.byteCount(style: .file))
-        guard file.activity == .uploading else { return total }
+        guard file.state == .uploading else { return total }
         return String(
             format: QueueSummary.message("core.outbox.bytes_progress"),
             Int64(file.bytesDone).formatted(.byteCount(style: .file)),

--- a/bae-macos/bae/bae/Views/StorageTableView.swift
+++ b/bae-macos/bae/bae/Views/StorageTableView.swift
@@ -996,10 +996,10 @@ private struct StorageStateLabel: View {
     }
 
     /// The per-release upload badge: only a release with a file in flight reads
-    /// as "Uploading"; one with work still waiting reads as "Queued", one
-    /// stalled on failures awaiting retry as "Retrying", and one whose files
-    /// all shipped this burst as "Done" (until the queue idles and the resting
-    /// state takes over). `remaining` is the release's unshipped file count.
+    /// as "Uploading"; one with work still waiting reads as "Queued", and one
+    /// stalled on failures awaiting retry as "Retrying". A release with
+    /// nothing left to ship has no badge — it falls back to the resting
+    /// state. `remaining` is the release's unshipped file count.
     @ViewBuilder
     private func uploadBadge(
         _ activity: BridgeUploadActivity,
@@ -1021,10 +1021,6 @@ private struct StorageStateLabel: View {
             )
             .foregroundStyle(.red)
             .lineLimit(1)
-        case .done:
-            Label("Done", systemImage: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-                .lineLimit(1)
         }
     }
 }

--- a/bae-macos/bae/baeTests/OutboxStoreTests.swift
+++ b/bae-macos/bae/baeTests/OutboxStoreTests.swift
@@ -30,7 +30,16 @@ struct OutboxStoreHasPendingCloudWorkTests {
                 BridgeUploadReleaseGroup(
                     releaseId: "release-a",
                     displayTitle: "Release A",
-                    fileCount: 3,
+                    files: [
+                        BridgeUploadFileOp(
+                            fileId: "file-1",
+                            displayName: "01 Track Title.flac",
+                            bytesDone: 0,
+                            bytesTotal: 1000,
+                            state: .queued,
+                            lastError: nil
+                        )
+                    ],
                     progress: OutboxStore.emptySnapshot.total
                 )
             ]

--- a/bae-windows/Views/StorageDialog.cs
+++ b/bae-windows/Views/StorageDialog.cs
@@ -538,7 +538,7 @@ internal sealed class StorageDialog
                         FontSize = 12,
                         TextWrapping = TextWrapping.Wrap,
                     });
-                    if (file.Activity == BridgeUploadActivity.Uploading && file.BytesTotal > 0)
+                    if (file.State == BridgeUploadFileState.Uploading && file.BytesTotal > 0)
                     {
                         fileColumn.Children.Add(new ProgressBar
                         {
@@ -552,12 +552,12 @@ internal sealed class StorageDialog
 
                     var state = new TextBlock
                     {
-                        Text = FileStateLabel(file.Activity),
+                        Text = FileStateLabel(file.State),
                         FontSize = 12,
                         Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
                         VerticalAlignment = VerticalAlignment.Center,
                     };
-                    if (file.Activity == BridgeUploadActivity.Retrying && file.LastError is string lastError)
+                    if (file.State == BridgeUploadFileState.Retrying && file.LastError is string lastError)
                     {
                         ToolTipService.SetToolTip(state, lastError);
                     }
@@ -792,8 +792,9 @@ internal sealed class StorageDialog
     }
 
     // A release group's aggregate badge, mirroring the macOS queue pane: the
-    // dominant activity plus the unshipped file count, or "Done" once every
-    // file shipped. Empty for a group core would never emit (no activity).
+    // dominant activity plus the unshipped file count. Finished releases
+    // aren't rendered, so there is no terminal badge. Empty for a group core
+    // would never emit (no activity).
     private static string UploadBadgeLabel(BridgeUploadProgress progress)
     {
         var pending = progress.Queued + progress.Active + progress.Failed;
@@ -802,34 +803,30 @@ internal sealed class StorageDialog
             BridgeUploadActivity.Uploading => Loc.Chrome("outbox.badge.uploading", "count", pending),
             BridgeUploadActivity.Queued => Loc.Chrome("outbox.badge.queued", "count", pending),
             BridgeUploadActivity.Retrying => Loc.Chrome("outbox.badge.retrying", "count", pending),
-            BridgeUploadActivity.Done => Loc.Chrome("outbox.state.done"),
             _ => string.Empty,
         };
     }
 
-    // A release group's byte progress: "45.2 MB of 103.1 MB" while work
-    // remains, or just the total once everything shipped. Cumulative over the
-    // queue burst, matching the bar beside it.
+    // A release group's byte progress: "45.2 MB of 103.1 MB", cumulative over
+    // the queue burst, matching the bar beside it.
     private static string UploadBytesLabel(BridgeUploadProgress progress)
     {
-        var total = Loc.Bytes(checked((long)progress.BytesTotal));
-        if (progress.Queued + progress.Active + progress.Failed == 0) return total;
         return Loc.Core(
             "core.outbox.bytes_progress",
             new Dictionary<string, object?>
             {
                 ["done"] = Loc.Bytes(checked((long)progress.BytesDone)),
-                ["total"] = total,
+                ["total"] = Loc.Bytes(checked((long)progress.BytesTotal)),
             });
     }
 
-    private static string FileStateLabel(BridgeUploadActivity activity) => activity switch
+    private static string FileStateLabel(BridgeUploadFileState state) => state switch
     {
-        BridgeUploadActivity.Uploading => Loc.Chrome("outbox.state.uploading"),
-        BridgeUploadActivity.Queued => Loc.Chrome("outbox.state.queued"),
-        BridgeUploadActivity.Retrying => Loc.Chrome("outbox.state.retrying"),
-        BridgeUploadActivity.Done => Loc.Chrome("outbox.state.done"),
-        _ => throw new ArgumentOutOfRangeException(nameof(activity), activity, "Unknown upload activity"),
+        BridgeUploadFileState.Uploading => Loc.Chrome("outbox.state.uploading"),
+        BridgeUploadFileState.Queued => Loc.Chrome("outbox.state.queued"),
+        BridgeUploadFileState.Retrying => Loc.Chrome("outbox.state.retrying"),
+        BridgeUploadFileState.Done => Loc.Chrome("outbox.state.done"),
+        _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown upload file state"),
     };
 
     // A file's byte text: "6.2 MB of 12.4 MB" while transferring; just the
@@ -837,7 +834,7 @@ internal sealed class StorageDialog
     private static string FileBytesLabel(BridgeUploadFileOp file)
     {
         var total = Loc.Bytes(checked((long)file.BytesTotal));
-        if (file.Activity != BridgeUploadActivity.Uploading) return total;
+        if (file.State != BridgeUploadFileState.Uploading) return total;
         return Loc.Core(
             "core.outbox.bytes_progress",
             new Dictionary<string, object?>


### PR DESCRIPTION
Field-testing the cumulative-progress change surfaced two problems. First, the pane froze on "Done" after a burst finished: `on_root_made_remote` re-emitted the outbox snapshot only for release roots, but a covers/artist-images root often commits last — so the drained snapshot never reached the UI (verified against the live library: queue tables empty, gate flipped, pane stuck). The observer now emits for every root and only gates the release-specific work.

Second, per review of the behavior: "Done" isn't a state this UI should show. A release with nothing left to ship now leaves the snapshot entirely — no Done badge in the queue pane or the storage table, the storage row falls straight back to "Cloud"/"Pinned", and the pane hides once nothing pending remains. Per-file Done checkmarks remain for files inside a still-uploading release. The per-file state gets its own bridge enum so badge switches never carry an impossible Done case, and the guards that presence-in-`perRelease` used to require (`isIdle`) are gone since presence now implies pending work.

Also fixes `baeTests/OutboxStoreTests.swift` for the new group shape — missed by #307 because a piped xcodebuild masked the test bundle's failing exit code locally.

## Test plan
- [x] `cargo test -p bae-core --lib` (1028 tests; new red-first test: a covers-root completion must emit `OutboxChanged`)
- [x] `cargo test -p bae-bridge --lib --features desktop`
- [x] macOS xcodebuild test (baeTests) with pipefail — TEST SUCCEEDED
- [x] clippy, cargo fmt, swift-format via pre-commit
- [ ] Windows CI (C# compiles only there; DispatcherQueue fix already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)