### PR TITLE
List and read a Windows import candidate's document files

### DIFF
--- a/bae-windows/ImportCandidate.cs
+++ b/bae-windows/ImportCandidate.cs
@@ -42,6 +42,11 @@ public sealed class ImportCandidate
     /// <summary>The candidate's playable audio files, for pre-import preview.</summary>
     public List<string> AudioPaths { get; set; } = new();
 
+    /// <summary>The candidate's readable evidence files — paired CUE sheets
+    /// first, then core's document files (logs, unpaired CUEs, text) in scan
+    /// order.</summary>
+    public List<ImportDocument> Documents { get; set; } = new();
+
     /// <summary>The on-disk folder to identify/import.</summary>
     public string FolderPath { get; set; } = string.Empty;
 
@@ -69,6 +74,15 @@ public sealed class ImportCandidate
         var line = string.Join("  ·  ", parts);
         return string.IsNullOrEmpty(Status) ? line : $"{line}  —  {Status}";
     }
+}
+
+/// <summary>A candidate's readable evidence file (CUE sheet, rip log, info
+/// text): its display name, absolute path, and size.</summary>
+public sealed class ImportDocument
+{
+    public string Name { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public long SizeBytes { get; set; }
 }
 
 public sealed class ImportCandidateRowStatus

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -582,6 +582,11 @@ internal static class NativeBae
         return (ImportCandidateRows(snapshot), snapshot.WatchedFolders);
     }
 
+    /// <summary>A text file's decoded contents (bridge-side encoding detection),
+    /// or the error line. No session handle: the read is a free bridge call.</summary>
+    internal static (string? Text, string? Error) ReadTextFile(string path) =>
+        CaptureBridgeValue(() => BaeBridgeMethods.ReadTextFile(path));
+
     internal static void AutoIdentifyFolder(AppHandle handle, string candidateKey, string folderPath) =>
         handle.AutoIdentifyFolder(candidateKey, folderPath);
 
@@ -922,6 +927,7 @@ internal static class NativeBae
             Matches = ImportMatches(runtime.IdentifyState),
             Signals = runtime.SignalsToolbar.Signals.Select(SignalBadge).ToList(),
             AudioPaths = AudioPaths(candidate.Files.Audio).ToList(),
+            Documents = ImportDocuments(candidate.Files),
             FolderPath = candidate.FolderPath,
             Skipped = candidate.Skipped,
             IsAdded = candidate.IsAdded,
@@ -942,6 +948,7 @@ internal static class NativeBae
             Matches = [],
             Signals = [],
             AudioPaths = [],
+            Documents = [],
             FolderPath = candidate.FolderPath,
             Invalid = true,
         };
@@ -1023,6 +1030,32 @@ internal static class NativeBae
             BridgeAudioContent.TrackFiles tracks => tracks.Files.Select(file => file.LocalPath).ToArray(),
             _ => throw new ArgumentOutOfRangeException(nameof(audio), audio, "Unknown audio content"),
         };
+
+    // A candidate's readable evidence files: paired CUE sheets first (they live
+    // on the audio content as CUE/FLAC pairs), then core's path-sorted document
+    // files (logs, unpaired CUEs, text). The same visual order as the file pane
+    // on other platforms, where the CUE rows sit above the documents section.
+    private static List<ImportDocument> ImportDocuments(BridgeCandidateFiles files)
+    {
+        var cues = files.Audio switch
+        {
+            BridgeAudioContent.CueFlacPairs cue => cue.Pairs.Select(pair => new ImportDocument
+            {
+                Name = pair.CueName,
+                Path = pair.CueLocalPath,
+                SizeBytes = checked((long)pair.CueSize),
+            }),
+            BridgeAudioContent.TrackFiles => Enumerable.Empty<ImportDocument>(),
+            _ => throw new ArgumentOutOfRangeException(nameof(files), files.Audio, "Unknown audio content"),
+        };
+        var documents = files.Documents.Select(file => new ImportDocument
+        {
+            Name = file.Name,
+            Path = file.LocalPath,
+            SizeBytes = checked((long)file.Size),
+        });
+        return cues.Concat(documents).ToList();
+    }
 
     private static string ImportFormat(BridgeAudioContent audio) =>
         audio is BridgeAudioContent.CueFlacPairs ? "CUE/FLAC" : string.Empty;

