### PR TITLE
Add an opt-out restore-on-launch playback preference to bae-windows

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -1008,10 +1008,12 @@ public sealed partial class MainWindow : Window
         // Clear the transport controls first so no ghost entry lingers during
         // shutdown; OnClosed doesn't go through TearDownLibrary. Idempotent.
         _mediaControls.Deactivate();
-        if (CurrentHandleOrNull() != null)
+        if (CurrentHandleOrNull() != null && PersistPlaybackStore.Load())
         {
-            // Persist the queue / current track / position before freeing the
-            // handle, so the next launch can restore where playback left off.
+            // The restore-on-launch preference is on: persist the queue /
+            // current track / position before freeing the handle, so the next
+            // launch can restore where playback left off. Off (the default)
+            // skips this save and lets process exit reclaim the handle.
             await ShutdownAndFreeCurrentHandle();
         }
 

--- a/bae-windows/Stores/PersistPlaybackModel.cs
+++ b/bae-windows/Stores/PersistPlaybackModel.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Bae.Windows;
+
+// Pure token parse/serialize for the "restore on launch" playback preference.
+// No WinRT, no I/O — the store layers the file read/write on top of this.
+public static class PersistPlaybackModel
+{
+    // The persisted preference, as the token the store writes to disk and reads
+    // back. Unknown or missing tokens fall back to off.
+    public static string Token(bool persist) =>
+        persist ? "on" : "off";
+
+    public static bool PersistFromToken(string? token) =>
+        string.Equals(token?.Trim(), "on", StringComparison.Ordinal);
+}

