### PR TITLE
Persist and restore the main window's bounds on Windows

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -12,6 +13,7 @@ using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Media.Imaging;
 using uniffi.bae_bridge;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Graphics;
 using Windows.Storage;
 using Windows.System;
 
@@ -68,6 +70,13 @@ public sealed partial class MainWindow : Window
     // loose-zip copy (IsAvailable is false).
     private readonly UpdateService _updateService = new();
 
+    // The window's last-seen normal (restored-state) bounds and whether it is
+    // maximized, tracked from AppWindow.Changed and written once in OnClosed.
+    // Normal bounds are recorded even while maximized, so restoring down after a
+    // relaunch lands on the user's chosen size rather than a display-sized rect.
+    private PixelRect? _lastNormalBounds;
+    private bool _maximized;
+
     // x:Bind Albums/Composers in the shell resolve here; the collections live in
     // the browser store (constructed before InitializeComponent so these are
     // non-null when the bindings first evaluate).
@@ -84,6 +93,14 @@ public sealed partial class MainWindow : Window
 
         InitializeComponent();
         Closed += OnClosed;
+
+        // Restore the window to its last-used position, size, and maximized state
+        // before the app activates it, so it appears already in place with no
+        // flicker. The saved bounds are clamped to the current displays; anything
+        // unusable leaves the system's default placement. Track later moves and
+        // resizes so OnClosed can persist the final normal bounds.
+        RestoreWindowBounds();
+        AppWindow.Changed += OnAppWindowChanged;
 
         // The window's HWND exists at construction, so bind the transport controls
         // to it now — before LoadLibrary starts the event stream that drives them.
@@ -894,6 +911,82 @@ public sealed partial class MainWindow : Window
         await _settingsDialog.Show();
     }
 
+    // Place the window at its saved bounds and maximized state. Wrapped whole:
+    // placement must never take down launch, so any failure logs and leaves the
+    // system's default placement.
+    private void RestoreWindowBounds()
+    {
+        try
+        {
+            var plan = WindowBoundsModel.PlanRestore(WindowBoundsStore.Load(), WorkAreasPrimaryFirst());
+            if (plan is null)
+            {
+                return;
+            }
+
+            AppWindow.MoveAndResize(new RectInt32(
+                plan.Bounds.X, plan.Bounds.Y, plan.Bounds.Width, plan.Bounds.Height));
+
+            // Apply the bounds first, then maximize, so AppWindow records the sane
+            // normal bounds as its restore-down target.
+            if (plan.Maximized && AppWindow.Presenter is OverlappedPresenter presenter)
+            {
+                presenter.Maximize();
+            }
+        }
+        catch (Exception exception)
+        {
+            BaeDiagnostics.Logger.Warning("Could not restore the saved window bounds.", exception);
+        }
+    }
+
+    // The current work areas, with the primary display first so a saved rect that
+    // overlaps no display falls back to it.
+    private static List<PixelRect> WorkAreasPrimaryFirst()
+    {
+        var workAreas = new List<PixelRect>();
+        var primary = DisplayArea.Primary;
+        if (primary is not null)
+        {
+            workAreas.Add(ToPixelRect(primary.WorkArea));
+        }
+
+        foreach (var display in DisplayArea.FindAll())
+        {
+            if (primary is null || display.DisplayId.Value != primary.DisplayId.Value)
+            {
+                workAreas.Add(ToPixelRect(display.WorkArea));
+            }
+        }
+
+        return workAreas;
+    }
+
+    private static PixelRect ToPixelRect(RectInt32 rect) =>
+        new(rect.X, rect.Y, rect.Width, rect.Height);
+
+    // Track the window's normal bounds and maximized state as it moves and
+    // resizes. A field assignment per event, no I/O: OnClosed does the single
+    // write. A minimized window carries no bounds worth saving, so it leaves the
+    // last-seen normal bounds and maximized flag untouched.
+    private void OnAppWindowChanged(AppWindow sender, AppWindowChangedEventArgs args)
+    {
+        if (sender.Presenter is not OverlappedPresenter presenter
+            || presenter.State == OverlappedPresenterState.Minimized)
+        {
+            return;
+        }
+
+        _maximized = presenter.State == OverlappedPresenterState.Maximized;
+
+        if ((args.DidPositionChange || args.DidSizeChange)
+            && presenter.State == OverlappedPresenterState.Restored)
+        {
+            _lastNormalBounds = new PixelRect(
+                sender.Position.X, sender.Position.Y, sender.Size.Width, sender.Size.Height);
+        }
+    }
+
     private async void OnClosed(object sender, WindowEventArgs args)
     {
         // Clear the transport controls first so no ghost entry lingers during
@@ -905,6 +998,14 @@ public sealed partial class MainWindow : Window
             // handle, so the next launch can restore where playback left off.
             await ShutdownAndFreeCurrentHandle();
         }
