### PR TITLE
Render the export queue and honor the export-location config on Windows

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -238,6 +238,7 @@ public sealed partial class MainWindow : Window
         _settingsDialog = new SettingsDialog(
             _session,
             () => Content.XamlRoot,
+            () => WinRT.Interop.WindowNative.GetWindowHandle(this),
             DispatcherQueue,
             _settings,
             _membersPane,

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -422,6 +422,17 @@ internal static class NativeBae
 
     internal static void RetryDownloads(AppHandle handle) => handle.RetryDownloads();
 
+    internal static BridgeExportSnapshot ExportSnapshot(AppHandle handle) =>
+        handle.GetExportSnapshot();
+
+    internal static void SetExportsPaused(AppHandle handle, bool paused) =>
+        handle.SetExportsPaused(paused);
+
+    internal static void CancelExport(AppHandle handle, string releaseId) =>
+        handle.CancelExport(releaseId);
+
+    internal static void RetryExports(AppHandle handle) => handle.RetryExports();
+
     internal static string? RetryOutbox(AppHandle handle) => CaptureError(() => Await(handle.RetryOutbox()));
 
     internal static string? SetSyncPaused(AppHandle handle, bool paused) =>
@@ -461,6 +472,9 @@ internal static class NativeBae
 
     internal static string? SetExportFilenameTemplate(AppHandle handle, string template) =>
         CaptureError(() => handle.SetExportFilenameTemplate(template));
+
+    internal static string? SetExportLocation(AppHandle handle, BridgeExportLocation location) =>
+        CaptureError(() => handle.SetExportLocation(location));
 
     internal static string? SetExportPresets(AppHandle handle, IEnumerable<ExportPreset> presets) =>
         CaptureError(() => handle.SetExportPresets(
@@ -831,6 +845,7 @@ internal static class NativeBae
             SyncAccount = config.Sync?.CloudAccountDisplay,
             SyncReady = syncStatus.SyncReady,
             PauseBetweenSides = config.PauseBetweenSides,
+            ExportLocation = config.ExportLocation,
             ExportFilenameTemplate = config.ExportFilenameTemplate,
             ExportPresets = config.ExportPresets.Select(ExportPreset).ToList(),
             DefaultTrackExportSelection = config.DefaultTrackExportSelection,

--- a/bae-windows/Settings.cs
+++ b/bae-windows/Settings.cs
@@ -24,6 +24,9 @@ public sealed class Settings
     public bool SyncReady { get; set; }
     public bool PauseBetweenSides { get; set; }
 
+    /// <summary>Where release exports write: a fixed folder, or prompt each time.</summary>
+    internal BridgeExportLocation ExportLocation { get; set; } = new BridgeExportLocation.AskEachTime();
+
     /// <summary>Template rendering a single-track export's suggested filename.</summary>
     public string ExportFilenameTemplate { get; set; } = string.Empty;
 

--- a/bae-windows/Stores/ExportFolderStore.cs
+++ b/bae-windows/Stores/ExportFolderStore.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+
+namespace Bae.Windows;
+
+// The last fixed export folder, remembered per device so re-selecting "save to a
+// folder" can restore it without re-prompting and the settings Location row can
+// show it under "ask each time". The authoritative destination is core's export
+// location config; this is only a UI convenience memory (the Windows sibling of
+// macOS's lastExportFolder), so a failed read or write degrades to "no folder"
+// rather than taking the app down.
+internal static class ExportFolderStore
+{
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "bae",
+        "export-folder.txt");
+
+    // The remembered folder, or null when nothing is saved yet or the file is
+    // blank/unreadable.
+    public static string? Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                var path = File.ReadAllText(FilePath).Trim();
+                return string.IsNullOrEmpty(path) ? null : path;
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not read the saved export folder.", exception);
+        }
+
+        return null;
+    }
+
+    // Remember the folder a fixed export location just landed on.
+    public static void Save(string dir)
+    {
+        try
+        {
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, dir);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not save the export folder.", exception);
+        }
+    }
+}

