### PR TITLE
Fix the frozen macOS queue pane by applying the queueUpdated snapshot directly

### DIFF
--- a/bae-macos/bae/bae/Services/AppService.swift
+++ b/bae-macos/bae/bae/Services/AppService.swift
@@ -79,7 +79,6 @@ final class AppService: BaeKit.AppService {
     /// deferred Discogs token. Called once after construction; previews skip it.
     func wireUp() {
         registerCommonProjections()
-        registerProjection(makeQueueProjection())
         registerProjection(makeExportProjection())
         registerProjection(makeImportCandidatesProjection())
         registerProjection(makeImportCandidateProjection())
@@ -114,19 +113,6 @@ final class AppService: BaeKit.AppService {
 }
 
 extension AppService {
-    private func makeQueueProjection() -> Projection<BridgeQueueSnapshot> {
-        Projection(
-            domain: .queue,
-            query: { [appHandle] _ in
-                try await appHandle.getQueueSnapshot()
-            },
-            apply: { [self] snapshot in
-                applyQueueSnapshot(snapshot)
-            },
-            onError: { [uiStore] error in uiStore.showError(error) }
-        )
-    }
-
     private func makeExportProjection() -> Projection<BridgeExportSnapshot> {
         Projection(
             domain: .exportQueue,

--- a/bae-macos/bae/bae/Services/UiEventReducer.swift
+++ b/bae-macos/bae/bae/Services/UiEventReducer.swift
@@ -170,7 +170,15 @@ enum UiEventReducer {
                 )
             )
 
-        case .releaseTransferProgress, .releaseTransferEnded, .queueUpdated:
+        case .queueUpdated(let snapshot):
+            // Core resolves the full queue projection before emitting, so the
+            // carried snapshot is the queue's update path — the same direct
+            // apply every other platform does. The manual and context lanes
+            // land on the store; `has_next`/`has_previous` drive Control
+            // Center's next/previous availability.
+            context.appService.applyQueueSnapshot(snapshot)
+
+        case .releaseTransferProgress, .releaseTransferEnded:
             break
 
         case .error, .errorCleared:

--- a/bae-macos/bae/baeTests/UiEventReducerTests.swift
+++ b/bae-macos/bae/baeTests/UiEventReducerTests.swift
@@ -1,0 +1,143 @@
+import BaeKit
+import MediaPlayer
+import Testing
+
+@testable import bae
+
+/// Drives the real macOS `UiEventReducer` sink with a faked `AppHandle` (no live
+/// core) and checks that a `queueUpdated` event lands its carried snapshot. Core
+/// resolves the queue projection before emitting, so the event is the queue's
+/// update path on macOS the same as on iOS/Windows/Android; the media-control
+/// next/previous availability rides the same snapshot. The suite is serialized
+/// and resets the process-global command center because it reads back the
+/// transport-command enabled flags.
+@MainActor
+@Suite("UiEventReducer queue", .serialized)
+struct UiEventReducerQueueTests {
+    @Test(
+        "queueUpdated applies its snapshot to the queue and transport commands"
+    )
+    func queueUpdatedAppliesSnapshot() {
+        let center = MPRemoteCommandCenter.shared()
+        center.nextTrackCommand.isEnabled = false
+        center.previousTrackCommand.isEnabled = false
+        defer {
+            center.nextTrackCommand.isEnabled = false
+            center.previousTrackCommand.isEnabled = false
+        }
+
+        let appService = makeAppService()
+        let sink = UiEventReducer.makeSink(appService: appService)
+
+        sink(
+            .queueUpdated(
+                snapshot: BridgeQueueSnapshot(
+                    manual: [
+                        makeEntry(entryId: "manual-1", trackId: "track-1")
+                    ],
+                    context: BridgePlaybackContext(
+                        kind: .release,
+                        shuffled: false,
+                        upcoming: [
+                            makeEntry(entryId: "upcoming-1", trackId: "track-2")
+                        ]
+                    ),
+                    hasNext: true,
+                    hasPrevious: false
+                )
+            )
+        )
+
+        #expect(
+            appService.playbackStore.manualQueue.map(\.entryId) == ["manual-1"]
+        )
+        #expect(
+            appService.playbackStore.queueContext?.upcoming.map(\.entryId)
+                == ["upcoming-1"]
+        )
+        #expect(center.nextTrackCommand.isEnabled)
+        #expect(!center.previousTrackCommand.isEnabled)
+    }
+
+    private func makeEntry(entryId: String, trackId: String) -> BridgeQueueEntry
+    {
+        BridgeQueueEntry(
+            entryId: entryId,
+            trackId: trackId,
+            title: "Track Title",
+            artistNames: "Artist Name",
+            durationMs: 180_000,
+            albumTitle: "Album Title",
+            coverImageId: nil
+        )
+    }
+
+    private func makeAppService() -> bae.AppService {
+        bae.AppService(
+            appHandle: FakeAppHandle(),
+            mediaControlService: MediaControlService(),
+            uiStore: UiStore(),
+            config: BridgeConfig(
+                libraryId: "lib-test",
+                libraryName: "Test Library",
+                libraryPath: "/tmp/test",
+                encryptionKeyStored: false,
+                encryptionKeyFingerprint: nil,
+                pauseBetweenSides: false,
+                exportLocation: .askEachTime,
+                exportFilenameTemplate: "",
+                exportPresets: [],
+                defaultTrackExportSelection: .original,
+                defaultReleaseExportSelection: .original,
+                mcp: BridgeMcpConfig(enabled: false, port: 47777),
+                discogsTokenStatus: .notConfigured,
+                discogsUsable: false,
+                sync: nil
+            ),
+            initialOutbox: OutboxStore.emptySnapshot
+        )
+    }
+}
+
+/// A handle-less `AppHandle` that answers the reads the macOS `AppService`
+/// constructor makes so a reducer test can build the real service without a live
+/// core. The reducer's queue path touches no handle method, so only the
+/// construction-time reads are overridden; any other call would hit the base
+/// FFI against the null handle and trap.
+private final class FakeAppHandle: AppHandle, @unchecked Sendable {
+    init() {
+        super.init(noHandle: AppHandle.NoHandle())
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func isSyncReady() -> Bool {
+        false
+    }
+
+    override func getDownloadSnapshot() -> BridgeDownloadSnapshot {
+        BridgeDownloadSnapshot(
+            downloads: [],
+            total: BridgeDownloadProgress(queued: 0, active: 0, failed: 0),
+            paused: false
+        )
+    }
+
+    override func getExportSnapshot() -> BridgeExportSnapshot {
+        BridgeExportSnapshot(
+            exports: [],
+            total: BridgeExportProgress(queued: 0, active: 0, failed: 0),
+            paused: false
+        )
+    }
+
+    override func getImportCandidates() -> BridgeImportCandidatesSnapshot {
+        BridgeImportCandidatesSnapshot(
+            watchedFolders: [],
+            folderCandidates: [],
+            invalidCandidates: []
+        )
+    }
+}


### PR DESCRIPTION
The macOS queue pane, the now-playing bar's queue lanes, and Control Center's next/previous availability stopped updating during normal use. When macOS state was routed through query-backed projections, the reducer's `queueUpdated` arm was dropped and the queue was left to a `.queue`-domain projection refetch. But nothing emits `Invalidation::Queue` in normal operation — core never produces it, and the only producer anywhere is the bridge's event-bus lag-recovery path, which fires only when the broadcast subscriber drops events. With no trigger, the projection never ran, so the queue froze until a dropped-event lag, i.e. effectively never.

`queueUpdated` already carries a fully-resolved `BridgeQueueSnapshot` — core resolves the projection against the database before emitting and skips the emission on resolve failure, and pump delivery is FIFO in emission order. iOS, Windows, and Android all direct-apply that carried snapshot; macOS was the outlier. This restores the direct apply: the reducer writes both queue lanes to the store and drives the transport-command availability from the same snapshot's `has_next`/`has_previous`. The never-triggered queue projection is removed so the queue keeps a single write path, matching the other three platforms.

## Test plan

- New `baeTests` suite drives the real `UiEventReducer` sink with a faked `AppHandle` (no live core) and asserts a `queueUpdated` event lands its manual and context lanes on the store and toggles the next/previous transport commands. It fails on the pre-fix reducer (queue stays empty, commands stay disabled) and passes after.
- `xcodebuild build test -scheme bae`: build succeeds, all 139 tests pass.
- swift-format lint, swiftlint --strict, periphery: clean.