### PR TITLE
Add remove/skip/sort and New/Added/Skipped tabs to the Windows import dialog

### DIFF
--- a/bae-windows/ImportCandidate.cs
+++ b/bae-windows/ImportCandidate.cs
@@ -45,6 +45,16 @@ public sealed class ImportCandidate
     /// <summary>The on-disk folder to identify/import.</summary>
     public string FolderPath { get; set; } = string.Empty;
 
+    /// <summary>The user manually skipped this candidate; it lists under Skipped.</summary>
+    public bool Skipped { get; set; }
+
+    /// <summary>Already imported (content-hash match); it lists under Added.</summary>
+    public bool IsAdded { get; set; }
+
+    /// <summary>A folder that failed validation: not importable, always under
+    /// Skipped, and it has no skip/unskip action.</summary>
+    public bool Invalid { get; set; }
+
     /// <summary>The list row, omitting absent fields. Used as the default item text.</summary>
     public override string ToString()
     {

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -556,8 +556,17 @@ internal static class NativeBae
     internal static string? ScanFolder(AppHandle handle, string path, bool clearFirst) =>
         CaptureError(() => handle.AddWatchedFolder(path));
 
-    internal static List<ImportCandidate> ImportCandidates(AppHandle handle) =>
-        ImportCandidateRows(handle.GetImportCandidates());
+    internal static string? RemoveWatchedFolder(AppHandle handle, string path) =>
+        CaptureError(() => handle.RemoveWatchedFolder(path));
+
+    internal static string? SetCandidateSkipped(AppHandle handle, string path, bool skipped) =>
+        CaptureError(() => handle.SetCandidateSkipped(path, skipped));
+
+    internal static (List<ImportCandidate> Rows, List<BridgeWatchedFolder> Folders) ImportCandidates(AppHandle handle)
+    {
+        var snapshot = handle.GetImportCandidates();
+        return (ImportCandidateRows(snapshot), snapshot.WatchedFolders);
+    }
 
     internal static void AutoIdentifyFolder(AppHandle handle, string candidateKey, string folderPath) =>
         handle.AutoIdentifyFolder(candidateKey, folderPath);
@@ -899,6 +908,8 @@ internal static class NativeBae
             Signals = runtime.SignalsToolbar.Signals.Select(SignalBadge).ToList(),
             AudioPaths = AudioPaths(candidate.Files.Audio).ToList(),
             FolderPath = candidate.FolderPath,
+            Skipped = candidate.Skipped,
+            IsAdded = candidate.IsAdded,
         };
 
     private static ImportCandidate InvalidImportCandidateRow(BridgeInvalidCandidate candidate) =>
@@ -917,6 +928,7 @@ internal static class NativeBae
             Signals = [],
             AudioPaths = [],
             FolderPath = candidate.FolderPath,
+            Invalid = true,
         };
 
     private static ImportCandidateRowStatus ImportRowStatus(BridgeCandidateRuntimeSnapshot runtime)

--- a/bae-windows/Stores/ImportListModel.cs
+++ b/bae-windows/Stores/ImportListModel.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bae.Windows;
+
+// Which of the import dialog's three tabs a candidate lists under.
+public enum CandidateTab
+{
+    New,
+    Added,
+    Skipped,
+}
+
+// The candidate-list sort order the dialog offers. The enum order is the sort
+// ComboBox order (a selected index maps straight to the value); the persisted
+// token is stable across platforms (the macOS catalog persists the same four).
+public enum CandidateSortOrder
+{
+    NameAZ,
+    NameZA,
+    DateAddedNewest,
+    DateAddedOldest,
+}
+
+// One candidate as the list model sees it: identity, display name, and the state
+// bits that decide its tab. Pure over primitives so tab assignment, counting, and
+// ordering are unit-tested apart from the WinUI dialog and the generated bridge
+// types.
+public sealed record ImportListRow(
+    string Key,
+    string Name,
+    bool Skipped,
+    bool IsAdded,
+    bool ImportComplete,
+    bool Invalid);
+
+public static class ImportListModel
+{
+    // Skipped wins over Added (a skipped candidate stays under Skipped even when it
+    // was also imported); an invalid folder always lists under Skipped; a candidate
+    // that completed an import or matches an already-imported folder is Added;
+    // everything else is New.
+    public static CandidateTab Tab(ImportListRow row)
+    {
+        if (row.Invalid || row.Skipped)
+        {
+            return CandidateTab.Skipped;
+        }
+        if (row.ImportComplete || row.IsAdded)
+        {
+            return CandidateTab.Added;
+        }
+        return CandidateTab.New;
+    }
+
+    public static (int New, int Added, int Skipped) Counts(IEnumerable<ImportListRow> rows)
+    {
+        var counts = (New: 0, Added: 0, Skipped: 0);
+        foreach (var row in rows)
+        {
+            switch (Tab(row))
+            {
+                case CandidateTab.New:
+                    counts.New++;
+                    break;
+                case CandidateTab.Added:
+                    counts.Added++;
+                    break;
+                case CandidateTab.Skipped:
+                    counts.Skipped++;
+                    break;
+            }
+        }
+        return counts;
+    }
+
+    // The keys to display for `tab`, ordered by `order`. Input order is the core
+    // snapshot order (watched-folder add order, then path), which is what "date
+    // added" means: newest keeps it, oldest reverses it; the name sorts are stable
+    // case-insensitive current-culture compares. Within the Skipped tab, the
+    // non-invalid rows come before the invalid ones, each group ordered
+    // independently.
+    public static List<string> DisplayedKeys(
+        IReadOnlyList<ImportListRow> rows, CandidateTab tab, CandidateSortOrder order)
+    {
+        var inTab = rows.Where(row => Tab(row) == tab).ToList();
+        if (tab == CandidateTab.Skipped)
+        {
+            var valid = Order(inTab.Where(row => !row.Invalid), order);
+            var invalid = Order(inTab.Where(row => row.Invalid), order);
+            return valid.Concat(invalid).ToList();
+        }
+        return Order(inTab, order).ToList();
+    }
+
+    private static IEnumerable<string> Order(IEnumerable<ImportListRow> rows, CandidateSortOrder order) =>
+        order switch
+        {
+            CandidateSortOrder.NameAZ => rows
+                .OrderBy(row => row.Name, StringComparer.CurrentCultureIgnoreCase)
+                .Select(row => row.Key),
+            CandidateSortOrder.NameZA => rows
+                .OrderByDescending(row => row.Name, StringComparer.CurrentCultureIgnoreCase)
+                .Select(row => row.Key),
+            CandidateSortOrder.DateAddedNewest => rows.Select(row => row.Key),
+            CandidateSortOrder.DateAddedOldest => rows.Select(row => row.Key).Reverse(),
+            _ => throw new ArgumentOutOfRangeException(nameof(order), order, "Unknown sort order"),
+        };
+
+    // Round-trip tokens for the persisted sort preference. The tokens match the
+    // values the macOS catalog persists for the same preference.
+    public static string Serialize(CandidateSortOrder order) => order switch
+    {
+        CandidateSortOrder.NameAZ => "nameAZ",
+        CandidateSortOrder.NameZA => "nameZA",
+        CandidateSortOrder.DateAddedNewest => "dateAddedNewest",
+        CandidateSortOrder.DateAddedOldest => "dateAddedOldest",
+        _ => throw new ArgumentOutOfRangeException(nameof(order), order, "Unknown sort order"),
+    };
+
+    // An unknown or absent token falls back to the default order — a sort
+    // preference degrades to the default rather than failing.
+    public static CandidateSortOrder ParseSortOrder(string? token) => token switch
+    {
+        "nameAZ" => CandidateSortOrder.NameAZ,
+        "nameZA" => CandidateSortOrder.NameZA,
+        "dateAddedNewest" => CandidateSortOrder.DateAddedNewest,
+        "dateAddedOldest" => CandidateSortOrder.DateAddedOldest,
+        _ => CandidateSortOrder.DateAddedNewest,
+    };
+}

