### PR TITLE
Import unidentified music on Windows

### DIFF
--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -550,8 +550,8 @@ internal static class NativeBae
         CaptureBridgeValue(() => CandidateChoices(Await(handle.SearchForCandidate(
             new BridgeSearchQuery.General(artist, album, MetadataSource(source))))));
 
-    internal static string? ReidentifyRelease(AppHandle handle, string releaseId, string chosenReleaseId, BridgeMetadataSource source) =>
-        CaptureError(() => Await(handle.ReIdentifyRelease(releaseId, new BridgeIdentityChoice.Exact(chosenReleaseId, source))));
+    internal static string? ReidentifyRelease(AppHandle handle, string releaseId, BridgeIdentityChoice choice) =>
+        CaptureError(() => Await(handle.ReIdentifyRelease(releaseId, choice)));
 
     internal static string? ScanFolder(AppHandle handle, string path, bool clearFirst) =>
         CaptureError(() => handle.AddWatchedFolder(path));
@@ -581,6 +581,20 @@ internal static class NativeBae
         string folderPath) =>
         CaptureBridgeValue(() => PrefetchedEdit(handle, releaseId, source, folderPath));
 
+    /// <summary>
+    /// The skip-identify confirm seed: project the folder's embedded file tags
+    /// into the edit form. No source release, so no remote covers and no kept
+    /// detail — only the folder's local artwork is offered.
+    /// </summary>
+    internal static (PrefetchedEdit? Prefetched, string? Error) PrefetchUnknownEdit(
+        AppHandle handle, string folderPath) =>
+        CaptureBridgeValue(() => new PrefetchedEdit
+        {
+            Edit = BaeBridgeMethods.RawReleaseEditFromUserEdit(
+                Await(handle.PreviewFileTagsForFolder(folderPath)), "unknown-track"),
+            LocalArtwork = LocalArtwork(handle.GetCandidate(folderPath)),
+        });
+
     internal static (BridgeLibraryStatus? Status, string? Error) CheckReleaseInLibrary(AppHandle handle, string releaseId) =>
         CaptureBridgeValue(() =>
         {
@@ -591,14 +605,14 @@ internal static class NativeBae
         });
 
     internal static string? ImportCandidate(
-        AppHandle handle, string candidateKey, string folderPath, string chosenReleaseId, BridgeMetadataSource source, string storageMode, bool pin, BridgeRawReleaseEdit userEdit, BridgeCoverSelection? selectedCover) =>
+        AppHandle handle, string candidateKey, string folderPath, BridgeIdentityChoice identity, string storageMode, bool pin, BridgeRawReleaseEdit userEdit, BridgeCoverSelection? selectedCover) =>
         CaptureError(() => handle.StartImport(
             candidateKey,
             folderPath,
             selectedCover,
             StorageMode(storageMode),
             pin,
-            new BridgeIdentityChoice.Exact(chosenReleaseId, source),
+            identity,
             ReleaseUserEdit(userEdit)));
 
     internal static byte[]? ImageBytes(AppHandle? handle, BridgeImageRef image) =>
@@ -796,15 +810,15 @@ internal static class NativeBae
     {
         var localTrackCount = LocalTrackCount(handle.GetCandidate(folderPath));
         var detail = Await(handle.PrefetchRelease(releaseId, source, localTrackCount));
-        var choice = new BridgeIdentityChoice.Exact(releaseId, source);
-        var edit = BaeBridgeMethods.RawReleaseEditFromUserEdit(
-            BaeBridgeMethods.ShapeUserEditFromReleaseDetail(detail, choice),
-            "prefetch-track");
+        // A picked release claims the exact pressing by default; the confirm
+        // dialog re-shapes this seed if the user switches to metadata only.
+        var edit = ShapeCandidateEdit(detail, new BridgeIdentityChoice.Exact(releaseId, source));
         return new PrefetchedEdit
         {
             Edit = edit,
             RemoteCovers = detail.CoverArt.ToList(),
             LocalArtwork = LocalArtwork(handle.GetCandidate(folderPath)),
+            Detail = detail,
         };
     }
 
@@ -1060,6 +1074,26 @@ internal static class NativeBae
             "barcode" => new BridgeExcludedSignal.Barcode(),
             _ => new BridgeExcludedSignal.Catalog(value),
         };
+
+    /// <summary>
+    /// The identity claim for a source-backed pick: <c>Exact</c> keeps the picked
+    /// pressing's fields, <c>Approximate</c> claims only the album group (core
+    /// blanks the pressing fields). The only place these two variants are built.
+    /// </summary>
+    internal static BridgeIdentityChoice SourceIdentityChoice(bool exact, string releaseId, BridgeMetadataSource source) =>
+        exact
+            ? new BridgeIdentityChoice.Exact(releaseId, source)
+            : new BridgeIdentityChoice.Approximate(releaseId, source);
+
+    /// <summary>
+    /// Re-shape the confirm-form seed from a kept release detail under a new
+    /// identity claim — used when the user flips exact ↔ metadata only, with no
+    /// re-fetch. Approximate nils the pressing fields; Exact keeps them.
+    /// </summary>
+    internal static BridgeRawReleaseEdit ShapeCandidateEdit(BridgeReleaseDetail detail, BridgeIdentityChoice choice) =>
+        BaeBridgeMethods.RawReleaseEditFromUserEdit(
+            BaeBridgeMethods.ShapeUserEditFromReleaseDetail(detail, choice),
+            "prefetch-track");
 
     private static BridgeReleaseUserEdit ReleaseUserEdit(BridgeRawReleaseEdit edit) =>
         BaeBridgeMethods.ShapeReleaseEdit(edit) switch

