### PR TITLE
Add album-grid quick actions and clickable now-playing bar on Windows

### DIFF
--- a/bae-windows/Album.cs
+++ b/bae-windows/Album.cs
@@ -19,6 +19,7 @@ public sealed class Album : INotifyPropertyChanged
 
     internal Album(BridgeAlbum album) : this(album.Id, album.Title, album.ArtistNames, album.Cover)
     {
+        PrimaryReleaseId = album.PrimaryReleaseId;
     }
 
     private Album(string id, string title, string artist, BridgeImageRef? cover)
@@ -35,6 +36,10 @@ public sealed class Album : INotifyPropertyChanged
     public string Id => _id;
     public string Title => _title;
     public string Artist => _artist;
+
+    /// <summary>The album's canonical release — the default play/queue target.
+    /// Null for search-result albums, whose bridge type doesn't carry it.</summary>
+    internal string? PrimaryReleaseId { get; }
 
     internal void AttachCover(LibraryHandle handle, DispatcherQueue dispatcherQueue) =>
         _cover.Attach(handle, dispatcherQueue);

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -65,7 +65,8 @@
             Padding="24"
             SelectionMode="None"
             IsItemClickEnabled="True"
-            ItemClick="OnAlbumClick">
+            ItemClick="OnAlbumClick"
+            RightTapped="OnAlbumGridRightTapped">
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="local:Album">
                     <StackPanel Width="180" Margin="8" Spacing="6">
@@ -169,11 +170,13 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <Border
+                    x:Name="NpCoverFrame"
                     Grid.Column="0"
                     Width="48"
                     Height="48"
                     CornerRadius="4"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    Tapped="OnNowPlayingInfoTapped">
                     <Image x:Name="NpCover" Stretch="UniformToFill" />
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
@@ -181,7 +184,8 @@
                         x:Name="NpTitle"
                         MaxLines="1"
                         TextTrimming="CharacterEllipsis"
-                        Style="{StaticResource BodyStrongTextBlockStyle}" />
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Tapped="OnNowPlayingInfoTapped" />
                     <TextBlock
                         x:Name="NpArtist"
                         MaxLines="1"

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -138,6 +138,10 @@ public sealed partial class MainWindow : Window
             QueueAddBadge,
             QueueAddBadgeScale,
             QueueAddBadgeText);
+        // The bar's art and title open the playing album; the tooltip is the
+        // affordance that they're clickable.
+        ToolTipService.SetToolTip(NpCoverFrame, Loc.Chrome("nowplaying.go_to_album"));
+        ToolTipService.SetToolTip(NpTitle, Loc.Chrome("nowplaying.go_to_album"));
         _import = new ImportStore(_session, _shell, _mediaControls);
         _projections = new ProjectionRegistry();
         _router = new UiEventRouter(_playback, _shell, _projections, _mediaControls, _import.HandlePreviewEvent);
