### PR TITLE
Extract CancellableTaskSlot for supersedable main-actor tasks

### DIFF
--- a/BaeKit/Sources/BaeKit/Concurrency/CancellableTaskSlot.swift
+++ b/BaeKit/Sources/BaeKit/Concurrency/CancellableTaskSlot.swift
@@ -1,0 +1,50 @@
+import Foundation
+import OSLog
+
+private let logger = Logger.bae("CancellableTaskSlot")
+
+/// A single-occupancy slot for a supersedable main-actor task: starting a
+/// new run cancels the one still in flight, so at most one is live and a
+/// stale result never lands after a newer request.
+@MainActor
+public final class CancellableTaskSlot {
+    private var task: Task<Void, Never>?
+
+    public init() {}
+
+    /// Cancel the run in flight and start `operation` in its place.
+    public func replace(_ operation: @escaping @MainActor () async -> Void) {
+        task?.cancel()
+        task = Task { @MainActor in await operation() }
+    }
+
+    /// Cancel the run in flight, ship `work` to a detached worker via
+    /// `DetachedWork.run`, and deliver on the main actor: the value to
+    /// `onSuccess`, any error to `onError`. Cancellation (a newer `replace`,
+    /// or `cancel`) is swallowed with a debug log — the superseding run owns
+    /// whatever surface the callbacks would have touched.
+    public func replace<T: Sendable>(
+        _ label: String,
+        work: @escaping @Sendable () throws -> T,
+        onSuccess: @escaping @MainActor (T) -> Void,
+        onError: @escaping @MainActor (Error) -> Void
+    ) {
+        replace {
+            do {
+                let value = try await DetachedWork.run(work)
+                onSuccess(value)
+            }
+            catch is CancellationError {
+                logger.debug("\(label) cancelled")
+            }
+            catch {
+                onError(error)
+            }
+        }
+    }
+
+    /// Cancel the run in flight without starting a new one.
+    public func cancel() {
+        task?.cancel()
+    }
+}

--- a/BaeKit/Sources/BaeKit/Services/LibrarySessionOpener.swift
+++ b/BaeKit/Sources/BaeKit/Services/LibrarySessionOpener.swift
@@ -59,7 +59,7 @@ public final class LibrarySessionOpener<
 
     /// The open still in flight, cancelled by the next `open` (or an explicit
     /// `cancel`) so its now-stale result never lands on the caller's screen.