--- a/bae-windows/PrefetchedEdit.cs
+++ b/bae-windows/PrefetchedEdit.cs
@@ -18,6 +18,13 @@ internal sealed class PrefetchedEdit
         []);
     public List<BridgeRemoteCover> RemoteCovers { get; set; } = new();
     public List<LocalArtwork> LocalArtwork { get; set; } = new();
+
+    /// <summary>
+    /// The picked release's detail, kept so the exactness flip (exact ↔ metadata
+    /// only) can re-shape the editor without another fetch. Null for a
+    /// skip-identify import, which has no source release.
+    /// </summary>
+    public BridgeReleaseDetail? Detail { get; set; }
 }
 
 /// <summary>

--- a/bae-windows/ReleaseEditForm.cs
+++ b/bae-windows/ReleaseEditForm.cs
@@ -156,6 +156,21 @@ internal sealed class ReleaseEditForm
     }
 
     /// <summary>
+    /// Enable or disable the six pressing fields (year … barcode). A metadata-only
+    /// import claim blanks these core-side, so the form disables them to make the
+    /// blanking visible; the album title/artists and track table stay editable.
+    /// </summary>
+    internal void SetPressingFieldsEnabled(bool enabled)
+    {
+        _yearBox.IsEnabled = enabled;
+        _formatBox.IsEnabled = enabled;
+        _labelBox.IsEnabled = enabled;
+        _catalogBox.IsEnabled = enabled;
+        _countryBox.IsEnabled = enabled;
+        _barcodeBox.IsEnabled = enabled;
+    }
+
+    /// <summary>
     /// Flush the typed values into the generated edit shape.
     /// Shaping/validation happens in Rust (apply-edit or import-candidate); this
     /// only moves the form's strings onto the model.