--- a/bae-windows/Stores/ImportSortStore.cs
+++ b/bae-windows/Stores/ImportSortStore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+
+namespace Bae.Windows;
+
+// The file-backed half of the import candidate-sort persistence: the round-trip
+// token lives in ImportListModel (unit-tested); this only moves that token to and
+// from a blob under the app's local data directory, mirroring how macOS keeps the
+// same preference in UserDefaults. A failed read or write degrades to the default
+// sort rather than taking the app down — the sort is a preference, not durable
+// state.
+internal static class ImportSortStore
+{
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "bae",
+        "import-sort.txt");
+
+    // Load the saved sort order, or the default when nothing is saved yet.
+    public static CandidateSortOrder Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                return ImportListModel.ParseSortOrder(File.ReadAllText(FilePath).Trim());
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not read the saved import sort.", exception);
+        }
+
+        return ImportListModel.ParseSortOrder(null);
+    }
+
+    public static void Save(CandidateSortOrder order)
+    {
+        try
+        {
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, ImportListModel.Serialize(order));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not save the import sort.", exception);
+        }
+    }
+}

--- a/bae-windows/Stores/ImportStore.cs
+++ b/bae-windows/Stores/ImportStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Microsoft.UI.Xaml.Controls;
 using uniffi.bae_bridge;
 
@@ -18,9 +19,29 @@ internal sealed class ImportStore
     private readonly ShellStore _shell;
     private readonly MediaControlService _mediaControls;
 
-    // The scan candidates, bound to the import dialog's list. Repopulated in place
-    // on every refresh so the bound list re-renders.
+    // The active tab's candidates in sort order, bound to the import dialog's list.
+    // Repopulated in place on every projection so the bound list re-renders; it is
+    // the displayed tab, not the whole scan.
     public ObservableCollection<ImportCandidate> Candidates { get; } = new();
+
+    // Every scanned candidate in core snapshot order (watched-folder add order,
+    // then path) — the "date added" baseline the projection tabs and sorts.
+    private readonly List<ImportCandidate> _all = new();
+
+    // The watched folders behind the current scan, bound to the dialog's folders
+    // section. Repopulated in place on each refresh.
+    public ObservableCollection<BridgeWatchedFolder> WatchedFolders { get; } = new();
+
+    // The tab the dialog currently shows; the projection filters Candidates to it.
+    // Resets to New on each dialog open and on teardown.
+    public CandidateTab ActiveTab { get; private set; } = CandidateTab.New;
+
+    // The persisted candidate-list sort order, loaded once at construction and
+    // saved whenever the dialog changes it.
+    public CandidateSortOrder SortOrder { get; private set; }
+
+    // The per-tab candidate counts from the last projection, for the tab labels.
+    public (int New, int Added, int Skipped) TabCounts { get; private set; }
 
     // The import dialog's status line after a candidate refresh: the no-releases
     // line when the scan turned up nothing, else blank. The dialog renders it on
@@ -43,10 +64,12 @@ internal sealed class ImportStore
         _session = session;
         _shell = shell;
         _mediaControls = mediaControls;
+        SortOrder = ImportSortStore.Load();
     }
 
-    // Re-read the scan candidates from core into Candidates and update the status
-    // line. A failed read surfaces the import banner; no handle is a no-op.
+    // Re-read the scan from core into _all and the watched folders, then project
+    // onto the active tab. A failed read surfaces the import banner; no handle is a
+    // no-op.
     public async void RefreshCandidates()
     {
         if (_session.CurrentHandleOrNull() == null)
@@ -54,37 +77,95 @@ internal sealed class ImportStore
             return;
         }
 
-        var (current, candidates) = await _session.RunForCurrentHandle(NativeBae.ImportCandidates);
+        var (current, result) = await _session.RunForCurrentHandle(NativeBae.ImportCandidates);
         if (!current)
         {
             return;
         }
-        if (candidates is null)
+        var (rows, folders) = result;
+        if (rows is null || folders is null)
         {
             _shell.ShowBanner(InfoBarSeverity.Error, Loc.Chrome("import.error_title"), Loc.Chrome("import.failed"));
             return;
         }
 
-        Candidates.Clear();
-        foreach (var candidate in candidates)
+        _all.Clear();
+        _all.AddRange(rows);
+        WatchedFolders.Clear();
+        foreach (var folder in folders)
         {
-            Candidates.Add(candidate);
+            WatchedFolders.Add(folder);
         }
-        CandidatesStatusText = Candidates.Count == 0 ? Loc.Chrome("import.no_releases") : string.Empty;
+        // The no-releases line reflects the whole scan, not the active tab: an empty
+        // tab under a non-empty scan shows a blank status and lets the tab counts
+        // explain it.
+        CandidatesStatusText = _all.Count == 0 ? Loc.Chrome("import.no_releases") : string.Empty;
+        Reproject();
+    }
+
+    // Show a different tab (absolute set — the caller passes the tab its button
+    // represents). Re-projects Candidates onto the new tab.
+    public void SetActiveTab(CandidateTab tab)
+    {
+        ActiveTab = tab;
+        Reproject();
+    }
+
+    // Change and persist the candidate-list sort order (absolute set — the caller
+    // passes the order its control represents). Re-projects Candidates.
+    public void SetSortOrder(CandidateSortOrder order)
+    {
+        SortOrder = order;
+        ImportSortStore.Save(order);
+        Reproject();
+    }
+
+    // Rebuild the tab counts and the displayed Candidates from _all for the active
+    // tab and sort order, then announce the refresh. Candidates becomes exactly the
+    // active tab's rows in sort order, so the bound list is the tab.
+    private void Reproject()
+    {
+        var listRows = _all.Select(ToListRow).ToList();
+        TabCounts = ImportListModel.Counts(listRows);
+        var displayed = ImportListModel.DisplayedKeys(listRows, ActiveTab, SortOrder);
+
+        var byKey = new Dictionary<string, ImportCandidate>(_all.Count);
+        foreach (var candidate in _all)
+        {
+            byKey[candidate.Key] = candidate;
+        }
+
+        Candidates.Clear();
+        foreach (var key in displayed)
+        {
+            Candidates.Add(byKey[key]);
+        }
         CandidatesRefreshed?.Invoke();
     }
 
