### PR TITLE
Toggle the Windows now-playing time labels between elapsed and remaining

### DIFF
--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -226,7 +226,7 @@
                             StepFrequency="0.001"
                             VerticalAlignment="Center" />
                         <TextBlock
-                            x:Name="NpRemaining"
+                            x:Name="NpDuration"
                             Grid.Column="2"
                             Text="0:00"
                             VerticalAlignment="Center"

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -126,7 +126,7 @@ public sealed partial class MainWindow : Window
             NpTitle,
             NpArtist,
             NpElapsed,
-            NpRemaining,
+            NpDuration,
             NpProgress,
             NpVolume,
             NpPlayPause,

--- a/bae-windows/Stores/PlaybackPositionModel.cs
+++ b/bae-windows/Stores/PlaybackPositionModel.cs
@@ -107,6 +107,26 @@ public static class PlaybackPositionModel
         return Loc.Duration((long)milliseconds);
     }
 
+    // The leading time label: elapsed, or a minus-prefixed remaining countdown
+    // when the user has toggled it (the trailing label is always the total).
+    public static string PositionLabel(bool showRemaining, ulong positionMs, ulong durationMs) =>
+        showRemaining
+            ? "-" + DurationLabel(RemainingDurationMs(positionMs, durationMs))
+            : DurationLabel(positionMs);
+
+    // The persisted time-label mode, as the token the store writes to disk and
+    // reads back. Unknown or missing tokens fall back to elapsed.
+    public static string TimeLabelToken(bool showRemaining) =>
+        showRemaining ? "remaining" : "elapsed";
+
+    public static bool ShowRemainingFromToken(string? token) =>
+        string.Equals(token?.Trim(), "remaining", StringComparison.Ordinal);
+
+    // The leading label's tooltip names the action a click performs, so it follows
+    // the current mode.
+    public static string TimeLabelTooltipKey(bool showRemaining) =>
+        showRemaining ? "nowplaying.show_elapsed" : "nowplaying.show_remaining";
+
     // Fold a fresh snapshot into the now-playing state, keeping the album when a
     // state already exists, or creating one for the track when it doesn't.
     public static NowPlayingState WithPosition(

--- a/bae-windows/Stores/TimeLabelStore.cs
+++ b/bae-windows/Stores/TimeLabelStore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+
+namespace Bae.Windows;
+
+// The file-backed choice of which mode the now-playing bar's leading time label
+// shows: elapsed, or a minus-prefixed remaining countdown. The bare token lives
+// under the app's local data directory, mirroring how macOS keeps the same
+// choice in UserDefaults. A failed read or write degrades to elapsed rather than
+// taking the app down — the label mode is a preference, not durable state.
+internal static class TimeLabelStore
+{
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "bae",
+        "time-label.txt");
+
+    // Load the saved label mode, or elapsed when nothing is saved yet.
+    public static bool Load()
+    {
+        string? token = null;
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                token = File.ReadAllText(FilePath);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not read the saved time-label mode.", exception);
+        }
+
+        return PlaybackPositionModel.ShowRemainingFromToken(token);
+    }
+
+    public static void Save(bool showRemaining)
+    {
+        try
+        {
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, PlaybackPositionModel.TimeLabelToken(showRemaining));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not save the time-label mode.", exception);
+        }
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>الاسم (ي–أ)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>تاريخ الإضافة (الأحدث)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>تاريخ الإضافة (الأقدم)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>عرض الوقت المتبقي</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>عرض الوقت المنقضي</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Име (Я–А)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Дата на добавяне (най-нови)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Дата на добавяне (най-стари)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>показване на оставащото време</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>показване на изминалото време</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>নাম (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>যোগের তারিখ (নতুনতম)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>যোগের তারিখ (পুরনোতম)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>অবশিষ্ট সময় দেখান</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>অতিবাহিত সময় দেখান</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Název (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Datum přidání (nejnovější)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Datum přidání (nejstarší)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>zobrazit zbývající čas</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>zobrazit uplynulý čas</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Name (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Hinzugefügt (neueste zuerst)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Hinzugefügt (älteste zuerst)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>verbleibende Zeit anzeigen</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>verstrichene Zeit anzeigen</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Name (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Date Added (Newest)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Date Added (Oldest)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>show remaining time</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>show elapsed time</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Nombre (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Fecha de adición (más reciente)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Fecha de adición (más antigua)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>mostrar el tiempo restante</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>mostrar el tiempo transcurrido</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Nom (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Date d'ajout (plus récent)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Date d'ajout (plus ancien)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>afficher le temps restant</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>afficher le temps écoulé</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>નામ (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>ઉમેરેલી તારીખ (નવાં પહેલાં)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>ઉમેરેલી તારીખ (જૂનાં પહેલાં)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>બાકી રહેલો સમય બતાવો</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>વીતેલો સમય બતાવો</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>שם (ת׳–א׳)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>תאריך הוספה (החדש ביותר)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>תאריך הוספה (הישן ביותר)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>הצגת הזמן שנותר</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>הצגת הזמן שחלף</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>नाम (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>जोड़े जाने की तारीख (सबसे नया)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>जोड़े जाने की तारीख (सबसे पुराना)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>शेष समय दिखाएँ</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>बीता हुआ समय दिखाएँ</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Naziv (Ž–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Datum dodavanja (najnovije)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Datum dodavanja (najstarije)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>prikaži preostalo vrijeme</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>prikaži proteklo vrijeme</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Nome (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Data di aggiunta (più recente)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Data di aggiunta (meno recente)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>mostra il tempo rimanente</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>mostra il tempo trascorso</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>名前（Z–A）</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>追加日（新しい順）</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>追加日（古い順）</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>残り時間を表示</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>経過時間を表示</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>ಹೆಸರು (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹೊಸದು)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹಳೆಯದು)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>ಉಳಿದಿರುವ ಸಮಯವನ್ನು ತೋರಿಸಿ</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>ಕಳೆದ ಸಮಯವನ್ನು ತೋರಿಸಿ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>이름(Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>추가한 날짜(최신)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>추가한 날짜(오래된 순)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>남은 시간 표시</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>경과 시간 표시</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>പേര് (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>ചേർത്ത തീയതി (പുതിയത്)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>ചേർത്ത തീയതി (പഴയത്)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>ശേഷിക്കുന്ന സമയം കാണിക്കുക</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>കഴിഞ്ഞ സമയം കാണിക്കുക</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>नाव (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>जोडल्याची तारीख (नवीनतम)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>जोडल्याची तारीख (सर्वात जुनी)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>उर्वरित वेळ दाखवा</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>झालेला वेळ दाखवा</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Naam (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Toegevoegd op (nieuwste)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Toegevoegd op (oudste)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>resterende tijd tonen</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>verstreken tijd tonen</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>ਨਾਂ (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>ਸ਼ਾਮਲ ਮਿਤੀ (ਸਭ ਤੋਂ ਨਵੀਂ)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>ਸ਼ਾਮਲ ਮਿਤੀ (ਸਭ ਤੋਂ ਪੁਰਾਣੀ)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>ਬਾਕੀ ਸਮਾਂ ਦਿਖਾਓ</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>ਬੀਤਿਆ ਸਮਾਂ ਦਿਖਾਓ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Nazwa (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Data dodania (od najnowszych)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Data dodania (od najstarszych)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>pokaż pozostały czas</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>pokaż miniony czas</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Nome (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Data de adição (mais recente)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Data de adição (mais antiga)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>mostrar tempo restante</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>mostrar tempo decorrido</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>பெயர் (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>சேர்த்த தேதி (புதியது)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>சேர்த்த தேதி (பழையது)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>மீதமுள்ள நேரத்தைக் காட்டு</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>கடந்த நேரத்தைக் காட்டு</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>పేరు (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>జోడించిన తేదీ (కొత్తవి)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>జోడించిన తేదీ (పాతవి)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>మిగిలిన సమయాన్ని చూపించు</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>గడిచిన సమయాన్ని చూపించు</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>ชื่อ (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>วันที่เพิ่ม (ใหม่สุด)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>วันที่เพิ่ม (เก่าสุด)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>แสดงเวลาที่เหลือ</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>แสดงเวลาที่ผ่านไป</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Ad (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Eklenme Tarihi (En Yeni)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Eklenme Tarihi (En Eski)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>kalan süreyi göster</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>geçen süreyi göster</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>За назвою (Я–А)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>За датою додавання (спочатку нові)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>За датою додавання (спочатку старі)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>показати час, що залишився</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>показати час, що минув</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>نام (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>شامل ہونے کی تاریخ (نیا پہلے)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>شامل ہونے کی تاریخ (پرانا پہلے)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>باقی وقت دکھائیں</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>گزرا ہوا وقت دکھائیں</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>Tên (Z–A)</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>Ngày thêm (mới nhất)</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>Ngày thêm (cũ nhất)</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>hiện thời gian còn lại</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>hiện thời gian đã phát</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>名称（Z–A）</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>添加日期（最新）</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>添加日期（最早）</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>显示剩余时间</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>显示已播放时间</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -367,4 +367,6 @@
   <data name="import.sort.name_za" xml:space="preserve"><value>名稱（Z–A）</value></data>
   <data name="import.sort.newest" xml:space="preserve"><value>加入日期（最新）</value></data>
   <data name="import.sort.oldest" xml:space="preserve"><value>加入日期（最舊）</value></data>
+  <data name="nowplaying.show_remaining" xml:space="preserve"><value>顯示剩餘時間</value></data>
+  <data name="nowplaying.show_elapsed" xml:space="preserve"><value>顯示已播放時間</value></data>
 </root>

--- a/bae-windows/Views/NowPlayingBarController.cs
+++ b/bae-windows/Views/NowPlayingBarController.cs
@@ -24,7 +24,7 @@ internal sealed class NowPlayingBarController
     private readonly TextBlock _title;
     private readonly TextBlock _artist;
     private readonly TextBlock _elapsed;
-    private readonly TextBlock _remaining;
+    private readonly TextBlock _duration;
     private readonly Slider _progress;
     private readonly Slider _volume;
     private readonly Button _playPause;
@@ -49,6 +49,16 @@ internal sealed class NowPlayingBarController
     // restarts it, replacing the count and resetting the timer.
     private DispatcherTimer? _queueBadgeTimer;
 
+    // Whether the leading time label shows a remaining countdown instead of
+    // elapsed time. Seeded from the persisted choice; the user flips it by
+    // clicking the label, and the choice persists across launches.
+    private bool _showRemaining;
+
+    // The last rendered position, so a label toggle re-renders immediately from
+    // it instead of waiting for the next progress tick. Cleared when the bar
+    // hides, so a stale position can't resurrect via a later toggle.
+    private PlaybackPositionRender? _lastPosition;
+
     public NowPlayingBarController(
         SessionStore session,
         PlaybackStore playback,
@@ -58,7 +68,7 @@ internal sealed class NowPlayingBarController
         TextBlock title,
         TextBlock artist,
         TextBlock elapsed,
-        TextBlock remaining,
+        TextBlock duration,
         Slider progress,
         Slider volume,
         Button playPause,
@@ -79,7 +89,7 @@ internal sealed class NowPlayingBarController
         _title = title;
         _artist = artist;
         _elapsed = elapsed;
-        _remaining = remaining;
+        _duration = duration;
         _progress = progress;
         _volume = volume;
         _playPause = playPause;
@@ -114,6 +124,13 @@ internal sealed class NowPlayingBarController
                     _session.WithCurrentHandle(handle => NativeBae.SeekByRatio(handle, _progress.Value));
                 }
             }), true);
+
+        // The leading label click-toggles between elapsed and remaining. The
+        // tooltip is the affordance that it's clickable, and it names the mode a
+        // click switches to, so it tracks the current state.
+        _showRemaining = TimeLabelStore.Load();
+        _elapsed.Tapped += (_, _) => ToggleTimeLabel();
+        ToolTipService.SetToolTip(_elapsed, Loc.Chrome(PlaybackPositionModel.TimeLabelTooltipKey(_showRemaining)));
 
         _playback.NowPlayingChanged += OnNowPlayingChanged;
         _playback.PlaybackStopped += OnPlaybackStopped;
@@ -152,6 +169,7 @@ internal sealed class NowPlayingBarController
     {
         _nowPlayingBar.Visibility = Visibility.Collapsed;
         _userSeeking = false;
+        _lastPosition = null;
     }
 
     private void OnNowPlayingChanged(NowPlayingBarTrack track)
@@ -176,6 +194,7 @@ internal sealed class NowPlayingBarController
     {
         _nowPlayingBar.Visibility = Visibility.Collapsed;
         _userSeeking = false;
+        _lastPosition = null;
         _loading.IsActive = false;
         _loading.Visibility = Visibility.Collapsed;
         _playPause.Visibility = Visibility.Visible;
@@ -198,15 +217,39 @@ internal sealed class NowPlayingBarController
         {
             _progress.Value = render.Progress;
         }
-        _elapsed.Text = PlaybackPositionModel.DurationLabel(render.PositionMs);
-        _remaining.Text = PlaybackPositionModel.DurationLabel(PlaybackPositionModel.RemainingDurationMs(render.PositionMs, render.DurationMs));
+        RenderTimeLabels(render);
     }
 
     private void RenderSeekPosition(double progress, ulong positionMs, ulong durationMs)
     {
         _progress.Value = progress;
-        _elapsed.Text = PlaybackPositionModel.DurationLabel(positionMs);
-        _remaining.Text = PlaybackPositionModel.DurationLabel(PlaybackPositionModel.RemainingDurationMs(positionMs, durationMs));
+        RenderTimeLabels(new PlaybackPositionRender(progress, positionMs, durationMs));
+    }
+
+    // Write both time labels: the leading label shows elapsed or a minus-prefixed
+    // remaining countdown per the current mode; the trailing label is always the
+    // track total. Remembers the position so a label toggle re-renders from it.
+    private void RenderTimeLabels(PlaybackPositionRender render)
+    {
+        _lastPosition = render;
+        _elapsed.Text = PlaybackPositionModel.PositionLabel(_showRemaining, render.PositionMs, render.DurationMs);
+        _duration.Text = PlaybackPositionModel.DurationLabel(render.DurationMs);
+    }
+
+    // Flip the leading label between elapsed and remaining, persist the choice,
+    // update the tooltip to name the new target mode, and re-render immediately
+    // from the last position so the label changes without waiting for the next
+    // progress tick. With no position yet there is nothing to re-render — the
+    // next tick picks the mode up.
+    private void ToggleTimeLabel()
+    {
+        _showRemaining = !_showRemaining;
+        TimeLabelStore.Save(_showRemaining);
+        ToolTipService.SetToolTip(_elapsed, Loc.Chrome(PlaybackPositionModel.TimeLabelTooltipKey(_showRemaining)));
+        if (_lastPosition is { } position)
+        {
+            RenderTimeLabels(position);
+        }
     }
 
     private void OnVolumeChanged(double volume)

--- a/bae-windows/bae-windows.Tests/PlaybackPositionModelTests.cs
+++ b/bae-windows/bae-windows.Tests/PlaybackPositionModelTests.cs
@@ -116,6 +116,68 @@ public sealed class PlaybackPositionModelTests
     public void Remaining_PositionBeyondDurationThrows() =>
         Assert.Throws<InvalidOperationException>(() => PlaybackPositionModel.RemainingDurationMs(200_001, 200_000));
 
+    // ── PositionLabel: elapsed, or a minus-prefixed remaining countdown ──
+
+    [Fact]
+    public void PositionLabel_ElapsedShowsPosition() =>
+        Assert.Equal(PlaybackPositionModel.DurationLabel(50_000), PlaybackPositionModel.PositionLabel(false, 50_000, 200_000));
+
+    [Fact]
+    public void PositionLabel_RemainingCountsDownWithMinusPrefix() =>
+        Assert.Equal("-2:30", PlaybackPositionModel.PositionLabel(true, 50_000, 200_000));
+
+    [Fact]
+    public void PositionLabel_RemainingAtTrackEndIsMinusZero() =>
+        Assert.Equal("-0:00", PlaybackPositionModel.PositionLabel(true, 200_000, 200_000));
+
+    [Fact]
+    public void PositionLabel_RemainingBeyondDurationThrows() =>
+        Assert.Throws<InvalidOperationException>(() => PlaybackPositionModel.PositionLabel(true, 200_001, 200_000));
+
+    // ── TimeLabelToken / ShowRemainingFromToken: round-trip and fallback ──
+
+    [Fact]
+    public void TimeLabelToken_RoundTripsRemaining() =>
+        Assert.True(PlaybackPositionModel.ShowRemainingFromToken(PlaybackPositionModel.TimeLabelToken(true)));
+
+    [Fact]
+    public void TimeLabelToken_RoundTripsElapsed() =>
+        Assert.False(PlaybackPositionModel.ShowRemainingFromToken(PlaybackPositionModel.TimeLabelToken(false)));
+
+    [Fact]
+    public void ShowRemainingFromToken_RemainingIsTrue() =>
+        Assert.True(PlaybackPositionModel.ShowRemainingFromToken("remaining"));
+
+    [Fact]
+    public void ShowRemainingFromToken_ElapsedIsFalse() =>
+        Assert.False(PlaybackPositionModel.ShowRemainingFromToken("elapsed"));
+
+    [Fact]
+    public void ShowRemainingFromToken_NullIsFalse() =>
+        Assert.False(PlaybackPositionModel.ShowRemainingFromToken(null));
+
+    [Fact]
+    public void ShowRemainingFromToken_EmptyIsFalse() =>
+        Assert.False(PlaybackPositionModel.ShowRemainingFromToken(""));
+
+    [Fact]
+    public void ShowRemainingFromToken_GarbageIsFalse() =>
+        Assert.False(PlaybackPositionModel.ShowRemainingFromToken("xyzzy"));
+
+    [Fact]
+    public void ShowRemainingFromToken_TrimsWhitespace() =>
+        Assert.True(PlaybackPositionModel.ShowRemainingFromToken(" remaining\n"));
+
+    // ── TimeLabelTooltipKey: names the mode a click switches to ──
+
+    [Fact]
+    public void TimeLabelTooltipKey_ElapsedOffersRemaining() =>
+        Assert.Equal("nowplaying.show_remaining", PlaybackPositionModel.TimeLabelTooltipKey(false));
+
+    [Fact]
+    public void TimeLabelTooltipKey_RemainingOffersElapsed() =>
+        Assert.Equal("nowplaying.show_elapsed", PlaybackPositionModel.TimeLabelTooltipKey(true));
+
     // ── ClearProjection: drop the projection, keep the snapshot ──
 
     [Fact]


### PR DESCRIPTION
The Windows now-playing bar showed a fixed elapsed label on the left and an un-prefixed live countdown on the right, with no way to switch between them and no memory of a choice. macOS instead lets the user click the leading time label to switch it between elapsed and a minus-prefixed remaining countdown, keeps the trailing label as the track's total duration, and persists the choice across launches.

This mirrors that behavior on Windows. The trailing label becomes the static total duration; the leading label click-toggles between elapsed and a minus-prefixed remaining countdown; and the choice is written to a small file-backed store (`%LocalAppData%/bae/time-label.txt`) alongside the other UI preferences, degrading to elapsed on any read/write failure since it is a preference, not durable state. The leading label's tooltip names the mode a click switches to, following the bar's existing convention that a clickable non-button element carries a tooltip as its affordance. The label math and token round-trip live in the pure `PlaybackPositionModel` and are unit-tested; the store does file I/O and stays out of the test project.

Localization for both new tooltip strings lands here across all 31 locale catalogs.

Windows compiles only in CI (`windows.yml`); every API used already has an in-repo receipt, so CI is the compile gate.

## Test plan

- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 189 passing, including the new `PlaybackPositionModel` facts (label modes, end-of-track, token round-trip and fallback, tooltip-key mapping).
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans.
- CI Windows build is the compile gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)