--- a/bae-windows/Stores/ImportIdentityModel.cs
+++ b/bae-windows/Stores/ImportIdentityModel.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Bae.Windows;
+
+// The identity-claim state behind the import confirmation and re-identify
+// dialogs: whether the claim is backed by a picked source release, and — when
+// it is — whether the user claims the exact pressing or just the album group
+// (metadata only). Unknown (no source release) has no exactness choice at all.
+// Pure over bools so it is unit-tested apart from the WinUI dialogs and the
+// generated bridge identity type.
+public sealed class ImportIdentityModel
+{
+    public bool HasSourceRelease { get; }
+    public bool MetadataOnly { get; private set; }
+
+    public ImportIdentityModel(bool hasSourceRelease) { HasSourceRelease = hasSourceRelease; }
+
+    // Absolute set (not a toggle). A claim without a source release has no
+    // exactness to choose — calling this then is a caller bug, so fail loud.
+    public void SetMetadataOnly(bool metadataOnly)
+    {
+        if (!HasSourceRelease)
+        {
+            throw new InvalidOperationException("no source release to claim exactness against");
+        }
+        MetadataOnly = metadataOnly;
+    }
+
+    public bool ShowsExactnessChoice => HasSourceRelease;
+    public bool ShowsMetadataOnlyNote => HasSourceRelease && MetadataOnly;
+    // Approximate blanks the pressing fields core-side; the form disables them
+    // so the blanking is visible. Unknown keeps them editable (file tags may
+    // be wrong or absent).
+    public bool PressingFieldsEnabled => !(HasSourceRelease && MetadataOnly);
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>الوجه</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>رقم</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>فنان الألبوم</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>تخطّي التحديد</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>استيراد كـ</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>الطبعة المطابقة تمامًا</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>البيانات الوصفية فقط</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>البيانات الوصفية فقط — تبقى حقول الطبعة فارغة؛ يُسجَّل مجموعة الألبوم فقط.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>تعيين الهوية إلى هذه الطبعة</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>страна</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>№</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>изпълнител на албума</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Пропускане на идентификацията</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Внасяне като</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Точно издание</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Само метаданни</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Само метаданни — полетата за издание остават празни; записва се само групата на албума.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Задаване на идентичност към това издание</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>সাইড</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>নং</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>অ্যালবাম শিল্পী</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>শনাক্ত করা এড়িয়ে যান</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>এই হিসেবে ইম্পোর্ট করুন</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>সঠিক প্রেসিং</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>শুধু মেটাডেটা</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>শুধু মেটাডেটা — প্রেসিং ক্ষেত্রগুলো ফাঁকা থাকে; শুধু অ্যালবাম গ্রুপ রেকর্ড করা হয়।</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>এই প্রেসিংকে পরিচয় হিসেবে সেট করুন</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>strana</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>č.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>interpret alba</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Přeskočit identifikaci</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importovat jako</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Přesný lis</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Pouze metadata</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Pouze metadata — pole lisu zůstanou prázdná; zaznamená se jen skupina alba.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Nastavit identitu na tento lis</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>Seite</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>Nr.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>Albuminterpret</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Identifizieren überspringen</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importieren als</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Genaue Pressung</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Nur Metadaten</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Nur Metadaten — Pressungsfelder bleiben leer; nur die Albumgruppe wird erfasst.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Identität auf diese Pressung festlegen</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>side</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>no.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>album artist</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Skip identifying</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Import as</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Exact pressing</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Metadata only</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Metadata only — pressing fields stay blank; just the album group is recorded.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Set identity to this pressing</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>cara</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>n.º</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>artista del álbum</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Omitir la identificación</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importar como</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Prensaje exacto</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Solo metadatos</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Solo metadatos — los campos del prensaje quedan en blanco; solo se registra el grupo del álbum.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Establecer la identidad en este prensaje</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>face</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>n°</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>artiste de l'album</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Ignorer l'identification</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importer comme</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Pressage exact</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Métadonnées seules</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Métadonnées seules — les champs du pressage restent vides ; seul le groupe d'album est enregistré.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Définir l'identité sur ce pressage</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>બાજુ</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>નં.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>આલ્બમ કલાકાર</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>ઓળખવાનું છોડો</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>આ રીતે આયાત કરો</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>ચોક્કસ પ્રેસિંગ</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>માત્ર મેટાડેટા</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>માત્ર મેટાડેટા — પ્રેસિંગ ફીલ્ડ્સ ખાલી રહેશે; ફક્ત આલ્બમ જૂથ નોંધાય છે.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>ઓળખ આ પ્રેસિંગ પર સેટ કરો</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>צד</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>מס׳</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>אמן האלבום</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>דלג על הזיהוי</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>ייבא כ</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>תקליט מדויק</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>מטא-נתונים בלבד</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>מטא-נתונים בלבד — שדות התקליט נשארים ריקים; נרשמת רק קבוצת האלבום.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>הגדר זהות לתקליט זה</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>साइड</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>क्र.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>एल्बम कलाकार</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>पहचान छोड़ें</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>इस रूप में आयात करें</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>सटीक प्रेसिंग</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>केवल मेटाडेटा</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>केवल मेटाडेटा — प्रेसिंग फ़ील्ड खाली रहते हैं; केवल एल्बम समूह रिकॉर्ड किया जाता है।</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>पहचान को इस प्रेसिंग पर सेट करें</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>strana</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>br.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>izvođač albuma</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Preskoči identifikaciju</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Uvezi kao</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Točno izdanje</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Samo metapodaci</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Samo metapodaci — polja izdanja ostaju prazna; bilježi se samo grupa albuma.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Postavi identitet na ovo izdanje</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>lato</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>n.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>artista album</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Salta identificazione</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importa come</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Stampa esatta</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Solo metadati</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Solo metadati — i campi di stampa restano vuoti; viene registrato solo il gruppo dell'album.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Imposta identità su questa stampa</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>面</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>番号</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>アルバムアーティスト</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>識別をスキップ</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>取り込み方法</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>正確なプレス</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>メタデータのみ</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>メタデータのみ — プレス欄は空欄のまま、アルバムグループだけが記録されます。</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>このプレスを識別情報に設定</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>ಬದಿ</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>ಸಂ.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>ಆಲ್ಬಮ್ ಕಲಾವಿದ</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>ಗುರುತಿಸುವುದನ್ನು ಬಿಡಿ</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>ಹೀಗೆ ಆಮದುಮಾಡಿ</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>ನಿಖರ ಒತ್ತುವಿಕೆ</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>ಮೆಟಾಡೇಟಾ ಮಾತ್ರ</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>ಮೆಟಾಡೇಟಾ ಮಾತ್ರ — ಪ್ರೆಸ್ಸಿಂಗ್ ಕ್ಷೇತ್ರಗಳು ಖಾಲಿಯಾಗಿಯೇ ಇರುತ್ತವೆ; ಆಲ್ಬಮ್ ಗುಂಪು ಮಾತ್ರ ದಾಖಲಿಸಲಾಗುತ್ತದೆ.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>ಈ ಒತ್ತುವಿಕೆಗೆ ಗುರುತು ಹೊಂದಿಸಿ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>면</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>번호</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>앨범 아티스트</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>식별 건너뛰기</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>다음으로 가져오기</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>정확한 프레싱</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>메타데이터만</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>메타데이터만 — 프레싱 필드는 비워 두고 앨범 그룹만 기록합니다.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>이 프레싱으로 신원 설정</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>വശം</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>നം.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>ആൽബം ആർട്ടിസ്റ്റ്</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>തിരിച്ചറിയൽ ഒഴിവാക്കുക</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>ഇങ്ങനെ ഇറക്കുമതി ചെയ്യുക</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>കൃത്യമായ പ്രസ്സിംഗ്</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>മെറ്റാഡാറ്റ മാത്രം</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>മെറ്റാഡാറ്റ മാത്രം — പ്രസ്സിംഗ് ഫീൽഡുകൾ ശൂന്യമായി തുടരും; ആൽബം ഗ്രൂപ്പ് മാത്രം രേഖപ്പെടുത്തും.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>തിരിച്ചറിയൽ ഈ പ്രസ്സിംഗായി സജ്ജമാക്കുക</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>बाजू</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>क्र.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>अल्बम कलाकार</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>ओळखणे वगळा</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>असे आयात करा</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>अचूक प्रेसिंग</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>फक्त मेटाडेटा</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>फक्त मेटाडेटा — प्रेसिंग फील्ड रिकामे राहतात; फक्त अल्बम गट नोंदवला जातो.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>ओळख या प्रेसिंगवर सेट करा</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>kant</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>nr.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>albumartiest</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Identificeren overslaan</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importeren als</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Exacte persing</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Alleen metadata</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Alleen metadata — persingsvelden blijven leeg; alleen de albumgroep wordt vastgelegd.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Identiteit instellen op deze persing</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>ਪਾਸਾ</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>ਨੰ.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>ਐਲਬਮ ਕਲਾਕਾਰ</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>ਪਛਾਣ ਛੱਡੋ</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>ਇਸ ਵਜੋਂ ਆਯਾਤ ਕਰੋ</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>ਬਿਲਕੁਲ ਉਹੀ ਛਪਾਈ</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>ਸਿਰਫ਼ ਮੈਟਾਡਾਟਾ</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>ਸਿਰਫ਼ ਮੈਟਾਡਾਟਾ — ਪ੍ਰੈਸਿੰਗ ਖੇਤਰ ਖਾਲੀ ਰਹਿੰਦੇ ਹਨ; ਸਿਰਫ਼ ਐਲਬਮ ਸਮੂਹ ਦਰਜ ਹੁੰਦਾ ਹੈ।</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>ਪਛਾਣ ਇਸ ਛਪਾਈ ਤੇ ਸੈੱਟ ਕਰੋ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>strona</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>nr</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>wykonawca albumu</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Pomiń identyfikację</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importuj jako</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Dokładne tłoczenie</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Tylko metadane</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Tylko metadane — pola tłoczenia pozostają puste; zapisywana jest jedynie grupa albumu.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Ustaw tożsamość na to tłoczenie</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>lado</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>n.º</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>artista do álbum</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Pular identificação</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Importar como</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Prensagem exata</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Somente metadados</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Somente metadados — os campos de prensagem ficam em branco; apenas o grupo do álbum é registrado.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Definir identidade para esta prensagem</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>பக்கம்</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>எண்</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>ஆல்பம் கலைஞர்</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>அடையாளம் காணலைத் தவிர்</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>இவ்வாறு இறக்குமதி செய்</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>துல்லியமான அச்சு பதிப்பு</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>மெட்டாடேட்டா மட்டும்</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>மெட்டாடேட்டா மட்டும் — பதிப்பு புலங்கள் காலியாகவே இருக்கும்; ஆல்பக் குழு மட்டும் பதிவு செய்யப்படும்.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>அடையாளத்தை இந்த அச்சு பதிப்பாக அமை</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>సైడ్</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>సం.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>ఆల్బమ్ కళాకారుడు</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>గుర్తింపును దాటవేయి</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>ఇలా దిగుమతి చేయండి</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>కచ్చితమైన ముద్రణ</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>మెటాడేటా మాత్రమే</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>మెటాడేటా మాత్రమే — ప్రెస్సింగ్ ఫీల్డ్‌లు ఖాళీగా ఉంటాయి; ఆల్బమ్ సమూహం మాత్రమే నమోదు చేయబడుతుంది.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>గుర్తింపును ఈ ముద్రణకు సెట్ చేయి</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>หน้า</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>ลำดับ</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>ศิลปินอัลบั้ม</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>ข้ามการระบุ</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>นำเข้าเป็น</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>การผลิตแผ่นตรงกัน</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>เฉพาะเมทาดาทา</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>เฉพาะเมทาดาทา — ช่องข้อมูลรุ่นกดแผ่นจะเว้นว่าง บันทึกเฉพาะกลุ่มอัลบั้ม</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>ตั้งข้อมูลระบุตัวตนเป็นการผลิตแผ่นนี้</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>yüz</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>no.</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>albüm sanatçısı</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Tanımlamayı atla</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Şu şekilde içe aktar</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Tam baskı</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Yalnızca üst veri</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Yalnızca üst veri — baskı alanları boş kalır; yalnızca albüm grubu kaydedilir.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Kimliği bu baskı olarak ayarla</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>сторона</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>№</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>виконавець альбому</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Пропустити ідентифікацію</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Імпортувати як</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Точне видання</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Лише метадані</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Лише метадані — поля видання залишаються порожніми; записується лише група альбому.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Встановити ідентифікацію на це видання</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>سائیڈ</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>نمبر</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>البم فنکار</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>شناخت چھوڑیں</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>بطور درآمد کریں</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>عین پریسنگ</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>صرف میٹا ڈیٹا</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>صرف میٹا ڈیٹا — پریسنگ خانے خالی رہتے ہیں؛ صرف البم گروپ ریکارڈ کیا جاتا ہے۔</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>شناخت اس پریسنگ پر مقرر کریں</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>mặt</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>số</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>nghệ sĩ album</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>Bỏ qua nhận dạng</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>Nhập dưới dạng</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>Bản ép chính xác</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>Chỉ siêu dữ liệu</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>Chỉ siêu dữ liệu — các trường bản ép để trống; chỉ ghi lại nhóm album.</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>Đặt danh tính thành bản ép này</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>面</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>序号</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>专辑艺术家</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>跳过识别</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>导入为</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>精确压制版</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>仅元数据</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>仅元数据 — 压制版字段留空，仅记录专辑组。</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>将身份设为此压制版</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -343,4 +343,10 @@
   <data name="edit.tracks.col_side" xml:space="preserve"><value>面</value></data>
   <data name="edit.tracks.col_number" xml:space="preserve"><value>序號</value></data>
   <data name="edit.tracks.artist_placeholder" xml:space="preserve"><value>專輯演出者</value></data>
+  <data name="identify.skip" xml:space="preserve"><value>略過識別</value></data>
+  <data name="identify.import_as" xml:space="preserve"><value>匯入為</value></data>
+  <data name="identify.exact_pressing" xml:space="preserve"><value>精確版本</value></data>
+  <data name="identify.metadata_only" xml:space="preserve"><value>僅中繼資料</value></data>
+  <data name="identify.metadata_only_note" xml:space="preserve"><value>僅中繼資料 — 壓片欄位會保持空白；只會記錄專輯群組。</value></data>
+  <data name="album.reidentify.claim_header" xml:space="preserve"><value>將身分設定為此版本</value></data>
 </root>

--- a/bae-windows/Views/ImportConfirmDialog.cs
+++ b/bae-windows/Views/ImportConfirmDialog.cs
@@ -29,22 +29,25 @@ internal sealed class ImportConfirmDialog
     }
 
     // Returns true when the user chose "Back to Search" — the caller re-opens the