-    // Replace a candidate row in place (ObservableCollection raises Replace so the
-    // bound list re-renders), applying an optional mutation and a live status.
+    private static ImportListRow ToListRow(ImportCandidate candidate) =>
+        new(
+            candidate.Key,
+            candidate.Name,
+            candidate.Skipped,
+            candidate.IsAdded,
+            candidate.RowStatus.Kind == "complete",
+            candidate.Invalid);
+
+    // Replace a candidate row in place, applying an optional mutation and a live
+    // status. Updates the snapshot baseline and, when the row is on the active tab,
+    // mirrors the replacement into Candidates (ObservableCollection raises Replace
+    // so the bound list re-renders). Tab membership is unchanged here — import-state
+    // changes that would re-tab a row arrive through an invalidation-driven refresh.
     public void UpdateCandidate(string? key, Action<ImportCandidate>? mutate, string status)
     {
-        var index = IndexOfCandidate(key);
+        var index = IndexInAll(key);
         if (index < 0)
         {
             return;
         }
 
-        var existing = Candidates[index];
+        var existing = _all[index];
         var updated = new ImportCandidate
         {
             Key = existing.Key,
@@ -97,9 +178,57 @@ internal sealed class ImportStore
             FolderPath = existing.FolderPath,
             RowStatus = existing.RowStatus,
             StatusOverride = status,
+            Skipped = existing.Skipped,
+            IsAdded = existing.IsAdded,
+            Invalid = existing.Invalid,
         };
         mutate?.Invoke(updated);
-        Candidates[index] = updated;
+        _all[index] = updated;
+
+        var displayedIndex = IndexOfCandidate(key);
+        if (displayedIndex >= 0)
+        {
+            Candidates[displayedIndex] = updated;
+        }
+    }
+
+    // Un-watch a folder: core drops it and its candidates, and the WatchedFolders /
+    // candidate invalidations re-render the dialog. A failed call surfaces the
+    // import banner; success is silent (the invalidation drives the refresh).
+    public async void RemoveWatchedFolder(string path)
+    {
+        var (current, error) = await _session.RunForCurrentHandle(
+            handle => NativeBae.RemoveWatchedFolder(handle, path));
+        if (current && error is not null)
+        {
+            _shell.ShowBanner(InfoBarSeverity.Error, Loc.Chrome("import.error_title"), error);
+        }
+    }
+
+    // Skip or un-skip a candidate: core persists the change and the candidate
+    // invalidation re-tabs the row. A failed call surfaces the import banner;
+    // success is silent (the invalidation drives the refresh).
+    public async void SetCandidateSkipped(string key, bool skipped)
+    {
+        var (current, error) = await _session.RunForCurrentHandle(
+            handle => NativeBae.SetCandidateSkipped(handle, key, skipped));
+        if (current && error is not null)
+        {
+            _shell.ShowBanner(InfoBarSeverity.Error, Loc.Chrome("import.error_title"), error);
+        }
+    }
+
+    private int IndexInAll(string? key)
+    {
+        for (var i = 0; i < _all.Count; i++)
+        {
+            if (_all[i].Key == key)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private int IndexOfCandidate(string? key)
@@ -192,7 +321,16 @@ internal sealed class ImportStore
     public System.Threading.Tasks.Task<bool> ToggleSignal(string candidateKey, string kind, string value) =>
         _session.RunForCurrentHandle(handle => NativeBae.ToggleSignalForCandidate(handle, candidateKey, kind, value));
 
-    // Scan candidates are per-library in-memory state; clear them on teardown so
-    // the next library doesn't inherit the previous one's candidate list.
-    public void Reset() => Candidates.Clear();
+    // Scan candidates and watched folders are per-library in-memory state; clear
+    // them on teardown so the next library doesn't inherit the previous one's list,
+    // and reset the tab to New. The sort order persists — it's a preference, not
+    // library state.
+    public void Reset()
+    {
+        Candidates.Clear();
+        _all.Clear();
+        WatchedFolders.Clear();
+        TabCounts = default;
+        ActiveTab = CandidateTab.New;
+    }
 }

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>هل تريد سحب حقول الألبوم والمقطوعة والطبعة من المصدر المحدَّد حديثًا؟ ستُستبدل التعديلات التي أجريتها.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>تحديث من مصدر جديد</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>الإبقاء على البيانات الوصفية الحالية</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>جديد ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>مُستورد ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>تم التخطّي ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>تخطّي</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>نقل إلى الجديد</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>إزالة المجلد</value></data>
+  <data name="import.sort" xml:space="preserve"><value>فرز</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>الاسم (أ–ي)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>الاسم (ي–أ)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>تاريخ الإضافة (الأحدث)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>تاريخ الإضافة (الأقدم)</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Да се извлекат полетата за албум, песни и издание от новоидентифицирания източник? Направените от вас редакции ще бъдат презаписани.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Обновяване от нов източник</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Запазване на текущите метаданни</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Нови ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Добавени ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Пропуснати ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Пропускане</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Преместване в Нови</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Премахване на папката</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Подреждане</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Име (А–Я)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Име (Я–А)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Дата на добавяне (най-нови)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Дата на добавяне (най-стари)</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>নতুন শনাক্ত করা উৎস থেকে অ্যালবাম, ট্র্যাক ও প্রেসিং ক্ষেত্রগুলো আনবেন? আপনার করা সম্পাদনা মুছে যাবে।</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>নতুন উৎস থেকে রিফ্রেশ করুন</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>বর্তমান মেটাডেটা রাখুন</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>নতুন ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>যোগ করা হয়েছে ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>এড়ানো হয়েছে ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>এড়িয়ে যান</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>নতুনে সরান</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ফোল্ডার সরান</value></data>
+  <data name="import.sort" xml:space="preserve"><value>সাজান</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>নাম (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>নাম (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>যোগের তারিখ (নতুনতম)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>যোগের তারিখ (পুরনোতম)</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Načíst pole alba, skladby a lisu z nově identifikovaného zdroje? Vaše úpravy budou přepsány.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Obnovit z nového zdroje</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Zachovat stávající metadata</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Nové ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Přidané ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Přeskočené ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Přeskočit</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Přesunout do Nových</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Odebrat složku</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Řazení</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Název (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Název (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Datum přidání (nejnovější)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Datum přidání (nejstarší)</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Album-, Titel- und Pressungsfelder aus der neu identifizierten Quelle übernehmen? Deine Änderungen werden überschrieben.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Aus neuer Quelle aktualisieren</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Aktuelle Metadaten behalten</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Neu ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Importiert ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Übersprungen ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Überspringen</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Zu „Neu“ verschieben</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Ordner entfernen</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sortieren</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Name (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Name (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Hinzugefügt (neueste zuerst)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Hinzugefügt (älteste zuerst)</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Pull the album, track, and pressing fields from the newly-identified source? Edits you've made are overwritten.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Refresh from new source</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Keep current metadata</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>New ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Added ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Skipped ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Skip</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Move to New</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Remove folder</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sort</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Name (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Name (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Date Added (Newest)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Date Added (Oldest)</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>¿Traer los campos del álbum, la pista y el prensaje desde la fuente recién identificada? Se sobrescribirán los cambios que hayas hecho.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Actualizar desde la nueva fuente</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Mantener los metadatos actuales</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Nuevos ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Añadidos ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Omitidas ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Omitir</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Mover a Nuevos</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Quitar carpeta</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Ordenar</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Nombre (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Nombre (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Fecha de adición (más reciente)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Fecha de adición (más antigua)</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Récupérer les champs de l'album, des pistes et du pressage depuis la nouvelle source identifiée ? Vos modifications seront écrasées.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Actualiser depuis la nouvelle source</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Conserver les métadonnées actuelles</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Nouveaux ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Ajoutés ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Ignorés ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Ignorer</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Déplacer vers Nouveaux</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Supprimer le dossier</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Trier</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Nom (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Nom (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Date d'ajout (plus récent)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Date d'ajout (plus ancien)</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>નવા ઓળખાયેલા સ્રોતમાંથી આલ્બમ, ટ્રૅક અને પ્રેસિંગ ક્ષેત્રો ખેંચવા? તમે કરેલા ફેરફારો પર લખાઈ જશે.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>નવા સ્રોત પરથી તાજું કરો</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>વર્તમાન મેટાડેટા રાખો</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>નવું ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>ઉમેરાયું ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>છોડેલું ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>છોડો</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>નવામાં ખસેડો</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ફોલ્ડર દૂર કરો</value></data>
+  <data name="import.sort" xml:space="preserve"><value>ક્રમમાં ગોઠવો</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>નામ (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>નામ (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>ઉમેરેલી તારીખ (નવાં પહેલાં)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>ઉમેરેલી તારીખ (જૂનાં પહેલાં)</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>למשוך את שדות האלבום, הרצועה והתקליט מהמקור שזוהה מחדש? עריכות שביצעתם יידרסו.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>רענן מהמקור החדש</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>שמור על המטא-נתונים הנוכחיים</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>חדש ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>נוסף ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>דולגו ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>דלג</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>העבר לחדשים</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>הסר תיקייה</value></data>
+  <data name="import.sort" xml:space="preserve"><value>מיון</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>שם (א׳–ת׳)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>שם (ת׳–א׳)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>תאריך הוספה (החדש ביותר)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>תאריך הוספה (הישן ביותר)</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>नए पहचाने गए स्रोत से एल्बम, ट्रैक और प्रेसिंग फील्ड लें? आपके किए बदलाव अधिलेखित हो जाएंगे।</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>नए स्रोत से रीफ्रेश करें</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>मौजूदा मेटाडेटा रखें</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>नया ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>जोड़ा गया ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>छोड़ा गया ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>छोड़ें</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>नए में ले जाएं</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>फोल्डर हटाएं</value></data>
+  <data name="import.sort" xml:space="preserve"><value>क्रमबद्ध करें</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>नाम (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>नाम (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>जोड़े जाने की तारीख (सबसे नया)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>जोड़े जाने की तारीख (सबसे पुराना)</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Preuzeti polja albuma, skladbe i izdanja iz novoidentificiranog izvora? Vaše izmjene bit će prepisane.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Osvježi iz novog izvora</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Zadrži trenutne metapodatke</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Novo ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Dodano ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Preskočeno ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Preskoči</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Premjesti u nove</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Ukloni mapu</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sortiraj</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Naziv (A–Ž)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Naziv (Ž–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Datum dodavanja (najnovije)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Datum dodavanja (najstarije)</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Recuperare i campi di album, brani e stampa dalla sorgente appena identificata? Le modifiche fatte verranno sovrascritte.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Aggiorna da nuova sorgente</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Mantieni i metadati attuali</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Nuovo ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Aggiunto ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Saltato ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Salta</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Sposta in nuovo</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Rimuovi cartella</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Ordina</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Nome (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Nome (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Data di aggiunta (più recente)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Data di aggiunta (meno recente)</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>新しく識別されたソースからアルバム、トラック、プレスの各項目を取得しますか？加えた編集は上書きされます。</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>新しいソースから更新</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>現在のメタデータを保持</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>新規 ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>取り込み済み ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>スキップ済み ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>スキップ</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>新規に移動</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>フォルダを削除</value></data>
+  <data name="import.sort" xml:space="preserve"><value>並べ替え</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>名前（A–Z）</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>名前（Z–A）</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>追加日（新しい順）</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>追加日（古い順）</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>ಹೊಸದಾಗಿ ಗುರುತಿಸಿದ ಮೂಲದಿಂದ ಆಲ್ಬಮ್, ಹಾಡು ಮತ್ತು ಒತ್ತುವಿಕೆ ಕ್ಷೇತ್ರಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳಬೇಕೇ? ನೀವು ಮಾಡಿದ ತಿದ್ದುಪಡಿಗಳು ಮೇಲೆಯಾಗಿ ಬರೆಯಲ್ಪಡುತ್ತವೆ.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>ಹೊಸ ಮೂಲದಿಂದ ತಾಜಾಗೊಳಿಸಿ</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>ಪ್ರಸ್ತುತ ಮೆಟಾಡೇಟಾವನ್ನು ಉಳಿಸಿ</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>ಹೊಸ ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>ಸೇರಿಸಲಾಗಿದೆ ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>ಬಿಡಲಾಗಿದೆ ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>ಬಿಟ್ಟುಬಿಡಿ</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>ಹೊಸದಕ್ಕೆ ಸರಿಸಿ</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ಫೋಲ್ಡರ್ ತೆಗೆದುಹಾಕಿ</value></data>
+  <data name="import.sort" xml:space="preserve"><value>ಕ್ರಮಗೊಳಿಸಿ</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>ಹೆಸರು (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>ಹೆಸರು (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹೊಸದು)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹಳೆಯದು)</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>새로 식별한 소스에서 앨범, 트랙, 프레싱 필드를 가져올까요? 수정한 내용은 덮어씁니다.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>새 소스에서 새로 고침</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>현재 메타데이터 유지</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>신규 ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>추가됨 ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>건너뜀 ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>건너뛰기</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>신규로 이동</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>폴더 제거</value></data>
+  <data name="import.sort" xml:space="preserve"><value>정렬</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>이름(A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>이름(Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>추가한 날짜(최신)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>추가한 날짜(오래된 순)</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>പുതുതായി തിരിച്ചറിഞ്ഞ ഉറവിടത്തിൽ നിന്ന് ആൽബം, ട്രാക്ക്, പ്രസ്സിംഗ് ഫീൽഡുകൾ എടുക്കണോ? നിങ്ങൾ ചെയ്ത തിരുത്തലുകൾ മായും.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>പുതിയ ഉറവിടത്തിൽ നിന്ന് പുതുക്കുക</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>നിലവിലെ മെറ്റാഡാറ്റ നിലനിർത്തുക</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>പുതിയത് ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>ചേർത്തു ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>ഒഴിവാക്കി ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>ഒഴിവാക്കുക</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>പുതിയതിലേക്ക് നീക്കുക</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ഫോൾഡർ നീക്കം ചെയ്യുക</value></data>
+  <data name="import.sort" xml:space="preserve"><value>ക്രമപ്പെടുത്തുക</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>പേര് (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>പേര് (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>ചേർത്ത തീയതി (പുതിയത്)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>ചേർത്ത തീയതി (പഴയത്)</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>नव्याने ओळखलेल्या स्रोतामधून अल्बम, गाणे आणि प्रेसिंग क्षेत्रे आणायची का? तुम्ही केलेली संपादने अधिलिखित होतील.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>नवीन स्रोतामधून ताजे करा</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>सध्याचा मेटाडेटा ठेवा</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>नवीन ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>जोडले ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>वगळले ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>वगळा</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>नवीनमध्ये हलवा</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>फोल्डर काढा</value></data>
+  <data name="import.sort" xml:space="preserve"><value>क्रम लावा</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>नाव (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>नाव (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>जोडल्याची तारीख (नवीनतम)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>जोडल्याची तारीख (सर्वात जुनी)</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Album-, nummer- en persingsvelden uit de nieuw geïdentificeerde bron halen? Je bewerkingen worden overschreven.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Vernieuwen vanuit nieuwe bron</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Huidige metadata behouden</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Nieuw ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Toegevoegd ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Overgeslagen ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Overslaan</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Naar nieuw verplaatsen</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Map verwijderen</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sorteren</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Naam (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Naam (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Toegevoegd op (nieuwste)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Toegevoegd op (oudste)</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>ਨਵੇਂ ਪਛਾਣੇ ਸਰੋਤ ਤੋਂ ਐਲਬਮ, ਟ੍ਰੈਕ ਅਤੇ ਛਪਾਈ ਖੇਤਰ ਲੈਣੇ ਹਨ? ਤੁਹਾਡੀਆਂ ਕੀਤੀਆਂ ਸੋਧਾਂ ਉੱਤੇ ਲਿਖ ਦਿੱਤਾ ਜਾਵੇਗਾ।</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>ਨਵੇਂ ਸਰੋਤ ਤੋਂ ਤਾਜ਼ਾ ਕਰੋ</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>ਮੌਜੂਦਾ ਮੈਟਾਡਾਟਾ ਰੱਖੋ</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>ਨਵਾਂ ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>ਸ਼ਾਮਲ ਕੀਤਾ ਗਿਆ ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>ਛੱਡਿਆ ਗਿਆ ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>ਛੱਡੋ</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>ਨਵੇਂ ਵਿੱਚ ਹਿਲਾਓ</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ਫੋਲਡਰ ਹਟਾਓ</value></data>
+  <data name="import.sort" xml:space="preserve"><value>ਕ੍ਰਮਬੱਧ ਕਰੋ</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>ਨਾਂ (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>ਨਾਂ (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>ਸ਼ਾਮਲ ਮਿਤੀ (ਸਭ ਤੋਂ ਨਵੀਂ)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>ਸ਼ਾਮਲ ਮਿਤੀ (ਸਭ ਤੋਂ ਪੁਰਾਣੀ)</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Pobrać pola albumu, utworów i tłoczenia z nowo zidentyfikowanego źródła? Wprowadzone zmiany zostaną nadpisane.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Odśwież z nowego źródła</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Zachowaj obecne metadane</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Nowe ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Dodane ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Pominięto ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Pomiń</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Przenieś do nowych</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Usuń folder</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sortuj</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Nazwa (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Nazwa (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Data dodania (od najnowszych)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Data dodania (od najstarszych)</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Puxar os campos de álbum, faixa e prensagem da fonte recém-identificada? As edições que você fez serão sobrescritas.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Atualizar a partir da nova fonte</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Manter metadados atuais</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Novos ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Adicionados ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Ignorados ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Ignorar</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Mover para Novos</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Remover pasta</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Ordenar</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Nome (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Nome (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Data de adição (mais recente)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Data de adição (mais antiga)</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>புதிதாக அடையாளம் காணப்பட்ட மூலத்திலிருந்து ஆல்பம், பாடல், அச்சு பதிப்பு புலங்களை எடுக்கவா? நீங்கள் செய்த திருத்தங்கள் மேலெழுதப்படும்.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>புதிய மூலத்திலிருந்து புதுப்பி</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>தற்போதைய மெட்டாடேட்டாவை வைத்திரு</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>புதியது ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>சேர்க்கப்பட்டது ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>தவிர்க்கப்பட்டது ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>தவிர்</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>புதியதற்கு நகர்த்து</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>கோப்புறையை நீக்கு</value></data>
+  <data name="import.sort" xml:space="preserve"><value>வரிசைப்படுத்து</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>பெயர் (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>பெயர் (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>சேர்த்த தேதி (புதியது)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>சேர்த்த தேதி (பழையது)</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>కొత్తగా గుర్తించిన మూలం నుంచి ఆల్బమ్, ట్రాక్, ముద్రణ ఫీల్డ్‌లను తీసుకురావాలా? మీరు చేసిన మార్పులు భర్తీ చేయబడతాయి.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>కొత్త మూలం నుంచి రిఫ్రెష్ చేయి</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>ప్రస్తుత మెటాడేటాను ఉంచండి</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>కొత్తది ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>జోడించబడింది ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>దాటవేయబడింది ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>దాటవేయి</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>కొత్తదానికి తరలించు</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ఫోల్డర్‌ను తీసివేయి</value></data>
+  <data name="import.sort" xml:space="preserve"><value>క్రమపరచు</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>పేరు (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>పేరు (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>జోడించిన తేదీ (కొత్తవి)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>జోడించిన తేదీ (పాతవి)</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>ดึงฟิลด์อัลบั้ม แทร็ก และการผลิตแผ่นจากแหล่งที่เพิ่งระบุหรือไม่ การแก้ไขที่คุณทำไว้จะถูกเขียนทับ</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>รีเฟรชจากแหล่งใหม่</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>เก็บเมทาดาทาปัจจุบันไว้</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>ใหม่ ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>เพิ่มแล้ว ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>ข้ามแล้ว ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>ข้าม</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>ย้ายไปใหม่</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>ลบโฟลเดอร์</value></data>
+  <data name="import.sort" xml:space="preserve"><value>จัดเรียง</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>ชื่อ (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>ชื่อ (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>วันที่เพิ่ม (ใหม่สุด)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>วันที่เพิ่ม (เก่าสุด)</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Albüm, parça ve baskı alanları yeni tanımlanan kaynaktan alınsın mı? Yaptığınız düzenlemelerin üzerine yazılır.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Yeni kaynaktan yenile</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Mevcut üst veriyi koru</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Yeni ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Eklendi ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Atlandı ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Atla</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Yeniye Taşı</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Klasörü Kaldır</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sırala</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Ad (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Ad (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Eklenme Tarihi (En Yeni)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Eklenme Tarihi (En Eski)</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Підтягнути поля альбому, треків і видання з нового ідентифікованого джерела? Внесені вами зміни буде перезаписано.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Оновити з нового джерела</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Зберегти поточні метадані</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Нові ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Додані ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Пропущені ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Пропустити</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Перемістити в нові</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Вилучити теку</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Сортування</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>За назвою (А–Я)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>За назвою (Я–А)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>За датою додавання (спочатку нові)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>За датою додавання (спочатку старі)</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>نئے شناخت شدہ ماخذ سے البم، نغمہ، اور پریسنگ خانے لیں؟ آپ کی کی گئی تبدیلیاں مٹ جائیں گی۔</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>نئے ماخذ سے تازہ کریں</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>موجودہ میٹا ڈیٹا رکھیں</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>نیا ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>شامل ہو گیا ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>چھوڑا گیا ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>چھوڑیں</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>نئے میں منتقل کریں</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>پوشہ ہٹائیں</value></data>
+  <data name="import.sort" xml:space="preserve"><value>ترتیب دیں</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>نام (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>نام (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>شامل ہونے کی تاریخ (نیا پہلے)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>شامل ہونے کی تاریخ (پرانا پہلے)</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>Lấy các trường album, bản nhạc và bản ép từ nguồn vừa nhận dạng? Các chỉnh sửa bạn đã thực hiện sẽ bị ghi đè.</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>Làm mới từ nguồn mới</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>Giữ siêu dữ liệu hiện tại</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>Mới ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>Đã thêm ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>Đã bỏ qua ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>Bỏ qua</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>Di chuyển sang mới</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>Xóa thư mục</value></data>
+  <data name="import.sort" xml:space="preserve"><value>Sắp xếp</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>Tên (A–Z)</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>Tên (Z–A)</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>Ngày thêm (mới nhất)</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>Ngày thêm (cũ nhất)</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>从新识别的来源拉取专辑、曲目和压制版字段？你所做的编辑将被覆盖。</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>从新来源刷新</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>保留当前元数据</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>新 ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>已添加 ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>已跳过 ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>跳过</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>移至“新”</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>移除文件夹</value></data>
+  <data name="import.sort" xml:space="preserve"><value>排序</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>名称（A–Z）</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>名称（Z–A）</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>添加日期（最新）</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>添加日期（最早）</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -356,4 +356,15 @@
   <data name="album.reidentify.refresh_body" xml:space="preserve"><value>要從新識別的來源取得專輯、曲目與版本欄位嗎？你所做的編輯會被覆寫。</value></data>
   <data name="album.reidentify.refresh_confirm" xml:space="preserve"><value>從新來源重新整理</value></data>
   <data name="album.reidentify.keep_current" xml:space="preserve"><value>保留目前中繼資料</value></data>
+  <data name="import.tab.new" xml:space="preserve"><value>新 ({count})</value></data>
+  <data name="import.tab.added" xml:space="preserve"><value>已加入 ({count})</value></data>
+  <data name="import.tab.skipped" xml:space="preserve"><value>已略過 ({count})</value></data>
+  <data name="import.candidate.skip" xml:space="preserve"><value>略過</value></data>
+  <data name="import.candidate.unskip" xml:space="preserve"><value>移至「新」</value></data>
+  <data name="import.folder.remove" xml:space="preserve"><value>移除資料夾</value></data>
+  <data name="import.sort" xml:space="preserve"><value>排序</value></data>
+  <data name="import.sort.name_az" xml:space="preserve"><value>名稱（A–Z）</value></data>
+  <data name="import.sort.name_za" xml:space="preserve"><value>名稱（Z–A）</value></data>
+  <data name="import.sort.newest" xml:space="preserve"><value>加入日期（最新）</value></data>
+  <data name="import.sort.oldest" xml:space="preserve"><value>加入日期（最舊）</value></data>
 </root>

--- a/bae-windows/Views/ImportDialog.cs
+++ b/bae-windows/Views/ImportDialog.cs
@@ -2,6 +2,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using uniffi.bae_bridge;
 
 namespace Bae.Windows;
 
@@ -41,6 +42,8 @@ internal sealed class ImportDialog
         {
             return;
         }
+        // Each dialog open starts on the New tab, like the recreated macOS view.
+        _import.SetActiveTab(CandidateTab.New);
         _import.RefreshCandidates();
 
         var scanButton = new Button { Content = Loc.Chrome("import.choose_folder") };
@@ -55,6 +58,65 @@ internal sealed class ImportDialog
         // makes the block visible), matching the prior in-place update.
         void RenderScanStatus() => status.Text = _import.CandidatesStatusText;
         _import.CandidatesRefreshed += RenderScanStatus;
+
+        // Watched-folders section: one row per watched folder, each with a remove
+        // control. Rebuilt on every candidate refresh; collapses when empty.
+        var foldersPanel = new StackPanel { Spacing = 4 };
+        void RenderFolders()
+        {
+            foldersPanel.Children.Clear();
+            foreach (var folder in _import.WatchedFolders)
+            {
+                foldersPanel.Children.Add(BuildFolderRow(folder));
+            }
+            foldersPanel.Visibility = _import.WatchedFolders.Count == 0
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        }
+        _import.CandidatesRefreshed += RenderFolders;
+
+        // Tab bar: New / Added / Skipped, each labeled with its live count; the
+        // active tab is emphasized. Clicking a tab shows it (absolute set).
+        var newTab = new Button();
+        var addedTab = new Button();
+        var skippedTab = new Button();
+        newTab.Click += (_, _) => _import.SetActiveTab(CandidateTab.New);
+        addedTab.Click += (_, _) => _import.SetActiveTab(CandidateTab.Added);
+        skippedTab.Click += (_, _) => _import.SetActiveTab(CandidateTab.Skipped);
+        void RenderTabs()
+        {
+            var counts = _import.TabCounts;
+            newTab.Content = Loc.Chrome("import.tab.new", "count", counts.New);
+            addedTab.Content = Loc.Chrome("import.tab.added", "count", counts.Added);
+            skippedTab.Content = Loc.Chrome("import.tab.skipped", "count", counts.Skipped);
+            StyleTab(newTab, _import.ActiveTab == CandidateTab.New);
+            StyleTab(addedTab, _import.ActiveTab == CandidateTab.Added);
+            StyleTab(skippedTab, _import.ActiveTab == CandidateTab.Skipped);
+        }
+        _import.CandidatesRefreshed += RenderTabs;
+
+        // Sort ComboBox: the four orders in enum order, so the selected index maps
+        // straight to the value. Seed the selection before subscribing so the
+        // initial value doesn't round-trip a save.
+        var sortBox = new ComboBox { Header = Loc.Chrome("import.sort") };
+        sortBox.Items.Add(Loc.Chrome("import.sort.name_az"));
+        sortBox.Items.Add(Loc.Chrome("import.sort.name_za"));
+        sortBox.Items.Add(Loc.Chrome("import.sort.newest"));
+        sortBox.Items.Add(Loc.Chrome("import.sort.oldest"));
+        sortBox.SelectedIndex = (int)_import.SortOrder;
+        sortBox.SelectionChanged += (_, _) =>
+        {
+            if (sortBox.SelectedIndex >= 0)
+            {
+                _import.SetSortOrder((CandidateSortOrder)sortBox.SelectedIndex);
+            }
+        };
+
+        var tabBar = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        tabBar.Children.Add(newTab);
+        tabBar.Children.Add(addedTab);
+        tabBar.Children.Add(skippedTab);
+        tabBar.Children.Add(sortBox);
 
         var list = new ListView
         {
@@ -133,7 +195,9 @@ internal sealed class ImportDialog
 
         var content = new StackPanel { Spacing = 8, Width = 420 };
         content.Children.Add(scanButton);
+        content.Children.Add(foldersPanel);
         content.Children.Add(status);
+        content.Children.Add(tabBar);
         content.Children.Add(list);
 
         var dialog = new ContentDialog
@@ -153,6 +217,8 @@ internal sealed class ImportDialog
         {
             IsOpen = false;
             _import.CandidatesRefreshed -= RenderScanStatus;
+            _import.CandidatesRefreshed -= RenderFolders;
+            _import.CandidatesRefreshed -= RenderTabs;
         }
     }
 
@@ -188,6 +254,74 @@ internal sealed class ImportDialog
                 }));
         }
 
+        // Skip / un-skip rides a right-click flyout. An invalid folder can't be
+        // skipped or unskipped (it always lists under Skipped), so it gets no
+        // flyout — mirroring the macOS invalid-candidate row.
+        if (!candidate.Invalid)
+        {
+            var flyout = new MenuFlyout();
+            var toggleSkip = new MenuFlyoutItem
+            {
+                Text = candidate.Skipped
+                    ? Loc.Chrome("import.candidate.unskip")
+                    : Loc.Chrome("import.candidate.skip"),
+            };
+            toggleSkip.Click += (_, _) =>
+                _import.SetCandidateSkipped(candidate.FolderPath, !candidate.Skipped);
+            flyout.Items.Add(toggleSkip);
+            row.ContextFlyout = flyout;
+        }
+
         return row;
+    }
+
+    // One watched-folder row: the folder name (its path on hover) and a remove
+    // control. Removing un-watches the folder straight away — no confirmation,
+    // matching the macOS folder-header menu.
+    private StackPanel BuildFolderRow(BridgeWatchedFolder folder)
+    {
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        var name = new TextBlock
+        {
+            Text = folder.Name,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        ToolTipService.SetToolTip(name, folder.Path);
+        row.Children.Add(name);
+
+        var remove = new Button
+        {
+            Content = "✕",
+            Padding = new Thickness(8, 3, 8, 3),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        ToolTipService.SetToolTip(remove, Loc.Chrome("import.folder.remove"));
+        remove.Click += (_, _) => _import.RemoveWatchedFolder(folder.Path);
+        row.Children.Add(remove);
+
+        return row;
+    }
+
+    // Emphasize the active tab and gray the inactive ones. The active tab reverts
+    // to the default foreground so it reads normally in either theme.
+    private static void StyleTab(Button tab, bool active)
+    {
+        tab.FontWeight = active
+            ? Microsoft.UI.Text.FontWeights.SemiBold
+            : Microsoft.UI.Text.FontWeights.Normal;
+        if (active)
+        {
+            tab.ClearValue(Control.ForegroundProperty);
+        }
+        else
+        {
+            tab.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
+        }
     }
 }

--- a/bae-windows/bae-windows.Tests/ImportListModelTests.cs
+++ b/bae-windows/bae-windows.Tests/ImportListModelTests.cs
@@ -1,0 +1,170 @@
+﻿using System.Collections.Generic;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+// The import candidate-list model: tab assignment (skipped wins over added,
+// invalid always Skipped), per-tab counts, the four sort orders over core
+// snapshot order, the Skipped tab's invalid-after-candidates split, and the
+// persisted-token round-trip.
+public sealed class ImportListModelTests
+{
+    private static ImportListRow Row(
+        string key,
+        string name = "name",
+        bool skipped = false,
+        bool isAdded = false,
+        bool complete = false,
+        bool invalid = false) =>
+        new(key, name, skipped, isAdded, complete, invalid);
+
+    [Fact]
+    public void Tab_SkippedWinsOverCompleteAndAdded()
+    {
+        var row = Row("k", skipped: true, isAdded: true, complete: true);
+        Assert.Equal(CandidateTab.Skipped, ImportListModel.Tab(row));
+    }
+
+    [Fact]
+    public void Tab_InvalidAlwaysSkipped()
+    {
+        Assert.Equal(CandidateTab.Skipped, ImportListModel.Tab(Row("k", invalid: true)));
+        // Invalid outranks an added match too.
+        Assert.Equal(
+            CandidateTab.Skipped,
+            ImportListModel.Tab(Row("k", isAdded: true, complete: true, invalid: true)));
+    }
+
+    [Fact]
+    public void Tab_CompleteIsAdded()
+    {
+        Assert.Equal(CandidateTab.Added, ImportListModel.Tab(Row("k", complete: true)));
+    }
+
+    [Fact]
+    public void Tab_IsAddedIsAdded()
+    {
+        Assert.Equal(CandidateTab.Added, ImportListModel.Tab(Row("k", isAdded: true)));
+    }
+
+    [Fact]
+    public void Tab_PlainIsNew()
+    {
+        Assert.Equal(CandidateTab.New, ImportListModel.Tab(Row("k")));
+    }
+
+    [Fact]
+    public void Counts_TallyEachTab()
+    {
+        var rows = new List<ImportListRow>
+        {
+            Row("a"),
+            Row("b"),
+            Row("c", isAdded: true),
+            Row("d", complete: true),
+            Row("e", skipped: true),
+            Row("f", invalid: true),
+        };
+        var counts = ImportListModel.Counts(rows);
+        Assert.Equal(2, counts.New);
+        Assert.Equal(2, counts.Added);
+        Assert.Equal(2, counts.Skipped);
+    }
+
+    [Fact]
+    public void DisplayedKeys_NewestIsInputOrder()
+    {
+        var rows = new List<ImportListRow> { Row("a"), Row("b"), Row("c") };
+        Assert.Equal(
+            new[] { "a", "b", "c" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.New, CandidateSortOrder.DateAddedNewest));
+    }
+
+    [Fact]
+    public void DisplayedKeys_OldestIsExactReverse()
+    {
+        var rows = new List<ImportListRow> { Row("a"), Row("b"), Row("c") };
+        Assert.Equal(
+            new[] { "c", "b", "a" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.New, CandidateSortOrder.DateAddedOldest));
+    }
+
+    [Fact]
+    public void DisplayedKeys_NameSortIsCaseInsensitive()
+    {
+        // Ordinal order would put "Bravo" (uppercase B) before "alpha" (lowercase a);
+        // a case-insensitive compare orders alpha before bravo.
+        var rows = new List<ImportListRow>
+        {
+            Row("bravo", name: "Bravo"),
+            Row("alpha", name: "alpha"),
+        };
+        Assert.Equal(
+            new[] { "alpha", "bravo" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.New, CandidateSortOrder.NameAZ));
+        Assert.Equal(
+            new[] { "bravo", "alpha" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.New, CandidateSortOrder.NameZA));
+    }
+
+    [Fact]
+    public void DisplayedKeys_NameSortIsStableForEqualNames()
+    {
+        // Two rows whose names compare equal keep their input order in both directions.
+        var rows = new List<ImportListRow>
+        {
+            Row("first", name: "same"),
+            Row("second", name: "SAME"),
+        };
+        Assert.Equal(
+            new[] { "first", "second" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.New, CandidateSortOrder.NameAZ));
+        Assert.Equal(
+            new[] { "first", "second" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.New, CandidateSortOrder.NameZA));
+    }
+
+    [Fact]
+    public void DisplayedKeys_SkippedTabPutsInvalidAfterCandidates()
+    {
+        var rows = new List<ImportListRow>
+        {
+            Row("skip1", skipped: true),
+            Row("invalid1", invalid: true),
+            Row("skip2", skipped: true),
+            Row("new1"),
+        };
+        // Newest keeps input order within each group: skipped first, invalid last.
+        Assert.Equal(
+            new[] { "skip1", "skip2", "invalid1" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.Skipped, CandidateSortOrder.DateAddedNewest));
+        // Oldest reverses within each group, keeping non-invalid before invalid.
+        Assert.Equal(
+            new[] { "skip2", "skip1", "invalid1" },
+            ImportListModel.DisplayedKeys(rows, CandidateTab.Skipped, CandidateSortOrder.DateAddedOldest));
+    }
+
+    [Fact]
+    public void SerializeParse_RoundTripsEveryOrder()
+    {
+        foreach (var order in new[]
+        {
+            CandidateSortOrder.NameAZ,
+            CandidateSortOrder.NameZA,
+            CandidateSortOrder.DateAddedNewest,
+            CandidateSortOrder.DateAddedOldest,
+        })
+        {
+            Assert.Equal(order, ImportListModel.ParseSortOrder(ImportListModel.Serialize(order)));
+        }
+    }
+
+    [Fact]
+    public void ParseSortOrder_UnknownOrNullIsDefault()
+    {
+        Assert.Equal(CandidateSortOrder.DateAddedNewest, ImportListModel.ParseSortOrder(null));
+        Assert.Equal(CandidateSortOrder.DateAddedNewest, ImportListModel.ParseSortOrder(""));
+        Assert.Equal(CandidateSortOrder.DateAddedNewest, ImportListModel.ParseSortOrder("bogus"));
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -16,13 +16,15 @@
       no WinRT dependency (the WinRT shell that applies its decisions lives in
       MediaControlService and is verified by compilation).
     - The store models (PlaybackPositionModel / SyncIndicatorModel /
-      ImportIdentityModel / ReidentifyResultsModel) — the now-playing-bar
-      seek/position math, the sync-indicator precedence, the import
-      identity-claim state (exact vs metadata-only, its note and pressing-field
-      enablement), and the re-identify results-list arbitration between the
-      auto-identify pipeline and a manual search, split out as plain BCL types
-      (the stores that hold bridge snapshots and the WinUI views and dialogs
-      that render them are verified by compilation).
+      ImportIdentityModel / ReidentifyResultsModel / ImportListModel) — the
+      now-playing-bar seek/position math, the sync-indicator precedence, the
+      import identity-claim state (exact vs metadata-only, its note and
+      pressing-field enablement), the re-identify results-list arbitration
+      between the auto-identify pipeline and a manual search, and the import
+      candidate-list tab assignment / counts / sort orders / persisted-token
+      round-trip, split out as plain BCL types (the stores that hold bridge
+      snapshots and the WinUI views and dialogs that render them are verified by
+      compilation).
     - The update-flow layer (UpdateFlow) — the state machine and display mapping
       behind the settings "updates" section (status keys, percent clamping,
       button gating, version-string normalization), over plain BCL types with no
@@ -61,6 +63,7 @@
     <Compile Include="../Stores/OrderedIntersection.cs" Link="OrderedIntersection.cs" />
     <Compile Include="../Stores/ImportIdentityModel.cs" Link="ImportIdentityModel.cs" />
     <Compile Include="../Stores/ReidentifyResultsModel.cs" Link="ReidentifyResultsModel.cs" />
+    <Compile Include="../Stores/ImportListModel.cs" Link="ImportListModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Windows import dialog was a flat candidate list with no way to un-watch a folder, dismiss a candidate, or reorder the list. Two shipped bridge calls — `remove_watched_folder` and `set_candidate_skipped` — had no Windows caller, and the candidates snapshot's `watched_folders`, `skipped`, and `is_added` fields were dropped during conversion, so a skipped or already-imported candidate had nowhere to render.

This brings the dialog to parity with macOS. A pure `ImportListModel` owns the decisions: tab assignment (skipped wins over added; an invalid folder always lists under Skipped; a completed or content-hash-matched candidate is Added; everything else is New), per-tab counts, and the four sort orders computed over the deterministic core snapshot order ("date added" newest keeps snapshot order, oldest reverses it; the name sorts are case-insensitive current-culture compares). `ImportSortStore` persists the chosen order under the app's local data directory, defaulting to date-added-newest.

`ImportStore` keeps the full scan in snapshot order and projects it onto the active tab, so the bound collection is always exactly the displayed tab. The dialog gains a watched-folders section with a per-folder remove control, New/Added/Skipped tab buttons with live counts, a persisted sort ComboBox, and a Skip / Move to New row context menu (absent on invalid rows, which can't be skipped). Remove and skip ride the already-registered watched-folders/candidate invalidations: the success path stays silent and lets the refresh re-render the row into its new tab, matching the macOS reducer model; failures surface the import banner.

Bridge and core are untouched — both methods and all three snapshot fields already exist. Eleven new chrome keys land in all 31 locale catalogs with real translations (including the ko/zh "New" wrong-context corrections carried over from the macOS catalog).

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 175 passed, including the new `ImportListModelTests` (tab matrix, counts, all four sort orders with stability and case-insensitivity, the Skipped-tab invalid-after-candidates split, and the serialize/parse round-trip).
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans across 365 keys.
- The Windows app compiles only in CI (`windows.yml`); every control type used here already appears in these files or their siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)