### PR TITLE
Run the identify pipeline in the Windows re-identify dialog and offer a metadata refresh

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -154,7 +154,8 @@ public sealed partial class MainWindow : Window
             _session,
             () => Content.XamlRoot,
             () => WinRT.Interop.WindowNative.GetWindowHandle(this),
-            text => StatusText.Text = text);
+            text => StatusText.Text = text,
+            _projections);
         _albumDetail = new AlbumDetailDialog(
             _session,
             () => Content.XamlRoot,

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -562,6 +562,31 @@ internal static class NativeBae
     internal static void AutoIdentifyFolder(AppHandle handle, string candidateKey, string folderPath) =>
         handle.AutoIdentifyFolder(candidateKey, folderPath);
 
+    internal static void AutoIdentifyRelease(AppHandle handle, string candidateKey, string releaseId) =>
+        handle.AutoIdentifyRelease(candidateKey, releaseId);
+
+    /// <summary>
+    /// The live identify-pipeline state for a re-identify candidate key: the
+    /// localizable row status, the found pressings, and the signals-toolbar
+    /// badges. Null until the pipeline's first event lands for the key.
+    /// </summary>
+    internal static (ImportCandidateRowStatus RowStatus, List<ReleaseCandidateChoice> Matches, List<SignalBadge> Signals)?
+        ReidentifyPipeline(AppHandle handle, string candidateKey) =>
+        handle.GetCandidate(candidateKey) is BridgeImportCandidateSnapshot.Runtime runtime
+            ? (ImportRowStatus(runtime.RuntimeSnapshot),
+               ImportMatches(runtime.RuntimeSnapshot.IdentifyState),
+               runtime.RuntimeSnapshot.SignalsToolbar.Signals.Select(SignalBadge).ToList())
+            : null;
+
+    /// <summary>
+    /// Reseed a release's metadata from its (just re-pointed) metadata source:
+    /// re-project via reset, then write the projection back. Identity rows are
+    /// untouched; the user's prior edits are overwritten by design.
+    /// </summary>
+    internal static string? RefreshMetadataFromSource(AppHandle handle, string releaseId) =>
+        CaptureError(() => Await(handle.UpdateReleaseMetadataUserEdit(
+            releaseId, Await(handle.ResetMetadataToSource(releaseId)))));
+
     internal static void ToggleSignalForCandidate(AppHandle handle, string candidateKey, string kind, string value) =>
         handle.ToggleSignalForCandidate(candidateKey, ExcludedSignal(kind, value));
 

--- a/bae-windows/Stores/ReidentifyResultsModel.cs
+++ b/bae-windows/Stores/ReidentifyResultsModel.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Bae.Windows;
+
+// Arbitrates the re-identify dialog's results list between its two producers:
+// the auto-identify pipeline (live — it replays on every candidate
+// invalidation, including badge-only updates) and a manual search the user
+// ran. A successful manual search takes the list over; pipeline refreshes
+// keep updating the status line and signal badges but leave the results
+// alone until a pipeline interaction (signal toggle, re-run) hands it back.
+// Pipeline renders are also change-gated: replaying an identical match set
+// must not rebuild the list, because rebuilding drops the user's selection.
+public sealed class ReidentifyResultsModel
+{
+    private List<string> _shownPipelineKeys = new();
+
+    public bool ManualResultsShown { get; private set; }
+
+    // Whether this pipeline refresh replaces the rendered results list.
+    // False while manual results own the list, and false when the match
+    // set is unchanged from the last render.
+    public bool ApplyPipelineMatches(IReadOnlyList<string> matchKeys)
+    {
+        if (ManualResultsShown || _shownPipelineKeys.SequenceEqual(matchKeys))
+        {
+            return false;
+        }
+        _shownPipelineKeys = matchKeys.ToList();
+        return true;
+    }
+
+    public void ApplyManualResults() => ManualResultsShown = true;
+
+    // A pipeline interaction (signal toggle / re-run) asks the pipeline for
+    // results again: the next pipeline refresh re-renders unconditionally.
+    public void ResumePipeline()
+    {
+        ManualResultsShown = false;
+        _shownPipelineKeys = new List<string>();
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>إدراج في الموضع {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>قائمة الانتظار فارغة</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>اسحب الألبومات إلى هنا أو شغّل ألبومًا</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>تم تحديث الهوية.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>هل تريد سحب حقول الألبوم والمقطوعة والطبعة من المصدر المحدَّد حديثًا؟ ستُستبدل التعديلات التي أجريتها.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>تحديث من مصدر جديد</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>الإبقاء على البيانات الوصفية الحالية</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>вмъкване на позиция {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>опашката е празна</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>плъзнете албуми тук или пуснете албум</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Идентичността е обновена.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Да се извлекат полетата за албум, песни и издание от новоидентифицирания източник? Направените от вас редакции ще бъдат презаписани.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Обновяване от нов източник</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Запазване на текущите метаданни</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>{position} নম্বর অবস্থানে যোগ করুন</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>সারি খালি</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>অ্যালবাম এখানে টেনে আনুন বা একটি অ্যালবাম চালান</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>পরিচয় আপডেট হয়েছে।</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>নতুন শনাক্ত করা উৎস থেকে অ্যালবাম, ট্র্যাক ও প্রেসিং ক্ষেত্রগুলো আনবেন? আপনার করা সম্পাদনা মুছে যাবে।</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>নতুন উৎস থেকে রিফ্রেশ করুন</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>বর্তমান মেটাডেটা রাখুন</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>vložit na pozici {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>fronta je prázdná</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>přetáhněte sem alba, nebo nějaké přehrajte</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identita aktualizována.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Načíst pole alba, skladby a lisu z nově identifikovaného zdroje? Vaše úpravy budou přepsány.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Obnovit z nového zdroje</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Zachovat stávající metadata</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>an Position {position} einfügen</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>Warteschlange ist leer</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>Alben hierher ziehen oder ein Album abspielen</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identität aktualisiert.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Album-, Titel- und Pressungsfelder aus der neu identifizierten Quelle übernehmen? Deine Änderungen werden überschrieben.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Aus neuer Quelle aktualisieren</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Aktuelle Metadaten behalten</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>insert at position {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>queue is empty</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>drag albums here or play an album</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identity updated.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Refresh from new source</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Keep current metadata</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>insertar en la posición {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>la cola está vacía</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>arrastra álbumes aquí o reproduce un álbum</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identidad actualizada.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>¿Traer los campos del álbum, la pista y el prensaje desde la fuente recién identificada? Se sobrescribirán los cambios que hayas hecho.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Actualizar desde la nueva fuente</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Mantener los metadatos actuales</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>insérer à la position {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>la file d'attente est vide</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>glissez des albums ici ou lancez la lecture d'un album</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identité mise à jour.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Récupérer les champs de l'album, des pistes et du pressage depuis la nouvelle source identifiée ? Vos modifications seront écrasées.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Actualiser depuis la nouvelle source</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Conserver les métadonnées actuelles</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>સ્થાન {position} પર ઉમેરો</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>કતાર ખાલી છે</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>આલ્બમ અહીં ખેંચો અથવા કોઈ આલ્બમ વગાડો</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>ઓળખ અપડેટ થઈ.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>નવા ઓળખાયેલા સ્રોતમાંથી આલ્બમ, ટ્રૅક અને પ્રેસિંગ ક્ષેત્રો ખેંચવા? તમે કરેલા ફેરફારો પર લખાઈ જશે.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>નવા સ્રોત પરથી તાજું કરો</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>વર્તમાન મેટાડેટા રાખો</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>הוספה במיקום {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>התור ריק</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>גררו אלבומים לכאן או נגנו אלבום</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>הזהות עודכנה.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>למשוך את שדות האלבום, הרצועה והתקליט מהמקור שזוהה מחדש? עריכות שביצעתם יידרסו.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>רענן מהמקור החדש</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>שמור על המטא-נתונים הנוכחיים</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>स्थान {position} पर जोड़ें</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>कतार खाली है</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>एल्बम यहाँ खींचें या कोई एल्बम चलाएँ</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>पहचान अपडेट हुई।</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>नए पहचाने गए स्रोत से एल्बम, ट्रैक और प्रेसिंग फील्ड लें? आपके किए बदलाव अधिलेखित हो जाएंगे।</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>नए स्रोत से रीफ्रेश करें</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>मौजूदा मेटाडेटा रखें</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>umetni na položaj {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>red je prazan</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>povucite albume ovamo ili pustite album</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identitet ažuriran.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Preuzeti polja albuma, skladbe i izdanja iz novoidentificiranog izvora? Vaše izmjene bit će prepisane.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Osvježi iz novog izvora</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Zadrži trenutne metapodatke</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>inserisci in posizione {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>la coda è vuota</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>trascina qui gli album o riproducine uno</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identità aggiornata.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Recuperare i campi di album, brani e stampa dalla sorgente appena identificata? Le modifiche fatte verranno sovrascritte.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Aggiorna da nuova sorgente</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Mantieni i metadati attuali</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>位置 {position} に挿入</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>キューは空です</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ここにアルバムをドラッグするか、アルバムを再生してください</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>識別情報を更新しました。</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>新しく識別されたソースからアルバム、トラック、プレスの各項目を取得しますか？加えた編集は上書きされます。</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>新しいソースから更新</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>現在のメタデータを保持</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>ಸ್ಥಾನ {position} ರಲ್ಲಿ ಸೇರಿಸಿ</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>ಸರತಿ ಖಾಲಿಯಾಗಿದೆ</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ಆಲ್ಬಮ್‌ಗಳನ್ನು ಇಲ್ಲಿಗೆ ಎಳೆಯಿರಿ ಅಥವಾ ಒಂದು ಆಲ್ಬಮ್ ಪ್ಲೇ ಮಾಡಿ</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>ಗುರುತು ನವೀಕರಿಸಲಾಗಿದೆ.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>ಹೊಸದಾಗಿ ಗುರುತಿಸಿದ ಮೂಲದಿಂದ ಆಲ್ಬಮ್, ಹಾಡು ಮತ್ತು ಒತ್ತುವಿಕೆ ಕ್ಷೇತ್ರಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳಬೇಕೇ? ನೀವು ಮಾಡಿದ ತಿದ್ದುಪಡಿಗಳು ಮೇಲೆಯಾಗಿ ಬರೆಯಲ್ಪಡುತ್ತವೆ.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>ಹೊಸ ಮೂಲದಿಂದ ತಾಜಾಗೊಳಿಸಿ</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>ಪ್ರಸ್ತುತ ಮೆಟಾಡೇಟಾವನ್ನು ಉಳಿಸಿ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>{position}번 위치에 삽입</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>대기열이 비어 있습니다</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>앨범을 여기로 끌어오거나 앨범을 재생하세요</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>신원이 업데이트되었습니다.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>새로 식별한 소스에서 앨범, 트랙, 프레싱 필드를 가져올까요? 수정한 내용은 덮어씁니다.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>새 소스에서 새로 고침</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>현재 메타데이터 유지</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>സ്ഥാനം {position}-ൽ ചേർക്കുക</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>ക്യൂ ശൂന്യമാണ്</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ആൽബങ്ങൾ ഇവിടേക്ക് വലിച്ചിടുക, അല്ലെങ്കിൽ ഒരു ആൽബം പ്ലേ ചെയ്യുക</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>തിരിച്ചറിയൽ പുതുക്കി.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>പുതുതായി തിരിച്ചറിഞ്ഞ ഉറവിടത്തിൽ നിന്ന് ആൽബം, ട്രാക്ക്, പ്രസ്സിംഗ് ഫീൽഡുകൾ എടുക്കണോ? നിങ്ങൾ ചെയ്ത തിരുത്തലുകൾ മായും.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>പുതിയ ഉറവിടത്തിൽ നിന്ന് പുതുക്കുക</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>നിലവിലെ മെറ്റാഡാറ്റ നിലനിർത്തുക</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>स्थान {position} वर जोडा</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>रांग रिकामी आहे</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>अल्बम इथे ओढा किंवा एखादा अल्बम वाजवा</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>ओळख अद्यतनित झाली.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>नव्याने ओळखलेल्या स्रोतामधून अल्बम, गाणे आणि प्रेसिंग क्षेत्रे आणायची का? तुम्ही केलेली संपादने अधिलिखित होतील.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>नवीन स्रोतामधून ताजे करा</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>सध्याचा मेटाडेटा ठेवा</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>invoegen op positie {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>wachtrij is leeg</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>sleep albums hierheen of speel een album af</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identiteit bijgewerkt.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Album-, nummer- en persingsvelden uit de nieuw geïdentificeerde bron halen? Je bewerkingen worden overschreven.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Vernieuwen vanuit nieuwe bron</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Huidige metadata behouden</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>ਸਥਿਤੀ {position} 'ਤੇ ਜੋੜੋ</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>ਕਤਾਰ ਖਾਲੀ ਹੈ</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ਐਲਬਮਾਂ ਇੱਥੇ ਖਿੱਚੋ ਜਾਂ ਕੋਈ ਐਲਬਮ ਚਲਾਓ</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>ਪਛਾਣ ਅਪਡੇਟ ਹੋਈ।</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>ਨਵੇਂ ਪਛਾਣੇ ਸਰੋਤ ਤੋਂ ਐਲਬਮ, ਟ੍ਰੈਕ ਅਤੇ ਛਪਾਈ ਖੇਤਰ ਲੈਣੇ ਹਨ? ਤੁਹਾਡੀਆਂ ਕੀਤੀਆਂ ਸੋਧਾਂ ਉੱਤੇ ਲਿਖ ਦਿੱਤਾ ਜਾਵੇਗਾ।</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>ਨਵੇਂ ਸਰੋਤ ਤੋਂ ਤਾਜ਼ਾ ਕਰੋ</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>ਮੌਜੂਦਾ ਮੈਟਾਡਾਟਾ ਰੱਖੋ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>wstaw na pozycji {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>kolejka jest pusta</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>przeciągnij tu albumy albo odtwórz album</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Tożsamość zaktualizowana.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Pobrać pola albumu, utworów i tłoczenia z nowo zidentyfikowanego źródła? Wprowadzone zmiany zostaną nadpisane.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Odśwież z nowego źródła</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Zachowaj obecne metadane</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>inserir na posição {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>a fila está vazia</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>arraste álbuns para cá ou toque um álbum</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Identidade atualizada.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Puxar os campos de álbum, faixa e prensagem da fonte recém-identificada? As edições que você fez serão sobrescritas.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Atualizar a partir da nova fonte</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Manter metadados atuais</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>இடம் {position} இல் சேர்</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>வரிசை காலியாக உள்ளது</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ஆல்பங்களை இங்கே இழுக்கவும் அல்லது ஒரு ஆல்பத்தை இயக்கவும்</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>அடையாளம் புதுப்பிக்கப்பட்டது.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>புதிதாக அடையாளம் காணப்பட்ட மூலத்திலிருந்து ஆல்பம், பாடல், அச்சு பதிப்பு புலங்களை எடுக்கவா? நீங்கள் செய்த திருத்தங்கள் மேலெழுதப்படும்.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>புதிய மூலத்திலிருந்து புதுப்பி</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>தற்போதைய மெட்டாடேட்டாவை வைத்திரு</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>స్థానం {position} వద్ద చేర్చండి</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>క్యూ ఖాళీగా ఉంది</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ఆల్బమ్‌లను ఇక్కడికి లాగండి లేదా ఒక ఆల్బమ్ ప్లే చేయండి</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>గుర్తింపు నవీకరించబడింది.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>కొత్తగా గుర్తించిన మూలం నుంచి ఆల్బమ్, ట్రాక్, ముద్రణ ఫీల్డ్‌లను తీసుకురావాలా? మీరు చేసిన మార్పులు భర్తీ చేయబడతాయి.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>కొత్త మూలం నుంచి రిఫ్రెష్ చేయి</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>ప్రస్తుత మెటాడేటాను ఉంచండి</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>แทรกที่ตำแหน่ง {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>คิวว่างเปล่า</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>ลากอัลบั้มมาที่นี่หรือเล่นอัลบั้ม</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>อัปเดตข้อมูลระบุตัวตนแล้ว</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>ดึงฟิลด์อัลบั้ม แทร็ก และการผลิตแผ่นจากแหล่งที่เพิ่งระบุหรือไม่ การแก้ไขที่คุณทำไว้จะถูกเขียนทับ</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>รีเฟรชจากแหล่งใหม่</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>เก็บเมทาดาทาปัจจุบันไว้</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>{position}. konuma ekle</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>kuyruk boş</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>albümleri buraya sürükleyin veya bir albüm çalın</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Kimlik güncellendi.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Albüm, parça ve baskı alanları yeni tanımlanan kaynaktan alınsın mı? Yaptığınız düzenlemelerin üzerine yazılır.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Yeni kaynaktan yenile</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Mevcut üst veriyi koru</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>вставити на позицію {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>черга порожня</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>перетягніть альбоми сюди або відтворіть альбом</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Ідентифікацію оновлено.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Підтягнути поля альбому, треків і видання з нового ідентифікованого джерела? Внесені вами зміни буде перезаписано.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Оновити з нового джерела</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Зберегти поточні метадані</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>پوزیشن {position} پر شامل کریں</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>قطار خالی ہے</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>البمز یہاں گھسیٹیں یا کوئی البم چلائیں</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>شناخت تازہ ہو گئی۔</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>نئے شناخت شدہ ماخذ سے البم، نغمہ، اور پریسنگ خانے لیں؟ آپ کی کی گئی تبدیلیاں مٹ جائیں گی۔</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>نئے ماخذ سے تازہ کریں</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>موجودہ میٹا ڈیٹا رکھیں</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>chèn vào vị trí {position}</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>hàng đợi trống</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>kéo album vào đây hoặc phát một album</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>Đã cập nhật danh tính.</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Lấy các trường album, bản nhạc và bản ép từ nguồn vừa nhận dạng? Các chỉnh sửa bạn đã thực hiện sẽ bị ghi đè.</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Làm mới từ nguồn mới</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>Giữ siêu dữ liệu hiện tại</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>插入到第 {position} 位</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>队列为空</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>将专辑拖到此处，或播放一张专辑</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>身份已更新。</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>从新识别的来源拉取专辑、曲目和压制版字段？你所做的编辑将被覆盖。</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>从新来源刷新</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>保留当前元数据</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -352,4 +352,8 @@
   <data name="queue.drop_insert_caption" xml:space="preserve"><value>插入到第 {position} 位</value></data>
   <data name="queue.empty.title" xml:space="preserve"><value>佇列是空的</value></data>
   <data name="queue.empty.hint" xml:space="preserve"><value>將專輯拖曳到這裡，或播放一張專輯</value></data>
+  <data name="album.reidentify.updated" xml:space="preserve"><value>身分已更新。</value></data>
+  <data name="album.reidentify.refresh_body" xml:space="preserve"><value>要從新識別的來源取得專輯、曲目與版本欄位嗎？你所做的編輯會被覆寫。</value></data>
+  <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>從新來源重新整理</value></data>
+  <data name="album.reidentify.keep_current" xml:space="preserve"><value>保留目前中繼資料</value></data>
 </root>

--- a/bae-windows/Views/ImportDialog.cs
+++ b/bae-windows/Views/ImportDialog.cs
@@ -2,7 +2,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using uniffi.bae_bridge;
 
 namespace Bae.Windows;
 
@@ -171,223 +170,24 @@ internal sealed class ImportDialog
 
         if (candidate.Signals.Count > 0)
         {
-            var badges = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            foreach (var signal in candidate.Signals)
-            {
-                badges.Children.Add(BuildSignalBadge(candidate.Key, signal));
-            }
-
-            badges.Children.Add(BuildRerunButton(candidate.Key));
-            row.Children.Add(badges);
+            row.Children.Add(SignalBadgeRow.Build(
+                candidate.Signals,
+                (kind, value) =>
+                {
+                    if (_session.CurrentHandleOrNull() != null)
+                    {
+                        _ = _import.ToggleSignal(candidate.Key, kind, value);
+                    }
+                },
+                () =>
+                {
+                    if (_session.CurrentHandleOrNull() != null)
+                    {
+                        _ = _import.RerunIdentify(candidate.Key);
+                    }
+                }));
         }
 
         return row;
-    }
-
-    // The trailing re-run control on the signals row: re-dispatches the
-    // candidate's lookups (keeping the user's exclusions). The re-derived state
-    // arrives through candidate invalidation.
-    private Button BuildRerunButton(string candidateKey)
-    {
-        var button = new Button
-        {
-            Content = "↻",
-            Padding = new Thickness(8, 3, 8, 3),
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        ToolTipService.SetToolTip(button, Loc.Chrome("import.rerun_identify"));
-        button.Click += (_, _) =>
-        {
-            if (_session.CurrentHandleOrNull() != null)
-            {
-                _ = _import.RerunIdentify(candidateKey);
-            }
-        };
-        return button;
-    }
-
-    // One signals badge: a kind label, the value (truncated), and a trailing
-    // state visual (spinner / count / dash / warning). Excluded badges dim and
-    // strike through but stay in place so the row's layout is stable. Clicking a
-    // badge toggles its signal in/out of triangulation (excluded badges re-include
-    // on click); the re-derived toolbar arrives through candidate invalidation.
-    // Mirrors the macOS SignalBadge anatomy in plain WinUI primitives.
-    private Button BuildSignalBadge(string candidateKey, SignalBadge signal)
-    {
-        var inner = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 6,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-
-        var label = new TextBlock
-        {
-            Text = SignalKindLabel(signal.Kind),
-            FontSize = 12,
-            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        if (signal.Excluded)
-        {
-            label.TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough;
-        }
-
-        inner.Children.Add(label);
-
-        if (!string.IsNullOrEmpty(signal.Value))
-        {
-            var value = new TextBlock
-            {
-                Text = TextTruncation.MiddleTruncate(signal.Value, 20),
-                FontSize = 11,
-                FontFamily = new FontFamily("Consolas"),
-                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
-                MaxWidth = 140,
-                // The character budget keeps the value under MaxWidth; CharacterEllipsis
-                // is only a backstop if a font measures wider than monospace estimates.
-                TextTrimming = TextTrimming.CharacterEllipsis,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            if (signal.Excluded)
-            {
-                value.TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough;
-            }
-
-            inner.Children.Add(value);
-        }
-
-        inner.Children.Add(BuildSignalState(signal));
-
-        // A Button, not a Border+Tapped: the ListView raises ItemClick from its own
-        // gesture handling and ignores a child that merely marks Tapped handled, but
-        // it honors a pointer-capturing control. So the badge press toggles the
-        // signal without also re-triggering auto-identify / opening the import
-        // dialog. MinWidth/Height 0 keeps it badge-sized, not the default button box.
-        var badge = new Button
-        {
-            Content = inner,
-            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
-            Padding = new Thickness(8, 3, 8, 3),
-            MinWidth = 0,
-            MinHeight = 0,
-            CornerRadius = new CornerRadius(8),
-            BorderThickness = new Thickness(1),
-            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.DimGray),
-            Margin = new Thickness(0, 0, 6, 0),
-            Opacity = signal.Excluded ? 0.45 : 1.0,
-        };
-
-        // Clicking toggles this signal's exclusion. Excluded badges stay clickable
-        // (to re-include). The catalog kind names a specific candidate by its value;
-        // disc_id / barcode are singletons (value ignored core-side).
-        ToolTipService.SetToolTip(
-            badge,
-            signal.Excluded ? Loc.Chrome("signal.include") : Loc.Chrome("signal.exclude"));
-        badge.Click += (_, _) =>
-        {
-            if (_session.CurrentHandleOrNull() != null)
-            {
-                var kind = signal.Kind;
-                var value = signal.Value ?? string.Empty;
-                _ = _import.ToggleSignal(candidateKey, kind, value);
-            }
-        };
-        return badge;
-    }
-
-    // The badge's trailing state visual, chosen by the pre-shaped SignalState the
-    // generated bridge carried over. An excluded badge shows the exclusion mark regardless.
-    private static FrameworkElement BuildSignalState(SignalBadge signal)
-    {
-        if (signal.Excluded)
-        {
-            return new TextBlock
-            {
-                Text = "✕",
-                FontSize = 11,
-                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-        }
-
-        switch (signal.State.Kind)
-        {
-            case "looking_up":
-                return new ProgressRing { IsActive = true, Width = 14, Height = 14 };
-            case "found":
-                return CountPill((signal.State.Count ?? 0).ToString(), Microsoft.UI.Colors.LightGreen);
-            case "confirms":
-                return signal.State.Count is > 0
-                    ? new TextBlock
-                    {
-                        Text = "✓",
-                        FontSize = 12,
-                        FontWeight = Microsoft.UI.Text.FontWeights.Bold,
-                        Foreground = new SolidColorBrush(Microsoft.UI.Colors.DeepSkyBlue),
-                        VerticalAlignment = VerticalAlignment.Center,
-                    }
-                    : CountPill("0", Microsoft.UI.Colors.Gray);
-            case "no_match":
-                return CountPill("0", Microsoft.UI.Colors.Gray);
-            case "skipped":
-                return new TextBlock
-                {
-                    Text = "–",
-                    FontSize = 12,
-                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
-                    VerticalAlignment = VerticalAlignment.Center,
-                };
-            case "failed":
-                var warning = new TextBlock
-                {
-                    Text = "⚠",
-                    FontSize = 12,
-                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Orange),
-                    VerticalAlignment = VerticalAlignment.Center,
-                };
-                // The structured lookup failure resolves its localized line for
-                // the hover tooltip; no prose crosses the bridge.
-                if (signal.State.Failure is { } failure)
-                {
-                    ToolTipService.SetToolTip(warning, BridgeDisplay.LocalizedLine(failure));
-                }
-                return warning;
-            default:
-                return new TextBlock { Text = string.Empty };
-        }
-    }
-
-    // The badge's kind label. Mirrors the macOS SignalBadgeStyle.label(for:);
-    // the wire kind names come from the generated bridge's snake_case mapping, resolved to a
-    // localized chrome label.
-    private static string SignalKindLabel(string kind) => kind switch
-    {
-        "disc_id" => Loc.Chrome("signal.kind.disc_id"),
-        "barcode" => Loc.Chrome("signal.kind.barcode"),
-        "catalog" => Loc.Chrome("signal.kind.catalog"),
-        _ => kind,
-    };
-
-    // A small count pill — a colored digit, the badge's settled-state readout.
-    private static Border CountPill(string text, global::Windows.UI.Color color)
-    {
-        return new Border
-        {
-            Child = new TextBlock
-            {
-                Text = text,
-                FontSize = 11,
-                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-                Foreground = new SolidColorBrush(color),
-            },
-            Padding = new Thickness(6, 1, 6, 1),
-            CornerRadius = new CornerRadius(6),
-            VerticalAlignment = VerticalAlignment.Center,
-        };
     }
 }

--- a/bae-windows/Views/ReleaseActionDialogs.cs
+++ b/bae-windows/Views/ReleaseActionDialogs.cs
@@ -20,17 +20,20 @@ internal sealed class ReleaseActionDialogs
     private readonly Func<XamlRoot?> _xamlRoot;
     private readonly Func<IntPtr> _windowHandle;
     private readonly Action<string> _setStatus;
+    private readonly ProjectionRegistry _projections;
 
     public ReleaseActionDialogs(
         SessionStore session,
         Func<XamlRoot?> xamlRoot,
         Func<IntPtr> windowHandle,
-        Action<string> setStatus)
+        Action<string> setStatus,
+        ProjectionRegistry projections)
     {
         _session = session;
         _xamlRoot = xamlRoot;
         _windowHandle = windowHandle;
         _setStatus = setStatus;
+        _projections = projections;
     }
 
     public async System.Threading.Tasks.Task ShowExportRelease(string releaseId)
@@ -240,6 +243,22 @@ internal sealed class ReleaseActionDialogs
             return;
         }
 
+        // The candidate key the identify pipeline runs under for this release.
+        // Core treats it as an opaque key; the same string drives the toolbar
+        // toggle/re-run wrappers and the snapshot read-back.
+        var key = "reidentify:" + releaseId;
+
+        // The live pipeline status line (gray) and the signals-toolbar host,
+        // shown above the manual-search fallback. The pipeline starts with the
+        // dialog, so the status seeds to "identifying…" until its first event.
+        var pipelineStatus = new TextBlock
+        {
+            Text = Loc.Chrome("identify.identifying"),
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            TextWrapping = TextWrapping.Wrap,
+        };
+        var badgeHost = new StackPanel();
+
         var artistBox = new TextBox { Header = Loc.Chrome("search.field.artist"), Text = seedArtist };
         var albumBox = new TextBox { Header = Loc.Chrome("search.field.album"), Text = seedAlbum };
         var sourceBox = new ComboBox { Header = Loc.Chrome("search.field.source") };
@@ -294,13 +313,17 @@ internal sealed class ReleaseActionDialogs
         exactRadio.Checked += (_, _) => identity.SetMetadataOnly(false);
         metadataRadio.Checked += (_, _) => identity.SetMetadataOnly(true);
 
+        // Auto-first, like the import picker: the pipeline status, its signal
+        // badges, and the live match list sit above the manual-search fallback.
         var form = new StackPanel { Spacing = 8, Width = 420 };
+        form.Children.Add(pipelineStatus);
+        form.Children.Add(badgeHost);
+        form.Children.Add(resultsList);
+        form.Children.Add(claimRow);
         form.Children.Add(artistBox);
         form.Children.Add(albumBox);
         form.Children.Add(sourceBox);
         form.Children.Add(searchButton);
-        form.Children.Add(resultsList);
-        form.Children.Add(claimRow);
         form.Children.Add(status);
 
         var dialog = new ContentDialog
@@ -315,6 +338,62 @@ internal sealed class ReleaseActionDialogs
         };
 
         var candidates = new List<ReleaseCandidateChoice>();
+
+        // Arbitrates who owns the match list: the auto-identify pipeline until a
+        // manual search takes it over, and a change-gate so a pipeline refresh
+        // that replays the same matches doesn't rebuild the list (which would
+        // drop the user's current pick).
+        var results = new ReidentifyResultsModel();
+
+        // A signal toggle / re-run asks the pipeline for results again, so it
+        // reclaims the list on its next refresh. The re-derived state arrives
+        // through the same candidate invalidation the refresh reads.
+        void ToggleSignal(string kind, string value)
+        {
+            results.ResumePipeline();
+            _ = _session.RunForCurrentHandle(
+                handle => NativeBae.ToggleSignalForCandidate(handle, key, kind, value));
+        }
+
+        void Rerun()
+        {
+            results.ResumePipeline();
+            _ = _session.RunForCurrentHandle(
+                handle => NativeBae.RerunIdentifyForCandidate(handle, key));
+        }
+
+        // Re-read the pipeline snapshot for this key and render its status line,
+        // signal badges, and (when it owns the list) match list. Invalidations
+        // for other candidates also land here — the registry dispatches by kind,
+        // not key — so a missing snapshot for our key is a no-op.
+        void RefreshFromPipeline()
+        {
+            var (current, snapshot) = _session.WithCurrentHandle(
+                handle => NativeBae.ReidentifyPipeline(handle, key));
+            if (!current || snapshot is null)
+            {
+                return;
+            }
+
+            var (rowStatus, matches, signals) = snapshot.Value;
+            pipelineStatus.Text = rowStatus.LocalizedLine;
+            pipelineStatus.Visibility = string.IsNullOrEmpty(rowStatus.LocalizedLine)
+                ? Visibility.Collapsed : Visibility.Visible;
+            badgeHost.Children.Clear();
+            if (signals.Count > 0)
+            {
+                badgeHost.Children.Add(SignalBadgeRow.Build(signals, ToggleSignal, Rerun));
+            }
+            if (results.ApplyPipelineMatches(matches.Select(match => match.ReleaseId).ToList()))
+            {
+                candidates = matches;
+                resultsList.ItemsSource = candidates.Select(candidate => candidate.Summary).ToList();
+            }
+        }
+
+        // Start the pipeline against the release's own files; its events flow
+        // through the candidate invalidation the registration below reads.
+        _session.WithCurrentHandle(handle => NativeBae.AutoIdentifyRelease(handle, key, releaseId));
 
         // The generated bridge search and commit both block on network/DB work; run them off
         // the UI thread so the dialog stays responsive.
@@ -339,6 +418,10 @@ internal sealed class ReleaseActionDialogs
                 return;
             }
 
+            // A successful manual search takes the results list over; later
+            // pipeline refreshes keep the status line and badges live but leave
+            // these results in place.
+            results.ApplyManualResults();
             candidates = search.Candidates ?? [];
             resultsList.ItemsSource = candidates.Select(candidate => candidate.Summary).ToList();
             status.Text = Loc.Chrome("search.no_matches");
@@ -404,6 +487,85 @@ internal sealed class ReleaseActionDialogs
             {
                 status.Text = error;
                 status.Visibility = Visibility.Visible;
+                args.Cancel = true;
+            }
+
+            deferral.Complete();
+        };
+
+        // The pipeline emits a candidate invalidation for every identify/signals
+        // event; refresh from each while the dialog is open, disposing the
+        // registration when it closes.
+        var registration = _projections.Register(
+            typeof(BridgeInvalidation.ImportCandidate), RefreshFromPipeline);
+        ContentDialogResult result;
+        try
+        {
+            result = await dialog.ShowAsync();
+        }
+        finally
+        {
+            registration.Dispose();
+        }
+
+        // A Primary result means a source-backed commit succeeded (the error
+        // paths cancel the close). Offer to reseed the metadata from the newly
+        // pointed source. The Secondary (Unknown) commit reseeds rows from the
+        // rip's file tags itself, so it has nothing to confirm.
+        if (result == ContentDialogResult.Primary)
+        {
+            await ShowRefreshPrompt(releaseId);
+        }
+    }
+
+    // After a source-backed identity commit, offer to reseed the release's
+    // metadata from the newly-pointed source. Refresh overwrites the user's
+    // prior edits by design; Keep leaves the stored metadata as-is. The identity
+    // itself is already committed either way.
+    private async System.Threading.Tasks.Task ShowRefreshPrompt(string releaseId)
+    {
+        var body = new TextBlock
+        {
+            Text = Loc.Chrome("album.reidentify.refresh_body"),
+            TextWrapping = TextWrapping.Wrap,
+        };
+        var error = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+            TextWrapping = TextWrapping.Wrap,
+            Visibility = Visibility.Collapsed,
+        };
+        var content = new StackPanel { Spacing = 8, Width = 420 };
+        content.Children.Add(body);
+        content.Children.Add(error);
+
+        var dialog = new ContentDialog
+        {
+            Title = Loc.Chrome("album.reidentify.updated"),
+            Content = content,
+            PrimaryButtonText = Loc.Chrome("album.reidentify.refresh_confirm"),
+            CloseButtonText = Loc.Chrome("album.reidentify.keep_current"),
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = _xamlRoot(),
+        };
+
+        // Refresh runs off the UI thread behind a deferral. On error keep the
+        // prompt open with the reason shown — the identity commit already
+        // succeeded, so the user can retry Refresh or fall back to Keep.
+        dialog.PrimaryButtonClick += async (_, args) =>
+        {
+            var deferral = args.GetDeferral();
+            var (current, refreshError) = await _session.RunForCurrentHandle(
+                handle => NativeBae.RefreshMetadataFromSource(handle, releaseId));
+            if (!current)
+            {
+                deferral.Complete();
+                return;
+            }
+            if (refreshError is not null)
+            {
+                error.Text = refreshError;
+                error.Visibility = Visibility.Visible;
                 args.Cancel = true;
             }
 

--- a/bae-windows/Views/SignalBadgeRow.cs
+++ b/bae-windows/Views/SignalBadgeRow.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using uniffi.bae_bridge;
+
+namespace Bae.Windows;
+
+// The signals-toolbar badge row shared by the import candidate list and the
+// re-identify dialog: one badge per signal (kind label, truncated value,
+// lookup-state visual), a trailing re-run control. Clicking a badge toggles
+// its signal in/out of triangulation; the re-derived state arrives through
+// candidate invalidation.
+internal static class SignalBadgeRow
+{
+    internal static StackPanel Build(
+        IReadOnlyList<SignalBadge> signals,
+        Action<string, string> onToggleSignal,   // (kind, value)
+        Action onRerun)
+    {
+        var badges = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        foreach (var signal in signals)
+        {
+            badges.Children.Add(BuildSignalBadge(signal, onToggleSignal));
+        }
+
+        badges.Children.Add(BuildRerunButton(onRerun));
+        return badges;
+    }
+
+    // The trailing re-run control on the signals row: re-dispatches the
+    // candidate's lookups (keeping the user's exclusions). The re-derived state
+    // arrives through candidate invalidation.
+    private static Button BuildRerunButton(Action onRerun)
+    {
+        var button = new Button
+        {
+            Content = "↻",
+            Padding = new Thickness(8, 3, 8, 3),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        ToolTipService.SetToolTip(button, Loc.Chrome("import.rerun_identify"));
+        button.Click += (_, _) => onRerun();
+        return button;
+    }
+
+    // One signals badge: a kind label, the value (truncated), and a trailing
+    // state visual (spinner / count / dash / warning). Excluded badges dim and
+    // strike through but stay in place so the row's layout is stable. Clicking a
+    // badge toggles its signal in/out of triangulation (excluded badges re-include
+    // on click); the re-derived toolbar arrives through candidate invalidation.
+    // Mirrors the macOS SignalBadge anatomy in plain WinUI primitives.
+    private static Button BuildSignalBadge(SignalBadge signal, Action<string, string> onToggleSignal)
+    {
+        var inner = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        var label = new TextBlock
+        {
+            Text = SignalKindLabel(signal.Kind),
+            FontSize = 12,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        if (signal.Excluded)
+        {
+            label.TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough;
+        }
+
+        inner.Children.Add(label);
+
+        if (!string.IsNullOrEmpty(signal.Value))
+        {
+            var value = new TextBlock
+            {
+                Text = TextTruncation.MiddleTruncate(signal.Value, 20),
+                FontSize = 11,
+                FontFamily = new FontFamily("Consolas"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                MaxWidth = 140,
+                // The character budget keeps the value under MaxWidth; CharacterEllipsis
+                // is only a backstop if a font measures wider than monospace estimates.
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            if (signal.Excluded)
+            {
+                value.TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough;
+            }
+
+            inner.Children.Add(value);
+        }
+
+        inner.Children.Add(BuildSignalState(signal));
+
+        // A Button, not a Border+Tapped: the ListView raises ItemClick from its own
+        // gesture handling and ignores a child that merely marks Tapped handled, but
+        // it honors a pointer-capturing control. So the badge press toggles the
+        // signal without also re-triggering auto-identify / opening the import
+        // dialog. MinWidth/Height 0 keeps it badge-sized, not the default button box.
+        var badge = new Button
+        {
+            Content = inner,
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            Padding = new Thickness(8, 3, 8, 3),
+            MinWidth = 0,
+            MinHeight = 0,
+            CornerRadius = new CornerRadius(8),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.DimGray),
+            Margin = new Thickness(0, 0, 6, 0),
+            Opacity = signal.Excluded ? 0.45 : 1.0,
+        };
+
+        // Clicking toggles this signal's exclusion. Excluded badges stay clickable
+        // (to re-include). The catalog kind names a specific candidate by its value;
+        // disc_id / barcode are singletons (value ignored core-side).
+        ToolTipService.SetToolTip(
+            badge,
+            signal.Excluded ? Loc.Chrome("signal.include") : Loc.Chrome("signal.exclude"));
+        badge.Click += (_, _) =>
+        {
+            var kind = signal.Kind;
+            var value = signal.Value ?? string.Empty;
+            onToggleSignal(kind, value);
+        };
+        return badge;
+    }
+
+    // The badge's trailing state visual, chosen by the pre-shaped SignalState the
+    // generated bridge carried over. An excluded badge shows the exclusion mark regardless.
+    private static FrameworkElement BuildSignalState(SignalBadge signal)
+    {
+        if (signal.Excluded)
+        {
+            return new TextBlock
+            {
+                Text = "✕",
+                FontSize = 11,
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+        }
+
+        switch (signal.State.Kind)
+        {
+            case "looking_up":
+                return new ProgressRing { IsActive = true, Width = 14, Height = 14 };
+            case "found":
+                return CountPill((signal.State.Count ?? 0).ToString(), Microsoft.UI.Colors.LightGreen);
+            case "confirms":
+                return signal.State.Count is > 0
+                    ? new TextBlock
+                    {
+                        Text = "✓",
+                        FontSize = 12,
+                        FontWeight = Microsoft.UI.Text.FontWeights.Bold,
+                        Foreground = new SolidColorBrush(Microsoft.UI.Colors.DeepSkyBlue),
+                        VerticalAlignment = VerticalAlignment.Center,
+                    }
+                    : CountPill("0", Microsoft.UI.Colors.Gray);
+            case "no_match":
+                return CountPill("0", Microsoft.UI.Colors.Gray);
+            case "skipped":
+                return new TextBlock
+                {
+                    Text = "–",
+                    FontSize = 12,
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+            case "failed":
+                var warning = new TextBlock
+                {
+                    Text = "⚠",
+                    FontSize = 12,
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Orange),
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                // The structured lookup failure resolves its localized line for
+                // the hover tooltip; no prose crosses the bridge.
+                if (signal.State.Failure is { } failure)
+                {
+                    ToolTipService.SetToolTip(warning, BridgeDisplay.LocalizedLine(failure));
+                }
+                return warning;
+            default:
+                return new TextBlock { Text = string.Empty };
+        }
+    }
+
+    // The badge's kind label. Mirrors the macOS SignalBadgeStyle.label(for:);
+    // the wire kind names come from the generated bridge's snake_case mapping, resolved to a
+    // localized chrome label.
+    private static string SignalKindLabel(string kind) => kind switch
+    {
+        "disc_id" => Loc.Chrome("signal.kind.disc_id"),
+        "barcode" => Loc.Chrome("signal.kind.barcode"),
+        "catalog" => Loc.Chrome("signal.kind.catalog"),
+        _ => kind,
+    };
+
+    // A small count pill — a colored digit, the badge's settled-state readout.
+    private static Border CountPill(string text, global::Windows.UI.Color color)
+    {
+        return new Border
+        {
+            Child = new TextBlock
+            {
+                Text = text,
+                FontSize = 11,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(color),
+            },
+            Padding = new Thickness(6, 1, 6, 1),
+            CornerRadius = new CornerRadius(6),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+    }
+}

--- a/bae-windows/bae-windows.Tests/ReidentifyResultsModelTests.cs
+++ b/bae-windows/bae-windows.Tests/ReidentifyResultsModelTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+// The re-identify results list arbitration: the pipeline owns the list until a
+// manual search takes it, and a pipeline render is skipped when its match set is
+// unchanged so the user's in-list selection survives a badge-only refresh.
+public sealed class ReidentifyResultsModelTests
+{
+    private static List<string> Keys(params string[] keys) => new(keys);
+
+    [Fact]
+    public void EmptyToEmptyRefresh_DoesNotRender()
+    {
+        var model = new ReidentifyResultsModel();
+        Assert.False(model.ApplyPipelineMatches(Keys()));
+    }
+
+    [Fact]
+    public void FirstNonEmptySet_Renders()
+    {
+        var model = new ReidentifyResultsModel();
+        Assert.True(model.ApplyPipelineMatches(Keys("rel-1", "rel-2")));
+    }
+
+    [Fact]
+    public void IdenticalReplay_DoesNotRender()
+    {
+        var model = new ReidentifyResultsModel();
+        model.ApplyPipelineMatches(Keys("rel-1", "rel-2"));
+        Assert.False(model.ApplyPipelineMatches(Keys("rel-1", "rel-2")));
+    }
+
+    [Fact]
+    public void ChangedSet_Renders()
+    {
+        var model = new ReidentifyResultsModel();
+        model.ApplyPipelineMatches(Keys("rel-1", "rel-2"));
+        Assert.True(model.ApplyPipelineMatches(Keys("rel-1", "rel-3")));
+    }
+
+    [Fact]
+    public void ManualResults_FreezePipelineRenders()
+    {
+        var model = new ReidentifyResultsModel();
+        model.ApplyManualResults();
+        Assert.True(model.ManualResultsShown);
+        // Even a brand-new match set is held back while manual results own the list.
+        Assert.False(model.ApplyPipelineMatches(Keys("rel-1")));
+        Assert.False(model.ApplyPipelineMatches(Keys("rel-2", "rel-3")));
+    }
+
+    [Fact]
+    public void ResumePipeline_ClearsManualFlagAndChangeCache()
+    {
+        var model = new ReidentifyResultsModel();
+        model.ApplyPipelineMatches(Keys("rel-1", "rel-2"));
+        model.ApplyManualResults();
+
+        model.ResumePipeline();
+        Assert.False(model.ManualResultsShown);
+        // The change cache is cleared too: a refresh whose set equals the last
+        // pipeline render still re-renders after a resume.
+        Assert.True(model.ApplyPipelineMatches(Keys("rel-1", "rel-2")));
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -16,11 +16,13 @@
       no WinRT dependency (the WinRT shell that applies its decisions lives in
       MediaControlService and is verified by compilation).
     - The store models (PlaybackPositionModel / SyncIndicatorModel /
-      ImportIdentityModel) — the now-playing-bar seek/position math, the
-      sync-indicator precedence, and the import identity-claim state (exact vs
-      metadata-only, its note and pressing-field enablement), split out as plain
-      BCL types (the stores that hold bridge snapshots and the WinUI views and
-      dialogs that render them are verified by compilation).
+      ImportIdentityModel / ReidentifyResultsModel) — the now-playing-bar
+      seek/position math, the sync-indicator precedence, the import
+      identity-claim state (exact vs metadata-only, its note and pressing-field
+      enablement), and the re-identify results-list arbitration between the
+      auto-identify pipeline and a manual search, split out as plain BCL types
+      (the stores that hold bridge snapshots and the WinUI views and dialogs
+      that render them are verified by compilation).
     - The update-flow layer (UpdateFlow) — the state machine and display mapping
       behind the settings "updates" section (status keys, percent clamping,
       button gating, version-string normalization), over plain BCL types with no
@@ -58,6 +60,7 @@
     <Compile Include="../Stores/QueueInsertModel.cs" Link="QueueInsertModel.cs" />
     <Compile Include="../Stores/OrderedIntersection.cs" Link="OrderedIntersection.cs" />
     <Compile Include="../Stores/ImportIdentityModel.cs" Link="ImportIdentityModel.cs" />
+    <Compile Include="../Stores/ReidentifyResultsModel.cs" Link="ReidentifyResultsModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Windows re-identify dialog was manual-search-only. Two gaps separated it from macOS's re-identify sheet: it never re-ran the auto-identify signal pipeline against the release's own files, so the only way to re-identify was to type an artist/album and search; and after a source-backed identity commit it left the release sitting on the old source's metadata with no offer to reseed from the newly-pointed source.

This runs the pipeline in the dialog. On open it seeds a `"reidentify:<releaseId>"` candidate key and fires the release-flavored auto-identify against the release's stored files, then renders the live status line, the signals-toolbar badges (each toggle and the re-run wired through the candidate wrappers the import dialog already uses), and the found pressings — all driven by the same `ImportCandidate` invalidations the import list consumes, with the registration disposed when the dialog closes. Because that invalidation fires on every identify/signals event, a pure `ReidentifyResultsModel` arbitrates who owns the results list: the pipeline holds it until a manual search takes over, a signal toggle or re-run hands it back, and identical replays are change-gated so a badge-only refresh never rebuilds the list and drops the user's in-progress pick.

After a successful source-backed commit the dialog offers a refresh-or-keep prompt: pull the album, track, and pressing fields from the new source (overwriting prior edits) or keep the current metadata. The identity is already committed either way; a refresh error keeps the prompt open so the user can retry or fall back to keep. The one-click Unknown commit reseeds rows from the rip's file tags inside the commit itself, so it has nothing to confirm and never prompts. Post-commit grid navigation stays out of scope — Windows album detail is a modal that has already closed, so the grid the user returns to refreshes through the commit's invalidations.

The signals-toolbar badge row moves out of `ImportDialog` into a shared `SignalBadgeRow` (pure code motion — the captures become callbacks) so the import list and the re-identify dialog render it identically. No bridge or core changes: every entry point this needs already exists. Four new catalog keys land with real translations across all 31 locales.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 162 pass, including the new `ReidentifyResultsModelTests` ownership/change-gating matrix.
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans (354 keys).
- The Windows app compiles only in CI (`windows.yml`); that is the compile gate for the WinRT/generated-bindings surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)