### PR TITLE
Make Windows bridge consumption fail closed on unknown variants

### DIFF
--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -734,10 +734,11 @@ internal static class NativeBae
         new BridgeSortCriterion(
             sortField switch
             {
+                "date_added" => BridgeSortField.DateAdded,
                 "title" => BridgeSortField.Title,
                 "artist" => BridgeSortField.Artist,
                 "year" => BridgeSortField.Year,
-                _ => BridgeSortField.DateAdded,
+                _ => throw new ArgumentOutOfRangeException(nameof(sortField), sortField, "Unknown album sort field"),
             },
             ascending ? BridgeSortDirection.Ascending : BridgeSortDirection.Descending),
     ];
@@ -746,9 +747,10 @@ internal static class NativeBae
         new(
             sortField switch
             {
+                "name" => BridgeComposerSortField.Name,
                 "work_count" => BridgeComposerSortField.WorkCount,
                 "linked_release_count" => BridgeComposerSortField.LinkedReleaseCount,
-                _ => BridgeComposerSortField.Name,
+                _ => throw new ArgumentOutOfRangeException(nameof(sortField), sortField, "Unknown composer sort field"),
             },
             ascending ? BridgeSortDirection.Ascending : BridgeSortDirection.Descending);
 
@@ -979,10 +981,11 @@ internal static class NativeBae
     private static string DiscogsStatusTag(BridgeDiscogsTokenStatus status) =>
         status switch
         {
+            BridgeDiscogsTokenStatus.NotConfigured => "not_configured",
             BridgeDiscogsTokenStatus.Valid => "valid",
             BridgeDiscogsTokenStatus.Unvalidated => "unvalidated",
             BridgeDiscogsTokenStatus.Rejected => "rejected",
-            _ => "not_configured",
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown Discogs token status"),
         };
 
     private static string SyncProviderTag(BridgeSyncProvider provider) =>
@@ -1068,7 +1071,7 @@ internal static class NativeBae
             BridgeDiscogsSaveOutcome.Valid => "valid",
             BridgeDiscogsSaveOutcome.Unvalidated => "unvalidated",
             BridgeDiscogsSaveOutcome.Rejected => "rejected",
-            _ => "rejected",
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unknown Discogs save outcome"),
         };
 
 

--- a/bae-windows/Stores/ImportStore.cs
+++ b/bae-windows/Stores/ImportStore.cs
@@ -156,6 +156,13 @@ internal sealed class ImportStore
                         ["total"] = loudness.TracksTotal,
                     }));
                 break;
+            default:
+                // The router forwards only the preview and candidate-loudness
+                // variants here; any other variant reaching this handler is a
+                // routing drift, so log it rather than dropping it silently.
+                BaeDiagnostics.Logger.Warning(
+                    $"Unexpected BridgeUiEvent variant {evt.GetType().Name} reached the import preview handler.");
+                break;
         }
     }
 

--- a/bae-windows/Stores/UiEventRouter.cs
+++ b/bae-windows/Stores/UiEventRouter.cs
@@ -106,6 +106,17 @@ internal sealed class UiEventRouter
             case BridgeUiEvent.CandidateImportLoudnessProgress:
                 _importEvents(evt);
                 break;
+            case BridgeUiEvent.ReleaseTransferProgress:
+            case BridgeUiEvent.ReleaseTransferEnded:
+                // Release-transfer progress/ended carry a pin/unpin/manage/unmanage
+                // in-flight indicator for a release row; the Windows release views
+                // don't render one, so there's no work to do here.
+                break;
+            default:
+                // A BridgeUiEvent variant with no arm above: log the drift so a new
+                // variant surfaces here instead of vanishing silently.
+                BaeDiagnostics.Logger.Warning($"Unhandled BridgeUiEvent variant {evt.GetType().Name}.");
+                break;
         }
     }
 }


### PR DESCRIPTION
The Rust converters fail the build when a core type gains a field, but the C# consumer side had no equivalent: UiEventRouter's switch silently dropped any bridge event variant it didn't name (the release-transfer events fall through today), and four NativeBae tag switches absorbed unknown enum members into silent defaults — a new sort field would quietly become date-added. New variants and members now surface: the event routers log unrecognized variants at warning with explicit named arms for the intentionally-ignored transfer events, and every bridge-enum tag switch throws on an unknown member, matching the file's majority idiom. No behavior change for existing inputs.

## Test plan

- [x] bae-windows.Tests (125) green
- [ ] Windows CI compile (the only compile gate for this app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tK3JoFW9Nsdb2Tc139iLH