--- a/bae-windows/Stores/PersistPlaybackStore.cs
+++ b/bae-windows/Stores/PersistPlaybackStore.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace Bae.Windows;
+
+// The file-backed choice of whether quitting the app performs the graceful
+// shutdown that saves the current track, position, queue, and volume for the
+// next launch to restore. The bare token lives under the app's local data
+// directory, mirroring how macOS keeps the same choice in UserDefaults under
+// the persistPlayback key. A failed read or write degrades to off rather than
+// taking the app down — the preference is a preference, not durable state.
+internal static class PersistPlaybackStore
+{
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "bae",
+        "persist-playback.txt");
+
+    // Load the saved preference, or off when nothing is saved yet.
+    public static bool Load()
+    {
+        string? token = null;
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                token = File.ReadAllText(FilePath);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not read the saved restore-on-launch preference.", exception);
+        }
+
+        return PersistPlaybackModel.PersistFromToken(token);
+    }
+
+    public static void Save(bool persist)
+    {
+        try
+        {
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, PersistPlaybackModel.Token(persist));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not save the restore-on-launch preference.", exception);
+        }
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>نسخ المعرّف</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>تم نسخ معرّف المكتبة</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>تعذّر فتح مجلد المكتبة</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>الاستعادة عند التشغيل</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>يحفظ المقطوعة الحالية والموضع وقائمة الانتظار ومستوى الصوت عند الخروج ويستعيدها عند التشغيل التالي.</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>копиране на ИД</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ИД на библиотеката е копиран</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>папката на библиотеката не може да се отвори</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Възстановяване при стартиране</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Запазва текущата песен, позиция, опашка и сила на звука при изход и ги възстановява при следващото стартиране.</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>আইডি কপি করুন</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>লাইব্রেরি আইডি কপি হয়েছে</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>লাইব্রেরি ফোল্ডার খোলা যায়নি</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>চালু হলে রিস্টোর করুন</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>বন্ধ করার সময় বর্তমান ট্র্যাক, অবস্থান, সারি ও ভলিউম সংরক্ষণ করে এবং পরেরবার চালু হলে সেগুলো ফিরিয়ে আনে।</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>kopírovat ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID knihovny zkopírováno</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>složku knihovny se nepodařilo otevřít</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Obnovit při spuštění</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Při ukončení uloží aktuální skladbu, pozici, frontu a hlasitost a při příštím spuštění je obnoví.</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID kopieren</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>Bibliotheks-ID kopiert</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>Bibliotheksordner konnte nicht geöffnet werden</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Beim Start wiederherstellen</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Speichert beim Beenden den aktuellen Titel, die Position, die Warteschlange und die Lautstärke und stellt sie beim nächsten Start wieder her.</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>copy ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>library ID copied</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>couldn't open the library folder</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restore on launch</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Saves the current track, position, queue, and volume on quit and restores them on next launch.</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>copiar ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID de la biblioteca copiado</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>no se pudo abrir la carpeta de la biblioteca</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restaurar al iniciar</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Guarda la pista actual, la posición, la cola y el volumen al salir y los restaura en el próximo inicio.</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>copier l'ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID de la bibliothèque copié</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>impossible d'ouvrir le dossier de la bibliothèque</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restaurer au lancement</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Enregistre la piste, la position, la file et le volume actuels à la fermeture et les restaure au prochain lancement.</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID કૉપિ કરો</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>લાઇબ્રેરી ID કૉપિ થઈ</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>લાઇબ્રેરી ફોલ્ડર ખોલી શકાયું નહીં</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>શરૂઆત પર પુનઃસ્થાપિત કરો</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>બંધ કરતી વખતે હાલનો ટ્રૅક, સ્થિતિ, કતાર અને અવાજ સાચવે છે અને આગામી શરૂઆત પર પુનઃસ્થાપિત કરે છે.</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>העתק מזהה</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>מזהה הספרייה הועתק</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>לא ניתן לפתוח את תיקיית הספרייה</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>שחזר בהפעלה</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>שומר את הרצועה הנוכחית, המיקום, התור והעוצמה ביציאה ומשחזר אותם בהפעלה הבאה.</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>आईडी कॉपी करें</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>लाइब्रेरी आईडी कॉपी की गई</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>लाइब्रेरी फ़ोल्डर नहीं खुल सका</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>शुरू होने पर बहाल करें</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>बंद करने पर मौजूदा ट्रैक, स्थिति, कतार और वॉल्यूम सहेजता है और अगली शुरुआत पर उन्हें बहाल करता है।</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>kopiraj ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID fonoteke kopiran</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>mapu fonoteke nije moguće otvoriti</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Vrati pri pokretanju</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Sprema trenutnu skladbu, položaj, red i glasnoću pri izlasku te ih vraća pri sljedećem pokretanju.</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>copia ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID della libreria copiato</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>impossibile aprire la cartella della libreria</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Ripristina all'avvio</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Salva brano corrente, posizione, coda e volume all'uscita e li ripristina al prossimo avvio.</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>IDをコピー</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ライブラリIDをコピーしました</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ライブラリフォルダーを開けませんでした</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>起動時に復元</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>終了時に現在のトラック、再生位置、キュー、音量を保存し、次回起動時に復元します。</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID ನಕಲಿಸಿ</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ಲೈಬ್ರರಿ ID ನಕಲಿಸಲಾಗಿದೆ</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ಲೈಬ್ರರಿ ಫೋಲ್ಡರ್ ತೆರೆಯಲಾಗಲಿಲ್ಲ</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ಪ್ರಾರಂಭಿಸುವಾಗ ಮರುಸ್ಥಾಪಿಸಿ</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>ಮುಚ್ಚುವಾಗ ಪ್ರಸ್ತುತ ಹಾಡು, ಸ್ಥಾನ, ಸರದಿ ಮತ್ತು ಧ್ವನಿಮಟ್ಟವನ್ನು ಉಳಿಸಿ, ಮುಂದಿನ ಪ್ರಾರಂಭದಲ್ಲಿ ಮರುಸ್ಥಾಪಿಸುತ್ತದೆ.</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID 복사</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>라이브러리 ID 복사됨</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>라이브러리 폴더를 열 수 없습니다</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>시작 시 복원</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>종료 시 현재 트랙, 위치, 대기열, 음량을 저장하고 다음 실행 때 복원합니다.</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID പകർത്തുക</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ലൈബ്രറി ID പകർത്തി</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ലൈബ്രറി ഫോൾഡർ തുറക്കാനായില്ല</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ആരംഭിക്കുമ്പോൾ പുനഃസ്ഥാപിക്കുക</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>പുറത്തുകടക്കുമ്പോൾ നിലവിലെ ട്രാക്ക്, സ്ഥാനം, നിര, ശബ്ദനില എന്നിവ സംരക്ഷിച്ച് അടുത്ത ആരംഭത്തിൽ പുനഃസ്ഥാപിക്കുന്നു.</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID कॉपी करा</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>संग्रहालय ID कॉपी केली</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>संग्रहालय फोल्डर उघडता आले नाही</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>सुरुवातीला पुनर्संचयित करा</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>बाहेर पडताना सध्याचे गाणे, स्थिती, रांग आणि आवाजपातळी जतन करते आणि पुढच्या सुरुवातीला ते पुनर्संचयित करते.</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID kopiëren</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>bibliotheek-ID gekopieerd</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>kan de bibliotheekmap niet openen</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Herstellen bij starten</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Bewaart het huidige nummer, de positie, wachtrij en volume bij afsluiten en herstelt ze bij de volgende start.</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID ਕਾਪੀ ਕਰੋ</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ID ਕਾਪੀ ਕੀਤੀ</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਫੋਲਡਰ ਨਹੀਂ ਖੁੱਲ੍ਹ ਸਕਿਆ</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ਸ਼ੁਰੂ ਹੋਣ ਤੇ ਮੁੜ-ਬਹਾਲ ਕਰੋ</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>ਬੰਦ ਕਰਦੇ ਸਮੇਂ ਮੌਜੂਦਾ ਟ੍ਰੈਕ, ਸਥਿਤੀ, ਕਤਾਰ ਅਤੇ ਆਵਾਜ਼ ਸੰਭਾਲਦਾ ਹੈ ਅਤੇ ਅਗਲੀ ਸ਼ੁਰੂਆਤ ਤੇ ਉਹਨਾਂ ਨੂੰ ਮੁੜ-ਬਹਾਲ ਕਰਦਾ ਹੈ।</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>kopiuj ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>skopiowano ID biblioteki</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>nie można otworzyć folderu biblioteki</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Przywracaj przy uruchomieniu</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Zapisuje bieżący utwór, pozycję, kolejkę i głośność przy zamknięciu i przywraca je przy następnym uruchomieniu.</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>copiar ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID da biblioteca copiado</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>não foi possível abrir a pasta da biblioteca</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restaurar ao abrir</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Salva a faixa, posição, fila e volume atuais ao sair e os restaura na próxima abertura.</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID நகலெடு</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>நூலக ID நகலெடுக்கப்பட்டது</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>நூலக கோப்புறையைத் திறக்க முடியவில்லை</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>தொடக்கத்தில் மீட்டமை</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>வெளியேறும் போது தற்போதைய பாடல், நிலை, வரிசை, ஒலியளவைச் சேமித்து, அடுத்த தொடக்கத்தில் மீட்டெடுக்கும்.</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID కాపీ చేయి</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>లైబ్రరీ ID కాపీ చేయబడింది</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>లైబ్రరీ ఫోల్డర్‌ను తెరవడం సాధ్యం కాలేదు</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ప్రారంభంలో పునరుద్ధరించు</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>మూసివేసేటప్పుడు ప్రస్తుత ట్రాక్, స్థానం, క్యూ, వాల్యూమ్‌ను సేవ్ చేసి తదుపరి ప్రారంభంలో పునరుద్ధరిస్తుంది.</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>คัดลอก ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>คัดลอก ID คลังแล้ว</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>เปิดโฟลเดอร์คลังไม่ได้</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>คืนค่าเมื่อเปิดแอป</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>บันทึกแทร็กปัจจุบัน ตำแหน่ง คิว และระดับเสียงเมื่อออก แล้วคืนค่าเมื่อเปิดครั้งถัดไป</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>kimliği kopyala</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>arşiv kimliği kopyalandı</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>arşiv klasörü açılamadı</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Açılışta geri yükle</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Çıkarken geçerli parçayı, konumu, sırayı ve ses düzeyini kaydeder; sonraki açılışta geri yükler.</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>копіювати ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>ID бібліотеки скопійовано</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>не вдалося відкрити папку бібліотеки</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Відновлювати під час запуску</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Зберігає поточний трек, позицію, чергу та гучність під час виходу й відновлює їх під час наступного запуску.</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>ID کاپی کریں</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>لائبریری ID کاپی ہو گئی</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>لائبریری فولڈر نہیں کھل سکا</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>شروع ہونے پر بحال کریں</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>بند کرتے وقت موجودہ نغمہ، پوزیشن، قطار، اور آواز محفوظ کرتا ہے اور اگلی شروعات پر بحال کرتا ہے۔</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>sao chép ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>đã sao chép ID thư viện</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>không thể mở thư mục thư viện</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Khôi phục khi khởi chạy</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Lưu bản nhạc hiện tại, vị trí, hàng đợi và âm lượng khi thoát rồi khôi phục ở lần mở tiếp theo.</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>复制 ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>已复制库 ID</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>无法打开库文件夹</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>启动时恢复</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>退出时保存当前曲目、播放位置、队列和音量，并在下次启动时恢复。</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -382,4 +382,6 @@
   <data name="libraries.copy_id" xml:space="preserve"><value>複製 ID</value></data>
   <data name="libraries.id_copied" xml:space="preserve"><value>已複製資料庫 ID</value></data>
   <data name="libraries.reveal_failed" xml:space="preserve"><value>無法開啟資料庫資料夾</value></data>
