### PR TITLE
Bring library reveal/copy-ID and switch shortcuts to bae-windows

### DIFF
--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -12,6 +12,17 @@
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Modifiers="Control" Key="F" Invoked="OnFocusSearchAccelerator" />
             <KeyboardAccelerator Modifiers="Control" Key="L" Invoked="OnGoToNowPlaying" />
+            <!-- Ctrl+1..9 switch to the Nth discovered library (discovery order,
+                 as the libraries dialog lists them). Ctrl+0 stays storage. -->
+            <KeyboardAccelerator Modifiers="Control" Key="Number1" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number2" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number3" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number4" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number5" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number6" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number7" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number8" Invoked="OnLibrarySwitchAccelerator" />
+            <KeyboardAccelerator Modifiers="Control" Key="Number9" Invoked="OnLibrarySwitchAccelerator" />
         </Grid.KeyboardAccelerators>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -765,6 +765,22 @@ public sealed partial class MainWindow : Window
         await OpenNowPlayingAlbum();
     }
 
+    // Ctrl+1..9 switch to the Nth discovered library. No-op when the digit is
+    // beyond the list or already the active library; open failures land on the
+    // existing status text and unlock dialog, like any other switch.
+    private async void OnLibrarySwitchAccelerator(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        args.Handled = true;
+        var digit = (int)sender.Key - (int)VirtualKey.Number0;
+        var libraries = LoadLibraries();
+        var target = LibrarySwitchModel.TargetLibraryId(
+            libraries.ConvertAll(library => (library.Id, library.IsActive)), digit);
+        if (target is not null)
+        {
+            await SwitchLibrary(target);
+        }
+    }
+
     // Clicking the bar's album art or track title jumps to the playing album —
     // the pointer version of the go-to-now-playing accelerator.
     private async void OnNowPlayingInfoTapped(object sender, TappedRoutedEventArgs e)