@@ -693,6 +697,21 @@ public sealed partial class MainWindow : Window
     private async void OnGoToNowPlaying(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
         args.Handled = true;
+        await OpenNowPlayingAlbum();
+    }
+
+    // Clicking the bar's album art or track title jumps to the playing album —
+    // the pointer version of the go-to-now-playing accelerator.
+    private async void OnNowPlayingInfoTapped(object sender, TappedRoutedEventArgs e)
+    {
+        e.Handled = true;
+        await OpenNowPlayingAlbum();
+    }
+
+    // Open the playing track's album and scroll it into view. No-op when nothing
+    // is playing.
+    private async System.Threading.Tasks.Task OpenNowPlayingAlbum()
+    {
         var albumId = _playback.NowPlayingAlbumId;
         if (CurrentHandleOrNull() == null || string.IsNullOrEmpty(albumId))
         {
@@ -783,6 +802,29 @@ public sealed partial class MainWindow : Window
         }
 
         await _albumDetail.Show(album.Id);
+    }
+
+    // Right-click / long-press on an album card: play or queue the album's
+    // canonical release without opening the detail dialog.
+    private void OnAlbumGridRightTapped(object sender, RightTappedRoutedEventArgs e)
+    {
+        if (CurrentHandleOrNull() == null
+            || (e.OriginalSource as FrameworkElement)?.DataContext is not Album album)
+        {
+            return;
+        }
+        var releaseId = album.PrimaryReleaseId;
+        if (string.IsNullOrEmpty(releaseId))
+        {
+            return;
+        }
+        e.Handled = true;
+        var element = (FrameworkElement)e.OriginalSource;
+        var menu = AlbumCardMenu.Build(
+            onPlay: () => WithCurrentHandle(handle => NativeBae.PlayRelease(handle, releaseId, -1, false)),
+            onPlayNext: () => WithCurrentHandle(handle => NativeBae.AddReleaseNext(handle, releaseId)),
+            onAddToQueue: () => WithCurrentHandle(handle => NativeBae.AddReleaseToQueue(handle, releaseId)));
+        menu.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
     }
 
     private async void OnStorageClick(object sender, RoutedEventArgs e)

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>جارٍ الموافقة على الجهاز…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>تعذرت الموافقة على هذا الجهاز</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>أدخل هذا الرمز على الجهاز الجديد.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>الانتقال إلى الألبوم</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>حذف</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>إلغاء</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>تعذّر تحميل صندوق الصادر</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>одобряване на устройството…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>това устройство не можа да бъде одобрено</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>въведете този код на новото устройство.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>отиди към албума</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>изтриване</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>отказ</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>изходящата опашка не може да бъде заредена</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>ডিভাইস অনুমোদন করা হচ্ছে…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>এই ডিভাইসটি অনুমোদন করা যায়নি</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>নতুন ডিভাইসে এই কোড লিখুন।</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>অ্যালবামে যান</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>মুছুন</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>বাতিল করুন</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>আউটবক্স লোড করা যায়নি</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>zařízení se schvaluje…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>toto zařízení se nepodařilo schválit</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>zadejte tento kód na novém zařízení.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>přejít na album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>smazat</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>zrušit</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>nelze načíst odchozí frontu</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>Gerät wird genehmigt…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>dieses Gerät konnte nicht genehmigt werden</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>gib diesen Code auf dem neuen Gerät ein.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>zum Album wechseln</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>löschen</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>abbrechen</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>Postausgang konnte nicht geladen werden</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>approving device…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>couldn't approve this device</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>enter this code on the new device.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>go to album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>delete</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>cancel</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>couldn't load the outbox</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>aprobando dispositivo…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>no se pudo aprobar este dispositivo</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>introduce este código en el dispositivo nuevo.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ir al álbum</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>eliminar</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>cancelar</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>no se pudo cargar la bandeja de salida</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>approbation de l’appareil…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>impossible d’approuver cet appareil</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>saisissez ce code sur le nouvel appareil.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>aller à l'album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>supprimer</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>annuler</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>impossible de charger la file d'envoi</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>ઉપકરણ મંજૂર થઈ રહ્યું છે…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>આ ઉપકરણ મંજૂર કરી શકાયું નહીં</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>નવા ઉપકરણ પર આ કોડ દાખલ કરો.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>આલ્બમ પર જાઓ</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>કાઢી નાખો</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>રદ કરો</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>આઉટબોક્સ લોડ કરી શકાયું નહીં</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>מאשר מכשיר…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>לא ניתן לאשר את המכשיר הזה</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>הזינו את הקוד הזה במכשיר החדש.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>מעבר לאלבום</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>מחק</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>ביטול</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>לא ניתן לטעון את תיבת היוצא</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>उपकरण मंजूर हो रहा है…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>यह उपकरण मंजूर नहीं किया जा सका</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>यह कोड नए उपकरण पर दर्ज करें।</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>एल्बम पर जाएँ</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>हटाएं</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>रद्द करें</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>आउटबॉक्स लोड नहीं हो सका</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>odobravanje uređaja…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>nije moguće odobriti ovaj uređaj</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>unesite ovaj kod na novom uređaju.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>idi na album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>izbriši</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>odustani</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>nije moguće učitati izlazni red</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>approvazione dispositivo…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>impossibile approvare questo dispositivo</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>inserisci questo codice sul nuovo dispositivo.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>vai all'album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>elimina</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>annulla</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>impossibile caricare la posta in uscita</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>デバイスを承認中…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>このデバイスを承認できませんでした</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>このコードを新しいデバイスに入力してください。</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>アルバムへ移動</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>削除</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>キャンセル</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>送信箱を読み込めませんでした</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>ಸಾಧನ ಅನುಮೋದಿಸಲಾಗುತ್ತಿದೆ…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>ಈ ಸಾಧನವನ್ನು ಅನುಮೋದಿಸಲಾಗಲಿಲ್ಲ</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>ಈ ಕೋಡ್ ಅನ್ನು ಹೊಸ ಸಾಧನದಲ್ಲಿ ನಮೂದಿಸಿ.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ಆಲ್ಬಂಗೆ ಹೋಗಿ</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>ಅಳಿಸಿ</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>ರದ್ದುಮಾಡಿ</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>ಹೊರಪೆಟ್ಟಿಗೆ ಲೋಡ್ ಆಗಲಿಲ್ಲ</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>기기 승인 중…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>이 기기를 승인할 수 없음</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>새 기기에 이 코드를 입력하세요.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>앨범으로 이동</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>삭제</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>취소</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>보낼 항목을 불러올 수 없음</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>ഉപകരണം അംഗീകരിക്കുന്നു…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>ഈ ഉപകരണം അംഗീകരിക്കാനായില്ല</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>ഈ കോഡ് പുതിയ ഉപകരണത്തിൽ നൽകുക.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ആൽബത്തിലേക്ക് പോകുക</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>ഇല്ലാതാക്കുക</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>റദ്ദാക്കുക</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>ഔട്ട്‌ബോക്സ് ലോഡ് ചെയ്യാനായില്ല</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>डिव्हाइस मंजूर करत आहे…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>हे डिव्हाइस मंजूर करता आले नाही</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>हा संकेत नवीन डिव्हाइसवर प्रविष्ट करा.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>अल्बमवर जा</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>हटवा</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>रद्द करा</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>आउटबॉक्स लोड करता आला नाही</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>apparaat goedkeuren…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>kan dit apparaat niet goedkeuren</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>voer deze code in op het nieuwe apparaat.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ga naar album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>verwijderen</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>annuleren</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>kan de outbox niet laden</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>ਡਿਵਾਈਸ ਮਨਜ਼ੂਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਮਨਜ਼ੂਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>ਨਵੇਂ ਡਿਵਾਈਸ ਉੱਤੇ ਇਹ ਕੋਡ ਦਾਖਲ ਕਰੋ।</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ਐਲਬਮ 'ਤੇ ਜਾਓ</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>ਮਿਟਾਓ</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>ਰੱਦ ਕਰੋ</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>ਆਉਟਬਾਕਸ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕਿਆ</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>zatwierdzanie urządzenia…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>nie udało się zatwierdzić tego urządzenia</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>wpisz ten kod na nowym urządzeniu.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>przejdź do albumu</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>usuń</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>anuluj</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>nie udało się wczytać skrzynki nadawczej</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>aprovando dispositivo…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>não foi possível aprovar este dispositivo</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>insira este código no novo dispositivo.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ir para o álbum</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>excluir</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>cancelar</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>não foi possível carregar a caixa de saída</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>சாதனத்துக்கு ஒப்புதல் அளிக்கப்படுகிறது…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>இந்த சாதனத்துக்கு ஒப்புதல் அளிக்க முடியவில்லை</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>இந்த குறியீட்டை புதிய சாதனத்தில் உள்ளிடவும்.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ஆல்பத்திற்குச் செல்</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>நீக்கு</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>ரத்து செய்</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>வெளிச்செல்லும் பெட்டியை ஏற்ற முடியவில்லை</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>పరికరాన్ని ఆమోదిస్తోంది…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>ఈ పరికరాన్ని ఆమోదించలేకపోయింది</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>ఈ కోడ్‌ను కొత్త పరికరంలో నమోదు చేయండి.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ఆల్బమ్‌కు వెళ్లండి</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>తొలగించు</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>రద్దు చేయి</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>బయటికి పంపే పెట్టెను లోడ్ చేయలేకపోయింది</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>กำลังอนุมัติอุปกรณ์…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>อนุมัติอุปกรณ์นี้ไม่ได้</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>ป้อนรหัสนี้บนอุปกรณ์ใหม่</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>ไปที่อัลบั้ม</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>ลบ</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>ยกเลิก</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>โหลดกล่องขาออกไม่ได้</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>cihaz onaylanıyor…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>bu cihaz onaylanamadı</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>bu kodu yeni cihazda girin.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>albüme git</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>sil</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>iptal</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>giden kutusu yüklenemedi</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>схвалення пристрою…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>не вдалося схвалити цей пристрій</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>введіть цей код на новому пристрої.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>перейти до альбому</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>видалити</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>скасувати</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>не вдалося завантажити чергу надсилання</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>آلہ منظور ہو رہا ہے…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>یہ آلہ منظور نہیں ہو سکا</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>یہ رمز نئے آلے پر درج کریں۔</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>البم پر جائیں</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>حذف کریں</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>منسوخ کریں</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>آؤٹ باکس لوڈ نہیں ہو سکا</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>đang phê duyệt thiết bị…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>không thể phê duyệt thiết bị này</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>nhập mã này trên thiết bị mới.</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>đi tới album</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>xóa</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>hủy</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>không thể tải hộp gửi</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>正在批准设备…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>无法批准此设备</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>在新设备上输入此代码。</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>转到专辑</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>删除</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>取消</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>无法加载发件箱</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -142,6 +142,7 @@
   <data name="members.approve.in_progress" xml:space="preserve"><value>正在核准裝置…</value></data>
   <data name="members.approve.failed" xml:space="preserve"><value>無法核准此裝置</value></data>
   <data name="members.approve.invited_hint" xml:space="preserve"><value>在新裝置輸入此代碼。</value></data>