+  <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>啟動時還原</value></data>
+  <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>結束時儲存目前曲目、位置、佇列與音量，並在下次啟動時還原。</value></data>
 </root>

--- a/bae-windows/Views/SettingsDialog.cs
+++ b/bae-windows/Views/SettingsDialog.cs
@@ -346,6 +346,24 @@ internal sealed class SettingsDialog
         pauseBetweenSides.Checked += async (_, _) => await SetPauseBetweenSides(true);
         pauseBetweenSides.Unchecked += async (_, _) => await SetPauseBetweenSides(false);
 
+        // Whether quitting performs the graceful shutdown that saves the
+        // current track, position, queue, and volume for the next launch to
+        // restore. Device-local (no bridge round-trip), so no error snap-back
+        // and no Refresh() involvement — a config invalidation doesn't carry it.
+        var restoreOnLaunch = new CheckBox
+        {
+            Content = Loc.Chrome("settings.playback.restore_on_launch"),
+            IsChecked = PersistPlaybackStore.Load(),
+        };
+        restoreOnLaunch.Checked += (_, _) => PersistPlaybackStore.Save(true);
+        restoreOnLaunch.Unchecked += (_, _) => PersistPlaybackStore.Save(false);
+        var restoreOnLaunchHelp = new TextBlock
+        {
+            Text = Loc.Chrome("settings.playback.restore_on_launch_help"),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        };
+
         // Export: the release-export destination policy (a fixed folder or a
         // prompt each time), then the single-track "Save As…" suggested-filename
         // template and the export presets. Writes round-trip through config