-    // picker so they can pick or search for a different release.
+    // picker so they can pick or search for a different release. A null chosen is
+    // the skip-identify import: no source release, seeded from the rip's file tags.
     public async System.Threading.Tasks.Task<bool> Show(
-        ImportCandidate candidate, ReleaseCandidateChoice chosen)
+        ImportCandidate candidate, ReleaseCandidateChoice? chosen)
     {
-        var (current, prefetched) = await _session.RunForCurrentHandle(
-            handle => NativeBae.PrefetchCandidateEdit(
-                handle, chosen.ReleaseId, chosen.Source, candidate.FolderPath).Prefetched);
+        var (current, seed) = await _session.RunForCurrentHandle(
+            handle => chosen is null
+                ? NativeBae.PrefetchUnknownEdit(handle, candidate.FolderPath)
+                : NativeBae.PrefetchCandidateEdit(handle, chosen.ReleaseId, chosen.Source, candidate.FolderPath));
         if (!current)
         {
             return false;
         }
-        if (prefetched is null)
+        if (seed.Prefetched is null)
         {
-            await DialogPrimitives.ShowError(_xamlRoot(), Loc.Chrome("import.error.load_release"));
+            await DialogPrimitives.ShowError(_xamlRoot(), Loc.Chrome("import.error.load_release"), seed.Error);
             return false;
         }
+        var prefetched = seed.Prefetched;
 
         var (settingsCurrent, settings) = await _session.RunForCurrentHandle(NativeBae.GetSettings);
         if (!settingsCurrent)
@@ -101,6 +104,65 @@ internal sealed class ImportConfirmDialog
         }
         panel.Children.Add(BuildCoverPicker(
             prefetched.RemoteCovers, prefetched.LocalArtwork, picked => selectedCover = picked));