+  <data name="nowplaying.go_to_album" xml:space="preserve"><value>前往專輯</value></data>
   <data name="outbox.delete.kind" xml:space="preserve"><value>刪除</value></data>
   <data name="outbox.cancel_item" xml:space="preserve"><value>取消</value></data>
   <data name="outbox.load_failed" xml:space="preserve"><value>無法載入寄件匣</value></data>

--- a/bae-windows/Views/AlbumCardMenu.cs
+++ b/bae-windows/Views/AlbumCardMenu.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Bae.Windows;
+
+// The album card's context menu: play the album's canonical release, or queue
+// it next / at the end — the same release-level actions the album-detail
+// overflow menu offers, reachable without opening the album.
+internal static class AlbumCardMenu
+{
+    internal static MenuFlyout Build(Action onPlay, Action onPlayNext, Action onAddToQueue)
+    {
+        var menu = new MenuFlyout();
+        var play = new MenuFlyoutItem { Text = Loc.Chrome("menu.play") };
+        play.Click += (_, _) => onPlay();
+        var playNext = new MenuFlyoutItem { Text = Loc.Chrome("menu.play_next") };
+        playNext.Click += (_, _) => onPlayNext();
+        var addToQueue = new MenuFlyoutItem { Text = Loc.Chrome("menu.add_to_queue") };
+        addToQueue.Click += (_, _) => onAddToQueue();
+        menu.Items.Add(play);
+        menu.Items.Add(playNext);
+        menu.Items.Add(addToQueue);
+        return menu;
+    }
+}