--- a/bae-windows/Stores/ExportQueueModel.cs
+++ b/bae-windows/Stores/ExportQueueModel.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+
+namespace Bae.Windows;
+
+// One export row's state, projected from the bridge export state at the dialog
+// edge so this decision layer stays free of WinRT and uniffi types.
+public enum ExportRowKind { Queued, Active, Failed }
+
+// The pure decision layer behind the storage dialog's Exporting section and the
+// settings export-location control. The export queue renders from the snapshot
+// and actions never optimistically mutate — this only maps counts and state to
+// catalog keys and resolves the export destination and the settings Location
+// row, so it is unit-tested apart from the WinUI surface that renders it.
+public static class ExportQueueModel
+{
+    // The band's leading label: the generic paused note while paused, else the
+    // section title. Mirrors the downloads band's paused/title split.
+    public static string BandTitleKey(bool paused) =>
+        paused ? "download.paused" : "export.title";
+
+    // The Core-table count labels for the band summary, in exporting/failed/
+    // queued order, non-zero counts only. The caller renders each through
+    // Loc.Core and joins with " · " — the same composition macOS's summary uses.
+    public static List<(string Key, long Count)> SummaryParts(long active, long failed, long queued)
+    {
+        var parts = new List<(string Key, long Count)>();
+        if (active > 0)
+        {
+            parts.Add(("core.queue.exporting", active));
+        }
+        if (failed > 0)
+        {
+            parts.Add(("core.queue.failed", failed));
+        }
+        if (queued > 0)
+        {
+            parts.Add(("core.queue.queued", queued));
+        }
+        return parts;
+    }
+
+    // Retry-failed is offered only when something is failed.
+    public static bool RetryEnabled(long failedCount) => failedCount > 0;
+
+    // The pause/resume toggle label: resume while paused, else pause.
+    public static string PauseToggleKey(bool paused) =>
+        paused ? "outbox.resume" : "outbox.pause";
+
+    // A row's state label key. Queued and failed reuse the download-state keys
+    // (their values are generic); active is export-specific because it carries
+    // the percent.
+    public static string StateKey(ExportRowKind kind) => kind switch
+    {
+        ExportRowKind.Active => "export.state.exporting",
+        ExportRowKind.Failed => "download.state.failed",
+        _ => "download.state.queued",
+    };
+
+    // Progress percent clamped to 0..100 for the bar and the label.
+    public static int ClampPercent(int percent) =>
+        percent < 0 ? 0 : percent > 100 ? 100 : percent;
+
+    // The destination for a release export: the configured fixed directory, or
+    // null meaning "prompt for a folder". A fixed location with a blank
+    // directory degrades to prompting rather than exporting to nowhere.
+    public static string? DestinationFor(bool isFixed, string? fixedDir) =>
+        isFixed && !string.IsNullOrWhiteSpace(fixedDir) ? fixedDir : null;
+
+    // The path shown in the settings Location row: the configured folder when
+    // fixed, else the last-remembered folder, else null (the caller shows the
+    // no-folder placeholder).
+    public static string? LocationRowPath(bool isFixed, string? fixedDir, string? remembered) =>
+        isFixed ? fixedDir : remembered;
+
+    // Selecting "save to a folder" prompts when nothing is remembered;
+    // otherwise the remembered folder is applied directly.
+    public static bool FixedSelectionNeedsPrompt(string? remembered) =>
+        string.IsNullOrWhiteSpace(remembered);
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>تاريخ الإضافة (الأقدم)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>عرض الوقت المتبقي</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>عرض الوقت المنقضي</value></data>
+  <data name="export.title" xml:space="preserve"><value>جارٍ التصدير</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>جارٍ التصدير {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>حفظ في مجلد</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>السؤال في كل مرة</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>الموقع</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>تغيير</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>لم يتم اختيار مجلد</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Дата на добавяне (най-стари)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>показване на оставащото време</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>показване на изминалото време</value></data>
+  <data name="export.title" xml:space="preserve"><value>експортиране</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>експортиране {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Запазване в папка</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Питай всеки път</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Местоположение</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Промяна</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Няма избрана папка</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>যোগের তারিখ (পুরনোতম)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>অবশিষ্ট সময় দেখান</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>অতিবাহিত সময় দেখান</value></data>
+  <data name="export.title" xml:space="preserve"><value>এক্সপোর্ট করা হচ্ছে</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% এক্সপোর্ট হচ্ছে</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>একটি ফোল্ডারে সংরক্ষণ করুন</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>প্রতিবার জিজ্ঞাসা করুন</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>অবস্থান</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>পরিবর্তন করুন</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>কোনো ফোল্ডার বেছে নেওয়া হয়নি</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Datum přidání (nejstarší)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>zobrazit zbývající čas</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>zobrazit uplynulý čas</value></data>
+  <data name="export.title" xml:space="preserve"><value>exportuje se</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>exportuje se {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Uložit do složky</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Vždy se zeptat</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Umístění</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Změnit</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Není vybrána žádná složka</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Hinzugefügt (älteste zuerst)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>verbleibende Zeit anzeigen</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>verstrichene Zeit anzeigen</value></data>
+  <data name="export.title" xml:space="preserve"><value>Exporte</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>wird exportiert… {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>In einem Ordner speichern</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Jedes Mal fragen</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Speicherort</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Ändern</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Kein Ordner ausgewählt</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Date Added (Oldest)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>show remaining time</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>show elapsed time</value></data>
+  <data name="export.title" xml:space="preserve"><value>exporting</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>exporting {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Save to a folder</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Ask each time</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Location</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Change</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>No folder chosen</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Fecha de adición (más antigua)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>mostrar el tiempo restante</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>mostrar el tiempo transcurrido</value></data>
+  <data name="export.title" xml:space="preserve"><value>exportando</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>exportando {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Guardar en una carpeta</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Preguntar cada vez</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Ubicación</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Cambiar</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>No se eligió ninguna carpeta</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Date d'ajout (plus ancien)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>afficher le temps restant</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>afficher le temps écoulé</value></data>
+  <data name="export.title" xml:space="preserve"><value>exportation</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>exportation {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Enregistrer dans un dossier</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Demander à chaque fois</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Emplacement</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Modifier</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Aucun dossier choisi</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>ઉમેરેલી તારીખ (જૂનાં પહેલાં)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>બાકી રહેલો સમય બતાવો</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>વીતેલો સમય બતાવો</value></data>
+  <data name="export.title" xml:space="preserve"><value>નિકાસ થઈ રહી છે</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% નિકાસ થઈ રહી છે</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>ફોલ્ડરમાં સાચવો</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>દર વખત પૂછો</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>સ્થાન</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>બદલો</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>કોઈ ફોલ્ડર પસંદ કર્યું નથી</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>תאריך הוספה (הישן ביותר)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>הצגת הזמן שנותר</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>הצגת הזמן שחלף</value></data>
+  <data name="export.title" xml:space="preserve"><value>מייצא</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>מייצא {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>שמירה בתיקייה</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>שאל בכל פעם</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>מיקום</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>שינוי</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>לא נבחרה תיקייה</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>जोड़े जाने की तारीख (सबसे पुराना)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>शेष समय दिखाएँ</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>बीता हुआ समय दिखाएँ</value></data>
+  <data name="export.title" xml:space="preserve"><value>निर्यात हो रहा है</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% निर्यात हो रहा है</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>फ़ोल्डर में सहेजें</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>हर बार पूछें</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>स्थान</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>बदलें</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>कोई फ़ोल्डर नहीं चुना गया</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Datum dodavanja (najstarije)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>prikaži preostalo vrijeme</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>prikaži proteklo vrijeme</value></data>
+  <data name="export.title" xml:space="preserve"><value>izvoz</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>izvoz {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Spremi u mapu</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Pitaj svaki put</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Lokacija</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Promijeni</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Nije odabrana mapa</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Data di aggiunta (meno recente)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>mostra il tempo rimanente</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>mostra il tempo trascorso</value></data>
+  <data name="export.title" xml:space="preserve"><value>esportazione</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>esportazione {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Salva in una cartella</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Chiedi ogni volta</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Posizione</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Cambia</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Nessuna cartella scelta</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>追加日（古い順）</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>残り時間を表示</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>経過時間を表示</value></data>
+  <data name="export.title" xml:space="preserve"><value>エクスポート中</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}%エクスポート中</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>フォルダに保存</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>毎回確認</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>場所</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>変更</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>フォルダが選択されていません</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹಳೆಯದು)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>ಉಳಿದಿರುವ ಸಮಯವನ್ನು ತೋರಿಸಿ</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>ಕಳೆದ ಸಮಯವನ್ನು ತೋರಿಸಿ</value></data>
+  <data name="export.title" xml:space="preserve"><value>ರಫ್ತು ಮಾಡಲಾಗುತ್ತಿದೆ</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% ರಫ್ತು ಮಾಡಲಾಗುತ್ತಿದೆ</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>ಫೋಲ್ಡರ್‌ಗೆ ಉಳಿಸಿ</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ಪ್ರತಿ ಬಾರಿ ಕೇಳಿ</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>ಸ್ಥಳ</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>ಬದಲಿಸಿ</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>ಯಾವುದೇ ಫೋಲ್ಡರ್ ಆಯ್ಕೆ ಮಾಡಿಲ್ಲ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>추가한 날짜(오래된 순)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>남은 시간 표시</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>경과 시간 표시</value></data>
+  <data name="export.title" xml:space="preserve"><value>내보내는 중</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>내보내는 중 {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>폴더에 저장</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>매번 묻기</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>위치</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>변경</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>선택한 폴더 없음</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>ചേർത്ത തീയതി (പഴയത്)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>ശേഷിക്കുന്ന സമയം കാണിക്കുക</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>കഴിഞ്ഞ സമയം കാണിക്കുക</value></data>
+  <data name="export.title" xml:space="preserve"><value>കയറ്റുമതി ചെയ്യുന്നു</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% കയറ്റുമതി ചെയ്യുന്നു</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>ഫോൾഡറിലേക്ക് സംരക്ഷിക്കുക</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ഓരോ തവണയും ചോദിക്കുക</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>സ്ഥലം</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>മാറ്റുക</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>ഫോൾഡർ തിരഞ്ഞെടുത്തിട്ടില്ല</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>जोडल्याची तारीख (सर्वात जुनी)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>उर्वरित वेळ दाखवा</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>झालेला वेळ दाखवा</value></data>
+  <data name="export.title" xml:space="preserve"><value>निर्यात करत आहे</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% निर्यात करत आहे</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>फोल्डरमध्ये जतन करा</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>प्रत्येक वेळी विचारा</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>स्थान</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>बदला</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>कोणतेही फोल्डर निवडले नाही</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Toegevoegd op (oudste)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>resterende tijd tonen</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>verstreken tijd tonen</value></data>
+  <data name="export.title" xml:space="preserve"><value>exporteren</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>exporteren {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Bewaar in een map</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Elke keer vragen</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Locatie</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Wijzig</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Geen map gekozen</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>ਸ਼ਾਮਲ ਮਿਤੀ (ਸਭ ਤੋਂ ਪੁਰਾਣੀ)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>ਬਾਕੀ ਸਮਾਂ ਦਿਖਾਓ</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>ਬੀਤਿਆ ਸਮਾਂ ਦਿਖਾਓ</value></data>
+  <data name="export.title" xml:space="preserve"><value>ਨਿਰਯਾਤ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% ਨਿਰਯਾਤ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>ਫੋਲਡਰ ਵਿੱਚ ਸੰਭਾਲੋ</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ਹਰ ਵਾਰ ਪੁੱਛੋ</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>ਟਿਕਾਣਾ</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>ਬਦਲੋ</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>ਕੋਈ ਫੋਲਡਰ ਨਹੀਂ ਚੁਣਿਆ ਗਿਆ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Data dodania (od najstarszych)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>pokaż pozostały czas</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>pokaż miniony czas</value></data>
+  <data name="export.title" xml:space="preserve"><value>eksportowanie</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>eksportowanie {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Zapisz w folderze</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Pytaj za każdym razem</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Lokalizacja</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Zmień</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Nie wybrano folderu</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Data de adição (mais antiga)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>mostrar tempo restante</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>mostrar tempo decorrido</value></data>
+  <data name="export.title" xml:space="preserve"><value>exportando</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>exportando {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Salvar em uma pasta</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Perguntar sempre</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Localização</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Alterar</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Nenhuma pasta escolhida</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>சேர்த்த தேதி (பழையது)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>மீதமுள்ள நேரத்தைக் காட்டு</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>கடந்த நேரத்தைக் காட்டு</value></data>
+  <data name="export.title" xml:space="preserve"><value>ஏற்றுமதி செய்யப்படுகிறது</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% ஏற்றுமதி செய்யப்படுகிறது</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>கோப்புறையில் சேமி</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ஒவ்வொரு முறையும் கேள்</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>இடம்</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>மாற்று</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>கோப்புறை தேர்வு செய்யப்படவில்லை</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>జోడించిన తేదీ (పాతవి)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>మిగిలిన సమయాన్ని చూపించు</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>గడిచిన సమయాన్ని చూపించు</value></data>
+  <data name="export.title" xml:space="preserve"><value>ఎగుమతి చేస్తోంది</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>ఎగుమతి చేస్తోంది {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>ఫోల్డర్‌లో సేవ్ చేయి</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ప్రతిసారీ అడుగు</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>స్థానం</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>మార్చు</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>ఫోల్డర్ ఎంచుకోలేదు</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>วันที่เพิ่ม (เก่าสุด)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>แสดงเวลาที่เหลือ</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>แสดงเวลาที่ผ่านไป</value></data>
+  <data name="export.title" xml:space="preserve"><value>กำลังส่งออก</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>กำลังส่งออก {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>บันทึกไปยังโฟลเดอร์</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ถามทุกครั้ง</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>ตำแหน่ง</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>เปลี่ยน</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>ยังไม่ได้เลือกโฟลเดอร์</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Eklenme Tarihi (En Eski)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>kalan süreyi göster</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>geçen süreyi göster</value></data>
+  <data name="export.title" xml:space="preserve"><value>dışa aktarılıyor</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>dışa aktarılıyor {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Bir klasöre kaydet</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Her seferinde sor</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Konum</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Değiştir</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Klasör seçilmedi</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>За датою додавання (спочатку старі)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>показати час, що залишився</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>показати час, що минув</value></data>
+  <data name="export.title" xml:space="preserve"><value>експорт</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>експорт {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Зберегти в папку</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Запитувати щоразу</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Розташування</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Змінити</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Папку не вибрано</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>شامل ہونے کی تاریخ (پرانا پہلے)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>باقی وقت دکھائیں</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>گزرا ہوا وقت دکھائیں</value></data>
+  <data name="export.title" xml:space="preserve"><value>برآمد ہو رہا ہے</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>{percent}% برآمد ہو رہا ہے</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>فولڈر میں محفوظ کریں</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>ہر بار پوچھیں</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>مقام</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>تبدیل کریں</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>کوئی فولڈر منتخب نہیں کیا گیا</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>Ngày thêm (cũ nhất)</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>hiện thời gian còn lại</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>hiện thời gian đã phát</value></data>
+  <data name="export.title" xml:space="preserve"><value>đang xuất</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>đang xuất {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>Lưu vào thư mục</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>Hỏi mỗi lần</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>Vị trí</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>Thay đổi</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>Chưa chọn thư mục</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>添加日期（最早）</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>显示剩余时间</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>显示已播放时间</value></data>
+  <data name="export.title" xml:space="preserve"><value>正在导出</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>正在导出 {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>保存到文件夹</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>每次询问</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>位置</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>更改</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>未选择文件夹</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -369,4 +369,11 @@
   <data name="import.sort.oldest" xml:space="preserve"><value>加入日期（最舊）</value></data>
   <data name="nowplaying.show_remaining" xml:space="preserve"><value>顯示剩餘時間</value></data>
   <data name="nowplaying.show_elapsed" xml:space="preserve"><value>顯示已播放時間</value></data>
+  <data name="export.title" xml:space="preserve"><value>正在匯出</value></data>
+  <data name="export.state.exporting" xml:space="preserve"><value>正在匯出 {percent}%</value></data>
+  <data name="settings.export.save_to_folder" xml:space="preserve"><value>儲存到資料夾</value></data>
+  <data name="settings.export.ask_each_time" xml:space="preserve"><value>每次詢問</value></data>
+  <data name="settings.export.location" xml:space="preserve"><value>位置</value></data>
+  <data name="settings.export.change_folder" xml:space="preserve"><value>變更</value></data>
+  <data name="settings.export.no_folder" xml:space="preserve"><value>未選擇資料夾</value></data>
 </root>

--- a/bae-windows/Views/ReleaseActionDialogs.cs
+++ b/bae-windows/Views/ReleaseActionDialogs.cs
@@ -97,17 +97,25 @@ internal sealed class ReleaseActionDialogs
             return;
         }
 
-        var picker = new global::Windows.Storage.Pickers.FolderPicker();
-        picker.FileTypeFilter.Add("*");
-        WinRT.Interop.InitializeWithWindow.Initialize(picker, _windowHandle());
-        var folder = await picker.PickSingleFolderAsync();
-        if (folder is null)
+        // The destination follows the export-location config: a fixed folder
+        // enqueues straight there, ask-each-time prompts for a folder.
+        var fixedLocation = settings.ExportLocation as BridgeExportLocation.Fixed;
+        var targetDir = ExportQueueModel.DestinationFor(fixedLocation is not null, fixedLocation?.Dir);
+        if (targetDir is null)
         {
-            return;
+            var picker = new global::Windows.Storage.Pickers.FolderPicker();
+            picker.FileTypeFilter.Add("*");
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, _windowHandle());
+            var folder = await picker.PickSingleFolderAsync();
+            if (folder is null)
+            {
+                return;
+            }
+            targetDir = folder.Path;
         }
 
         var (exportCurrent, error) = await _session.RunForCurrentHandle(
-            handle => NativeBae.ExportRelease(handle, releaseId, folder.Path, selection));
+            handle => NativeBae.ExportRelease(handle, releaseId, targetDir, selection));
         if (!exportCurrent)
         {
             return;

--- a/bae-windows/Views/SettingsDialog.cs
+++ b/bae-windows/Views/SettingsDialog.cs
@@ -24,6 +24,7 @@ internal sealed class SettingsDialog
 {
     private readonly SessionStore _session;
     private readonly Func<XamlRoot?> _xamlRoot;
+    private readonly Func<IntPtr> _windowHandle;
     private readonly DispatcherQueue _dispatcher;
     private readonly SettingsStore _settings;
     private readonly MembersPane _membersPane;
@@ -36,6 +37,7 @@ internal sealed class SettingsDialog
     public SettingsDialog(
         SessionStore session,
         Func<XamlRoot?> xamlRoot,
+        Func<IntPtr> windowHandle,
         DispatcherQueue dispatcher,
         SettingsStore settings,
         MembersPane membersPane,
@@ -47,6 +49,7 @@ internal sealed class SettingsDialog
     {
         _session = session;
         _xamlRoot = xamlRoot;
+        _windowHandle = windowHandle;
         _dispatcher = dispatcher;
         _settings = settings;
         _membersPane = membersPane;
@@ -343,16 +346,47 @@ internal sealed class SettingsDialog
         pauseBetweenSides.Checked += async (_, _) => await SetPauseBetweenSides(true);
         pauseBetweenSides.Unchecked += async (_, _) => await SetPauseBetweenSides(false);
 
-        // Export: the single-track "Save As…" suggested-filename template and the
-        // metadata tags an export embeds. Windows has no release export, so this is
-        // the per-track section only. Writes round-trip through config invalidation into
-        // the settings re-read (RenderExport); the checkboxes send the whole seven-
-        // bool set (set-state), never one mutated field.
+        // Export: the release-export destination policy (a fixed folder or a
+        // prompt each time), then the single-track "Save As…" suggested-filename
+        // template and the export presets. Writes round-trip through config
+        // invalidation into the settings re-read (RenderExport) with no optimistic
+        // mutation; the checkboxes send the whole set (set-state), never one
+        // mutated field.
         var exportLabel = new TextBlock
         {
             Text = Loc.Chrome("settings.export.label"),
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
         };
+        // Where release exports write. The authoritative destination is core's
+        // export-location config, written through set_export_location and settled
+        // by the config re-read; the remembered folder is a local convenience
+        // memory (the greyed path under "ask each time", the folder restored when
+        // re-selecting "save to a folder").
+        var saveToFolder = new RadioButton
+        {
+            Content = Loc.Chrome("settings.export.save_to_folder"),
+            GroupName = "exportLocation",
+        };
+        var askEachTime = new RadioButton
+        {
+            Content = Loc.Chrome("settings.export.ask_each_time"),
+            GroupName = "exportLocation",
+        };
+        var locationPath = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var changeFolder = new Button { Content = Loc.Chrome("settings.export.change_folder") };
+        var locationRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        locationRow.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("settings.export.location"),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        locationRow.Children.Add(locationPath);
+        locationRow.Children.Add(changeFolder);
         var exportTemplate = new TextBox
         {
             Header = Loc.Chrome("settings.export.filename_format"),
@@ -387,12 +421,105 @@ internal sealed class SettingsDialog
             }
 
             refreshingSettings = true;
+            RenderExportLocation(settings);
             exportTemplate.Text = settings.ExportFilenameTemplate;
             PopulateExportSelection(defaultTrackExport, settings, release: false);
             PopulateExportSelection(defaultReleaseExport, settings, release: true);
             RenderExportPresets(settings);
             refreshingSettings = false;
         }
+
+        // Drive the export-location controls from the config: which radio is
+        // checked, the Location-row path (the fixed folder, or the remembered
+        // folder greyed under "ask each time"), and whether Change is available.
+        void RenderExportLocation(Settings settings)
+        {
+            var fixedLocation = settings.ExportLocation as BridgeExportLocation.Fixed;
+            var isFixed = fixedLocation is not null;
+            saveToFolder.IsChecked = isFixed;
+            askEachTime.IsChecked = !isFixed;
+            locationPath.Text = ExportQueueModel.LocationRowPath(isFixed, fixedLocation?.Dir, ExportFolderStore.Load())
+                ?? Loc.Chrome("settings.export.no_folder");
+            changeFolder.IsEnabled = isFixed;
+            locationPath.Opacity = isFixed ? 1.0 : 0.5;
+        }
+
+        // The folder picker for a fixed export location, run in the app window.
+        // Returns the chosen path, or null when the user cancelled.
+        async System.Threading.Tasks.Task<string?> PickExportFolder()
+        {
+            var picker = new global::Windows.Storage.Pickers.FolderPicker();
+            picker.FileTypeFilter.Add("*");
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, _windowHandle());
+            var folder = await picker.PickSingleFolderAsync();
+            return folder?.Path;
+        }
+
+        // Write the export location through the bridge and let the config
+        // invalidation re-read settle the controls. A fixed folder is remembered
+        // only after the write lands; an error snaps the controls back.
+        async System.Threading.Tasks.Task SaveExportLocation(BridgeExportLocation location)
+        {
+            ClearSettingsError();
+            var (current, error) = await _session.RunForCurrentHandle(
+                handle => NativeBae.SetExportLocation(handle, location));
+            if (!current)
+            {
+                return;
+            }
+            if (error is not null)
+            {
+                ShowSettingsError(error);
+                _settings.Reload();
+                return;
+            }
+            if (location is BridgeExportLocation.Fixed fixedLocation)
+            {
+                ExportFolderStore.Save(fixedLocation.Dir);
+            }
+        }
+
+        askEachTime.Checked += async (_, _) =>
+        {
+            if (refreshingSettings)
+            {
+                return;
+            }
+            await SaveExportLocation(new BridgeExportLocation.AskEachTime());
+        };
+        saveToFolder.Checked += async (_, _) =>
+        {
+            if (refreshingSettings)
+            {
+                return;
+            }
+            var remembered = ExportFolderStore.Load();
+            if (ExportQueueModel.FixedSelectionNeedsPrompt(remembered))
+            {
+                var dir = await PickExportFolder();
+                if (dir is null)
+                {
+                    // Cancelled with no remembered folder: snap the radio back to
+                    // the stored location.
+                    _settings.Reload();
+                    return;
+                }
+                await SaveExportLocation(new BridgeExportLocation.Fixed(dir));
+            }
+            else
+            {
+                await SaveExportLocation(new BridgeExportLocation.Fixed(remembered!));
+            }
+        };
+        changeFolder.Click += async (_, _) =>
+        {
+            var dir = await PickExportFolder();
+            if (dir is null)
+            {
+                return;
+            }
+            await SaveExportLocation(new BridgeExportLocation.Fixed(dir));
+        };
 
         void PopulateExportSelection(ComboBox combo, Settings settings, bool release)
         {
@@ -936,6 +1063,9 @@ internal sealed class SettingsDialog
         content.Children.Add(libraryLabel);
         content.Children.Add(pauseBetweenSides);
         content.Children.Add(exportLabel);
+        content.Children.Add(saveToFolder);
+        content.Children.Add(askEachTime);
+        content.Children.Add(locationRow);
         content.Children.Add(exportTemplate);
         content.Children.Add(exportTokensHelp);
         content.Children.Add(defaultTrackExport);

--- a/bae-windows/Views/StorageDialog.cs
+++ b/bae-windows/Views/StorageDialog.cs
@@ -316,6 +316,126 @@ internal sealed class StorageDialog
             }
         }
 
+        // Exporting: the release-export queue with a summary band (Retry-failed
+        // and Pause/Resume) and per-item progress plus Cancel. Hidden (empty
+        // panel) when nothing is queued. The queue renders from the snapshot and
+        // actions never optimistically mutate — each reload (and the export-queue
+        // invalidation) re-renders the section.
+        var exportsPanel = new StackPanel { Spacing = 4 };
+        async System.Threading.Tasks.Task LoadExports()
+        {
+            exportsPanel.Children.Clear();
+            var (current, snapshot) = await _session.RunForCurrentHandle(NativeBae.ExportSnapshot);
+            if (!current)
+            {
+                return;
+            }
+
+            // Hidden when the export queue is idle, like the downloads panel.
+            if (snapshot.Exports.Length == 0)
+            {
+                return;
+            }
+
+            string StateLabel(BridgeExportOp op) => op.State switch
+            {
+                BridgeExportState.Active active => Loc.Chrome(
+                    "export.state.exporting", "percent", ExportQueueModel.ClampPercent((int)active.Percent)),
+                BridgeExportState.Failed => Loc.Chrome(ExportQueueModel.StateKey(ExportRowKind.Failed)),
+                _ => Loc.Chrome(ExportQueueModel.StateKey(ExportRowKind.Queued)),
+            };
+
+            // Header: a label (or "paused"), the count summary, Retry (only with
+            // failures), and a pause/resume toggle — mirroring the downloads band.
+            var paused = snapshot.Paused;
+            var band = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            band.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome(ExportQueueModel.BandTitleKey(paused)),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            var summaryParts = ExportQueueModel.SummaryParts(
+                snapshot.Total.Active, snapshot.Total.Failed, snapshot.Total.Queued);
+            if (!paused && summaryParts.Count > 0)
+            {
+                band.Children.Add(new TextBlock
+                {
+                    Text = string.Join(" · ", summaryParts.Select(part => Loc.Core(part.Key, "count", part.Count))),
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+            }
+            var retry = new Button
+            {
+                Content = Loc.Chrome("outbox.retry_now"),
+                IsEnabled = ExportQueueModel.RetryEnabled(snapshot.Total.Failed),
+            };
+            retry.Click += async (_, _) =>
+            {
+                retry.IsEnabled = false;
+                await _session.RunForCurrentHandle(NativeBae.RetryExports);
+                await LoadExports();
+            };
+            band.Children.Add(retry);
+            var pause = new Button { Content = Loc.Chrome(ExportQueueModel.PauseToggleKey(paused)) };
+            pause.Click += async (_, _) =>
+            {
+                pause.IsEnabled = false;
+                await _session.RunForCurrentHandle(handle => NativeBae.SetExportsPaused(handle, !paused));
+                await LoadExports();
+            };
+            band.Children.Add(pause);
+            exportsPanel.Children.Add(band);
+
+            // One row per export: title, "N files · size · state", an optional
+            // progress bar while active, and a cancel.
+            foreach (var op in snapshot.Exports)
+            {
+                var itemGrid = new Grid { ColumnSpacing = 8 };
+                itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                var labelColumn = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
+                labelColumn.Children.Add(new TextBlock { Text = op.Title, TextWrapping = TextWrapping.Wrap });
+                var detail = new TextBlock
+                {
+                    Text = $"{Loc.Chrome("storage.files", "count", op.FileCount)} · {Loc.Bytes(op.TotalSize)} · {StateLabel(op)}",
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                };
+                // A failed export carries its error on the detail line's tooltip,
+                // like the outbox file rows.
+                if (op.State is BridgeExportState.Failed failed)
+                {
+                    ToolTipService.SetToolTip(detail, failed.Error);
+                }
+                labelColumn.Children.Add(detail);
+                if (op.State is BridgeExportState.Active active)
+                {
+                    labelColumn.Children.Add(new ProgressBar
+                    {
+                        Minimum = 0,
+                        Maximum = 100,
+                        Value = ExportQueueModel.ClampPercent((int)active.Percent),
+                        Height = 4,
+                    });
+                }
+                Grid.SetColumn(labelColumn, 0);
+                itemGrid.Children.Add(labelColumn);
+
+                var releaseId = op.ReleaseId;
+                var cancel = new Button { Content = Loc.Chrome("action.cancel") };
+                cancel.Click += async (_, _) =>
+                {
+                    cancel.IsEnabled = false;
+                    await _session.RunForCurrentHandle(handle => NativeBae.CancelExport(handle, releaseId));
+                    await LoadExports();
+                };
+                Grid.SetColumn(cancel, 1);
+                itemGrid.Children.Add(cancel);
+                exportsPanel.Children.Add(itemGrid);
+            }
+        }
+
         var outboxPanel = new StackPanel { Spacing = 4 };
         async System.Threading.Tasks.Task LoadOutbox()
         {
@@ -595,11 +715,13 @@ internal sealed class StorageDialog
         }
 
         await LoadDownloads();
+        await LoadExports();
         await LoadOutbox();
 
         var content = new StackPanel { Spacing = 8 };
         content.Children.Add(storageStatus);
         content.Children.Add(downloadsPanel);
+        content.Children.Add(exportsPanel);
         content.Children.Add(outboxPanel);
         content.Children.Add(listPanel);
 
@@ -626,6 +748,7 @@ internal sealed class StorageDialog
                 _ = LoadDownloads();
                 _ = LoadStorageRows();
             }),
+            _projections.Register(typeof(BridgeInvalidation.ExportQueue), () => _ = LoadExports()),
             _projections.Register(typeof(BridgeInvalidation.Album), () => _ = LoadStorageRows()),
             _projections.Register(typeof(BridgeInvalidation.Release), () => _ = LoadStorageRows()),
         };

--- a/bae-windows/bae-windows.Tests/ExportQueueModelTests.cs
+++ b/bae-windows/bae-windows.Tests/ExportQueueModelTests.cs
@@ -1,0 +1,149 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+// The export queue's pure decision layer: the band/state catalog keys, the
+// count summary, retry/pause gating, percent clamping, and the export
+// destination and settings Location-row resolution.
+public sealed class ExportQueueModelTests
+{
+    [Fact]
+    public void BandTitle_SplitsOnPaused()
+    {
+        Assert.Equal("export.title", ExportQueueModel.BandTitleKey(paused: false));
+        Assert.Equal("download.paused", ExportQueueModel.BandTitleKey(paused: true));
+    }
+
+    [Fact]
+    public void PauseToggle_SplitsOnPaused()
+    {
+        Assert.Equal("outbox.pause", ExportQueueModel.PauseToggleKey(paused: false));
+        Assert.Equal("outbox.resume", ExportQueueModel.PauseToggleKey(paused: true));
+    }
+
+    [Fact]
+    public void SummaryParts_Idle_IsEmpty()
+    {
+        Assert.Empty(ExportQueueModel.SummaryParts(active: 0, failed: 0, queued: 0));
+    }
+
+    [Fact]
+    public void SummaryParts_EachCountAlone()
+    {
+        Assert.Equal(
+            new[] { ("core.queue.exporting", 3L) },
+            ExportQueueModel.SummaryParts(active: 3, failed: 0, queued: 0));
+        Assert.Equal(
+            new[] { ("core.queue.failed", 2L) },
+            ExportQueueModel.SummaryParts(active: 0, failed: 2, queued: 0));
+        Assert.Equal(
+            new[] { ("core.queue.queued", 5L) },
+            ExportQueueModel.SummaryParts(active: 0, failed: 0, queued: 5));
+    }
+
+    [Fact]
+    public void SummaryParts_AllThree_InExportingFailedQueuedOrder()
+    {
+        var parts = ExportQueueModel.SummaryParts(active: 1, failed: 2, queued: 3);
+        Assert.Equal(
+            new[]
+            {
+                ("core.queue.exporting", 1L),
+                ("core.queue.failed", 2L),
+                ("core.queue.queued", 3L),
+            },
+            parts);
+    }
+
+    [Fact]
+    public void SummaryParts_CountsPassThrough()
+    {
+        var parts = ExportQueueModel.SummaryParts(active: 11, failed: 22, queued: 33);
+        Assert.Equal(new long[] { 11, 22, 33 }, parts.Select(p => p.Count));
+    }
+
+    [Fact]
+    public void Retry_GatedOnFailures()
+    {
+        Assert.False(ExportQueueModel.RetryEnabled(0));
+        Assert.True(ExportQueueModel.RetryEnabled(1));
+    }
+
+    [Theory]
+    [InlineData(ExportRowKind.Queued, "download.state.queued")]
+    [InlineData(ExportRowKind.Active, "export.state.exporting")]
+    [InlineData(ExportRowKind.Failed, "download.state.failed")]
+    public void StateKey_MapsEachKind(ExportRowKind kind, string expected)
+    {
+        Assert.Equal(expected, ExportQueueModel.StateKey(kind));
+    }
+
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(47, 47)]
+    [InlineData(100, 100)]
+    [InlineData(150, 100)]
+    public void ClampPercent_ClampsToRange(int input, int expected)
+    {
+        Assert.Equal(expected, ExportQueueModel.ClampPercent(input));
+    }
+
+    [Theory]
+    [InlineData(false, "/music/exports")]
+    [InlineData(false, null)]
+    public void DestinationFor_AskEachTime_AlwaysPrompts(bool isFixed, string? dir)
+    {
+        Assert.Null(ExportQueueModel.DestinationFor(isFixed, dir));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DestinationFor_FixedButBlank_Prompts(string? dir)
+    {
+        Assert.Null(ExportQueueModel.DestinationFor(isFixed: true, dir));
+    }
+
+    [Fact]
+    public void DestinationFor_FixedWithDir_UsesDir()
+    {
+        Assert.Equal("/music/exports", ExportQueueModel.DestinationFor(isFixed: true, "/music/exports"));
+    }
+
+    [Fact]
+    public void LocationRowPath_Fixed_ShowsDir()
+    {
+        Assert.Equal(
+            "/music/exports",
+            ExportQueueModel.LocationRowPath(isFixed: true, fixedDir: "/music/exports", remembered: "/old"));
+    }
+
+    [Fact]
+    public void LocationRowPath_AskWithRemembered_ShowsRemembered()
+    {
+        Assert.Equal(
+            "/old",
+            ExportQueueModel.LocationRowPath(isFixed: false, fixedDir: null, remembered: "/old"));
+    }
+
+    [Fact]
+    public void LocationRowPath_AskWithNothing_IsNull()
+    {
+        Assert.Null(ExportQueueModel.LocationRowPath(isFixed: false, fixedDir: null, remembered: null));
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("   ", true)]
+    [InlineData("/music/exports", false)]
+    public void FixedSelectionNeedsPrompt_OnBlankRemembered(string? remembered, bool expected)
+    {
+        Assert.Equal(expected, ExportQueueModel.FixedSelectionNeedsPrompt(remembered));
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -25,6 +25,11 @@
       round-trip, split out as plain BCL types (the stores that hold bridge
       snapshots and the WinUI views and dialogs that render them are verified by
       compilation).
+    - The export-queue decision layer (ExportQueueModel) — the Exporting
+      section's band/state catalog keys, count summary, retry/pause gating and
+      percent clamping, plus the export destination and settings Location-row
+      resolution, over plain BCL types (the storage dialog and settings dialog
+      that render bridge snapshots through it are verified by compilation).
     - The update-flow layer (UpdateFlow) — the state machine and display mapping
       behind the settings "updates" section (status keys, percent clamping,
       button gating, version-string normalization), over plain BCL types with no
@@ -64,6 +69,7 @@
     <Compile Include="../Stores/ImportIdentityModel.cs" Link="ImportIdentityModel.cs" />
     <Compile Include="../Stores/ReidentifyResultsModel.cs" Link="ReidentifyResultsModel.cs" />
     <Compile Include="../Stores/ImportListModel.cs" Link="ImportListModel.cs" />
+    <Compile Include="../Stores/ExportQueueModel.cs" Link="ExportQueueModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Windows release exports were fire-and-forget. `EnqueueExport` ran and nothing ever showed the queue, so there was no progress, no pause, no cancel, no retry — and every export prompted for a destination folder even though core already carries an export-location preference. All five bridge methods (`get_export_snapshot`, `cancel_export`, `retry_exports`, `set_exports_paused`, `set_export_location`) and both location variants already shipped, unused by Windows; this is Windows UI plus one pure decision layer and a small convenience store, with no bridge or core changes.

The storage dialog gains an Exporting section between Downloads and Outbox, mirroring the shipped Downloads section and the macOS Storage Manager's Exporting pane: hidden when the queue is idle, a band with the paused/title label, the Core-table count summary, a failed-gated Retry and a Pause/Resume toggle, and one row per export with a files·size·state detail line (the error on a failed row's tooltip), a progress bar while active, and a per-row Cancel. It live-refreshes on the export-queue invalidation and disposes its registration on close. Actions never optimistically mutate — the reload and the invalidation re-render the section.

The release-export flow now follows the export-location config: a fixed folder enqueues straight there, ask-each-time prompts for a folder as before, with the format dialog unchanged. Settings grows a save-to-a-folder / ask-each-time radio group leading the export section, with a Location row whose Change button is disabled unless a fixed folder is set; selections write through `set_export_location` and let the config invalidation settle the controls, and the last fixed folder is remembered in a per-device convenience store (the macOS `lastExportFolder` model) only after a fixed write lands.

The count/state key mapping, the export destination, and the settings Location-row resolution live in a WinRT-free `ExportQueueModel` so they are unit-tested apart from the WinUI surface. Seven new chrome keys are added across all 31 locale catalogs with real translations.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 217 passed (includes the new ExportQueueModelTests matrix: summary parts, state keys, retry/pause gating, percent clamping, destination and Location-row resolution).
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans (374 keys), no allowlist additions.
- The app compiles only in CI (`windows.yml`); every control/API used here has an in-repo precedent. CI is the compile gate.