--- a/bae-windows/Stores/ImportStore.cs
+++ b/bae-windows/Stores/ImportStore.cs
@@ -175,6 +175,7 @@ internal sealed class ImportStore
             Matches = existing.Matches,
             Signals = existing.Signals,
             AudioPaths = existing.AudioPaths,
+            Documents = existing.Documents,
             FolderPath = existing.FolderPath,
             RowStatus = existing.RowStatus,
             StatusOverride = status,

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>الموقع</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>تغيير</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>لم يتم اختيار مجلد</value></data>
+  <data name="import.documents" xml:space="preserve"><value>المستندات</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>تعذرت قراءة {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Местоположение</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Промяна</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Няма избрана папка</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Документи</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Не можа да се прочете {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>অবস্থান</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>পরিবর্তন করুন</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>কোনো ফোল্ডার বেছে নেওয়া হয়নি</value></data>
+  <data name="import.documents" xml:space="preserve"><value>ডকুমেন্ট</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} পড়া যায়নি: {error}</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Umístění</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Změnit</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Není vybrána žádná složka</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Dokumenty</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Nelze přečíst {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Speicherort</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Ändern</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Kein Ordner ausgewählt</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Dokumente</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} konnte nicht gelesen werden: {error}</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Location</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Change</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>No folder chosen</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Documents</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Could not read {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Ubicación</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Cambiar</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>No se eligió ninguna carpeta</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Documentos</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>No se pudo leer {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Emplacement</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Modifier</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Aucun dossier choisi</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Documents</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Impossible de lire {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>સ્થાન</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>બદલો</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>કોઈ ફોલ્ડર પસંદ કર્યું નથી</value></data>
+  <data name="import.documents" xml:space="preserve"><value>દસ્તાવેજો</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} વાંચી શકાયું નહીં: {error}</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>מיקום</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>שינוי</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>לא נבחרה תיקייה</value></data>
+  <data name="import.documents" xml:space="preserve"><value>מסמכים</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>לא ניתן לקרוא את {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>स्थान</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>बदलें</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>कोई फ़ोल्डर नहीं चुना गया</value></data>
+  <data name="import.documents" xml:space="preserve"><value>दस्तावेज़</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} पढ़ा नहीं जा सका: {error}</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Lokacija</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Promijeni</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nije odabrana mapa</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Dokumenti</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Nije moguće pročitati {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Posizione</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Cambia</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nessuna cartella scelta</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Documenti</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Impossibile leggere {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>場所</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>変更</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>フォルダが選択されていません</value></data>
+  <data name="import.documents" xml:space="preserve"><value>ドキュメント</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name}を読み取れませんでした: {error}</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>ಸ್ಥಳ</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>ಬದಲಿಸಿ</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>ಯಾವುದೇ ಫೋಲ್ಡರ್ ಆಯ್ಕೆ ಮಾಡಿಲ್ಲ</value></data>
+  <data name="import.documents" xml:space="preserve"><value>ದಾಖಲೆಗಳು</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} ಓದಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>위치</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>변경</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>선택한 폴더 없음</value></data>
+  <data name="import.documents" xml:space="preserve"><value>문서</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name}을(를) 읽을 수 없음: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>സ്ഥലം</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>മാറ്റുക</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>ഫോൾഡർ തിരഞ്ഞെടുത്തിട്ടില്ല</value></data>
+  <data name="import.documents" xml:space="preserve"><value>ഡോക്യുമെന്റുകൾ</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} വായിക്കാനായില്ല: {error}</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>स्थान</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>बदला</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>कोणतेही फोल्डर निवडले नाही</value></data>
+  <data name="import.documents" xml:space="preserve"><value>दस्तऐवज</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} वाचता आले नाही: {error}</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Locatie</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Wijzig</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Geen map gekozen</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Documenten</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Kan {name} niet lezen: {error}</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>ਟਿਕਾਣਾ</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>ਬਦਲੋ</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>ਕੋਈ ਫੋਲਡਰ ਨਹੀਂ ਚੁਣਿਆ ਗਿਆ</value></data>
+  <data name="import.documents" xml:space="preserve"><value>ਦਸਤਾਵੇਜ਼</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} ਪੜ੍ਹਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ: {error}</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Lokalizacja</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Zmień</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nie wybrano folderu</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Dokumenty</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Nie można odczytać {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Localização</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Alterar</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nenhuma pasta escolhida</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Documentos</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Não foi possível ler {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>இடம்</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>மாற்று</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>கோப்புறை தேர்வு செய்யப்படவில்லை</value></data>
+  <data name="import.documents" xml:space="preserve"><value>ஆவணங்கள்</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} ஐப் படிக்க முடியவில்லை: {error}</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>స్థానం</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>మార్చు</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>ఫోల్డర్ ఎంచుకోలేదు</value></data>
+  <data name="import.documents" xml:space="preserve"><value>పత్రాలు</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} చదవలేకపోయింది: {error}</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>ตำแหน่ง</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>เปลี่ยน</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>ยังไม่ได้เลือกโฟลเดอร์</value></data>
+  <data name="import.documents" xml:space="preserve"><value>เอกสาร</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>ไม่สามารถอ่าน {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Konum</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Değiştir</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Klasör seçilmedi</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Belgeler</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} okunamadı: {error}</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Розташування</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Змінити</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Папку не вибрано</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Документи</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Не вдалося прочитати {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>مقام</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>تبدیل کریں</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>کوئی فولڈر منتخب نہیں کیا گیا</value></data>
+  <data name="import.documents" xml:space="preserve"><value>دستاویزات</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>{name} پڑھا نہیں جا سکا: {error}</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>Vị trí</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>Thay đổi</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>Chưa chọn thư mục</value></data>
+  <data name="import.documents" xml:space="preserve"><value>Tài liệu</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>Không thể đọc {name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>位置</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>更改</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>未选择文件夹</value></data>
+  <data name="import.documents" xml:space="preserve"><value>文档</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>无法读取{name}: {error}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -376,4 +376,6 @@
   <data name="settings.export.location" xml:space="preserve"><value>位置</value></data>
   <data name="settings.export.change_folder" xml:space="preserve"><value>變更</value></data>
   <data name="settings.export.no_folder" xml:space="preserve"><value>未選擇資料夾</value></data>
+  <data name="import.documents" xml:space="preserve"><value>文件</value></data>
+  <data name="import.document.read_failed" xml:space="preserve"><value>無法讀取{name}: {error}</value></data>
 </root>

--- a/bae-windows/Views/ImportPickerDialog.cs
+++ b/bae-windows/Views/ImportPickerDialog.cs
@@ -101,6 +101,45 @@ internal sealed class ImportPickerDialog
             IsPrimaryButtonEnabled = false,
         };
 
+        // The candidate's readable evidence files (paired CUE sheets, rip logs,
+        // info text). Clicking one hides the picker to make room for the viewer
+        // (one ContentDialog shows at a time) and hands the decoded text to the
+        // loop below; a failed read renders in the picker's status block instead.
+        (string Name, string Text)? pendingDocument = null;
+        if (candidate.Documents.Count > 0)
+        {
+            var documentsSection = new StackPanel { Spacing = 8 };
+            documentsSection.Children.Add(new TextBlock
+            {
+                Text = Loc.Chrome("import.documents"),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            });
+            foreach (var document in candidate.Documents)
+            {
+                var docButton = new Button
+                {
+                    Content = $"{document.Name}  ·  {Loc.Bytes(document.SizeBytes)}",
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                };
+                docButton.Click += (_, _) =>
+                {
+                    var (text, error) = NativeBae.ReadTextFile(document.Path);
+                    if (error is not null)
+                    {
+                        status.Text = Loc.Chrome("import.document.read_failed",
+                            new Dictionary<string, object?> { ["name"] = document.Name, ["error"] = error });
+                        status.Visibility = Visibility.Visible;
+                        return;
+                    }
+                    pendingDocument = (document.Name, text!);
+                    dialog.Hide();
+                };
+                documentsSection.Children.Add(docButton);
+            }
+            // Below the candidate name and audio-preview row, above the results.
+            content.Children.Insert(renderPreview is null ? 1 : 2, documentsSection);
+        }
+
         searchButton.Click += async (_, _) =>
         {
             var source = (string)sourceBox.SelectedItem;
@@ -144,6 +183,18 @@ internal sealed class ImportPickerDialog
             while (true)
             {
                 var pickerResult = await dialog.ShowAsync();
+
+                // A document click hid the picker to make room for the viewer;
+                // present it, then re-open the picker with its search results and
+                // selection intact. The audio preview keeps playing underneath, so
+                // this path leaves the preview session untouched.
+                if (pendingDocument is { } doc)
+                {
+                    pendingDocument = null;
+                    await ShowDocument(doc.Name, doc.Text);
+                    continue;
+                }
+
                 _session.WithCurrentHandle(NativeBae.PreviewStop);
 
                 ReleaseCandidateChoice? chosen;
@@ -180,5 +231,31 @@ internal sealed class ImportPickerDialog
             }
             _import.ClearPreview();
         }
+    }
+
+    // The document viewer: the file's decoded text, monospace and selectable, in
+    // a scrollable modal — the Windows shape of the macOS document overlay. The
+    // title is the raw file name; ContentDialog's built-in max width caps the
+    // wrapped text.
+    private async System.Threading.Tasks.Task ShowDocument(string name, string text)
+    {
+        var viewer = new ContentDialog
+        {
+            Title = name,
+            Content = new ScrollViewer
+            {
+                Content = new TextBlock
+                {
+                    Text = text,
+                    FontFamily = new FontFamily("Consolas"),
+                    TextWrapping = TextWrapping.Wrap,
+                    IsTextSelectionEnabled = true,
+                },
+                MaxHeight = 480,
+            },
+            CloseButtonText = Loc.Chrome("action.close"),
+            XamlRoot = _xamlRoot(),
+        };
+        await viewer.ShowAsync();
     }
 }