@@ -1062,6 +1080,8 @@ internal sealed class SettingsDialog
         var discogsLabel = new TextBlock { Text = Loc.Chrome("settings.discogs.label") };
         content.Children.Add(libraryLabel);
         content.Children.Add(pauseBetweenSides);
+        content.Children.Add(restoreOnLaunch);
+        content.Children.Add(restoreOnLaunchHelp);
         content.Children.Add(exportLabel);
         content.Children.Add(saveToFolder);
         content.Children.Add(askEachTime);
@@ -1334,9 +1354,14 @@ internal sealed class SettingsDialog
 
         if (restartUpdateRequested)
         {
-            // ApplyUpdatesAndRestart exits the process, so persist playback state
-            // and flush diagnostics first — the work OnClosed would otherwise do.
-            await _session.ShutdownAndFreeCurrentHandle();
+            // ApplyUpdatesAndRestart exits the process, so this is a second
+            // app-exit path: gate the state-saving shutdown on the same
+            // restore-on-launch preference OnClosed does, then flush
+            // diagnostics unconditionally — the work OnClosed would otherwise do.
+            if (PersistPlaybackStore.Load())
+            {
+                await _session.ShutdownAndFreeCurrentHandle();
+            }
             BaeDiagnostics.Flush();
             _updateService.ApplyAndRestart();
             return;

--- a/bae-windows/bae-windows.Tests/PersistPlaybackModelTests.cs
+++ b/bae-windows/bae-windows.Tests/PersistPlaybackModelTests.cs
@@ -1,0 +1,48 @@
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the token parse/serialize for the "restore on launch" playback
+/// preference: round-trip, and the off-by-default fallback for missing or
+/// unrecognized tokens.
+/// </summary>
+public sealed class PersistPlaybackModelTests
+{
+    [Fact]
+    public void Token_OnIsOn() =>
+        Assert.Equal("on", PersistPlaybackModel.Token(true));
+
+    [Fact]
+    public void Token_OffIsOff() =>
+        Assert.Equal("off", PersistPlaybackModel.Token(false));
+
+    [Fact]
+    public void PersistFromToken_RoundTripsOn() =>
+        Assert.True(PersistPlaybackModel.PersistFromToken(PersistPlaybackModel.Token(true)));
+
+    [Fact]
+    public void PersistFromToken_RoundTripsOff() =>
+        Assert.False(PersistPlaybackModel.PersistFromToken(PersistPlaybackModel.Token(false)));
+
+    [Fact]
+    public void PersistFromToken_NullIsFalse() =>
+        Assert.False(PersistPlaybackModel.PersistFromToken(null));
+
+    [Fact]
+    public void PersistFromToken_EmptyIsFalse() =>
+        Assert.False(PersistPlaybackModel.PersistFromToken(""));
+
+    [Fact]
+    public void PersistFromToken_UnknownIsFalse() =>
+        Assert.False(PersistPlaybackModel.PersistFromToken("yes"));
+
+    [Fact]
+    public void PersistFromToken_TrimsWhitespace() =>
+        Assert.True(PersistPlaybackModel.PersistFromToken(" on\n"));
+
+    [Fact]
+    public void PersistFromToken_IsCaseSensitive() =>
+        Assert.False(PersistPlaybackModel.PersistFromToken("On"));
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -17,17 +17,18 @@
       MediaControlService and is verified by compilation).
     - The store models (PlaybackPositionModel / SyncIndicatorModel /
       ImportIdentityModel / ReidentifyResultsModel / ImportListModel /
-      LibrarySwitchModel) — the now-playing-bar seek/position math, the
-      sync-indicator precedence, the import identity-claim state (exact vs
-      metadata-only, its note and pressing-field enablement), the re-identify
-      results-list arbitration between the auto-identify pipeline and a manual
-      search, the import candidate-list tab assignment / counts / sort orders /
-      persisted-token round-trip, the main-window bounds clamp (validation of
-      the saved rect plus the fit-onto-the-current-displays math that keeps a
-      restored window reachable), and the Ctrl+1..9 library-switch digit → id
-      mapping, split out as plain BCL types (the stores that hold bridge
-      snapshots and the WinUI views and dialogs that render them are verified by
-      compilation).
+      LibrarySwitchModel / PersistPlaybackModel) — the now-playing-bar
+      seek/position math, the sync-indicator precedence, the import
+      identity-claim state (exact vs metadata-only, its note and
+      pressing-field enablement), the re-identify results-list arbitration
+      between the auto-identify pipeline and a manual search, the import
+      candidate-list tab assignment / counts / sort orders / persisted-token
+      round-trip, the main-window bounds clamp (validation of the saved rect
+      plus the fit-onto-the-current-displays math that keeps a restored window
+      reachable), the Ctrl+1..9 library-switch digit → id mapping, and the
+      restore-on-launch playback preference's token round-trip, split out as
+      plain BCL types (the stores that hold bridge snapshots and the WinUI
+      views and dialogs that render them are verified by compilation).
     - The export-queue decision layer (ExportQueueModel) — the Exporting
       section's band/state catalog keys, count summary, retry/pause gating and
       percent clamping, plus the export destination and settings Location-row