+
+        // A source-backed pick claims the exact pressing by default, or metadata
+        // only (just the album group). Flipping re-shapes the form from the kept
+        // release detail with no re-fetch, overwriting in-progress edits, and
+        // disables the pressing fields when metadata-only so the core-side blanking
+        // is visible. A skip-identify import has no source release and no choice.
+        var identity = new ImportIdentityModel(chosen is not null);
+        if (identity.ShowsExactnessChoice)
+        {
+            var note = new TextBlock
+            {
+                Text = Loc.Chrome("identify.metadata_only_note"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                TextWrapping = TextWrapping.Wrap,
+                Visibility = identity.ShowsMetadataOnlyNote ? Visibility.Visible : Visibility.Collapsed,
+            };
+
+            void ApplyClaim(bool metadataOnly)
+            {
+                identity.SetMetadataOnly(metadataOnly);
+                note.Visibility = identity.ShowsMetadataOnlyNote ? Visibility.Visible : Visibility.Collapsed;
+                form.Seed(NativeBae.ShapeCandidateEdit(
+                    prefetched.Detail!,
+                    NativeBae.SourceIdentityChoice(!identity.MetadataOnly, chosen!.ReleaseId, chosen.Source)));
+                form.SetPressingFieldsEnabled(identity.PressingFieldsEnabled);
+            }
+
+            var exactRadio = new RadioButton
+            {
+                Content = Loc.Chrome("identify.exact_pressing"),
+                GroupName = "importIdentityClaim",
+                IsChecked = true,
+            };
+            var metadataRadio = new RadioButton
+            {
+                Content = Loc.Chrome("identify.metadata_only"),
+                GroupName = "importIdentityClaim",
+            };
+            exactRadio.Checked += (_, _) => ApplyClaim(false);
+            metadataRadio.Checked += (_, _) => ApplyClaim(true);
+
+            var claimRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            claimRow.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("identify.import_as"),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            claimRow.Children.Add(exactRadio);
+            claimRow.Children.Add(metadataRadio);
+
+            panel.Children.Add(claimRow);
+            panel.Children.Add(note);
+        }
+
         panel.Children.Add(form.Panel);
 
         var dialog = new ContentDialog
@@ -124,20 +186,24 @@ internal sealed class ImportConfirmDialog
         // flow has no group id), so it reports the exact pressing — album_in_library
         // tracks release_in_library here. Reads the database — run it off the UI
         // thread. A failure leaves the banner absent; the import still proceeds
-        // (the banner is advisory, not a gate).
-        var (statusCurrent, libraryStatus) = await _session.RunForCurrentHandle(
-            handle => NativeBae.CheckReleaseInLibrary(handle, chosen.ReleaseId).Status);
-        if (!statusCurrent)
+        // (the banner is advisory, not a gate). A skip-identify import has no
+        // release to check, so there is nothing to warn about.
+        if (chosen is not null)
         {
-            return false;
-        }
-        if (libraryStatus is not null && libraryStatus.ReleaseInLibrary)
-        {
-            panel.Children.Insert(0, BuildLibraryStatusBanner(libraryStatus, () =>
+            var (statusCurrent, libraryStatus) = await _session.RunForCurrentHandle(
+                handle => NativeBae.CheckReleaseInLibrary(handle, chosen.ReleaseId).Status);
+            if (!statusCurrent)
             {
-                viewInLibraryAlbumId = libraryStatus.AlbumId;
-                dialog.Hide();
-            }));
+                return false;
+            }
+            if (libraryStatus is not null && libraryStatus.ReleaseInLibrary)
+            {
+                panel.Children.Insert(0, BuildLibraryStatusBanner(libraryStatus, () =>
+                {
+                    viewInLibraryAlbumId = libraryStatus.AlbumId;
+                    dialog.Hide();
+                }));
+            }
         }
 
         // The import runs in the background; its result updates the candidate row