--- a/bae-windows/Stores/LibrarySwitchModel.cs
+++ b/bae-windows/Stores/LibrarySwitchModel.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace Bae.Windows;
+
+// Maps a library-switch shortcut digit (Ctrl+1..9) onto the discovered-libraries
+// list. No WinUI — the caller reduces its BridgeLibrary list to (id, isActive)
+// pairs and applies the returned id.
+public static class LibrarySwitchModel
+{
+    // digit is 1-based (Ctrl+1 -> 1). Returns the library id to switch to, or
+    // null to no-op: digit outside 1..9, digit beyond the list, or the target is
+    // already active.
+    public static string? TargetLibraryId(
+        IReadOnlyList<(string Id, bool IsActive)> libraries, int digit)
+    {
+        if (digit < 1 || digit > 9 || digit > libraries.Count)
+        {
+            return null;
+        }
+
+        var target = libraries[digit - 1];
+        return target.IsActive ? null : target.Id;
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>لم يتم اختيار مجلد</value></data>
   <data name="import.documents" xml:space="preserve"><value>المستندات</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>تعذرت قراءة {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>الإظهار في مستكشف الملفات</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>نسخ المعرّف</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>تم نسخ معرّف المكتبة</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>تعذّر فتح مجلد المكتبة</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Няма избрана папка</value></data>
   <data name="import.documents" xml:space="preserve"><value>Документи</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Не можа да се прочете {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>показване във Файлов мениджър</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>копиране на ИД</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ИД на библиотеката е копиран</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>папката на библиотеката не може да се отвори</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>কোনো ফোল্ডার বেছে নেওয়া হয়নি</value></data>
   <data name="import.documents" xml:space="preserve"><value>ডকুমেন্ট</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} পড়া যায়নি: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>ফাইল এক্সপ্লোরারে দেখান</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>আইডি কপি করুন</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>লাইব্রেরি আইডি কপি হয়েছে</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>লাইব্রেরি ফোল্ডার খোলা যায়নি</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Není vybrána žádná složka</value></data>
   <data name="import.documents" xml:space="preserve"><value>Dokumenty</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Nelze přečíst {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>zobrazit v Průzkumníku souborů</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>kopírovat ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID knihovny zkopírováno</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>složku knihovny se nepodařilo otevřít</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Kein Ordner ausgewählt</value></data>
   <data name="import.documents" xml:space="preserve"><value>Dokumente</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} konnte nicht gelesen werden: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>im Explorer anzeigen</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID kopieren</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>Bibliotheks-ID kopiert</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>Bibliotheksordner konnte nicht geöffnet werden</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>No folder chosen</value></data>
   <data name="import.documents" xml:space="preserve"><value>Documents</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Could not read {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>show in Explorer</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>copy ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>library ID copied</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>couldn't open the library folder</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>No se eligió ninguna carpeta</value></data>
   <data name="import.documents" xml:space="preserve"><value>Documentos</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>No se pudo leer {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>mostrar en el Explorador de archivos</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>copiar ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID de la biblioteca copiado</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>no se pudo abrir la carpeta de la biblioteca</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Aucun dossier choisi</value></data>
   <data name="import.documents" xml:space="preserve"><value>Documents</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Impossible de lire {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>afficher dans l'Explorateur de fichiers</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>copier l'ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID de la bibliothèque copié</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>impossible d'ouvrir le dossier de la bibliothèque</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>કોઈ ફોલ્ડર પસંદ કર્યું નથી</value></data>
   <data name="import.documents" xml:space="preserve"><value>દસ્તાવેજો</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} વાંચી શકાયું નહીં: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>ફાઇલ એક્સપ્લોરરમાં બતાવો</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID કૉપિ કરો</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>લાઇબ્રેરી ID કૉપિ થઈ</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>લાઇબ્રેરી ફોલ્ડર ખોલી શકાયું નહીં</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>לא נבחרה תיקייה</value></data>
   <data name="import.documents" xml:space="preserve"><value>מסמכים</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>לא ניתן לקרוא את {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>הצג בסייר הקבצים</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>העתק מזהה</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>מזהה הספרייה הועתק</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>לא ניתן לפתוח את תיקיית הספרייה</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>कोई फ़ोल्डर नहीं चुना गया</value></data>
   <data name="import.documents" xml:space="preserve"><value>दस्तावेज़</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} पढ़ा नहीं जा सका: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>फ़ाइल एक्सप्लोरर में दिखाएँ</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>आईडी कॉपी करें</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>लाइब्रेरी आईडी कॉपी की गई</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>लाइब्रेरी फ़ोल्डर नहीं खुल सका</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nije odabrana mapa</value></data>
   <data name="import.documents" xml:space="preserve"><value>Dokumenti</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Nije moguće pročitati {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>prikaži u Eksploreru za datoteke</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>kopiraj ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID fonoteke kopiran</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>mapu fonoteke nije moguće otvoriti</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nessuna cartella scelta</value></data>
   <data name="import.documents" xml:space="preserve"><value>Documenti</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Impossibile leggere {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>mostra in Esplora file</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>copia ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID della libreria copiato</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>impossibile aprire la cartella della libreria</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>フォルダが選択されていません</value></data>
   <data name="import.documents" xml:space="preserve"><value>ドキュメント</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name}を読み取れませんでした: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>エクスプローラーで表示</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>IDをコピー</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ライブラリIDをコピーしました</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>ライブラリフォルダーを開けませんでした</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>ಯಾವುದೇ ಫೋಲ್ಡರ್ ಆಯ್ಕೆ ಮಾಡಿಲ್ಲ</value></data>
   <data name="import.documents" xml:space="preserve"><value>ದಾಖಲೆಗಳು</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} ಓದಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>ಫೈಲ್ ಎಕ್ಸ್‌ಪ್ಲೋರರ್‌ನಲ್ಲಿ ತೋರಿಸಿ</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID ನಕಲಿಸಿ</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ಲೈಬ್ರರಿ ID ನಕಲಿಸಲಾಗಿದೆ</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>ಲೈಬ್ರರಿ ಫೋಲ್ಡರ್ ತೆರೆಯಲಾಗಲಿಲ್ಲ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>선택한 폴더 없음</value></data>
   <data name="import.documents" xml:space="preserve"><value>문서</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name}을(를) 읽을 수 없음: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>파일 탐색기에서 보기</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID 복사</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>라이브러리 ID 복사됨</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>라이브러리 폴더를 열 수 없습니다</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>ഫോൾഡർ തിരഞ്ഞെടുത്തിട്ടില്ല</value></data>
   <data name="import.documents" xml:space="preserve"><value>ഡോക്യുമെന്റുകൾ</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} വായിക്കാനായില്ല: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>ഫയൽ എക്സ്‌പ്ലോററിൽ കാണിക്കുക</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID പകർത്തുക</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ലൈബ്രറി ID പകർത്തി</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>ലൈബ്രറി ഫോൾഡർ തുറക്കാനായില്ല</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>कोणतेही फोल्डर निवडले नाही</value></data>
   <data name="import.documents" xml:space="preserve"><value>दस्तऐवज</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} वाचता आले नाही: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>फाइल एक्सप्लोररमध्ये दाखवा</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID कॉपी करा</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>संग्रहालय ID कॉपी केली</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>संग्रहालय फोल्डर उघडता आले नाही</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Geen map gekozen</value></data>
   <data name="import.documents" xml:space="preserve"><value>Documenten</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Kan {name} niet lezen: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>weergeven in Verkenner</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID kopiëren</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>bibliotheek-ID gekopieerd</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>kan de bibliotheekmap niet openen</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>ਕੋਈ ਫੋਲਡਰ ਨਹੀਂ ਚੁਣਿਆ ਗਿਆ</value></data>
   <data name="import.documents" xml:space="preserve"><value>ਦਸਤਾਵੇਜ਼</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} ਪੜ੍ਹਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>ਫਾਈਲ ਐਕਸਪਲੋਰਰ ਵਿੱਚ ਦਿਖਾਓ</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID ਕਾਪੀ ਕਰੋ</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ID ਕਾਪੀ ਕੀਤੀ</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਫੋਲਡਰ ਨਹੀਂ ਖੁੱਲ੍ਹ ਸਕਿਆ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nie wybrano folderu</value></data>
   <data name="import.documents" xml:space="preserve"><value>Dokumenty</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Nie można odczytać {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>pokaż w Eksploratorze plików</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>kopiuj ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>skopiowano ID biblioteki</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>nie można otworzyć folderu biblioteki</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Nenhuma pasta escolhida</value></data>
   <data name="import.documents" xml:space="preserve"><value>Documentos</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Não foi possível ler {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>mostrar no Explorador de Arquivos</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>copiar ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID da biblioteca copiado</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>não foi possível abrir a pasta da biblioteca</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>கோப்புறை தேர்வு செய்யப்படவில்லை</value></data>
   <data name="import.documents" xml:space="preserve"><value>ஆவணங்கள்</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} ஐப் படிக்க முடியவில்லை: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>கோப்பு எக்ஸ்ப்ளோரரில் காட்டு</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID நகலெடு</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>நூலக ID நகலெடுக்கப்பட்டது</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>நூலக கோப்புறையைத் திறக்க முடியவில்லை</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>ఫోల్డర్ ఎంచుకోలేదు</value></data>
   <data name="import.documents" xml:space="preserve"><value>పత్రాలు</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} చదవలేకపోయింది: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>ఫైల్ ఎక్స్‌ప్లోరర్‌లో చూపించు</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID కాపీ చేయి</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>లైబ్రరీ ID కాపీ చేయబడింది</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>లైబ్రరీ ఫోల్డర్‌ను తెరవడం సాధ్యం కాలేదు</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>ยังไม่ได้เลือกโฟลเดอร์</value></data>
   <data name="import.documents" xml:space="preserve"><value>เอกสาร</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>ไม่สามารถอ่าน {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>แสดงใน File Explorer</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>คัดลอก ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>คัดลอก ID คลังแล้ว</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>เปิดโฟลเดอร์คลังไม่ได้</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Klasör seçilmedi</value></data>
   <data name="import.documents" xml:space="preserve"><value>Belgeler</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} okunamadı: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>Dosya Gezgini'nde göster</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>kimliği kopyala</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>arşiv kimliği kopyalandı</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>arşiv klasörü açılamadı</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Папку не вибрано</value></data>
   <data name="import.documents" xml:space="preserve"><value>Документи</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Не вдалося прочитати {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>показати в Провіднику</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>копіювати ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>ID бібліотеки скопійовано</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>не вдалося відкрити папку бібліотеки</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>کوئی فولڈر منتخب نہیں کیا گیا</value></data>
   <data name="import.documents" xml:space="preserve"><value>دستاویزات</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>{name} پڑھا نہیں جا سکا: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>فائل ایکسپلورر میں دکھائیں</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>ID کاپی کریں</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>لائبریری ID کاپی ہو گئی</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>لائبریری فولڈر نہیں کھل سکا</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>Chưa chọn thư mục</value></data>
   <data name="import.documents" xml:space="preserve"><value>Tài liệu</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>Không thể đọc {name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>hiển thị trong File Explorer</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>sao chép ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>đã sao chép ID thư viện</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>không thể mở thư mục thư viện</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>未选择文件夹</value></data>
   <data name="import.documents" xml:space="preserve"><value>文档</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>无法读取{name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>在文件资源管理器中显示</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>复制 ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>已复制库 ID</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>无法打开库文件夹</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -378,4 +378,8 @@
   <data name="settings.export.no_folder" xml:space="preserve"><value>未選擇資料夾</value></data>
   <data name="import.documents" xml:space="preserve"><value>文件</value></data>
   <data name="import.document.read_failed" xml:space="preserve"><value>無法讀取{name}: {error}</value></data>
+  <data name="libraries.reveal" xml:space="preserve"><value>在檔案總管中顯示</value></data>
+  <data name="libraries.copy_id" xml:space="preserve"><value>複製 ID</value></data>
+  <data name="libraries.id_copied" xml:space="preserve"><value>已複製資料庫 ID</value></data>
+  <data name="libraries.reveal_failed" xml:space="preserve"><value>無法開啟資料庫資料夾</value></data>
 </root>

--- a/bae-windows/Views/LibrariesDialog.cs
+++ b/bae-windows/Views/LibrariesDialog.cs
@@ -37,7 +37,7 @@ internal sealed class LibrariesDialog
     {
         var libraries = _loadLibraries();
 
-        var list = new StackPanel { Spacing = 4, MinWidth = 360 };
+        var list = new StackPanel { Spacing = 4, MinWidth = 480 };
         var status = new TextBlock
         {
             Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
@@ -45,6 +45,16 @@ internal sealed class LibrariesDialog
             Visibility = Visibility.Collapsed,
         };
         list.Children.Add(status);
+
+        // Neutral confirmation for "copy ID", following the settings dialog's
+        // token-copy feedback: persists until overwritten or the dialog closes.
+        var copyFeedback = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            TextWrapping = TextWrapping.Wrap,
+            Visibility = Visibility.Collapsed,
+        };
+        list.Children.Add(copyFeedback);
 
         var dialog = new ContentDialog
         {
@@ -58,9 +68,12 @@ internal sealed class LibrariesDialog
         {
             var id = library.Id;
             var isActive = library.IsActive;
+            var path = library.Path;
 
             var row = new Grid { ColumnSpacing = 4 };
             row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
             // Click the name to switch to that library; the active one can't switch
@@ -80,6 +93,41 @@ internal sealed class LibrariesDialog
             };
             Grid.SetColumn(switchButton, 0);
             row.Children.Add(switchButton);
+
+            // Open the library's folder in File Explorer (its contents, matching
+            // macOS's reveal). Success needs no feedback; failure lands on the
+            // shared salmon status line.
+            var revealButton = new Button { Content = Loc.Chrome("libraries.reveal") };
+            revealButton.Click += async (_, _) =>
+            {
+                try
+                {
+                    if (!await Windows.System.Launcher.LaunchFolderPathAsync(path))
+                    {
+                        status.Text = Loc.Chrome("libraries.reveal_failed");
+                        status.Visibility = Visibility.Visible;
+                    }
+                }
+                catch (Exception)
+                {
+                    status.Text = Loc.Chrome("libraries.reveal_failed");
+                    status.Visibility = Visibility.Visible;
+                }
+            };
+            Grid.SetColumn(revealButton, 1);
+            row.Children.Add(revealButton);
+
+            // Copy the library's UUID to the clipboard, confirming in the neutral
+            // feedback line above.
+            var copyIdButton = new Button { Content = Loc.Chrome("libraries.copy_id") };
+            copyIdButton.Click += (_, _) =>
+            {
+                ClipboardHelper.CopyToClipboard(id);
+                copyFeedback.Text = Loc.Chrome("libraries.id_copied");
+                copyFeedback.Visibility = Visibility.Visible;
+            };
+            Grid.SetColumn(copyIdButton, 2);
+            row.Children.Add(copyIdButton);
 
             // Rename via a flyout editor (a nested ContentDialog can't open over this
             // one). Saving updates the row label in place; no list rebuild needed.
@@ -126,7 +174,7 @@ internal sealed class LibrariesDialog
                 renameFlyout.Hide();
             };
             var renameButton = new Button { Content = Loc.Chrome("libraries.rename"), Flyout = renameFlyout };
-            Grid.SetColumn(renameButton, 1);
+            Grid.SetColumn(renameButton, 3);
             row.Children.Add(renameButton);
 
             list.Children.Add(row);

--- a/bae-windows/bae-windows.Tests/LibrarySwitchModelTests.cs
+++ b/bae-windows/bae-windows.Tests/LibrarySwitchModelTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the digit → library-id mapping behind the Ctrl+1..9 library-switch
+/// accelerators: positional addressing, the active-target and out-of-range
+/// no-ops, and the empty-list case.
+/// </summary>
+public sealed class LibrarySwitchModelTests
+{
+    private static IReadOnlyList<(string Id, bool IsActive)> Libraries(int activeIndex, params string[] ids)
+    {
+        var list = new List<(string Id, bool IsActive)>();
+        for (var i = 0; i < ids.Length; i++)
+        {
+            list.Add((ids[i], i == activeIndex));
+        }
+        return list;
+    }
+
+    [Fact]
+    public void Digit1_ReturnsFirstLibrary()
+    {
+        var libraries = Libraries(activeIndex: 1, "lib-a", "lib-b", "lib-c");
+        Assert.Equal("lib-a", LibrarySwitchModel.TargetLibraryId(libraries, 1));
+    }
+
+    [Fact]
+    public void DigitOnActiveLibrary_ReturnsNull()
+    {
+        var libraries = Libraries(activeIndex: 1, "lib-a", "lib-b", "lib-c");
+        Assert.Null(LibrarySwitchModel.TargetLibraryId(libraries, 2));
+    }
+
+    [Fact]
+    public void DigitBeyondList_ReturnsNull()
+    {
+        var libraries = Libraries(activeIndex: 0, "lib-a", "lib-b");
+        Assert.Null(LibrarySwitchModel.TargetLibraryId(libraries, 3));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    public void DigitOutsideDomain_ReturnsNull(int digit)
+    {
+        var libraries = Libraries(activeIndex: 0, "lib-a", "lib-b", "lib-c");
+        Assert.Null(LibrarySwitchModel.TargetLibraryId(libraries, digit));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(9)]
+    public void EmptyList_ReturnsNull(int digit)
+    {
+        var libraries = new List<(string Id, bool IsActive)>();
+        Assert.Null(LibrarySwitchModel.TargetLibraryId(libraries, digit));
+    }
+
+    [Fact]
+    public void AddressingIsPositional_IndependentOfActiveEntry()
+    {
+        var libraries = Libraries(activeIndex: 2, "lib-a", "lib-b", "lib-c", "lib-d");
+        Assert.Equal("lib-a", LibrarySwitchModel.TargetLibraryId(libraries, 1));
+        Assert.Equal("lib-b", LibrarySwitchModel.TargetLibraryId(libraries, 2));
+        Assert.Equal("lib-d", LibrarySwitchModel.TargetLibraryId(libraries, 4));
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -16,15 +16,16 @@
       no WinRT dependency (the WinRT shell that applies its decisions lives in
       MediaControlService and is verified by compilation).
     - The store models (PlaybackPositionModel / SyncIndicatorModel /
-      ImportIdentityModel / ReidentifyResultsModel / ImportListModel) — the
-      now-playing-bar seek/position math, the sync-indicator precedence, the
-      import identity-claim state (exact vs metadata-only, its note and
-      pressing-field enablement), the re-identify results-list arbitration
-      between the auto-identify pipeline and a manual search, and the import
-      candidate-list tab assignment / counts / sort orders / persisted-token
-      round-trip, and the main-window bounds clamp (validation of the saved rect
-      plus the fit-onto-the-current-displays math that keeps a restored window
-      reachable), split out as plain BCL types (the stores that hold bridge
+      ImportIdentityModel / ReidentifyResultsModel / ImportListModel /
+      LibrarySwitchModel) — the now-playing-bar seek/position math, the
+      sync-indicator precedence, the import identity-claim state (exact vs
+      metadata-only, its note and pressing-field enablement), the re-identify
+      results-list arbitration between the auto-identify pipeline and a manual
+      search, the import candidate-list tab assignment / counts / sort orders /
+      persisted-token round-trip, the main-window bounds clamp (validation of
+      the saved rect plus the fit-onto-the-current-displays math that keeps a
+      restored window reachable), and the Ctrl+1..9 library-switch digit → id
+      mapping, split out as plain BCL types (the stores that hold bridge
       snapshots and the WinUI views and dialogs that render them are verified by
       compilation).
     - The export-queue decision layer (ExportQueueModel) — the Exporting
@@ -62,6 +63,7 @@
     <Compile Include="../MediaControlState.cs" Link="MediaControlState.cs" />
     <Compile Include="../Stores/PlaybackPositionModel.cs" Link="PlaybackPositionModel.cs" />
     <Compile Include="../Stores/SyncIndicatorModel.cs" Link="SyncIndicatorModel.cs" />
+    <Compile Include="../Stores/LibrarySwitchModel.cs" Link="LibrarySwitchModel.cs" />
     <Compile Include="../UpdateFlow.cs" Link="UpdateFlow.cs" />
     <Compile Include="../Stores/LibrarySort.cs" Link="LibrarySort.cs" />
     <Compile Include="../TextTruncation.cs" Link="TextTruncation.cs" />


### PR DESCRIPTION
macOS has three library-level conveniences the Windows app lacks: revealing the library folder in the file manager, copying the library UUID to the clipboard, and direct keyboard shortcuts for switching libraries. On Windows, switching required opening the libraries dialog and clicking a row, and revealing a folder or copying an id was not possible from the UI at all.

All three land on surfaces natural to the Windows app. The libraries dialog — already the library switcher — grows a per-row "show in Explorer" and "copy ID" button next to rename. These are per-library rather than active-library-only (as macOS does it) because `BridgeLibrary` already carries each library's path and id, so acting on any row costs no extra plumbing. Reveal opens the folder's contents via `LaunchFolderPathAsync` (the same semantics as macOS's reveal), reporting a failure on the dialog's existing status line; copy confirms in a new neutral feedback line following the settings dialog's token-copy pattern. Switching gets Ctrl+1..9 window accelerators that select the Nth discovered library, in the same order the dialog lists them; Ctrl+0 stays storage.

The one piece of real decision logic — mapping a shortcut digit onto the discovered-libraries list, including the out-of-range and already-active no-ops — lives in a WinRT-free `LibrarySwitchModel` so it is unit-tested off-host, following `SyncIndicatorModel`. The four new chrome strings are translated into all 31 locale catalogs, with "Explorer" localized to each locale's File Explorer product name. No bridge or bae-core changes.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 226 pass, including the new `LibrarySwitchModelTests`.
- `python3 scripts/loc-chrome-orphans.py` — 0 orphans.
- Button wiring, launcher/clipboard calls, and accelerator firing are verified by the Windows CI build like the rest of the dialog code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)