-    private var openTask: Task<Void, Never>?
+    private let slot = CancellableTaskSlot()
 
     public init(
         makeHandle: @escaping @Sendable (String) throws -> Handle,
@@ -79,8 +79,7 @@ public final class LibrarySessionOpener<
         libraryId: String,
         onOutcome: @escaping @MainActor (Outcome) -> Void
     ) {
-        openTask?.cancel()
-        openTask = Task { @MainActor in
+        slot.replace {
             let outcome = await self.run(libraryId: libraryId)
             onOutcome(outcome)
         }
@@ -90,7 +89,7 @@ public final class LibrarySessionOpener<
     /// the caller tears its session down (close) so a parked `initApp` can't
     /// resume past its cancellation check and land a library after the close.
     public func cancel() {
-        openTask?.cancel()
+        slot.cancel()
     }
 
     private func run(libraryId: String) async -> Outcome {

--- a/bae-macos/bae/bae/BaeApp.swift
+++ b/bae-macos/bae/bae/BaeApp.swift
@@ -481,16 +481,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     )
     /// In-flight library-list reload, cancelled when a newer one supersedes it.
-    @ObservationIgnored
-    private var reloadTask: Task<Void, Never>?
+    private let reloadSlot = CancellableTaskSlot()
     /// In-flight rename / lock, cancelled on library close.
-    @ObservationIgnored
-    private var renameTask: Task<Void, Never>?
-    @ObservationIgnored
-    private var lockTask: Task<Void, Never>?
+    private let renameSlot = CancellableTaskSlot()
+    private let lockSlot = CancellableTaskSlot()
     /// In-flight forget, cancelled on library close.
-    @ObservationIgnored
-    private var forgetTask: Task<Void, Never>?
+    private let forgetSlot = CancellableTaskSlot()
 
     private var skipsApplicationServices: Bool {
         AppRuntime.skipsApplicationServices(
@@ -607,9 +603,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // its post-await cancellation check and write `.library`/`appService`
         // back after the close.
         opener.cancel()
-        renameTask?.cancel()
-        lockTask?.cancel()
-        forgetTask?.cancel()
+        renameSlot.cancel()
+        lockSlot.cancel()
+        forgetSlot.cancel()
         mediaControlService.deactivate(playbackStore: service.playbackStore)
         Task { [handle = service.appHandle] in
             await handle.shutdown()
@@ -628,22 +624,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the Open Library submenu. A newer reload cancels an in-flight one; on
     /// failure we log and keep the last good list rather than blanking the menu.
     func reloadLibraries() {
-        reloadTask?.cancel()
-        reloadTask = Task { @MainActor in
-            do {
-                libraries = try await DetachedWork.run {
-                    try discoverLibraries()
-                }
-            }
-            catch is CancellationError {
-                logger.debug("discoverLibraries cancelled")
-            }
-            catch {
+        reloadSlot.replace(
+            "discoverLibraries",
+            work: { try discoverLibraries() },
+            onSuccess: { self.libraries = $0 },
+            onError: {
                 logger.error(
-                    "Failed to list libraries: \(error.localizedDescription)"
+                    "Failed to list libraries: \($0.localizedDescription)"
                 )
             }
-        }
+        )
     }
 
     /// Switch to the library `offset` positions from the active one in the
@@ -667,25 +657,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func renameLibrary(_ libraryId: String, to newName: String) {
         guard let sync = appService?.sync else { return }
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
-        renameTask?.cancel()
-        renameTask = Task { @MainActor in
-            do {
-                try await DetachedWork.run {
-                    try sync.renameLibrary(libraryId, trimmed)
-                }
-                renameLibrarySheet = nil
-                reloadLibraries()
-            }
-            catch is CancellationError {
-                logger.debug("rename cancelled for \(libraryId)")
-            }
-            catch {
+        renameSlot.replace(
+            "rename of \(libraryId)",
+            work: { try sync.renameLibrary(libraryId, trimmed) },
+            onSuccess: {
+                self.renameLibrarySheet = nil
+                self.reloadLibraries()
+            },
+            onError: {
                 logger.error(
-                    "Failed to rename \(libraryId): \(error.localizedDescription)"
+                    "Failed to rename \(libraryId): \($0.localizedDescription)"
                 )
-                renameLibrarySheet?.error = error.localizedDescription
+                self.renameLibrarySheet?.error = $0.localizedDescription
             }
-        }
+        )
     }
 
     /// Lock the active library off the main actor: drop its encryption key from
@@ -693,23 +678,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// on next launch. Errors surface through `loadError`.
     func lockActiveLibrary() {
         guard let sync = appService?.sync else { return }
-        lockTask?.cancel()
-        lockTask = Task { @MainActor in
-            do {
-                try await DetachedWork.run {
-                    try sync.lockActiveLibrary()
-                }
-            }
-            catch is CancellationError {
-                logger.debug("lock cancelled")
-            }
-            catch {
+        lockSlot.replace(
+            "lock",
+            work: { try sync.lockActiveLibrary() },
+            onSuccess: {},
+            onError: {
                 logger.error(
-                    "Failed to lock library: \(error.localizedDescription)"
+                    "Failed to lock library: \($0.localizedDescription)"
                 )
-                loadError = error.localizedDescription
+                self.loadError = $0.localizedDescription
             }
-        }
+        )
     }
 }
 
@@ -731,32 +710,27 @@ extension AppDelegate {
             )
             return
         }
-        forgetTask?.cancel()
-        forgetTask = Task { @MainActor in
-            do {
-                try await DetachedWork.run { [handle = service.appHandle] in
-                    try handle.forgetLibrary()
-                }
-            }
-            catch is CancellationError {
-                logger.debug("forget cancelled")
-                return
-            }
-            catch {
+        forgetSlot.replace(
+            "forget",
+            work: { [handle = service.appHandle] in
+                try handle.forgetLibrary()
+            },
+            onSuccess: {
+                self.closeLibrary()
+                self.reloadLibraries()
+            },
+            onError: {
                 logger.error(
-                    "Failed to remove library: \(error.localizedDescription)"
+                    "Failed to remove library: \($0.localizedDescription)"
                 )
-                uiStore.showError(
+                self.uiStore.showError(
                     String(
                         localized:
-                            "Couldn't remove library: \(error.localizedDescription)"
+                            "Couldn't remove library: \($0.localizedDescription)"
                     )
                 )
-                return
             }
-            closeLibrary()
-            reloadLibraries()
-        }
+        )
     }
 }
 

--- a/bae-macos/bae/baeTests/CancellableTaskSlotTests.swift
+++ b/bae-macos/bae/baeTests/CancellableTaskSlotTests.swift
@@ -1,0 +1,202 @@
+import BaeKit
+import Foundation
+import Testing
+
+/// Exercises `CancellableTaskSlot`'s supersede and delivery semantics: a new
+/// run cancels the one in flight, the detached-work envelope routes a value to
+/// `onSuccess` and an error to `onError`, and a cancelled run swallows both.
+@MainActor
+@Suite("CancellableTaskSlot")
+struct CancellableTaskSlotTests {
+
+    @Test("a second run cancels the first, whose callbacks never fire")
+    func replaceSupersedesInFlight() async {
+        let slot = CancellableTaskSlot()
+        let recorder = Recorder()
+        let firstStarted = Latch()
+        let firstGate = DispatchSemaphore(value: 0)
+        let firstDone = Latch()
+
+        // The first run parks in its detached work until released, so the
+        // second run reliably supersedes it while it is genuinely in flight.
+        slot.replace(
+            "first",
+            work: { () -> Int in
+                defer { firstDone.fire() }
+                firstStarted.fire()
+                firstGate.wait()
+                try Task.checkCancellation()
+                return 1
+            },
+            onSuccess: { recorder.succeed($0) },
+            onError: { recorder.fail($0) }
+        )
+        await firstStarted.wait()
+
+        slot.replace(
+            "second",
+            work: { 2 },
+            onSuccess: { recorder.succeed($0) },
+            onError: { recorder.fail($0) }
+        )
+
+        // Release the first; superseded, it throws cancellation and lands
+        // nothing, while the second delivers its value.
+        firstGate.signal()
+        await firstDone.wait()
+        await recorder.awaitCallback()
+
+        #expect(recorder.successes == [2])
+        #expect(recorder.errors.isEmpty)
+    }
+
+    @Test("the envelope delivers the work's value to onSuccess")
+    func envelopeDeliversValue() async {
+        let slot = CancellableTaskSlot()
+        let recorder = Recorder()
+
+        slot.replace(
+            "value",
+            work: { 7 },
+            onSuccess: { recorder.succeed($0) },
+            onError: { recorder.fail($0) }
+        )
+        await recorder.awaitCallback()
+
+        #expect(recorder.successes == [7])
+        #expect(recorder.errors.isEmpty)
+    }
+
+    @Test("the envelope routes a thrown error to onError")
+    func envelopeRoutesError() async {
+        struct WorkError: Error {}
+        let slot = CancellableTaskSlot()
+        let recorder = Recorder()
+
+        slot.replace(
+            "error",
+            work: { () -> Int in throw WorkError() },
+            onSuccess: { recorder.succeed($0) },
+            onError: { recorder.fail($0) }
+        )
+        await recorder.awaitCallback()
+
+        #expect(recorder.successes.isEmpty)
+        #expect(recorder.errors.count == 1)
+        #expect(recorder.errors.first is WorkError)
+    }
+
+    @Test("cancelling a parked run swallows both callbacks")
+    func cancelSwallowsCallbacks() async {
+        let slot = CancellableTaskSlot()
+        let recorder = Recorder()
+        let started = Latch()
+        let gate = DispatchSemaphore(value: 0)
+        let done = Latch()
+
+        slot.replace(
+            "parked",
+            work: { () -> Int in
+                defer { done.fire() }
+                started.fire()
+                gate.wait()
+                try Task.checkCancellation()
+                return 1
+            },
+            onSuccess: { recorder.succeed($0) },
+            onError: { recorder.fail($0) }
+        )
+        await started.wait()
+
+        slot.cancel()
+        gate.signal()
+        // Once the detached work has exited having thrown cancellation, neither
+        // callback can fire: success needs a returned value, and the error arm
+        // ignores `CancellationError`.
+        await done.wait()
+
+        #expect(recorder.successes.isEmpty)
+        #expect(recorder.errors.isEmpty)
+    }
+
+    @Test("cancel with nothing in flight is a no-op and leaves the slot usable")
+    func cancelWithNothingInFlight() async {
+        let slot = CancellableTaskSlot()
+        let recorder = Recorder()
+
+        slot.cancel()
+
+        slot.replace(
+            "after-cancel",
+            work: { 5 },
+            onSuccess: { recorder.succeed($0) },
+            onError: { recorder.fail($0) }
+        )
+        await recorder.awaitCallback()
+
+        #expect(recorder.successes == [5])
+    }
+
+    // MARK: - Fixtures
+
+    /// Collects the envelope callbacks on the main actor and lets a test await
+    /// the first arrival, whichever order the delivery and the await happen in.
+    @MainActor
+    private final class Recorder {
+        private(set) var successes: [Int] = []
+        private(set) var errors: [Error] = []
+        private var arrival: CheckedContinuation<Void, Never>?
+
+        func succeed(_ value: Int) {
+            successes.append(value)
+            signalArrival()
+        }
+
+        func fail(_ error: Error) {
+            errors.append(error)
+            signalArrival()
+        }
+
+        func awaitCallback() async {
+            if !successes.isEmpty || !errors.isEmpty { return }
+            await withCheckedContinuation { arrival = $0 }
+        }
+
+        private func signalArrival() {
+            arrival?.resume()
+            arrival = nil
+        }
+    }
+
+    /// A one-shot signal fireable from any thread — the detached work signals it
+    /// off the main actor, and the test awaits it — resolving whichever order
+    /// the fire and the wait happen in.
+    private final class Latch: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fired = false
+        private var waiter: CheckedContinuation<Void, Never>?
+
+        func fire() {
+            lock.lock()
+            let waiter = waiter
+            self.waiter = nil
+            fired = true
+            lock.unlock()
+            waiter?.resume()
+        }
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                if fired {
+                    lock.unlock()
+                    continuation.resume()
+                }
+                else {
+                    waiter = continuation
+                    lock.unlock()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The cancel-on-replace task envelope — cancel the run in flight, start a detached worker, deliver the value or error on the main actor, swallow cancellation with a debug log — existed as four hand-kept copies on the macOS app delegate (reload, rename, lock, forget) and once more inside BaeKit's LibrarySessionOpener. Each copy had to keep the same correctness-critical ordering by hand, and each new supersedable operation meant writing it again.

BaeKit now owns the envelope as CancellableTaskSlot: a bare cancel-and-replace primitive (used by the opener, whose body maps errors into its Outcome itself) and a generic DetachedWork envelope taking the work, success, and error closures (used by all four delegate sites). The per-site behavior — reload keeping the last good list on error, rename dismissing its sheet on success, forget closing and reloading — stays exactly where it was, in the closures. The only observable change is the cancellation debug-log category moving to the slot's own logger.

## Test plan
- [x] New CancellableTaskSlotTests: supersede, envelope success, envelope error, cancellation swallow, no-op cancel
- [x] LibrarySessionOpenerTests and AppDelegateTests unchanged and green (regression pins)
- [x] xcodebuild build + baeTests, swift-format, swiftlint --strict, periphery all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)