### PR DESCRIPTION
Windows import candidates surfaced only their audio paths. The CUE sheets and rip logs that ship with a rip — the evidence a user reaches for to sanity-check a candidate before importing — were neither listed nor readable, even though macOS has long listed them in its file pane and opened them in a monospace viewer. This closes that gap on Windows.

Core already categorizes a candidate's files and delivers them with the candidate over the bridge, and the bridge already exposes a text reader that does encoding detection (which matters for CUE and log files written by rippers in legacy codepages). Nothing new was needed below the UI. The candidate conversion now carries core's document list — paired CUE sheets first, then core's path-sorted documents, matching the order the file pane shows on other platforms — and the import picker renders a Documents section with each file's name and localized size.

Opening a document reads it through the shipped bridge reader and shows the decoded text in a scrollable, selectable monospace ContentDialog. Because only one ContentDialog can show at a time, the picker rides its existing hide-then-reopen loop: a document click hides the picker, the viewer shows, and the picker reopens with its search results and selection intact. The audio preview keeps playing underneath, and a failed read surfaces in the picker's status block rather than being swallowed.

The two new strings are appended to all 31 locale catalogs with real translations.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 217 passed.
- `python3 scripts/loc-chrome-orphans.py` — 0 Windows orphans (376 keys).
- Windows compiles only in CI; every control/API used here already appears in these files or siblings, and the one new generated symbol (`BaeBridgeMethods.ReadTextFile`) follows the shipped free-function naming pattern. CI is the compile gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)