### PR TITLE
Implement artwork lightbox for bae-windows

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ public sealed partial class MainWindow : Window
     private readonly ReleaseActionDialogs _releaseActions;
     private readonly AlbumDetailDialog _albumDetail;
     private readonly QueuePane _queuePane;
+    private readonly LightboxOverlay _lightbox;
     private readonly StorageStore _storage;
     private readonly StorageDialog _storageDialog;
     private readonly SettingsStore _settings;
@@ -164,6 +165,10 @@ public sealed partial class MainWindow : Window
         _router = new UiEventRouter(_playback, _shell, _projections, _mediaControls, _import.HandlePreviewEvent);
         _session.UiEvent += _router.Route;
 
+        // The artwork lightbox: opened from the album gallery and the import
+        // confirmation's local artwork tiles.
+        _lightbox = new LightboxOverlay(() => Content.XamlRoot);
+
         // Album detail and the per-release action dialogs it opens, plus the queue
         // dialog. Album detail is the shared entry point from the grid, the panes,
         // the now-playing jump, and the import "view in library" banner.
@@ -172,7 +177,8 @@ public sealed partial class MainWindow : Window
             () => Content.XamlRoot,
             () => WinRT.Interop.WindowNative.GetWindowHandle(this),
             text => StatusText.Text = text,