+
+        // Persist the last-seen normal bounds and maximized state, if the window
+        // ever settled into a restored position, so the next launch reopens here.
+        if (_lastNormalBounds is PixelRect normalBounds)
+        {
+            WindowBoundsStore.Save(WindowBoundsModel.Serialize(normalBounds, _maximized));
+        }
+
         BaeDiagnostics.Flush();
     }
 }

--- a/bae-windows/Stores/WindowBoundsModel.cs
+++ b/bae-windows/Stores/WindowBoundsModel.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Bae.Windows;
+
+// A rectangle in physical (raw) pixels, the coordinate space AppWindow and
+// DisplayArea.WorkArea report in. Origin can be negative (a display left of or
+// above the primary).
+public readonly record struct PixelRect(int X, int Y, int Width, int Height)
+{
+    public int Right => X + Width;
+
+    public int Bottom => Y + Height;
+}
+
+// What the restore glue should do at launch: place the window at Bounds, and
+// maximize it afterwards if Maximized. A null plan (nothing saved, or the saved
+// blob failed validation) means leave the system's default placement.
+public sealed record WindowRestorePlan(PixelRect Bounds, bool Maximized);
+
+// Owns the window-bounds on-disk shape, the validation of a saved blob, and the
+// clamping that keeps a restored window reachable on the current display
+// arrangement. Plain BCL types only, so it is unit-tested off the WinUI build;
+// the glue that reads real DisplayAreas and moves the AppWindow lives in
+// MainWindow and is verified by compilation.
+public static class WindowBoundsModel
+{
+    // The smallest saved size worth restoring: anything smaller is a degenerate
+    // or garbage rect and falls back to the system's default placement.
+    private const int MinWidth = 200;
+    private const int MinHeight = 150;
+
+    // A restored window must show at least this much of its width on some display
+    // and keep its title bar within reach, so it can always be moved or closed.
+    private const int MinVisibleWidth = 100;
+    private const int TitleBarBand = 38;
+
+    // Serialize the window's normal (restored-state) bounds and maximized flag.
+    // The saved rect is always the normal bounds — never the maximized rect —
+    // with the maximized state carried by the separate flag.
+    public static string Serialize(PixelRect normalBounds, bool maximized)
+    {
+        var payload = new Dictionary<string, object>
+        {
+            ["x"] = normalBounds.X,
+            ["y"] = normalBounds.Y,
+            ["width"] = normalBounds.Width,
+            ["height"] = normalBounds.Height,
+            ["maximized"] = maximized,
+        };
+        return JsonSerializer.Serialize(payload);
+    }
+
+    // Parse a saved blob and clamp its bounds to the current display arrangement.
+    // Returns null when nothing usable is saved: an absent, empty, or unparseable
+    // blob; a root that is not an object; a missing/non-integer coordinate; a
+    // degenerate size; or an empty work-area list. The caller passes the work
+    // areas with the primary display first, so a rect intersecting none falls
+    // back to it.
+    public static WindowRestorePlan? PlanRestore(string? json, IReadOnlyList<PixelRect> workAreas)
+    {
+        if (string.IsNullOrWhiteSpace(json) || workAreas.Count == 0)
+        {
+            return null;
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !TryGetInt(root, "x", out var x)
+                || !TryGetInt(root, "y", out var y)
+                || !TryGetInt(root, "width", out var width)
+                || !TryGetInt(root, "height", out var height))
+            {
+                return null;
+            }
+
+            if (width < MinWidth || height < MinHeight)
+            {
+                return null;
+            }
+
+            var maximized = root.TryGetProperty("maximized", out var flag)
+                && flag.ValueKind == JsonValueKind.True;
+
+            var saved = new PixelRect(x, y, width, height);
+            return new WindowRestorePlan(Clamp(saved, workAreas), maximized);
+        }
+    }
+
+    // Fit a saved rect back onto the current displays: shrink it to the target
+    // work area if a monitor got smaller, then, only if too little of it (or its
+    // title bar) would be reachable, move it fully inside the target. A window
+    // straddling two adjacent displays stays put because it passes the reach test.
+    private static PixelRect Clamp(PixelRect saved, IReadOnlyList<PixelRect> workAreas)
+    {
+        var target = TargetWorkArea(saved, workAreas);
+
+        var width = Math.Min(saved.Width, target.Width);
+        var height = Math.Min(saved.Height, target.Height);
+        var sized = new PixelRect(saved.X, saved.Y, width, height);
+
+        if (IsReachable(sized, workAreas))
+        {
+            return sized;
+        }
+
+        var clampedX = Math.Clamp(sized.X, target.X, target.Right - width);
+        var clampedY = Math.Clamp(sized.Y, target.Y, target.Bottom - height);
+        return new PixelRect(clampedX, clampedY, width, height);
+    }
+
+    // The work area sharing the most area with the saved rect; the first work
+    // area (the primary display) when the rect overlaps none.
+    private static PixelRect TargetWorkArea(PixelRect rect, IReadOnlyList<PixelRect> workAreas)
+    {
+        var best = workAreas[0];
+        var bestArea = 0;
+        foreach (var workArea in workAreas)
+        {
+            var area = IntersectionArea(rect, workArea);
+            if (area > bestArea)
+            {
+                bestArea = area;
+                best = workArea;
+            }
+        }
+
+        return best;
+    }
+
+    // Whether some display shows enough of the rect's width and holds its top
+    // edge low enough that the title bar stays grabbable.
+    private static bool IsReachable(PixelRect rect, IReadOnlyList<PixelRect> workAreas)
+    {
+        foreach (var workArea in workAreas)
+        {
+            var overlap = Math.Min(rect.Right, workArea.Right) - Math.Max(rect.X, workArea.X);
+            if (overlap >= MinVisibleWidth
+                && rect.Y >= workArea.Y
+                && rect.Y <= workArea.Bottom - TitleBarBand)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int IntersectionArea(PixelRect a, PixelRect b)
+    {
+        var width = Math.Max(0, Math.Min(a.Right, b.Right) - Math.Max(a.X, b.X));
+        var height = Math.Max(0, Math.Min(a.Bottom, b.Bottom) - Math.Max(a.Y, b.Y));
+        return width * height;
+    }
+
+    private static bool TryGetInt(JsonElement root, string name, out int value)
+    {
+        value = 0;
+        return root.TryGetProperty(name, out var element)
+            && element.ValueKind == JsonValueKind.Number
+            && element.TryGetInt32(out value);
+    }
+}

--- a/bae-windows/Stores/WindowBoundsStore.cs
+++ b/bae-windows/Stores/WindowBoundsStore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+
+namespace Bae.Windows;
+
+// The file-backed half of the main window's bounds persistence: the on-disk
+// shape, validation, and clamping math live in WindowBoundsModel (unit-tested);
+// this only moves that JSON to and from a blob under the app's local data
+// directory, mirroring how macOS lets the system restore the window frame. A
+// failed read or write degrades to the system's default placement rather than
+// taking the app down — the window bounds are a preference, not durable state.
+internal static class WindowBoundsStore
+{
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "bae",
+        "window-bounds.json");
+
+    // Load the saved bounds blob, or null when nothing is saved yet.
+    public static string? Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                return File.ReadAllText(FilePath);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not read the saved window bounds.", exception);
+        }
+
+        return null;
+    }
+
+    public static void Save(string json)
+    {
+        try
+        {
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, json);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not save the window bounds.", exception);
+        }
+    }
+}