### PR DESCRIPTION
On Windows the album grid was click-to-open only, and the now-playing bar's cover and title were inert. Playing or queueing an album meant opening the detail dialog first, and the only route back to whatever was playing was the Ctrl+L accelerator. This mirrors the macOS parity behavior (roadmap C4): quick actions on grid cards plus a clickable bar.

Right-click or long-press on an album card now shows a context menu — Play, Play Next, Add to Queue — that targets the album's canonical release using the same release-level calls the album-detail overflow menu already issues, so no new bridge or NativeBae surface is needed. The primary release id rides on the grid item (populated from `BridgeAlbum`, which always carries it); left-click still opens the detail dialog and selection stays off. Clicking the bar's cover or title jumps to the playing album through a shared helper that both the accelerator and the new tap handlers call, inheriting the guards and the scroll-to-playing-track behavior. A single new tooltip string is the affordance that the art and title are clickable; the three menu labels reuse keys already translated in every locale.

Single-selection only; grid multi-select and bulk actions remain out of scope.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 142 passed (no new tests; the change adds no decision layer, only WinUI wiring).
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans; the new `nowplaying.go_to_album` key is referenced from `MainWindow.xaml.cs`.
- The Windows app compiles only in CI (`windows.yml` via `build.yml`); that build is the compile gate for the WinUI surface.