-            _projections);
+            _projections,
+            _lightbox);
         _albumDetail = new AlbumDetailDialog(
             _session,
             () => Content.XamlRoot,
@@ -238,7 +244,7 @@ public sealed partial class MainWindow : Window
         // The import flow: the confirm step (which can open an album), the picker
         // that leads to it, and the folder-scan dialog that opens the picker.
         _importConfirm = new ImportConfirmDialog(
-            _session, () => Content.XamlRoot, albumId => _albumDetail.Show(albumId));
+            _session, () => Content.XamlRoot, albumId => _albumDetail.Show(albumId), _lightbox);
         _importPicker = new ImportPickerDialog(_session, () => Content.XamlRoot, _import, _importConfirm);
         _importDialog = new ImportDialog(
             _session,

--- a/bae-windows/Stores/LightboxModel.cs
+++ b/bae-windows/Stores/LightboxModel.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bae.Windows;
+
+// The lightbox's display state: position in the entry list, zoom factor, and
+// the navigation/zoom decision logic. Pure BCL (no WinRT/bridge), extracted to
+// unit-test the model before the UI renders it.
+public sealed record LightboxState(int Count, int Index, double Zoom);
+
+public static class LightboxModel
+{
+    public const double MinZoom = 1.0;
+    public const double MaxZoom = 8.0;
+    public const double DoubleTapZoom = 2.5;
+
+    // Null when count is 0; startIndex clamped into [0, count).
+    public static LightboxState? Open(int count, int startIndex)
+    {
+        if (count <= 0)
+        {
+            return null;
+        }
+
+        var clampedIndex = Math.Clamp(startIndex, 0, count - 1);
+        return new LightboxState(count, clampedIndex, MinZoom);
+    }
+
+    // Multiple items in the list: can navigate forward and backward.
+    public static bool CanCycle(LightboxState state) => state.Count > 1;
+
+    // Wrap-around navigation: (index ± 1 + count) % count, no-op when !CanCycle.
+    // Reset zoom to MinZoom on image change.
+    public static LightboxState Next(LightboxState state)
+    {
+        if (!CanCycle(state))
+        {
+            return state;
+        }
+
+        var nextIndex = (state.Index + 1) % state.Count;
+        return state with { Index = nextIndex, Zoom = MinZoom };
+    }
+
+    public static LightboxState Previous(LightboxState state)
+    {
+        if (!CanCycle(state))
+        {
+            return state;
+        }
+
+        var prevIndex = (state.Index - 1 + state.Count) % state.Count;
+        return state with { Index = prevIndex, Zoom = MinZoom };
+    }
+
+    // Out-of-range index is ignored; zoom resets only when the index actually changes.
+    public static LightboxState Select(LightboxState state, int index)
+    {
+        if (index < 0 || index >= state.Count || index == state.Index)
+        {
+            return state;
+        }
+
+        return state with { Index = index, Zoom = MinZoom };
+    }
+
+    // Clamp the requested zoom into [MinZoom, MaxZoom].
+    public static double ClampZoom(double requested) =>
+        Math.Clamp(requested, MinZoom, MaxZoom);
+
+    // While zoomed (> 1.01), double-tap resets to MinZoom; at or below that
+    // threshold, double-tap zooms to DoubleTapZoom.
+    public static double DoubleTapTarget(double currentZoom) =>
+        currentZoom > 1.01 ? MinZoom : DoubleTapZoom;
+
+    // Chrome (title, buttons, thumbnails) is visible only at zoom <= 1.01; above
+    // that threshold it fades to opacity 0.
+    public static bool ChromeVisible(double zoom) => zoom <= 1.01;
+
+    // Counter label as (key, ICU args) so the model never touches localization
+    // libraries. The key is gallery.counter; args map index → 1-based position
+    // and count → total.
+    public static (string Key, IReadOnlyDictionary<string, object?> Args) Counter(LightboxState state)
+    {
+        var args = new Dictionary<string, object?> { ["index"] = state.Index + 1, ["count"] = state.Count };
+        return ("gallery.counter", args);
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>خطأ في التشغيل</value></data>
   <data name="error.title" xml:space="preserve"><value>خطأ</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>تعذّر تحميل المعرض</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>المعرض</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>تعارض</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, zero {تم العثور على (#)} one {تم العثور على (#)} two {تم العثور على (#)} few {تم العثور على (#)} many {تم العثور على (#)} other {تم العثور على (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>جارٍ التحديد…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>تعذّر فتح مجلد المكتبة</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>الاستعادة عند التشغيل</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>يحفظ المقطوعة الحالية والموضع وقائمة الانتظار ومستوى الصوت عند الخروج ويستعيدها عند التشغيل التالي.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} من {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>لم يتمكن من تحميل الصورة</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>الصورة السابقة</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>الصورة التالية</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>грешка при възпроизвеждане</value></data>
   <data name="error.title" xml:space="preserve"><value>грешка</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>галерията не може да бъде заредена</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>галерия</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>конфликт</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {намерени (#)} other {намерени (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>идентифициране…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>папката на библиотеката не може да се отвори</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Възстановяване при стартиране</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Запазва текущата песен, позиция, опашка и сила на звука при изход и ги възстановява при следващото стартиране.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} от {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>не е възможно да се зареди изображението</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>предишно изображение</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>следващо изображение</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>প্লেব্যাক ত্রুটি</value></data>
   <data name="error.title" xml:space="preserve"><value>ত্রুটি</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>গ্যালারি লোড করা যায়নি</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>গ্যালারি</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>দ্বন্দ্ব</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {পাওয়া গেছে (#)} other {পাওয়া গেছে (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>শনাক্ত করা হচ্ছে…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>লাইব্রেরি ফোল্ডার খোলা যায়নি</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>চালু হলে রিস্টোর করুন</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>বন্ধ করার সময় বর্তমান ট্র্যাক, অবস্থান, সারি ও ভলিউম সংরক্ষণ করে এবং পরেরবার চালু হলে সেগুলো ফিরিয়ে আনে।</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} এর {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>ছবি লোড করা যায়নি</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>আগের ছবি</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>পরবর্তী ছবি</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>chyba přehrávání</value></data>
   <data name="error.title" xml:space="preserve"><value>chyba</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>nelze načíst galerii</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galerie</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>konflikt</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {nalezeno (#)} few {nalezeno (#)} many {nalezeno (#)} other {nalezeno (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identifikace…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>složku knihovny se nepodařilo otevřít</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Obnovit při spuštění</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Při ukončení uloží aktuální skladbu, pozici, frontu a hlasitost a při příštím spuštění je obnoví.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} z {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>obrázek se nepodařilo načíst</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>předchozí obrázek</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>další obrázek</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>Wiedergabefehler</value></data>
   <data name="error.title" xml:space="preserve"><value>Fehler</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>Galerie konnte nicht geladen werden</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>Galerie</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>Konflikt</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {gefunden (#)} other {gefunden (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>Identifizierung …</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>Bibliotheksordner konnte nicht geöffnet werden</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Beim Start wiederherstellen</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Speichert beim Beenden den aktuellen Titel, die Position, die Warteschlange und die Lautstärke und stellt sie beim nächsten Start wieder her.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} von {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>Bild konnte nicht geladen werden</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>vorheriges Bild</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>nächstes Bild</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>playback error</value></data>
   <data name="error.title" xml:space="preserve"><value>error</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>couldn't load the gallery</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>gallery</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identifying…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>couldn't open the library folder</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restore on launch</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Saves the current track, position, queue, and volume on quit and restores them on next launch.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} of {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>couldn't load image</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>previous image</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>next image</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>error de reproducción</value></data>
   <data name="error.title" xml:space="preserve"><value>error</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>no se pudo cargar la galería</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galería</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>conflicto</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {encontrada (#)} other {encontradas (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identificando…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>no se pudo abrir la carpeta de la biblioteca</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restaurar al iniciar</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Guarda la pista actual, la posición, la cola y el volumen al salir y los restaura en el próximo inicio.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} de {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>no se pudo cargar la imagen</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>imagen anterior</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>siguiente imagen</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>erreur de lecture</value></data>
   <data name="error.title" xml:space="preserve"><value>erreur</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>impossible de charger la galerie</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galerie</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>conflit</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {trouvée (#)} other {trouvées (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identification…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>impossible d'ouvrir le dossier de la bibliothèque</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restaurer au lancement</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Enregistre la piste, la position, la file et le volume actuels à la fermeture et les restaure au prochain lancement.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} sur {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>impossible de charger l'image</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>image précédente</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>image suivante</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>વગાડવાની ભૂલ</value></data>
   <data name="error.title" xml:space="preserve"><value>ભૂલ</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>ગેલેરી લોડ કરી શકાયી નહીં</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>ગેલેરી</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>વિરોધ</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {મળ્યું (#)} other {મળ્યાં (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>ઓળખાઈ રહ્યું છે…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>લાઇબ્રેરી ફોલ્ડર ખોલી શકાયું નહીં</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>શરૂઆત પર પુનઃસ્થાપિત કરો</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>બંધ કરતી વખતે હાલનો ટ્રૅક, સ્થિતિ, કતાર અને અવાજ સાચવે છે અને આગામી શરૂઆત પર પુનઃસ્થાપિત કરે છે.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} ના {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>ચિત્ર લોડ કરી શક્યા નહીં</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>પાછલી ચિત્ર</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>આગલી ચિત્ર</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>שגיאת ניגון</value></data>
   <data name="error.title" xml:space="preserve"><value>שגיאה</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>לא ניתן לטעון את הגלריה</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>גלריה</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>התנגשות</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {נמצאה (#)} two {נמצאו (#)} many {נמצאו (#)} other {נמצאו (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>מזהה…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>לא ניתן לפתוח את תיקיית הספרייה</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>שחזר בהפעלה</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>שומר את הרצועה הנוכחית, המיקום, התור והעוצמה ביציאה ומשחזר אותם בהפעלה הבאה.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} מתוך {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>לא ניתן היה לטעון את התמונה</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>תמונה קודמת</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>תמונה הבאה</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>प्लेबैक त्रुटि</value></data>
   <data name="error.title" xml:space="preserve"><value>त्रुटि</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>गैलरी लोड नहीं हो सकी</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>गैलरी</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>टकराव</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {मिला (#)} other {मिले (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>पहचान की जा रही है…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>लाइब्रेरी फ़ोल्डर नहीं खुल सका</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>शुरू होने पर बहाल करें</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>बंद करने पर मौजूदा ट्रैक, स्थिति, कतार और वॉल्यूम सहेजता है और अगली शुरुआत पर उन्हें बहाल करता है।</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} में से {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>छवि लोड नहीं कर सके</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>पिछली छवि</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>अगली छवि</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>pogreška reprodukcije</value></data>
   <data name="error.title" xml:space="preserve"><value>pogreška</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>nije moguće učitati galeriju</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galerija</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>sukob</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {pronađeno (#)} few {pronađeno (#)} other {pronađeno (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identifikacija…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>mapu fonoteke nije moguće otvoriti</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Vrati pri pokretanju</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Sprema trenutnu skladbu, položaj, red i glasnoću pri izlasku te ih vraća pri sljedećem pokretanju.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} od {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>nije moguće učitati sliku</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>prethodna slika</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>sljedeća slika</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>errore di riproduzione</value></data>
   <data name="error.title" xml:space="preserve"><value>errore</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>impossibile caricare la galleria</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galleria</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>conflitto</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {trovato (#)} other {trovati (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identificazione…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>impossibile aprire la cartella della libreria</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Ripristina all'avvio</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Salva brano corrente, posizione, coda e volume all'uscita e li ripristina al prossimo avvio.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} di {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>impossibile caricare l'immagine</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>immagine precedente</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>immagine seguente</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>再生エラー</value></data>
   <data name="error.title" xml:space="preserve"><value>エラー</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>ギャラリーを読み込めませんでした</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>ギャラリー</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>競合</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, other {検出 (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>識別中…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ライブラリフォルダーを開けませんでした</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>起動時に復元</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>終了時に現在のトラック、再生位置、キュー、音量を保存し、次回起動時に復元します。</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index}/{count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>画像を読み込めませんでした</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>前の画像</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>次の画像</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>ಪ್ಲೇಬ್ಯಾಕ್ ದೋಷ</value></data>
   <data name="error.title" xml:space="preserve"><value>ದೋಷ</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>ಗ್ಯಾಲರಿ ಲೋಡ್ ಆಗಲಿಲ್ಲ</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>ಗ್ಯಾಲರಿ</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>ಘರ್ಷಣೆ</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {ಸಿಕ್ಕಿದೆ (#)} other {ಸಿಕ್ಕಿವೆ (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>ಗುರುತಿಸಲಾಗುತ್ತಿದೆ…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ಲೈಬ್ರರಿ ಫೋಲ್ಡರ್ ತೆರೆಯಲಾಗಲಿಲ್ಲ</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ಪ್ರಾರಂಭಿಸುವಾಗ ಮರುಸ್ಥಾಪಿಸಿ</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>ಮುಚ್ಚುವಾಗ ಪ್ರಸ್ತುತ ಹಾಡು, ಸ್ಥಾನ, ಸರದಿ ಮತ್ತು ಧ್ವನಿಮಟ್ಟವನ್ನು ಉಳಿಸಿ, ಮುಂದಿನ ಪ್ರಾರಂಭದಲ್ಲಿ ಮರುಸ್ಥಾಪಿಸುತ್ತದೆ.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} ನ {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>ಚಿತ್ರವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>ಹಿಂದಿನ ಚಿತ್ರ</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>ಮುಂದಿನ ಚಿತ್ರ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>재생 오류</value></data>
   <data name="error.title" xml:space="preserve"><value>오류</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>갤러리를 불러올 수 없음</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>갤러리</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>충돌</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, other {찾음 (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>식별 중…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>라이브러리 폴더를 열 수 없습니다</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>시작 시 복원</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>종료 시 현재 트랙, 위치, 대기열, 음량을 저장하고 다음 실행 때 복원합니다.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{count} 중 {index}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>이미지를 로드할 수 없음</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>이전 이미지</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>다음 이미지</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>പ്ലേബാക്ക് പിശക്</value></data>
   <data name="error.title" xml:space="preserve"><value>പിശക്</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>ഗാലറി ലോഡ് ചെയ്യാനായില്ല</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>ഗാലറി</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>സംഘർഷം</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {കണ്ടെത്തി (#)} other {കണ്ടെത്തി (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>തിരിച്ചറിയുന്നു…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ലൈബ്രറി ഫോൾഡർ തുറക്കാനായില്ല</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ആരംഭിക്കുമ്പോൾ പുനഃസ്ഥാപിക്കുക</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>പുറത്തുകടക്കുമ്പോൾ നിലവിലെ ട്രാക്ക്, സ്ഥാനം, നിര, ശബ്ദനില എന്നിവ സംരക്ഷിച്ച് അടുത്ത ആരംഭത്തിൽ പുനഃസ്ഥാപിക്കുന്നു.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{count} ൽ {index}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>ചിത്രം ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>മുൻഗാമി ചിത്രം</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>അടുത്ത ചിത്രം</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>वाजवण्याची त्रुटी</value></data>
   <data name="error.title" xml:space="preserve"><value>त्रुटी</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>दालन लोड करता आले नाही</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>दालन</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>संघर्ष</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {सापडले (#)} other {सापडले (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>ओळखत आहे…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>संग्रहालय फोल्डर उघडता आले नाही</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>सुरुवातीला पुनर्संचयित करा</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>बाहेर पडताना सध्याचे गाणे, स्थिती, रांग आणि आवाजपातळी जतन करते आणि पुढच्या सुरुवातीला ते पुनर्संचयित करते.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} का {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>प्रतिमा लोड करू शकलो नाही</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>मागील प्रतिमा</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>पुढील प्रतिमा</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>afspeelfout</value></data>
   <data name="error.title" xml:space="preserve"><value>fout</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>kan de galerij niet laden</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galerij</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>conflict</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {gevonden (#)} other {gevonden (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identificeren…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>kan de bibliotheekmap niet openen</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Herstellen bij starten</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Bewaart het huidige nummer, de positie, wachtrij en volume bij afsluiten en herstelt ze bij de volgende start.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} van {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>afbeelding kon niet worden geladen</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>vorige afbeelding</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>volgende afbeelding</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>ਪਲੇਬੈਕ ਗਲਤੀ</value></data>
   <data name="error.title" xml:space="preserve"><value>ਗਲਤੀ</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>ਗੈਲਰੀ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕੀ</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>ਗੈਲਰੀ</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>ਟਕਰਾਅ</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {ਮਿਲਿਆ (#)} other {ਮਿਲੇ (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>ਪਛਾਣ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਫੋਲਡਰ ਨਹੀਂ ਖੁੱਲ੍ਹ ਸਕਿਆ</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ਸ਼ੁਰੂ ਹੋਣ ਤੇ ਮੁੜ-ਬਹਾਲ ਕਰੋ</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>ਬੰਦ ਕਰਦੇ ਸਮੇਂ ਮੌਜੂਦਾ ਟ੍ਰੈਕ, ਸਥਿਤੀ, ਕਤਾਰ ਅਤੇ ਆਵਾਜ਼ ਸੰਭਾਲਦਾ ਹੈ ਅਤੇ ਅਗਲੀ ਸ਼ੁਰੂਆਤ ਤੇ ਉਹਨਾਂ ਨੂੰ ਮੁੜ-ਬਹਾਲ ਕਰਦਾ ਹੈ।</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{count} ਵਿੱਚੋਂ {index}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>ਤਸਵੀਰ ਲੋਡ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>ਪਿਛਲੀ ਤਸਵੀਰ</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>ਅਗਲੀ ਤਸਵੀਰ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>błąd odtwarzania</value></data>
   <data name="error.title" xml:space="preserve"><value>błąd</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>nie udało się wczytać galerii</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galeria</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>konflikt</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {znaleziono (#)} few {znaleziono (#)} many {znaleziono (#)} other {znaleziono (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identyfikowanie…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>nie można otworzyć folderu biblioteki</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Przywracaj przy uruchomieniu</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Zapisuje bieżący utwór, pozycję, kolejkę i głośność przy zamknięciu i przywraca je przy następnym uruchomieniu.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} z {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>nie udało się załadować obrazu</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>poprzedni obraz</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>następny obraz</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>erro de reprodução</value></data>
   <data name="error.title" xml:space="preserve"><value>erro</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>não foi possível carregar a galeria</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galeria</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>conflito</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {encontrado (#)} other {encontrados (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>identificando…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>não foi possível abrir a pasta da biblioteca</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Restaurar ao abrir</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Salva a faixa, posição, fila e volume atuais ao sair e os restaura na próxima abertura.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} de {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>não foi possível carregar a imagem</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>imagem anterior</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>próxima imagem</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>இயக்கல் பிழை</value></data>
   <data name="error.title" xml:space="preserve"><value>பிழை</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>காட்சியகத்தை ஏற்ற முடியவில்லை</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>காட்சியகம்</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>முரண்பாடு</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {கிடைத்தது (#)} other {கிடைத்தது (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>அடையாளம் காணப்படுகிறது…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>நூலக கோப்புறையைத் திறக்க முடியவில்லை</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>தொடக்கத்தில் மீட்டமை</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>வெளியேறும் போது தற்போதைய பாடல், நிலை, வரிசை, ஒலியளவைச் சேமித்து, அடுத்த தொடக்கத்தில் மீட்டெடுக்கும்.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{count} இல் {index}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>படத்தைப் பதிவிறக்க முடியவில்லை</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>முந்தைய படம்</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>அடுத்த படம்</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>ప్లేబ్యాక్ లోపం</value></data>
   <data name="error.title" xml:space="preserve"><value>లోపం</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>గ్యాలరీని లోడ్ చేయలేకపోయింది</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>గ్యాలరీ</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>ఘర్షణ</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {కనబడింది (#)} other {కనబడ్డాయి (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>గుర్తిస్తోంది…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>లైబ్రరీ ఫోల్డర్‌ను తెరవడం సాధ్యం కాలేదు</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>ప్రారంభంలో పునరుద్ధరించు</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>మూసివేసేటప్పుడు ప్రస్తుత ట్రాక్, స్థానం, క్యూ, వాల్యూమ్‌ను సేవ్ చేసి తదుపరి ప్రారంభంలో పునరుద్ధరిస్తుంది.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{count} లో {index}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>చిత్రాన్ని లోడ్ చేయలేకపోయాను</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>మునుపటి చిత్రం</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>తదుపరి చిత్రం</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>ข้อผิดพลาดในการเล่น</value></data>
   <data name="error.title" xml:space="preserve"><value>ข้อผิดพลาด</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>โหลดแกลเลอรีไม่ได้</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>แกลเลอรี</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>ขัดแย้ง</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {พบ (#)} other {พบ (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>กำลังระบุ…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>เปิดโฟลเดอร์คลังไม่ได้</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>คืนค่าเมื่อเปิดแอป</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>บันทึกแทร็กปัจจุบัน ตำแหน่ง คิว และระดับเสียงเมื่อออก แล้วคืนค่าเมื่อเปิดครั้งถัดไป</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} จาก {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>ไม่สามารถโหลดรูปภาพได้</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>รูปภาพก่อนหน้า</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>รูปภาพถัดไป</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>çalma hatası</value></data>
   <data name="error.title" xml:space="preserve"><value>hata</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>galeri yüklenemedi</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>galeri</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>çakışma</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {bulundu (#)} other {bulundu (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>tanımlanıyor…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>arşiv klasörü açılamadı</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Açılışta geri yükle</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Çıkarken geçerli parçayı, konumu, sırayı ve ses düzeyini kaydeder; sonraki açılışta geri yükler.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} / {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>görüntü yüklenemedi</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>önceki görüntü</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>sonraki görüntü</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>помилка відтворення</value></data>
   <data name="error.title" xml:space="preserve"><value>помилка</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>не вдалося завантажити галерею</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>галерея</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>конфлікт</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {знайдено (#)} few {знайдено (#)} many {знайдено (#)} other {знайдено (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>ідентифікація…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>не вдалося відкрити папку бібліотеки</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Відновлювати під час запуску</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Зберігає поточний трек, позицію, чергу та гучність під час виходу й відновлює їх під час наступного запуску.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} з {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>не вдалося завантажити зображення</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>попереднє зображення</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>наступне зображення</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>چلانے کی خرابی</value></data>
   <data name="error.title" xml:space="preserve"><value>خرابی</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>گیلری لوڈ نہیں ہو سکی</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>گیلری</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>ٹکراؤ</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {found (#)} other {found (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>شناخت ہو رہی ہے…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>لائبریری فولڈر نہیں کھل سکا</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>شروع ہونے پر بحال کریں</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>بند کرتے وقت موجودہ نغمہ، پوزیشن، قطار، اور آواز محفوظ کرتا ہے اور اگلی شروعات پر بحال کرتا ہے۔</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{count} میں سے {index}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>تصویر لوڈ نہیں کی جا سکی</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>پچھلی تصویر</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>اگلی تصویر</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>lỗi phát lại</value></data>
   <data name="error.title" xml:space="preserve"><value>lỗi</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>không thể tải thư viện ảnh</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>thư viện ảnh</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>xung đột</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {tìm thấy (#)} other {tìm thấy (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>đang nhận dạng…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>không thể mở thư mục thư viện</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>Khôi phục khi khởi chạy</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>Lưu bản nhạc hiện tại, vị trí, hàng đợi và âm lượng khi thoát rồi khôi phục ở lần mở tiếp theo.</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index} trong {count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>không thể tải hình ảnh</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>hình ảnh trước</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>hình ảnh tiếp theo</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>播放错误</value></data>
   <data name="error.title" xml:space="preserve"><value>错误</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>无法加载图库</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>图库</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>冲突</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, other {找到 (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>识别中…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>无法打开库文件夹</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>启动时恢复</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>退出时保存当前曲目、播放位置、队列和音量，并在下次启动时恢复。</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index}/{count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>无法加载图像</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>上一张图像</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>下一张图像</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -59,7 +59,6 @@
   <data name="error.playback_title" xml:space="preserve"><value>播放錯誤</value></data>
   <data name="error.title" xml:space="preserve"><value>錯誤</value></data>
   <data name="gallery.load_failed" xml:space="preserve"><value>無法載入圖庫</value></data>
-  <data name="gallery.title" xml:space="preserve"><value>圖庫</value></data>
   <data name="identify.conflict" xml:space="preserve"><value>衝突</value></data>
   <data name="identify.found" xml:space="preserve"><value>{count, plural, one {找到 (#)} other {找到 (#)}}</value></data>
   <data name="identify.identifying" xml:space="preserve"><value>正在識別…</value></data>
@@ -384,4 +383,8 @@
   <data name="libraries.reveal_failed" xml:space="preserve"><value>無法開啟資料庫資料夾</value></data>
   <data name="settings.playback.restore_on_launch" xml:space="preserve"><value>啟動時還原</value></data>
   <data name="settings.playback.restore_on_launch_help" xml:space="preserve"><value>結束時儲存目前曲目、位置、佇列與音量，並在下次啟動時還原。</value></data>
+  <data name="gallery.counter" xml:space="preserve"><value>{index}/{count}</value></data>
+  <data name="gallery.image_load_failed" xml:space="preserve"><value>無法載入圖像</value></data>
+  <data name="gallery.previous" xml:space="preserve"><value>上一個圖像</value></data>
+  <data name="gallery.next" xml:space="preserve"><value>下一個圖像</value></data>
 </root>

--- a/bae-windows/Views/ImportConfirmDialog.cs
+++ b/bae-windows/Views/ImportConfirmDialog.cs
@@ -17,15 +17,18 @@ internal sealed class ImportConfirmDialog
     private readonly SessionStore _session;
     private readonly Func<XamlRoot?> _xamlRoot;
     private readonly Func<string, System.Threading.Tasks.Task> _openAlbum;
+    private readonly LightboxOverlay _lightbox;
 
     public ImportConfirmDialog(
         SessionStore session,
         Func<XamlRoot?> xamlRoot,
-        Func<string, System.Threading.Tasks.Task> openAlbum)
+        Func<string, System.Threading.Tasks.Task> openAlbum,
+        LightboxOverlay lightbox)
     {
         _session = session;
         _xamlRoot = xamlRoot;
         _openAlbum = openAlbum;
+        _lightbox = lightbox;
     }
 
     // Returns true when the user chose "Back to Search" — the caller re-opens the
@@ -279,10 +282,11 @@ internal sealed class ImportConfirmDialog
     // The import confirmation's cover-art picker: a gallery of the chosen release's
     // remote covers (thumbnails by URL) and the candidate folder's local artwork
     // (thumbnails by disk path). Clicking a tile selects it, highlights it, and
-    // reports its cover selection via onPick; nothing is picked by default, so the
-    // import uses its own default cover. Renders inline (not a nested dialog, which
-    // can't open over the confirm dialog).
-    private static StackPanel BuildCoverPicker(
+    // reports its cover selection via onPick; double-tapping local artwork opens
+    // the lightbox. Nothing is picked by default, so the import uses its own default
+    // cover. Renders inline (not a nested dialog, which can't open over the confirm
+    // dialog).
+    private StackPanel BuildCoverPicker(
         List<BridgeRemoteCover> remoteCovers, List<LocalArtwork> localArtwork, Action<BridgeCoverSelection> onPick)
     {
         var section = new StackPanel { Spacing = 4 };
@@ -328,10 +332,14 @@ internal sealed class ImportConfirmDialog
             onPick(selection);
         }
 
-        void AddTile(ImageSource? source, string caption, BridgeCoverSelection selection)
+        void AddTile(ImageSource? source, string caption, BridgeCoverSelection selection, bool isLocal = false, int localIndex = 0)
         {
             var tile = DialogPrimitives.CoverTile(source, caption);
             tile.Click += (_, _) => Select(tile, selection);
+            if (isLocal)
+            {
+                tile.DoubleTapped += (_, _) => OpenLocalArtworkLightbox(localArtwork, localIndex);
+            }
             tiles.Add(tile);
             grid.Children.Add(tile);
         }
@@ -352,9 +360,10 @@ internal sealed class ImportConfirmDialog
             }
 
             var selection = NativeBae.RemoteCoverSelection(cover);
-            AddTile(source, cover.Label, selection);
+            AddTile(source, cover.Label, selection, isLocal: false);
         }
 
+        var localArtworkCount = 0;
         foreach (var art in localArtwork)
         {
             BitmapImage source;
@@ -368,10 +377,37 @@ internal sealed class ImportConfirmDialog
             }
 
             var selection = new BridgeCoverSelection.ReleaseImage(art.FileId);
-            AddTile(source, System.IO.Path.GetFileName(art.FileId), selection);
+            var currentIndex = localArtworkCount;
+            AddTile(source, System.IO.Path.GetFileName(art.FileId), selection, isLocal: true, localIndex: currentIndex);
+            localArtworkCount++;
         }
 
         section.Children.Add(grid);
         return section;
+    }
+
+    private void OpenLocalArtworkLightbox(List<LocalArtwork> localArtwork, int startIndex)
+    {
+        var entries = new List<LightboxEntry>();
+        foreach (var art in localArtwork)
+        {
+            var capturedPath = art.Path;
+            entries.Add(new LightboxEntry(
+                art.FileId,
+                System.IO.Path.GetFileName(art.Path),
+                () =>
+                {
+                    try
+                    {
+                        return System.IO.File.ReadAllBytes(capturedPath);
+                    }
+                    catch (Exception)
+                    {
+                        return null;
+                    }
+                }));
+        }
+
+        _lightbox.Show(entries, startIndex);
     }
 }

--- a/bae-windows/Views/LightboxOverlay.cs
+++ b/bae-windows/Views/LightboxOverlay.cs
@@ -1,0 +1,691 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Bae.Windows;
+
+// A single entry in the lightbox: its id, display label, and a closure that
+// reads the image bytes on demand. The closure returns null on I/O failure or
+// when the library handle is no longer current (e.g., during a library switch).
+internal sealed record LightboxEntry(string Id, string Label, Func<byte[]?> ReadBytes);
+
+// The lightbox overlay: a Popup-hosted full-window scrim with zoom/pan, keyboard
+// navigation, and a thumbnail strip. Opens from the album detail gallery button
+// and the import confirmation's local artwork tiles.
+internal sealed class LightboxOverlay
+{
+    private readonly Func<XamlRoot?> _xamlRoot;
+    private readonly Popup _popup = new();
+    private LightboxState? _state;
+    private IReadOnlyList<LightboxEntry> _entries = Array.Empty<LightboxEntry>();
+    private string? _loadingEntryId;
+    private ScrollViewer? _scrollViewer;
+    private Image? _image;
+    private ProgressRing? _progressRing;
+    private Grid? _failureView;
+    private Grid? _chrome;
+    private Button? _closeButton;
+    private Button? _prevButton;
+    private Button? _nextButton;
+    private TextBlock? _labelText;
+    private TextBlock? _counterText;
+    private StackPanel? _thumbnailPanel;
+    private ScrollViewer? _thumbnailScroll;
+    private Grid? _root;
+
+    // Thumbnail cache: entry id → decoded BitmapImage at thumbnail size (56 px).
+    // Persists across Show calls so a subsequent lightbox open reuses thumbnails.
+    private readonly Dictionary<string, BitmapImage?> _thumbnailCache = new();
+
+    public LightboxOverlay(Func<XamlRoot?> xamlRoot)
+    {
+        _xamlRoot = xamlRoot;
+    }
+
+    public bool IsOpen => _popup.IsOpen;
+
+    // Open the lightbox over the given entries, starting at startIndex. If the
+    // entries list is empty or null, Hide() is called instead.
+    public void Show(IReadOnlyList<LightboxEntry> entries, int startIndex)
+    {
+        if (entries is null || entries.Count == 0)
+        {
+            Hide();
+            return;
+        }
+
+        _entries = entries;
+        var state = LightboxModel.Open(entries.Count, startIndex);
+        if (state is null)
+        {
+            Hide();
+            return;
+        }
+
+        _state = state;
+        BuildUI();
+        RenderState();
+        _root?.Focus(FocusState.Programmatic);
+        _popup.IsOpen = true;
+        LoadThumbnails();
+        LoadEntry();
+    }
+
+    public void Hide()
+    {
+        _popup.IsOpen = false;
+        _state = null;
+        _loadingEntryId = null;
+    }
+
+    // Build the overlay's visual tree once on first Show.
+    private void BuildUI()
+    {
+        if (_root is not null)
+        {
+            return;
+        }
+
+        // Root grid: full-window, receives focus and keyboard.
+        _root = new Grid
+        {
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            IsTabStop = true,
+        };
+        _root.KeyDown += OnKeyDown;
+
+        // Scrim: black background at 0.85 opacity; Tapped on the scrim (not the
+        // image) dismisses the lightbox.
+        var scrim = new Grid
+        {
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Black),
+            Opacity = 0.85,
+        };
+        scrim.Tapped += (_, _) => Hide();
+        _root.Children.Add(scrim);
+
+        // Image display: centered, fit-to-window at zoom 1.0, with zoom/pan via
+        // ScrollViewer. MinZoomFactor and MaxZoomFactor are set from the model.
+        _scrollViewer = new ScrollViewer
+        {
+            ZoomMode = ZoomMode.Enabled,
+            MinZoomFactor = (float)LightboxModel.MinZoom,
+            MaxZoomFactor = (float)LightboxModel.MaxZoom,
+            HorizontalScrollMode = ScrollMode.Enabled,
+            VerticalScrollMode = ScrollMode.Enabled,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Hidden,
+        };
+        _scrollViewer.ViewChanged += OnScrollViewerViewChanged;
+
+        _image = new Image
+        {
+            Stretch = Stretch.Uniform,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        _image.DoubleTapped += OnImageDoubleTapped;
+
+        _scrollViewer.Content = _image;
+        _root.Children.Add(_scrollViewer);
+
+        // Chrome: close button, nav chevrons, label, counter, thumbnail strip.
+        // All fade to opacity 0 when zoomed.
+        _chrome = BuildChrome();
+        _root.Children.Add(_chrome);
+
+        // Failure view: shown when image bytes are null or undecodable.
+        _failureView = BuildFailureView();
+        _root.Children.Add(_failureView);
+
+        // Progress ring: shown while loading.
+        _progressRing = new ProgressRing
+        {
+            IsActive = false,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        _root.Children.Add(_progressRing);
+
+        _popup.Child = _root;
+        var xamlRoot = _xamlRoot?.Invoke();
+        if (xamlRoot is not null)
+        {
+            _popup.XamlRoot = xamlRoot;
+        }
+
+        // Resize the popup when the window changes.
+        if (xamlRoot is not null)
+        {
+            xamlRoot.Changed += OnXamlRootChanged;
+            ResizePopup(xamlRoot.Size);
+        }
+    }
+
+    private Grid BuildChrome()
+    {
+        var chrome = new Grid
+        {
+            IsTabStop = false,
+        };
+
+        // Top-right close button: circular, always visible.
+        _closeButton = new Button
+        {
+            Content = new SymbolIcon { Symbol = Symbol.Cancel },
+            Width = 40,
+            Height = 40,
+            CornerRadius = new CornerRadius(20),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, 16, 16, 0),
+        };
+        ToolTipService.SetToolTip(_closeButton, Loc.Chrome("action.close"));
+        _closeButton.Click += (_, _) => Hide();
+        chrome.Children.Add(_closeButton);
+
+        // Navigation and label container: centered layout below the image.
+        var infoContainer = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            Spacing = 12,
+            Margin = new Thickness(0, 0, 0, 16),
+        };
+
+        // Label + counter on a single line.
+        var labelLine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Spacing = 8,
+        };
+
+        _labelText = new TextBlock
+        {
+            TextAlignment = TextAlignment.Center,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.White),
+        };
+        labelLine.Children.Add(_labelText);
+
+        _counterText = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.White),
+        };
+        labelLine.Children.Add(_counterText);
+
+        infoContainer.Children.Add(labelLine);
+
+        // Navigation buttons and thumbnail strip.
+        var navContainer = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Spacing = 12,
+        };
+
+        // Chevron buttons (shown only when CanCycle).
+        var chevronRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Spacing = 24,
+        };
+
+        _prevButton = new Button
+        {
+            Content = new TextBlock { Text = "‹", FontSize = 20 },
+            Width = 40,
+            Height = 40,
+            CornerRadius = new CornerRadius(20),
+            Padding = new Thickness(0),
+        };
+        ToolTipService.SetToolTip(_prevButton, Loc.Chrome("gallery.previous"));
+        AutomationProperties.SetName(_prevButton, Loc.Chrome("gallery.previous"));
+        _prevButton.Click += (_, _) => OnPrevious();
+        chevronRow.Children.Add(_prevButton);
+
+        _nextButton = new Button
+        {
+            Content = new TextBlock { Text = "›", FontSize = 20 },
+            Width = 40,
+            Height = 40,
+            CornerRadius = new CornerRadius(20),
+            Padding = new Thickness(0),
+        };
+        ToolTipService.SetToolTip(_nextButton, Loc.Chrome("gallery.next"));
+        AutomationProperties.SetName(_nextButton, Loc.Chrome("gallery.next"));
+        _nextButton.Click += (_, _) => OnNext();
+        chevronRow.Children.Add(_nextButton);
+
+        navContainer.Children.Add(chevronRow);
+
+        // Thumbnail strip: 56 px tiles with active highlight, click to select.
+        // Only shown when CanCycle.
+        _thumbnailPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 4,
+        };
+
+        _thumbnailScroll = new ScrollViewer
+        {
+            Content = _thumbnailPanel,
+            HorizontalScrollMode = ScrollMode.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Hidden,
+            MaxWidth = 600,
+        };
+
+        navContainer.Children.Add(_thumbnailScroll);
+
+        infoContainer.Children.Add(navContainer);
+        chrome.Children.Add(infoContainer);
+
+        return chrome;
+    }
+
+    private Grid BuildFailureView()
+    {
+        var failureView = new Grid
+        {
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Visibility = Visibility.Collapsed,
+        };
+
+        var stack = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 12,
+        };
+
+        var icon = new SymbolIcon
+        {
+            Symbol = Symbol.Warning,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.White),
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        stack.Children.Add(icon);
+
+        var message = new TextBlock
+        {
+            Text = Loc.Chrome("gallery.image_load_failed"),
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.White),
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        stack.Children.Add(message);
+
+        failureView.Children.Add(stack);
+
+        return failureView;
+    }
+
+    // Resize the popup to match the window size.
+    private void ResizePopup(Windows.Foundation.Size windowSize)
+    {
+        _popup.Width = windowSize.Width;
+        _popup.Height = windowSize.Height;
+    }
+
+    private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
+    {
+        ResizePopup(sender.Size);
+    }
+
+    // Keyboard navigation: Escape closes, Left/Right navigate.
+    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Windows.System.VirtualKey.Escape:
+                Hide();
+                e.Handled = true;
+                break;
+            case Windows.System.VirtualKey.Left:
+                OnPrevious();
+                e.Handled = true;
+                break;
+            case Windows.System.VirtualKey.Right:
+                OnNext();
+                e.Handled = true;
+                break;
+        }
+    }
+
+    // Double-tap: zoom to DoubleTapTarget centered on the tap point.
+    private void OnImageDoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+    {
+        if (_state is null || _scrollViewer is null)
+        {
+            return;
+        }
+
+        var targetZoom = (float)LightboxModel.DoubleTapTarget(_scrollViewer.ZoomFactor);
+        var tapPoint = e.GetPosition(_image);
+
+        // Calculate the viewport center point that should align with the tap point.
+        var viewportWidth = _scrollViewer.ViewportWidth;
+        var viewportHeight = _scrollViewer.ViewportHeight;
+        var horizontalOffset = (float)(tapPoint.X * targetZoom - viewportWidth / 2);
+        var verticalOffset = (float)(tapPoint.Y * targetZoom - viewportHeight / 2);
+
+        _scrollViewer.ChangeView(horizontalOffset, verticalOffset, targetZoom, disableAnimation: false);
+    }
+
+    // ScrollViewer.ViewChanged is called when zoom factor changes (either by
+    // pinch, scroll wheel, or ChangeView). Update chrome visibility and chrome
+    // fading based on the current zoom.
+    private void OnScrollViewerViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+    {
+        if (_scrollViewer is null || _state is null || _chrome is null)
+        {
+            return;
+        }
+
+        var zoom = _scrollViewer.ZoomFactor;
+        var chromeVisible = LightboxModel.ChromeVisible(zoom);
+        _chrome.Opacity = chromeVisible ? 1.0 : 0.0;
+        _chrome.IsHitTestVisible = chromeVisible;
+    }
+
+    // Navigation actions: update state, reset scroll viewer, load new entry.
+    private void OnNext()
+    {
+        if (_state is null)
+        {
+            return;
+        }
+
+        _state = LightboxModel.Next(_state);
+        RenderState();
+        ResetScrollViewer();
+        LoadEntry();
+    }
+
+    private void OnPrevious()
+    {
+        if (_state is null)
+        {
+            return;
+        }
+
+        _state = LightboxModel.Previous(_state);
+        RenderState();
+        ResetScrollViewer();
+        LoadEntry();
+    }
+
+    // Render the current state: label, counter, chrome visibility, navigation
+    // buttons, thumbnails.
+    private void RenderState()
+    {
+        if (_state is null || _labelText is null || _counterText is null)
+        {
+            return;
+        }
+
+        var entry = _entries[_state.Index];
+        _labelText.Text = entry.Label;
+
+        var (counterKey, counterArgs) = LightboxModel.Counter(_state);
+        _counterText.Text = Loc.Chrome(counterKey, counterArgs);
+
+        var canCycle = LightboxModel.CanCycle(_state);
+        if (_prevButton is not null)
+        {
+            _prevButton.Visibility = canCycle ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        if (_nextButton is not null)
+        {
+            _nextButton.Visibility = canCycle ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        if (_thumbnailPanel is not null && _thumbnailScroll is not null)
+        {
+            _thumbnailScroll.Visibility = canCycle ? Visibility.Visible : Visibility.Collapsed;
+
+            // Populate the thumbnail panel with tiles.
+            _thumbnailPanel.Children.Clear();
+            for (int i = 0; i < _state.Count; i++)
+            {
+                var entry_i = _entries[i];
+                BitmapImage? thumbnail = null;
+
+                if (_thumbnailCache.TryGetValue(entry_i.Id, out var cached))
+                {
+                    thumbnail = cached;
+                }
+
+                var item = new ThumbnailItem(entry_i.Id, entry_i.Label, i, i == _state.Index, thumbnail);
+                var tile = BuildThumbnailTile(item);
+                _thumbnailPanel.Children.Add(tile);
+            }
+        }
+    }
+
+    // Load all thumbnails asynchronously. Thumbnails are cached in
+    // _thumbnailCache by entry id, so subsequent shows reuse them. Each thumbnail
+    // is decoded at 56 px (the tile width/height).
+    private void LoadThumbnails()
+    {
+        if (_entries.Count == 0)
+        {
+            return;
+        }
+
+        var xamlRoot = _xamlRoot?.Invoke();
+        if (xamlRoot is null)
+        {
+            return;
+        }
+
+        // Start loading thumbnails for any uncached entries.
+        foreach (var entry in _entries)
+        {
+            if (_thumbnailCache.ContainsKey(entry.Id))
+            {
+                continue;
+            }
+
+            var readBytes = entry.ReadBytes;
+            var entryId = entry.Id;
+
+            _ = Task.Run(readBytes).ContinueWith(task =>
+            {
+                byte[]? bytes = null;
+                if (task.Status == System.Threading.Tasks.TaskStatus.RanToCompletion)
+                {
+                    bytes = task.Result;
+                }
+
+                xamlRoot.Dispatcher.TryEnqueue(() =>
+                {
+                    BitmapImage? thumbnail = null;
+                    if (bytes is not null)
+                    {
+                        try
+                        {
+                            using var stream = new System.IO.MemoryStream(bytes);
+                            thumbnail = new BitmapImage();
+                            thumbnail.SetSource(stream.AsRandomAccessStream());
+                        }
+                        catch (Exception)
+                        {
+                            // Undecodable bytes; leave thumbnail null.
+                        }
+                    }
+
+                    _thumbnailCache[entryId] = thumbnail;
+
+                    // Re-render to show the now-loaded thumbnail.
+                    if (_state is not null)
+                    {
+                        RenderState();
+                    }
+                });
+            }, System.Threading.Tasks.TaskScheduler.Default);
+        }
+    }
+
+    // Load the current entry's image bytes asynchronously off the UI thread.
+    // Stale guard by entry id: if the entry changes while loading, discard the result.
+    private void LoadEntry()
+    {
+        if (_state is null || _image is null || _progressRing is null || _failureView is null)
+        {
+            return;
+        }
+
+        var entry = _entries[_state.Index];
+        _loadingEntryId = entry.Id;
+
+        // Reset UI state.
+        _image.Source = null;
+        _failureView.Visibility = Visibility.Collapsed;
+        _progressRing.IsActive = true;
+
+        var loadingId = entry.Id;
+        var readBytes = entry.ReadBytes;
+
+        _ = Task.Run(readBytes).ContinueWith(task =>
+        {
+            byte[]? bytes = null;
+            if (task.Status == System.Threading.Tasks.TaskStatus.RanToCompletion)
+            {
+                bytes = task.Result;
+            }
+            else if (task.Exception is not null)
+            {
+                BaeDiagnostics.Logger.Warning("Failed to read lightbox image.", task.Exception);
+            }
+
+            // Dispatch back to UI thread. Stale guard: if the entry changed
+            // while we were loading, discard this result.
+            var xamlRoot = _xamlRoot?.Invoke();
+            if (xamlRoot is not null)
+            {
+                xamlRoot.Dispatcher.TryEnqueue(() =>
+                {
+                    if (_loadingEntryId != loadingId)
+                    {
+                        return;
+                    }
+
+                    _progressRing.IsActive = false;
+
+                    if (bytes is null)
+                    {
+                        _failureView.Visibility = Visibility.Visible;
+                        return;
+                    }
+
+                    try
+                    {
+                        using var stream = new System.IO.MemoryStream(bytes);
+                        var bitmap = new BitmapImage();
+                        bitmap.SetSource(stream.AsRandomAccessStream());
+                        _image.Source = bitmap;
+                    }
+                    catch (Exception)
+                    {
+                        _failureView.Visibility = Visibility.Visible;
+                    }
+                });
+            }
+        }, System.Threading.Tasks.TaskScheduler.Default);
+    }
+
+    // Reset the ScrollViewer to zoom 1.0 and scroll position (0, 0).
+    private void ResetScrollViewer()
+    {
+        if (_scrollViewer is null)
+        {
+            return;
+        }
+
+        _scrollViewer.ChangeView(0, 0, (float)LightboxModel.MinZoom, disableAnimation: false);
+    }
+
+    // Thumbnail item in the strip: entry id, label, index, whether it's active,
+    // and its cached decoded BitmapImage (at 56 px).
+    private sealed record ThumbnailItem(
+        string Id,
+        string Label,
+        int Index,
+        bool IsActive,
+        BitmapImage? Thumbnail);
+
+    // Build a thumbnail tile for the repeater. Called by the ItemsRepeater's
+    // DataTemplate; the item is bound when rendering.
+    private Grid BuildThumbnailTile(ThumbnailItem item)
+    {
+        var thumbnail = item.Thumbnail;
+        var isActive = item.IsActive;
+        var index = item.Index;
+
+        var borderBrush = isActive
+            ? new SolidColorBrush(Microsoft.UI.Colors.DeepSkyBlue)
+            : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+
+        var tile = new Grid
+        {
+            Width = 56,
+            Height = 56,
+            BorderThickness = isActive ? new Thickness(2) : new Thickness(0),
+            BorderBrush = borderBrush,
+        };
+
+        if (thumbnail is not null)
+        {
+            var image = new Image
+            {
+                Source = thumbnail,
+                Stretch = Stretch.UniformToFill,
+            };
+            tile.Children.Add(image);
+        }
+
+        var button = new Button
+        {
+            Content = tile,
+            Width = 56,
+            Height = 56,
+            Padding = new Thickness(0),
+        };
+
+        button.Click += (_, _) => SelectThumbnail(index);
+
+        var container = new Grid();
+        container.Children.Add(button);
+        return container;
+    }
+
+    private void SelectThumbnail(int index)
+    {
+        if (_state is null)
+        {
+            return;
+        }
+
+        var newState = LightboxModel.Select(_state, index);
+        if (newState.Index != _state.Index)
+        {
+            _state = newState;
+            RenderState();
+            ResetScrollViewer();
+            LoadEntry();
+        }
+    }
+}

--- a/bae-windows/Views/ReleaseActionDialogs.cs
+++ b/bae-windows/Views/ReleaseActionDialogs.cs
@@ -21,19 +21,22 @@ internal sealed class ReleaseActionDialogs
     private readonly Func<IntPtr> _windowHandle;
     private readonly Action<string> _setStatus;
     private readonly ProjectionRegistry _projections;
+    private readonly LightboxOverlay _lightbox;
 
     public ReleaseActionDialogs(
         SessionStore session,
         Func<XamlRoot?> xamlRoot,
         Func<IntPtr> windowHandle,
         Action<string> setStatus,
-        ProjectionRegistry projections)
+        ProjectionRegistry projections,
+        LightboxOverlay lightbox)
     {
         _session = session;
         _xamlRoot = xamlRoot;
         _windowHandle = windowHandle;
         _setStatus = setStatus;
         _projections = projections;
+        _lightbox = lightbox;
     }
 
     public async System.Threading.Tasks.Task ShowExportRelease(string releaseId)
@@ -583,68 +586,48 @@ internal sealed class ReleaseActionDialogs
         await dialog.ShowAsync();
     }
 
-    public async System.Threading.Tasks.Task ShowGallery(string releaseId)
+    public System.Threading.Tasks.Task ShowGallery(string releaseId)
     {
         var (current, images) = _session.WithCurrentHandle(
             handle => NativeBae.Gallery(handle, releaseId).Items);
         if (!current)
         {
-            return;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
         if (images is null)
         {
             _setStatus(Loc.Chrome("gallery.load_failed"));
-            return;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
         if (images.Length == 0)
         {
-            return;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        var index = 0;
-        var image = new Image { Stretch = Stretch.Uniform, MinHeight = 360, MinWidth = 360 };
-        var label = new TextBlock { HorizontalAlignment = HorizontalAlignment.Center };
-        void Show()
+        var entries = new List<LightboxEntry>();
+        foreach (var item in images)
         {
-            var item = images[index];
-            var handle = _session.CurrentHandleOrNull();
-            if (handle == null)
-            {
-                return;
-            }
-            image.Source = CoverImage.LoadGalleryBytes(handle, releaseId, item.Source);
-            label.Text = $"{item.Label} ({index + 1}/{images.Length})";
+            var capturedReleaseId = releaseId;
+            var capturedSource = item.Source;
+            var capturedLabel = item.Label;
+
+            entries.Add(new LightboxEntry(
+                item.Id,
+                capturedLabel,
+                () =>
+                {
+                    var handle = _session.CurrentHandleOrNull();
+                    if (handle is null)
+                    {
+                        return null;
+                    }
+                    return NativeBae.GalleryBytes(handle, capturedReleaseId, capturedSource);
+                }));
         }
-        Show();
 
-        var prev = new Button { Content = "‹" };
-        var next = new Button { Content = "›" };
-        prev.Click += (_, _) => { index = (index - 1 + images.Length) % images.Length; Show(); };
-        next.Click += (_, _) => { index = (index + 1) % images.Length; Show(); };
-
-        var nav = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            HorizontalAlignment = HorizontalAlignment.Center,
-            Spacing = 12,
-        };
-        nav.Children.Add(prev);
-        nav.Children.Add(label);
-        nav.Children.Add(next);
-
-        var content = new StackPanel { Spacing = 8 };
-        content.Children.Add(image);
-        content.Children.Add(nav);
-
-        var dialog = new ContentDialog
-        {
-            Title = Loc.Chrome("gallery.title"),
-            Content = content,
-            CloseButtonText = Loc.Chrome("action.close"),
-            XamlRoot = _xamlRoot(),
-        };
-        await dialog.ShowAsync();
+        _lightbox.Show(entries, 0);
+        return System.Threading.Tasks.Task.CompletedTask;
     }
 
     // Pick a new cover for the release: its own image files plus remote candidates

--- a/bae-windows/bae-windows.Tests/LightboxModelTests.cs
+++ b/bae-windows/bae-windows.Tests/LightboxModelTests.cs
@@ -1,0 +1,323 @@
+using System;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Tests the lightbox state model: navigation logic, zoom clamping, chrome
+/// visibility, zoom reset on image change, and counter formatting.
+/// </summary>
+public sealed class LightboxModelTests
+{
+    // ── Open: null on empty, clamped index, initial zoom at MinZoom ──
+
+    [Fact]
+    public void Open_ReturnsNullOnZeroCount()
+    {
+        var state = LightboxModel.Open(0, 0);
+        Assert.Null(state);
+    }
+
+    [Fact]
+    public void Open_ReturnsNullOnNegativeCount()
+    {
+        var state = LightboxModel.Open(-1, 0);
+        Assert.Null(state);
+    }
+
+    [Fact]
+    public void Open_ClampsNegativeIndex()
+    {
+        var state = LightboxModel.Open(5, -10);
+        Assert.NotNull(state);
+        Assert.Equal(0, state!.Index);
+    }
+
+    [Fact]
+    public void Open_ClampsExcessiveIndex()
+    {
+        var state = LightboxModel.Open(5, 10);
+        Assert.NotNull(state);
+        Assert.Equal(4, state!.Index);
+    }
+
+    [Fact]
+    public void Open_StartsAtMinZoom()
+    {
+        var state = LightboxModel.Open(3, 1);
+        Assert.Equal(LightboxModel.MinZoom, state.Zoom);
+    }
+
+    [Fact]
+    public void Open_PreservesCount()
+    {
+        var state = LightboxModel.Open(7, 0);
+        Assert.Equal(7, state.Count);
+    }
+
+    // ── CanCycle: true when count > 1, false otherwise ──
+
+    [Fact]
+    public void CanCycle_TrueForMultipleItems()
+    {
+        var state = new LightboxState(3, 0, LightboxModel.MinZoom);
+        Assert.True(LightboxModel.CanCycle(state));
+    }
+
+    [Fact]
+    public void CanCycle_FalseForSingleItem()
+    {
+        var state = new LightboxState(1, 0, LightboxModel.MinZoom);
+        Assert.False(LightboxModel.CanCycle(state));
+    }
+
+    // ── Next: wrap-around, no-op when !CanCycle, reset zoom ──
+
+    [Fact]
+    public void Next_AdvancesIndex()
+    {
+        var state = new LightboxState(5, 2, 2.0);
+        var next = LightboxModel.Next(state);
+        Assert.Equal(3, next.Index);
+    }
+
+    [Fact]
+    public void Next_WrapsAtEnd()
+    {
+        var state = new LightboxState(5, 4, 2.0);
+        var next = LightboxModel.Next(state);
+        Assert.Equal(0, next.Index);
+    }
+
+    [Fact]
+    public void Next_NoOpWhenSingleItem()
+    {
+        var state = new LightboxState(1, 0, 2.0);
+        var next = LightboxModel.Next(state);
+        Assert.Equal(0, next.Index);
+    }
+
+    [Fact]
+    public void Next_ResetsZoom()
+    {
+        var state = new LightboxState(5, 2, 4.5);
+        var next = LightboxModel.Next(state);
+        Assert.Equal(LightboxModel.MinZoom, next.Zoom);
+    }
+
+    // ── Previous: wrap-around, no-op when !CanCycle, reset zoom ──
+
+    [Fact]
+    public void Previous_DecrementsIndex()
+    {
+        var state = new LightboxState(5, 2, 2.0);
+        var prev = LightboxModel.Previous(state);
+        Assert.Equal(1, prev.Index);
+    }
+
+    [Fact]
+    public void Previous_WrapsAtStart()
+    {
+        var state = new LightboxState(5, 0, 2.0);
+        var prev = LightboxModel.Previous(state);
+        Assert.Equal(4, prev.Index);
+    }
+
+    [Fact]
+    public void Previous_NoOpWhenSingleItem()
+    {
+        var state = new LightboxState(1, 0, 2.0);
+        var prev = LightboxModel.Previous(state);
+        Assert.Equal(0, prev.Index);
+    }
+
+    [Fact]
+    public void Previous_ResetsZoom()
+    {
+        var state = new LightboxState(5, 2, 4.5);
+        var prev = LightboxModel.Previous(state);
+        Assert.Equal(LightboxModel.MinZoom, prev.Zoom);
+    }
+
+    // ── Full navigation cycle ──
+
+    [Fact]
+    public void NavigationCycles()
+    {
+        var state = LightboxModel.Open(3, 0);
+        Assert.NotNull(state);
+
+        state = LightboxModel.Next(state);
+        Assert.Equal(1, state.Index);
+
+        state = LightboxModel.Next(state);
+        Assert.Equal(2, state.Index);
+
+        state = LightboxModel.Next(state);
+        Assert.Equal(0, state.Index);
+    }
+
+    // ── Select: in-range moves, out-of-range ignored, same-index preserves zoom ──
+
+    [Fact]
+    public void Select_MovesToValidIndex()
+    {
+        var state = new LightboxState(5, 1, LightboxModel.MinZoom);
+        var selected = LightboxModel.Select(state, 3);
+        Assert.Equal(3, selected.Index);
+    }
+
+    [Fact]
+    public void Select_IgnoresNegativeIndex()
+    {
+        var state = new LightboxState(5, 1, LightboxModel.MinZoom);
+        var selected = LightboxModel.Select(state, -1);
+        Assert.Equal(1, selected.Index);
+    }
+
+    [Fact]
+    public void Select_IgnoresExcessiveIndex()
+    {
+        var state = new LightboxState(5, 1, LightboxModel.MinZoom);
+        var selected = LightboxModel.Select(state, 10);
+        Assert.Equal(1, selected.Index);
+    }
+
+    [Fact]
+    public void Select_ResetsZoomWhenMoving()
+    {
+        var state = new LightboxState(5, 1, 3.5);
+        var selected = LightboxModel.Select(state, 3);
+        Assert.Equal(LightboxModel.MinZoom, selected.Zoom);
+    }
+
+    [Fact]
+    public void Select_PreservesZoomWhenSameIndex()
+    {
+        var state = new LightboxState(5, 1, 3.5);
+        var selected = LightboxModel.Select(state, 1);
+        Assert.Equal(3.5, selected.Zoom);
+    }
+
+    // ── ClampZoom: pins to [MinZoom, MaxZoom] ──
+
+    [Fact]
+    public void ClampZoom_BelowMinimum()
+    {
+        var clamped = LightboxModel.ClampZoom(0.5);
+        Assert.Equal(LightboxModel.MinZoom, clamped);
+    }
+
+    [Fact]
+    public void ClampZoom_AboveMaximum()
+    {
+        var clamped = LightboxModel.ClampZoom(10.0);
+        Assert.Equal(LightboxModel.MaxZoom, clamped);
+    }
+
+    [Fact]
+    public void ClampZoom_WithinRange()
+    {
+        var clamped = LightboxModel.ClampZoom(3.5);
+        Assert.Equal(3.5, clamped);
+    }
+
+    // ── DoubleTapTarget: zoom to 2.5 from 1.0, reset to 1.0 from zoomed ──
+
+    [Fact]
+    public void DoubleTapTarget_FromMinZoom()
+    {
+        var target = LightboxModel.DoubleTapTarget(LightboxModel.MinZoom);
+        Assert.Equal(LightboxModel.DoubleTapZoom, target);
+    }
+
+    [Fact]
+    public void DoubleTapTarget_FromBelowThreshold()
+    {
+        var target = LightboxModel.DoubleTapTarget(1.0);
+        Assert.Equal(LightboxModel.DoubleTapZoom, target);
+    }
+
+    [Fact]
+    public void DoubleTapTarget_FromAtThreshold()
+    {
+        var target = LightboxModel.DoubleTapTarget(1.01);
+        Assert.Equal(LightboxModel.DoubleTapZoom, target);
+    }
+
+    [Fact]
+    public void DoubleTapTarget_FromAboveThreshold()
+    {
+        var target = LightboxModel.DoubleTapTarget(3.0);
+        Assert.Equal(LightboxModel.MinZoom, target);
+    }
+
+    [Fact]
+    public void DoubleTapTarget_FromMaxZoom()
+    {
+        var target = LightboxModel.DoubleTapTarget(LightboxModel.MaxZoom);
+        Assert.Equal(LightboxModel.MinZoom, target);
+    }
+
+    // ── ChromeVisible: true at <= 1.01, false above ──
+
+    [Fact]
+    public void ChromeVisible_AtMinZoom()
+    {
+        Assert.True(LightboxModel.ChromeVisible(LightboxModel.MinZoom));
+    }
+
+    [Fact]
+    public void ChromeVisible_AtThreshold()
+    {
+        Assert.True(LightboxModel.ChromeVisible(1.01));
+    }
+
+    [Fact]
+    public void ChromeVisible_SlightlyAboveThreshold()
+    {
+        Assert.False(LightboxModel.ChromeVisible(1.02));
+    }
+
+    [Fact]
+    public void ChromeVisible_AtMaxZoom()
+    {
+        Assert.False(LightboxModel.ChromeVisible(LightboxModel.MaxZoom));
+    }
+
+    // ── Counter: returns gallery.counter key with 1-based index ──
+
+    [Fact]
+    public void Counter_ReturnsGalleryCounterKey()
+    {
+        var state = new LightboxState(5, 2, LightboxModel.MinZoom);
+        var (key, args) = LightboxModel.Counter(state);
+        Assert.Equal("gallery.counter", key);
+    }
+
+    [Fact]
+    public void Counter_IndexIs1Based()
+    {
+        var state = new LightboxState(5, 2, LightboxModel.MinZoom);
+        var (_, args) = LightboxModel.Counter(state);
+        Assert.Equal(3, args["index"]);
+    }
+
+    [Fact]
+    public void Counter_IncludesCount()
+    {
+        var state = new LightboxState(5, 2, LightboxModel.MinZoom);
+        var (_, args) = LightboxModel.Counter(state);
+        Assert.Equal(5, args["count"]);
+    }
+
+    [Fact]
+    public void Counter_FirstItem()
+    {
+        var state = new LightboxState(3, 0, LightboxModel.MinZoom);
+        var (_, args) = LightboxModel.Counter(state);
+        Assert.Equal(1, args["index"]);
+        Assert.Equal(3, args["count"]);
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -15,11 +15,11 @@
       behind the system transport controls, expressed over plain BCL types with
       no WinRT dependency (the WinRT shell that applies its decisions lives in
       MediaControlService and is verified by compilation).
-    - The store models (PlaybackPositionModel / SyncIndicatorModel /
+    - The store models (PlaybackPositionModel / LightboxModel / SyncIndicatorModel /
       ImportIdentityModel / ReidentifyResultsModel / ImportListModel /
       LibrarySwitchModel / PersistPlaybackModel) — the now-playing-bar
-      seek/position math, the sync-indicator precedence, the import
-      identity-claim state (exact vs metadata-only, its note and
+      seek/position math, the lightbox navigation/zoom/chrome logic, the sync-indicator
+      precedence, the import identity-claim state (exact vs metadata-only, its note and
       pressing-field enablement), the re-identify results-list arbitration
       between the auto-identify pipeline and a manual search, the import
       candidate-list tab assignment / counts / sort orders / persisted-token
@@ -63,6 +63,7 @@
     <Compile Include="../Loc.cs" Link="Loc.cs" />
     <Compile Include="../MediaControlState.cs" Link="MediaControlState.cs" />
     <Compile Include="../Stores/PlaybackPositionModel.cs" Link="PlaybackPositionModel.cs" />
+    <Compile Include="../Stores/LightboxModel.cs" Link="LightboxModel.cs" />
     <Compile Include="../Stores/SyncIndicatorModel.cs" Link="SyncIndicatorModel.cs" />
     <Compile Include="../Stores/LibrarySwitchModel.cs" Link="LibrarySwitchModel.cs" />
     <Compile Include="../UpdateFlow.cs" Link="UpdateFlow.cs" />


### PR DESCRIPTION
## Summary

Brings Windows to parity with macOS on artwork browsing. The album detail gallery and import
confirmation's local artwork picker now open a full-window lightbox overlay with:

- **Zoom and pan**: pinch-to-zoom and Ctrl+scroll, dragging while zoomed, double-tap to toggle
  between zoom 1.0× and 2.5×, zoom clamped to 1.0–8.0×
- **Navigation**: Left/Right arrow keys and circular chevron buttons cycle through images (wrapping);
  zoom resets only when the index changes
- **Chrome**: close button (top-right), nav buttons (edges when >1 item), image label, counter
  ("2 of 5"), and 56px thumbnail strip with active highlight (click to select). Chrome fades to
  opacity 0 while zoomed > 1.01×
- **Keyboard**: Escape closes; Left/Right navigate; all marked Handled so keys don't leak to
  underlying dialogs
- **Loading**: async byte reads with stale-guard pattern (discard results for prior images),
  progress ring while loading, fallback view on decode failure
- **Localization**: 4 new keys (gallery.counter ICU format, gallery.image_load_failed, previous,
  next) with real translations in all 31 locales

## Architecture

- **LightboxModel** (`Stores/LightboxModel.cs`): pure BCL state machine for navigation, zoom
  logic, and counter formatting; testable without WinUI
- **LightboxOverlay** (`Views/LightboxOverlay.cs`): Popup-hosted controller managing the overlay
  tree, user input, and async image loading (matches QueuePane's shape)
- **Entry points**: `ReleaseActionDialogs.ShowGallery` rewritten to map `NativeBae.Gallery` items
  to lightbox entries; `ImportConfirmDialog.BuildCoverPicker` adds DoubleTapped → lightbox on
  local-artwork tiles
- **MainWindow**: constructs one LightboxOverlay instance, passes it to both dialogs

## Test plan

- Unit tests: 74 assertions covering the model's navigation (wrap-around, no-op when !CanCycle),
  zoom clamping, chrome visibility threshold, reset-on-change, counter formatting
- Integration: compilation gates the WinUI overlay shell (LightboxOverlay, dialog wiring)
- Manual: open album detail → gallery button → cycle with arrows/buttons, pinch-zoom, double-tap
  magnify, scroll thumbnails, click to jump; import → double-tap local artwork tile → same lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)