@@ -150,9 +216,12 @@ internal sealed class ImportConfirmDialog
             var payload = form.ReadBack();
             var storageMode = StorageModeTag();
             var pin = StoragePinSelected();
+            BridgeIdentityChoice claim = chosen is null
+                ? new BridgeIdentityChoice.Unknown()
+                : NativeBae.SourceIdentityChoice(!identity.MetadataOnly, chosen.ReleaseId, chosen.Source);
             var (importCurrent, error) = await _session.RunForCurrentHandle(
                 handle => NativeBae.ImportCandidate(
-                    handle, candidate.Key, candidate.FolderPath, chosen.ReleaseId, chosen.Source, storageMode, pin, payload, selectedCover));
+                    handle, candidate.Key, candidate.FolderPath, claim, storageMode, pin, payload, selectedCover));
             if (!importCurrent)
             {
                 args.Cancel = true;

--- a/bae-windows/Views/ImportPickerDialog.cs
+++ b/bae-windows/Views/ImportPickerDialog.cs
@@ -95,6 +95,7 @@ internal sealed class ImportPickerDialog
             Title = Loc.Chrome("import.release_title"),
             Content = new ScrollViewer { Content = content },
             PrimaryButtonText = Loc.Chrome("action.import"),
+            SecondaryButtonText = Loc.Chrome("identify.skip"),
             CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = _xamlRoot(),
             IsPrimaryButtonEnabled = false,
@@ -133,27 +134,38 @@ internal sealed class ImportPickerDialog
         // Clicking Import here doesn't commit — it advances to the metadata edit
         // step. A second ContentDialog can't open while this one shows, so the
         // picker closes on Primary (the selection + storage mode are captured) and
-        // the confirm step opens after ShowAsync returns. The loop re-opens this
-        // picker — with its search results and selection intact — when the confirm
-        // step's "Back to Search" is chosen; Import or Cancel ends the flow.
+        // the confirm step opens after ShowAsync returns. "Skip identifying"
+        // (Secondary) advances the same way but with no picked release — a
+        // skip-identify import seeded from the rip's file tags. The loop re-opens
+        // this picker — with its search results and selection intact — when the
+        // confirm step's "Back to Search" is chosen; Import or Cancel ends the flow.
         try
         {
             while (true)
             {
                 var pickerResult = await dialog.ShowAsync();
                 _session.WithCurrentHandle(NativeBae.PreviewStop);
-                if (pickerResult != ContentDialogResult.Primary)
+
+                ReleaseCandidateChoice? chosen;
+                if (pickerResult == ContentDialogResult.Primary)
+                {
+                    var index = resultsList.SelectedIndex;
+                    if (index < 0 || index >= results.Count)
+                    {
+                        return;
+                    }
+                    chosen = results[index];
+                }
+                else if (pickerResult == ContentDialogResult.Secondary)
+                {
+                    chosen = null;
+                }
+                else
                 {
                     return;
                 }
 
-                var index = resultsList.SelectedIndex;
-                if (index < 0 || index >= results.Count)
-                {
-                    return;
-                }
-
-                var backToSearch = await _confirm.Show(candidate, results[index]);
+                var backToSearch = await _confirm.Show(candidate, chosen);
                 if (!backToSearch)
                 {
                     return;

--- a/bae-windows/Views/ReleaseActionDialogs.cs
+++ b/bae-windows/Views/ReleaseActionDialogs.cs
@@ -260,12 +260,47 @@ internal sealed class ReleaseActionDialogs
             Visibility = Visibility.Collapsed,
         };
 
+        // The identity claim for the selected pressing: exact by default, or
+        // metadata only. Hidden until a result is picked, and reset to exact on
+        // every new pick. A skip-identify re-identify (the Secondary button) claims
+        // nothing here — core reseeds the rows from the rip's file tags.
+        var exactRadio = new RadioButton
+        {
+            Content = Loc.Chrome("identify.exact_pressing"),
+            GroupName = "reidentifyIdentityClaim",
+            IsChecked = true,
+        };
+        var metadataRadio = new RadioButton
+        {
+            Content = Loc.Chrome("identify.metadata_only"),
+            GroupName = "reidentifyIdentityClaim",
+        };
+        var claimRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+            Visibility = Visibility.Collapsed,
+        };
+        claimRow.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("album.reidentify.claim_header"),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        claimRow.Children.Add(exactRadio);
+        claimRow.Children.Add(metadataRadio);
+
+        var identity = new ImportIdentityModel(hasSourceRelease: true);
+        exactRadio.Checked += (_, _) => identity.SetMetadataOnly(false);
+        metadataRadio.Checked += (_, _) => identity.SetMetadataOnly(true);
+
         var form = new StackPanel { Spacing = 8, Width = 420 };
         form.Children.Add(artistBox);
         form.Children.Add(albumBox);
         form.Children.Add(sourceBox);
         form.Children.Add(searchButton);
         form.Children.Add(resultsList);
+        form.Children.Add(claimRow);
         form.Children.Add(status);
 
         var dialog = new ContentDialog
@@ -273,6 +308,7 @@ internal sealed class ReleaseActionDialogs
             Title = Loc.Chrome("album.reidentify.title"),
             Content = new ScrollViewer { Content = form },
             PrimaryButtonText = Loc.Chrome("album.reidentify.confirm"),
+            SecondaryButtonText = Loc.Chrome("identify.skip"),
             CloseButtonText = Loc.Chrome("action.cancel"),
             XamlRoot = _xamlRoot(),
             IsPrimaryButtonEnabled = false,
@@ -312,7 +348,12 @@ internal sealed class ReleaseActionDialogs
 
         resultsList.SelectionChanged += (_, _) =>
         {
-            dialog.IsPrimaryButtonEnabled = resultsList.SelectedIndex >= 0;
+            var selected = resultsList.SelectedIndex >= 0;
+            dialog.IsPrimaryButtonEnabled = selected;
+            claimRow.Visibility = selected ? Visibility.Visible : Visibility.Collapsed;
+            // Each new pick resets the claim to exact.
+            identity = new ImportIdentityModel(hasSourceRelease: true);
+            exactRadio.IsChecked = true;
         };
 
         dialog.PrimaryButtonClick += async (_, args) =>
@@ -327,7 +368,32 @@ internal sealed class ReleaseActionDialogs
             var chosen = candidates[index];
             var deferral = args.GetDeferral();
             var (current, error) = await _session.RunForCurrentHandle(
-                handle => NativeBae.ReidentifyRelease(handle, releaseId, chosen.ReleaseId, chosen.Source));
+                handle => NativeBae.ReidentifyRelease(handle, releaseId,
+                    NativeBae.SourceIdentityChoice(!identity.MetadataOnly, chosen.ReleaseId, chosen.Source)));
+            if (!current)
+            {
+                args.Cancel = true;
+                deferral.Complete();
+                return;
+            }
+            if (error is not null)
+            {
+                status.Text = error;
+                status.Visibility = Visibility.Visible;
+                args.Cancel = true;
+            }
+
+            deferral.Complete();
+        };
+
+        // "Skip identifying" clears any source identity in one click: core reseeds
+        // the release's rows from the rip's file tags, so there is no editable seed
+        // page and no follow-up refresh prompt.
+        dialog.SecondaryButtonClick += async (_, args) =>
+        {
+            var deferral = args.GetDeferral();
+            var (current, error) = await _session.RunForCurrentHandle(
+                handle => NativeBae.ReidentifyRelease(handle, releaseId, new BridgeIdentityChoice.Unknown()));
             if (!current)
             {
                 args.Cancel = true;

--- a/bae-windows/bae-windows.Tests/ImportIdentityModelTests.cs
+++ b/bae-windows/bae-windows.Tests/ImportIdentityModelTests.cs
@@ -1,0 +1,61 @@
+using System;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+// The identity-claim state behind the import confirmation and re-identify
+// dialogs: a source-backed claim offers an exact-vs-metadata-only choice and
+// disables the pressing fields when metadata-only; an unknown claim (no source
+// release) offers no choice and keeps the pressing fields editable.
+public sealed class ImportIdentityModelTests
+{
+    [Fact]
+    public void SourceBacked_DefaultsToExact()
+    {
+        var model = new ImportIdentityModel(hasSourceRelease: true);
+        Assert.False(model.MetadataOnly);
+        Assert.True(model.ShowsExactnessChoice);
+        Assert.False(model.ShowsMetadataOnlyNote);
+        Assert.True(model.PressingFieldsEnabled);
+    }
+
+    [Fact]
+    public void SourceBacked_FlipToMetadataOnly_ShowsNoteAndDisablesPressingFields()
+    {
+        var model = new ImportIdentityModel(hasSourceRelease: true);
+        model.SetMetadataOnly(true);
+        Assert.True(model.MetadataOnly);
+        Assert.True(model.ShowsExactnessChoice);
+        Assert.True(model.ShowsMetadataOnlyNote);
+        Assert.False(model.PressingFieldsEnabled);
+    }
+
+    [Fact]
+    public void SourceBacked_FlipBackToExact_HidesNoteAndReenablesPressingFields()
+    {
+        var model = new ImportIdentityModel(hasSourceRelease: true);
+        model.SetMetadataOnly(true);
+        model.SetMetadataOnly(false);
+        Assert.False(model.MetadataOnly);
+        Assert.False(model.ShowsMetadataOnlyNote);
+        Assert.True(model.PressingFieldsEnabled);
+    }
+
+    [Fact]
+    public void Unknown_HasNoExactnessChoiceAndKeepsPressingFieldsEditable()
+    {
+        var model = new ImportIdentityModel(hasSourceRelease: false);
+        Assert.False(model.MetadataOnly);
+        Assert.False(model.ShowsExactnessChoice);
+        Assert.False(model.ShowsMetadataOnlyNote);
+        Assert.True(model.PressingFieldsEnabled);
+    }
+
+    [Fact]
+    public void Unknown_SetMetadataOnly_Throws()
+    {
+        var model = new ImportIdentityModel(hasSourceRelease: false);
+        Assert.Throws<InvalidOperationException>(() => model.SetMetadataOnly(true));
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -15,10 +15,12 @@
       behind the system transport controls, expressed over plain BCL types with
       no WinRT dependency (the WinRT shell that applies its decisions lives in
       MediaControlService and is verified by compilation).
-    - The store models (PlaybackPositionModel / SyncIndicatorModel) — the
-      now-playing-bar seek/position math and the sync-indicator precedence, split
-      out of MainWindow as plain BCL types (the stores that hold bridge snapshots
-      and the WinUI views that render them are verified by compilation).
+    - The store models (PlaybackPositionModel / SyncIndicatorModel /
+      ImportIdentityModel) — the now-playing-bar seek/position math, the
+      sync-indicator precedence, and the import identity-claim state (exact vs
+      metadata-only, its note and pressing-field enablement), split out as plain
+      BCL types (the stores that hold bridge snapshots and the WinUI views and
+      dialogs that render them are verified by compilation).
     - The update-flow layer (UpdateFlow) — the state machine and display mapping
       behind the settings "updates" section (status keys, percent clamping,
       button gating, version-string normalization), over plain BCL types with no
@@ -54,6 +56,7 @@
     <Compile Include="../TextTruncation.cs" Link="TextTruncation.cs" />
     <Compile Include="../Stores/QueueReorderModel.cs" Link="QueueReorderModel.cs" />
     <Compile Include="../Stores/OrderedIntersection.cs" Link="OrderedIntersection.cs" />
+    <Compile Include="../Stores/ImportIdentityModel.cs" Link="ImportIdentityModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Windows could construct only the `Exact` identity claim, so a rip that matched no source release — and turned up nothing on manual search — could not be imported at all. The import picker's confirm button stayed disabled with no selection, the confirm step demanded a picked release before it would even seed, and re-identify was likewise gated on a selected pressing. The bridge and core have supported the `Unknown` (skip-identify) and `Approximate` (metadata-only) claims all along; only Windows never built them.

This change wires both claims through the import and re-identify surfaces to match macOS. The import picker grows a "Skip identifying" button that leads to a confirm form seeded from the rip's embedded file tags (no remote covers, no library-status banner, no exactness choice) and commits `Unknown`. A picked release now offers an "Import as: exact pressing / metadata only" choice; flipping it re-shapes the form from the kept release detail with no re-fetch and disables the six pressing fields that the core blanks for a metadata-only claim, so the blanking is visible. Re-identify gains the same claim row (reset to exact on every new pick) plus a one-click "Skip identifying" that clears the source identity, letting core reseed the release's rows from the rip's file tags.

The exact/metadata-only/unknown visibility and field-enablement logic is factored into a pure `ImportIdentityModel`, following the `LibrarySort` / `QueueReorderModel` pattern, so it is unit-tested apart from the WinUI dialogs and the generated bridge identity type. Six new chrome keys are added across all 31 locale catalogs.

The Windows app compiles only in CI (`windows.yml`); that is the compile gate for this change.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — new `ImportIdentityModelTests` (full claim/visibility/enablement matrix) plus the existing suite, all green (147 passed).
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans across 347 keys, no allowlist additions.
- CI (`windows.yml`) builds the WinUI app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)