@@ -75,6 +76,7 @@
     <Compile Include="../Stores/ImportListModel.cs" Link="ImportListModel.cs" />
     <Compile Include="../Stores/ExportQueueModel.cs" Link="ExportQueueModel.cs" />
     <Compile Include="../Stores/WindowBoundsModel.cs" Link="WindowBoundsModel.cs" />
+    <Compile Include="../Stores/PersistPlaybackModel.cs" Link="PersistPlaybackModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

macOS bae has a "Restore on launch" preference (persistPlayback, default off) that gates whether quitting performs the graceful shutdown that saves the current track, position, queue, and volume for the next launch to restore. bae-windows had no such preference — its window-close handler unconditionally ran the state-saving shutdown, so Windows always persisted playback across launches with no way to turn it off.

This brings Windows to parity: a new PersistPlaybackStore (a file-backed store under `%LocalAppData%\bae\`, sibling to TimeLabelStore) backs a CheckBox in the settings dialog next to the existing pause-between-sides toggle. The preference gates only the state-saving shutdown call itself, in both app-exit paths — `MainWindow.OnClosed` and the apply-update-and-restart path in `SettingsDialog` — leaving window-bounds persistence, diagnostics flush, and mid-session library teardown unconditional, exactly matching what the macOS reference does. The default is off, a deliberate behavior change from Windows' prior always-persist default. No bridge or core changes: the restore side stays unconditional, as it already is on macOS.

The two new strings are localized across all 31 `Resources.resw` catalogs, lifted verbatim from the existing macOS translations for the same copy.

## Test plan

- [x] `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 259 passed
- [x] `python3 scripts/loc-chrome-orphans.py` — 0 orphans
- [ ] Manual, on a Windows box: toggle off (default) — quit and relaunch does not resume playback; toggle on — quit and relaunch resumes queue/track/position/volume; the apply-update-and-restart path respects the toggle the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)