--- a/bae-windows/bae-windows.Tests/WindowBoundsModelTests.cs
+++ b/bae-windows/bae-windows.Tests/WindowBoundsModelTests.cs
@@ -1,0 +1,219 @@
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the pure window-bounds logic: the serialize/parse round-trip, the
+/// validation that rejects garbage or degenerate saved rects, and the clamping
+/// that keeps a restored window reachable when the display arrangement shrank or
+/// a monitor went away. No WinUI or DisplayArea dependency.
+/// </summary>
+public sealed class WindowBoundsModelTests
+{
+    // Single-display arrangement: one work area starting at the origin.
+    private static readonly PixelRect[] SingleDisplay = { new(0, 0, 1920, 1040) };
+
+    // Multi-display arrangement: primary first, then a display to its right and a
+    // negative-origin display to its left.
+    private static readonly PixelRect[] MultiDisplay =
+    {
+        new(0, 0, 1920, 1040),
+        new(1920, 0, 1920, 1160),
+        new(-1280, 0, 1280, 1024),
+    };
+
+    // ── Round-trip / valid restore ──
+
+    [Fact]
+    public void PlanRestore_RoundTripsBoundsAndFlag()
+    {
+        var bounds = new PixelRect(100, 80, 1100, 800);
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(bounds, maximized: false),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        Assert.Equal(bounds, plan!.Bounds);
+        Assert.False(plan.Maximized);
+    }
+
+    [Fact]
+    public void PlanRestore_StraddlingTwoDisplaysStaysPut()
+    {
+        // Spans the seam between the primary and the display to its right, with a
+        // grabbable title bar on both — restored exactly where it was.
+        var bounds = new PixelRect(1600, 100, 900, 700);
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(bounds, maximized: false),
+            MultiDisplay);
+
+        Assert.NotNull(plan);
+        Assert.Equal(bounds, plan!.Bounds);
+    }
+
+    [Fact]
+    public void PlanRestore_NegativeOriginDisplayRestoresUnmoved()
+    {
+        // A rect fully on the negative-origin display is not off-screen.
+        var bounds = new PixelRect(-1000, 100, 800, 600);
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(bounds, maximized: false),
+            MultiDisplay);
+
+        Assert.NotNull(plan);
+        Assert.Equal(bounds, plan!.Bounds);
+    }
+
+    // ── Off-screen clamp ──
+
+    [Fact]
+    public void PlanRestore_RectOnUnpluggedDisplayClampsIntoFallback()
+    {
+        // Saved on a display that is no longer present; only the primary remains.
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(2200, 100, 800, 600), maximized: false),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        AssertInside(plan!.Bounds, SingleDisplay[0]);
+        Assert.Equal(800, plan.Bounds.Width);
+        Assert.Equal(600, plan.Bounds.Height);
+    }
+
+    [Fact]
+    public void PlanRestore_TitleBarAboveWorkAreaClamps()
+    {
+        // The top edge sits above the display, so the title bar is unreachable.
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(100, -200, 800, 600), maximized: false),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        AssertInside(plan!.Bounds, SingleDisplay[0]);
+        Assert.True(plan.Bounds.Y >= SingleDisplay[0].Y);
+    }
+
+    [Fact]
+    public void PlanRestore_HorizontalSliverClamps()
+    {
+        // Only a thin sliver of width overlaps the display (less than the minimum
+        // visible width), so the window is pulled back on-screen.
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(1870, 100, 800, 600), maximized: false),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        AssertInside(plan!.Bounds, SingleDisplay[0]);
+    }
+
+    // ── Monitor-shrink clamp ──
+
+    [Fact]
+    public void PlanRestore_OversizedRectShrinksToWorkArea()
+    {
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(0, 0, 2560, 1400), maximized: false),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        Assert.Equal(1920, plan!.Bounds.Width);
+        Assert.Equal(1040, plan.Bounds.Height);
+        AssertInside(plan.Bounds, SingleDisplay[0]);
+    }
+
+    [Fact]
+    public void PlanRestore_FitsBySizeButTitleBarBelowShrunkDisplayRepositions()
+    {
+        // Fits by size, but after the display got shorter the title bar sits below
+        // its bottom edge (unreachable) — repositioned to sit fully inside.
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(1400, 1010, 800, 300), maximized: false),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        AssertInside(plan!.Bounds, SingleDisplay[0]);
+        Assert.Equal(800, plan.Bounds.Width);
+        Assert.Equal(300, plan.Bounds.Height);
+    }
+
+    // ── Garbage / corrupt saved values → null plan ──
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json")]
+    [InlineData("[1, 2, 3]")]
+    [InlineData("{\"x\":100,\"y\":80}")]
+    [InlineData("{\"x\":\"100\",\"y\":\"80\",\"width\":\"800\",\"height\":\"600\"}")]
+    [InlineData("{\"x\":0,\"y\":0,\"width\":0,\"height\":600}")]
+    [InlineData("{\"x\":0,\"y\":0,\"width\":-800,\"height\":600}")]
+    [InlineData("{\"x\":0,\"y\":0,\"width\":50,\"height\":600}")]
+    [InlineData("{\"x\":0,\"y\":0,\"width\":800,\"height\":100}")]
+    public void PlanRestore_GarbageReturnsNull(string? json) =>
+        Assert.Null(WindowBoundsModel.PlanRestore(json, SingleDisplay));
+
+    [Fact]
+    public void PlanRestore_EmptyWorkAreasReturnsNull() =>
+        Assert.Null(WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(100, 80, 800, 600), maximized: false),
+            new PixelRect[0]));
+
+    [Fact]
+    public void PlanRestore_AbsentMaximizedReadsAsFalse()
+    {
+        var plan = WindowBoundsModel.PlanRestore(
+            "{\"x\":100,\"y\":80,\"width\":800,\"height\":600}",
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        Assert.False(plan!.Maximized);
+    }
+
+    [Fact]
+    public void PlanRestore_NonBooleanMaximizedReadsAsFalse()
+    {
+        var plan = WindowBoundsModel.PlanRestore(
+            "{\"x\":100,\"y\":80,\"width\":800,\"height\":600,\"maximized\":\"yes\"}",
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        Assert.False(plan!.Maximized);
+    }
+
+    // ── Maximized round-trip ──
+
+    [Fact]
+    public void PlanRestore_MaximizedPreservesNormalBounds()
+    {
+        var normal = new PixelRect(200, 150, 1100, 800);
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(normal, maximized: true),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        Assert.True(plan!.Maximized);
+        Assert.Equal(normal, plan.Bounds);
+    }
+
+    [Fact]
+    public void PlanRestore_MaximizedWithOffScreenNormalBoundsClamps()
+    {
+        var plan = WindowBoundsModel.PlanRestore(
+            WindowBoundsModel.Serialize(new PixelRect(2200, 100, 800, 600), maximized: true),
+            SingleDisplay);
+
+        Assert.NotNull(plan);
+        Assert.True(plan!.Maximized);
+        AssertInside(plan.Bounds, SingleDisplay[0]);
+    }
+
+    private static void AssertInside(PixelRect rect, PixelRect workArea)
+    {
+        Assert.True(rect.X >= workArea.X, "left edge inside");
+        Assert.True(rect.Y >= workArea.Y, "top edge inside");
+        Assert.True(rect.Right <= workArea.Right, "right edge inside");
+        Assert.True(rect.Bottom <= workArea.Bottom, "bottom edge inside");
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -22,7 +22,9 @@
       pressing-field enablement), the re-identify results-list arbitration
       between the auto-identify pipeline and a manual search, and the import
       candidate-list tab assignment / counts / sort orders / persisted-token
-      round-trip, split out as plain BCL types (the stores that hold bridge
+      round-trip, and the main-window bounds clamp (validation of the saved rect
+      plus the fit-onto-the-current-displays math that keeps a restored window
+      reachable), split out as plain BCL types (the stores that hold bridge
       snapshots and the WinUI views and dialogs that render them are verified by
       compilation).
     - The export-queue decision layer (ExportQueueModel) — the Exporting
@@ -70,6 +72,7 @@
     <Compile Include="../Stores/ReidentifyResultsModel.cs" Link="ReidentifyResultsModel.cs" />
     <Compile Include="../Stores/ImportListModel.cs" Link="ImportListModel.cs" />
     <Compile Include="../Stores/ExportQueueModel.cs" Link="ExportQueueModel.cs" />
+    <Compile Include="../Stores/WindowBoundsModel.cs" Link="WindowBoundsModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On macOS the system restores the main window's frame across launches for free. On Windows, bae opened at whatever default placement WinUI picked and never read or wrote the window's position, size, or maximized state, so a user who sized the window to fit their setup lost that arrangement on every restart.

This remembers the main window's normal (restored-state) bounds and maximized flag and restores them on the next launch, clamped to the current display arrangement. Clamping keeps a restored window reachable: it shrinks a rect to a monitor that got smaller, and when a display was unplugged or rearranged so too little of the window (or its title bar) would be grabbable, it pulls the window fully back onto the target display. A window intentionally straddling two monitors, or sitting on a negative-origin display, is left exactly where it was.

The split follows the existing store/model pattern. All validation and clamping math lives in a pure BCL model (`WindowBoundsModel`) with no WinUI dependency, so it is unit-tested on the macOS dev host; `WindowBoundsStore` only moves the JSON blob under the app's local data directory, like the sort store next to it. The WinRT glue in `MainWindow` reads the real `DisplayArea` work areas, restores the window before the app activates it (so it appears already in place), tracks the normal bounds and maximized state from `AppWindow.Changed`, and writes once in `OnClosed` alongside the existing close-time persistence. Losing the bounds on a hard crash is acceptable for a preference — one write on the established close hook, no debounce timer.

No new user-visible strings, so no catalog changes.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 241 pass, including the new `WindowBoundsModelTests` covering the valid round-trip, two-display straddle, off-screen/title-bar/sliver clamps, negative-origin displays, monitor-shrink, garbage/corrupt blobs, and the maximized round-trip preserving normal bounds.
- `python3 scripts/loc-chrome-orphans.py` — 0 orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)