### PR TITLE
Windows: storage filter tabs, sortable columns, and album-detail storage actions

### DIFF
--- a/bae-windows/AlbumDetail.cs
+++ b/bae-windows/AlbumDetail.cs
@@ -39,6 +39,21 @@ public sealed class Release
     public List<Track> Tracks { get; }
     public List<ReleaseFile> Files { get; }
 
+    /// <summary>Whether this release lives in the cloud (Remote) rather than
+    /// locally.</summary>
+    public bool IsManaged => _release.StorageState == BridgeReleaseStorageState.Remote;
+
+    /// <summary>Whether coven keeps this release's blobs pinned (kept offline) on
+    /// this device.</summary>
+    public bool Pinned => _release.Pinned;
+
+    /// <summary>The storage transitions available right now, gated on cloud-home
+    /// by the core; the album-detail storage band renders one button per entry.</summary>
+    public IReadOnlyList<BridgeReleaseStorageAction> StorageActions => _release.StorageActions;
+
+    /// <summary>The transition in flight for this release, or null when idle.</summary>
+    public BridgeReleaseStorageAction? TransferAction => _release.TransferAction;
+
     /// <summary>The picker label.</summary>
     public override string ToString() => DisplayName;
 }

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -45,6 +45,7 @@ public sealed partial class MainWindow : Window
     private readonly SyncStatusStore _sync;
     private readonly PlaybackStore _playback;
     private readonly ProjectionRegistry _projections;
+    private readonly TransferProgressStore _transferProgress;
     private readonly UiEventRouter _router;
     private readonly NowPlayingBarController _nowPlayingBar;
     private readonly ImportStore _import;
@@ -162,12 +163,22 @@ public sealed partial class MainWindow : Window
         ToolTipService.SetToolTip(NpTitle, Loc.Chrome("nowplaying.go_to_album"));
         _import = new ImportStore(_session, _shell, _mediaControls);
         _projections = new ProjectionRegistry();
-        _router = new UiEventRouter(_playback, _shell, _projections, _mediaControls, _import.HandlePreviewEvent);
+        // In-flight release transfers (pin/unpin/manage/unmanage), driven by core's
+        // ReleaseTransferProgress/Ended events the router routes, read by the
+        // storage dialog rows and the album-detail storage band. Constructed before
+        // the router so it can route into it, and shared with the stores below.
+        _transferProgress = new TransferProgressStore();
+        _router = new UiEventRouter(
+            _playback, _shell, _projections, _mediaControls, _import.HandlePreviewEvent, _transferProgress);
         _session.UiEvent += _router.Route;
 
         // The artwork lightbox: opened from the album gallery and the import
         // confirmation's local artwork tiles.
         _lightbox = new LightboxOverlay(() => Content.XamlRoot);
+
+        // The storage sheet's non-UI operations, shared by the storage dialog and
+        // the album-detail storage band so both run transitions the same way.
+        _storage = new StorageStore(_session, _transferProgress);
 
         // Album detail and the per-release action dialogs it opens, plus the queue
         // dialog. Album detail is the shared entry point from the grid, the panes,
@@ -184,22 +195,25 @@ public sealed partial class MainWindow : Window
             () => Content.XamlRoot,
             () => WinRT.Interop.WindowNative.GetWindowHandle(this),
             text => StatusText.Text = text,
-            _releaseActions);
+            _releaseActions,
+            _storage,
+            _transferProgress,
+            _projections);
         _queuePane = new QueuePane(
             _session,
             _playback,
             QueuePaneHost,
             message => _shell.ShowBanner(InfoBarSeverity.Error, Loc.Chrome("error.playback_title"), message));
 
-        // The storage sheet and its non-UI operations. The dialog registers its
-        // live-refresh handlers on the projection registry while open.
-        _storage = new StorageStore(_session);
+        // The storage sheet. The dialog registers its live-refresh handlers on the
+        // projection registry while open.
         _storageDialog = new StorageDialog(
             _session,
             () => Content.XamlRoot,
             () => WinRT.Interop.WindowNative.GetWindowHandle(this),
             _storage,
-            _projections);
+            _projections,
+            _transferProgress);
 
         // The composer/search panes and the library-lifecycle dialogs. The window
         // stays the navigation shell (open/close/switch); these render and drive
@@ -529,6 +543,7 @@ public sealed partial class MainWindow : Window
         _queuePane.Hide();
         _import.Reset();
         _browser.Reset();
+        _transferProgress.Reset();
         SearchBox.Text = string.Empty;
         StatusText.Text = string.Empty;
         _mediaControls.Deactivate();

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -205,6 +205,20 @@ internal static class NativeBae
         return bridgeAction is null ? null : BaeBridgeMethods.BridgeTransferActionKey(bridgeAction.Value);
     }
 
+    /// <summary>The wire tag for a storage action ("pin"/"unpin"/"manage"/
+    /// "unmanage") — the inverse of <see cref="TransferActionKey"/>, used to
+    /// carry a transfer action into the transfer overlay, which is bridge-type
+    /// free.</summary>
+    internal static string TransferActionToken(BridgeReleaseStorageAction action) =>
+        action switch
+        {
+            BridgeReleaseStorageAction.Pin => "pin",
+            BridgeReleaseStorageAction.Unpin => "unpin",
+            BridgeReleaseStorageAction.MakeRemote => "manage",
+            BridgeReleaseStorageAction.MakeLocal => "unmanage",
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown storage action"),
+        };
+
     /// <summary>The libraries discovered on this device.</summary>
     internal static List<BridgeLibrary> Libraries() =>
         BaeBridgeMethods.DiscoverLibraries()
@@ -395,6 +409,16 @@ internal static class NativeBae
             var sort = new BridgeStorageSort(BridgeStorageSortField.AlbumTitle, BridgeStorageSortDirection.Ascending);
             var count = Await(handle.StorageCount(filter));
             return Await(handle.StoragePage(sort, filter, 0, count)).Rows;
+        });
+
+    /// <summary>A single release's live storage fields (state, pin, available
+    /// actions, in-flight transfer), for refreshing the album-detail storage
+    /// band. Null when the release is gone.</summary>
+    internal static (Release? Release, string? Error) ReleaseStorage(AppHandle handle, string releaseId) =>
+        CaptureBridgeValue(() =>
+        {
+            var release = Await(handle.FindReleaseDetail(releaseId));
+            return release is null ? null : new Release(release);
         });
 
     internal static string? PinRelease(AppHandle handle, string releaseId) =>

--- a/bae-windows/Stores/StorageListModel.cs
+++ b/bae-windows/Stores/StorageListModel.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bae.Windows;
+
+// The storage dialog's four filter tabs. All lists every release; Unmanaged and
+// Managed split on storage state; Uploading is driven solely by the release
+// having pending outbox uploads.
+public enum StorageTab { All, Unmanaged, Managed, Uploading }
+
+// The five sortable columns. Storage (the sixth column) is inert, so it has no
+// field here. SortDirection is reused from LibrarySort.cs.
+public enum StorageSortField { AlbumTitle, ArtistNames, Format, FileCount, TotalSize }
+
+// One release row as the model sees it, projected at the dialog edge from a
+// BridgeStorageRow, the outbox snapshot, and the transfer overlay. Pure over
+// primitives so tab membership, ordering, the footer, and the persisted sort are
+// unit-tested apart from the WinUI dialog and the generated bridge types.
+public sealed record StorageListRow(
+    string ReleaseId,
+    string AlbumTitle,
+    string ArtistNames,
+    string? Format,
+    bool IsManaged,
+    bool Pinned,
+    long FileCount,
+    long TotalSize,
+    bool Uploading);
+
+// The storage list's tab/sort/footer logic and its localized vocabulary. Client-
+// side over the one full snapshot the dialog fetches: ordering an album title is
+// a locale-aware compare (the locale never crosses the bridge), and keeping the
+// whole matrix here makes it unit-testable.
+public static class StorageListModel
+{
+    // Tab membership. Uploading reads only the outbox-driven flag, so an
+    // uploading release lists under Uploading regardless of its storage state,
+    // matching core's server-side Uploading filter.
+    public static bool InTab(StorageListRow row, StorageTab tab) => tab switch
+    {
+        StorageTab.All => true,
+        StorageTab.Unmanaged => !row.IsManaged,
+        StorageTab.Managed => row.IsManaged,
+        StorageTab.Uploading => row.Uploading,
+        _ => throw new ArgumentOutOfRangeException(nameof(tab), tab, "Unknown storage tab"),
+    };
+
+    // The rows to display for a tab in sort order. Dedupes by ReleaseId (last
+    // wins, matching the dialog's rowsById), never throws on any input, string
+    // sorts are stable case-insensitive current-culture compares with a null
+    // Format read as empty, numeric sorts on the raw longs, and ties keep
+    // snapshot order.
+    public static List<StorageListRow> Displayed(
+        IReadOnlyList<StorageListRow> rows, StorageTab tab,
+        StorageSortField field, SortDirection direction)
+    {
+        var inTab = DedupedInTab(rows, tab);
+        IEnumerable<StorageListRow> ordered = field switch
+        {
+            StorageSortField.AlbumTitle => OrderString(inTab, row => row.AlbumTitle, direction),
+            StorageSortField.ArtistNames => OrderString(inTab, row => row.ArtistNames, direction),
+            StorageSortField.Format => OrderString(inTab, row => row.Format ?? string.Empty, direction),
+            StorageSortField.FileCount => OrderNumber(inTab, row => row.FileCount, direction),
+            StorageSortField.TotalSize => OrderNumber(inTab, row => row.TotalSize, direction),
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown storage sort field"),
+        };
+        return ordered.ToList();
+    }
+
+    // The footer over the displayed tab: the row count and the summed TotalSize.
+    // Sums arithmetically over the deduped tab, so negative or duplicate rows
+    // never throw.
+    public static (int Count, long TotalSize) Footer(IReadOnlyList<StorageListRow> rows, StorageTab tab)
+    {
+        var inTab = DedupedInTab(rows, tab);
+        return (inTab.Count, inTab.Sum(row => row.TotalSize));
+    }
+
+    // Header click: the active field flips direction; a new field selects it
+    // ascending.
+    public static (StorageSortField Field, SortDirection Direction) Toggle(
+        StorageSortField currentField, SortDirection currentDirection, StorageSortField clicked) =>
+        clicked == currentField
+            ? (currentField, currentDirection == SortDirection.Ascending
+                ? SortDirection.Descending
+                : SortDirection.Ascending)
+            : (clicked, SortDirection.Ascending);
+
+    public static string TabLabelKey(StorageTab tab) => tab switch
+    {
+        StorageTab.All => "storage.tab.all",
+        StorageTab.Unmanaged => "storage.tab.unmanaged",
+        StorageTab.Managed => "storage.tab.managed",
+        StorageTab.Uploading => "storage.tab.uploading",
+        _ => throw new ArgumentOutOfRangeException(nameof(tab), tab, "Unknown storage tab"),
+    };
+
+    public static string ColumnLabelKey(StorageSortField field) => field switch
+    {
+        StorageSortField.AlbumTitle => "storage.column.album",
+        StorageSortField.ArtistNames => "storage.column.artist",
+        StorageSortField.Format => "storage.column.format",
+        StorageSortField.FileCount => "storage.column.files",
+        StorageSortField.TotalSize => "storage.column.size",
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown storage sort field"),
+    };
+
+    // The inert sixth column's header label.
+    public static string StorageColumnLabelKey => "storage.column.storage";
+
+    // The persisted sort token, locale-free, "field:direction".
+    public static string Serialize(StorageSortField field, SortDirection direction) =>
+        $"{FieldToken(field)}:{DirectionToken(direction)}";
+
+    // Parse a persisted token back to a field and direction. An absent, empty, or
+    // unparseable token degrades to albumTitle ascending — a sort preference
+    // degrades to the default rather than failing.
+    public static (StorageSortField Field, SortDirection Direction) ParseSort(string? token)
+    {
+        var parts = token?.Split(':');
+        if (parts is { Length: 2 }
+            && TryParseField(parts[0], out var field)
+            && TryParseDirection(parts[1], out var direction))
+        {
+            return (field, direction);
+        }
+        return (StorageSortField.AlbumTitle, SortDirection.Ascending);
+    }
+
+    private static List<StorageListRow> DedupedInTab(IReadOnlyList<StorageListRow> rows, StorageTab tab)
+    {
+        // Last write for a release id wins, keeping its first-seen position so
+        // ties in the sort stay in snapshot order.
+        var deduped = new List<StorageListRow>();
+        var indexById = new Dictionary<string, int>();
+        foreach (var row in rows)
+        {
+            if (indexById.TryGetValue(row.ReleaseId, out var existing))
+            {
+                deduped[existing] = row;
+            }
+            else
+            {
+                indexById[row.ReleaseId] = deduped.Count;
+                deduped.Add(row);
+            }
+        }
+        return deduped.Where(row => InTab(row, tab)).ToList();
+    }
+
+    private static IEnumerable<StorageListRow> OrderString(
+        IEnumerable<StorageListRow> rows, Func<StorageListRow, string> key, SortDirection direction) =>
+        direction == SortDirection.Ascending
+            ? rows.OrderBy(key, StringComparer.CurrentCultureIgnoreCase)
+            : rows.OrderByDescending(key, StringComparer.CurrentCultureIgnoreCase);
+
+    private static IEnumerable<StorageListRow> OrderNumber(
+        IEnumerable<StorageListRow> rows, Func<StorageListRow, long> key, SortDirection direction) =>
+        direction == SortDirection.Ascending ? rows.OrderBy(key) : rows.OrderByDescending(key);
+
+    private static string FieldToken(StorageSortField field) => field switch
+    {
+        StorageSortField.AlbumTitle => "albumTitle",
+        StorageSortField.ArtistNames => "artistNames",
+        StorageSortField.Format => "format",
+        StorageSortField.FileCount => "fileCount",
+        StorageSortField.TotalSize => "totalSize",
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown storage sort field"),
+    };
+
+    private static string DirectionToken(SortDirection direction) => direction switch
+    {
+        SortDirection.Ascending => "ascending",
+        SortDirection.Descending => "descending",
+        _ => throw new ArgumentOutOfRangeException(nameof(direction), direction, "Unknown sort direction"),
+    };
+
+    private static bool TryParseField(string? token, out StorageSortField field)
+    {
+        switch (token)
+        {
+            case "albumTitle": field = StorageSortField.AlbumTitle; return true;
+            case "artistNames": field = StorageSortField.ArtistNames; return true;
+            case "format": field = StorageSortField.Format; return true;
+            case "fileCount": field = StorageSortField.FileCount; return true;
+            case "totalSize": field = StorageSortField.TotalSize; return true;
+            default: field = default; return false;
+        }
+    }
+
+    private static bool TryParseDirection(string? token, out SortDirection direction)
+    {
+        switch (token)
+        {
+            case "ascending": direction = SortDirection.Ascending; return true;
+            case "descending": direction = SortDirection.Descending; return true;
+            default: direction = default; return false;
+        }
+    }
+}
+
+// The in-flight transfer overlay: release id → action token ("pin"/"unpin"/
+// "manage"/"unmanage", the same wire tags NativeBae.TransferActionKey accepts).
+// Apply overwrites; Clear of an unknown id is a no-op returning false; TokenFor
+// returns null when the release is idle. Pure over primitives so the terminal-
+// cleanup and no-op-clear behavior are unit-tested apart from the store shell.
+public sealed class StorageTransferOverlay
+{
+    private readonly Dictionary<string, string> _tokens = new();
+
+    public void Apply(string releaseId, string actionToken) => _tokens[releaseId] = actionToken;
+
+    public bool Clear(string releaseId) => _tokens.Remove(releaseId);
+
+    public string? TokenFor(string releaseId) => _tokens.TryGetValue(releaseId, out var token) ? token : null;
+
+    public IReadOnlyCollection<string> ActiveReleaseIds => _tokens.Keys;
+}

--- a/bae-windows/Stores/StorageSortStore.cs
+++ b/bae-windows/Stores/StorageSortStore.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace Bae.Windows;
+
+// The file-backed half of the storage-list sort persistence: the round-trip
+// token lives in StorageListModel (unit-tested); this only moves that token to
+// and from a blob under the app's local data directory, mirroring how macOS
+// keeps the same preference in UserDefaults. A failed read or write degrades to
+// the default sort rather than taking the app down — the sort is a preference,
+// not durable state. The filter tab is not persisted; it resets to All on each
+// open.
+internal static class StorageSortStore
+{
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "bae",
+        "storage-sort.txt");
+
+    // Load the saved field and direction, or the default when nothing is saved.
+    public static (StorageSortField Field, SortDirection Direction) Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                return StorageListModel.ParseSort(File.ReadAllText(FilePath).Trim());
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not read the saved storage sort.", exception);
+        }
+
+        return StorageListModel.ParseSort(null);
+    }
+
+    public static void Save(StorageSortField field, SortDirection direction)
+    {
+        try
+        {
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, StorageListModel.Serialize(field, direction));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            BaeDiagnostics.Logger.Warning("Could not save the storage sort.", exception);
+        }
+    }
+}

--- a/bae-windows/Stores/StorageStore.cs
+++ b/bae-windows/Stores/StorageStore.cs
@@ -15,14 +15,32 @@ namespace Bae.Windows;
 internal sealed class StorageStore
 {
     private readonly SessionStore _session;
+    private readonly TransferProgressStore _transfers;
     private readonly HashSet<string> _unmanagingReleases = new();
 
-    public StorageStore(SessionStore session)
+    public StorageStore(SessionStore session, TransferProgressStore transfers)
     {
         _session = session;
+        _transfers = transfers;
     }
 
     public bool IsUnmanaging(string releaseId) => _unmanagingReleases.Contains(releaseId);
+
+    // Of the given releases, those with a transition in flight: an outbox upload,
+    // a queued/downloading pin, a running unmanage, or an event-reported transfer
+    // in the overlay. A release in this set offers only Cancel — the storage
+    // actions would race the transition. Returns the outbox read error, if any,
+    // so the caller can surface it like the panel load does.
+    public async System.Threading.Tasks.Task<(HashSet<string> Transitioning, string? Error)> TransitioningReleases(
+        List<string> releaseIds)
+    {
+        var (uploading, uploadError) = await UploadingReleases(releaseIds);
+        var transitioning = new HashSet<string>(uploading);
+        transitioning.UnionWith(await DownloadingReleases(releaseIds));
+        transitioning.UnionWith(releaseIds.Where(IsUnmanaging));
+        transitioning.UnionWith(releaseIds.Where(id => _transfers.TokenFor(id) is not null));
+        return (transitioning, uploadError);
+    }
 
     // The transitions every release in the selection allows, intersected so the
     // menu only offers actions applicable to all. Order follows the first release's

--- a/bae-windows/Stores/TransferProgressStore.cs
+++ b/bae-windows/Stores/TransferProgressStore.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bae.Windows;
+
+// App-lifetime, UI-thread store of in-flight release transfers (pin/unpin/
+// manage/unmanage). Wraps a StorageTransferOverlay and raises Changed so the
+// storage dialog rows and the album-detail storage band re-render their in-flight
+// indicators as core's ReleaseTransferProgress / ReleaseTransferEnded events
+// arrive. Cleared when the library closes or switches, like the other per-library
+// stores, so a transfer from the prior library never bleeds into the next one.
+internal sealed class TransferProgressStore
+{
+    private readonly StorageTransferOverlay _overlay = new();
+
+    public event Action? Changed;
+
+    public void Apply(string releaseId, string actionToken)
+    {
+        _overlay.Apply(releaseId, actionToken);
+        Changed?.Invoke();
+    }
+
+    public void Clear(string releaseId)
+    {
+        if (_overlay.Clear(releaseId))
+        {
+            Changed?.Invoke();
+        }
+    }
+
+    public string? TokenFor(string releaseId) => _overlay.TokenFor(releaseId);
+
+    public IReadOnlyCollection<string> ActiveReleaseIds => _overlay.ActiveReleaseIds;
+
+    // Drop every in-flight entry on library close/switch.
+    public void Reset()
+    {
+        var active = _overlay.ActiveReleaseIds.ToList();
+        if (active.Count == 0)
+        {
+            return;
+        }
+        foreach (var releaseId in active)
+        {
+            _overlay.Clear(releaseId);
+        }
+        Changed?.Invoke();
+    }
+}

--- a/bae-windows/Stores/UiEventRouter.cs
+++ b/bae-windows/Stores/UiEventRouter.cs
@@ -17,19 +17,22 @@ internal sealed class UiEventRouter
     private readonly ProjectionRegistry _projections;
     private readonly MediaControlService _mediaControls;
     private readonly Action<BridgeUiEvent> _importEvents;
+    private readonly TransferProgressStore _transfers;
 
     public UiEventRouter(
         PlaybackStore playback,
         ShellStore shell,
         ProjectionRegistry projections,
         MediaControlService mediaControls,
-        Action<BridgeUiEvent> importEvents)
+        Action<BridgeUiEvent> importEvents,
+        TransferProgressStore transfers)
     {
         _playback = playback;
         _shell = shell;
         _projections = projections;
         _mediaControls = mediaControls;
         _importEvents = importEvents;
+        _transfers = transfers;
     }
 
     public void Route(BridgeUiEvent evt)
@@ -106,11 +109,17 @@ internal sealed class UiEventRouter
             case BridgeUiEvent.CandidateImportLoudnessProgress:
                 _importEvents(evt);
                 break;
-            case BridgeUiEvent.ReleaseTransferProgress:
-            case BridgeUiEvent.ReleaseTransferEnded:
-                // Release-transfer progress/ended carry a pin/unpin/manage/unmanage
-                // in-flight indicator for a release row; the Windows release views
-                // don't render one, so there's no work to do here.
+            case BridgeUiEvent.ReleaseTransferProgress transfer:
+                // A pin/unpin/manage/unmanage transition started: light the
+                // in-flight indicator on the storage row and album-detail band
+                // until the matching ended event lands.
+                _transfers.Apply(transfer.ReleaseId, NativeBae.TransferActionToken(transfer.Action));
+                break;
+            case BridgeUiEvent.ReleaseTransferEnded ended:
+                // The transition finished (success or failure) — clear the
+                // indicator. Core's drop guard guarantees this event even on abort,
+                // so overlay entries cannot leak.
+                _transfers.Clear(ended.ReleaseId);
                 break;
             default:
                 // A BridgeUiEvent variant with no arm above: log the drift so a new

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>لم يتمكن من تحميل الصورة</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>الصورة السابقة</value></data>
   <data name="gallery.next" xml:space="preserve"><value>الصورة التالية</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>الكل</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>غير مُدار</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>مُدار</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>جارٍ الرفع</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>الألبوم</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>الفنان</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>الصيغة</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>التخزين</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ملفات</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>الحجم</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, zero {# إصدار} one {إصدار واحد} two {إصداران} few {# إصدارات} many {# إصدارًا} other {# إصدار}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>الإجمالي: {size}</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>не е възможно да се зареди изображението</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>предишно изображение</value></data>
   <data name="gallery.next" xml:space="preserve"><value>следващо изображение</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Всички</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Неуправлявани</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Управлявани</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Качване</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Албум</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Изпълнител</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Формат</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Хранилище</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Файлове</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Размер</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# издание} other {# издания}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Общо: {size}</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>ছবি লোড করা যায়নি</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>আগের ছবি</value></data>
   <data name="gallery.next" xml:space="preserve"><value>পরবর্তী ছবি</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>সব</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>অপরিচালিত</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>পরিচালিত</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>আপলোড হচ্ছে</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>অ্যালবাম</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>শিল্পী</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>ফরম্যাট</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>স্টোরেজ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ফাইল</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>আকার</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {#টি রিলিজ} other {#টি রিলিজ}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>মোট: {size}</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>obrázek se nepodařilo načíst</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>předchozí obrázek</value></data>
   <data name="gallery.next" xml:space="preserve"><value>další obrázek</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Vše</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Nespravované</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Spravované</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Nahrávání</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Interpret</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Formát</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Úložiště</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Soubory</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Velikost</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# vydání} few {# vydání} many {# vydání} other {# vydání}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Celkem: {size}</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>Bild konnte nicht geladen werden</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>vorheriges Bild</value></data>
   <data name="gallery.next" xml:space="preserve"><value>nächstes Bild</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Alle</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Nicht verwaltet</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Verwaltet</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Wird hochgeladen</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Interpret</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Format</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Speicher</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Dateien</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Größe</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# Release} other {# Releases}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Gesamt: {size}</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>couldn't load image</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>previous image</value></data>
   <data name="gallery.next" xml:space="preserve"><value>next image</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>All</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Unmanaged</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Managed</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Uploading</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Artist</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Format</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Storage</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Files</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Size</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# release} other {# releases}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Total: {size}</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>no se pudo cargar la imagen</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>imagen anterior</value></data>
   <data name="gallery.next" xml:space="preserve"><value>siguiente imagen</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Todos</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Sin gestionar</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Gestionadas</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Subiendo</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Álbum</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Artista</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Formato</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Almacenamiento</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Archivos</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Tamaño</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# lanzamiento} other {# lanzamientos}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Total: {size}</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>impossible de charger l'image</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>image précédente</value></data>
   <data name="gallery.next" xml:space="preserve"><value>image suivante</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Tout</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Non gérés</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Gérés</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Envoi</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Artiste</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Format</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Stockage</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Fichiers</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Taille</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# sortie} other {# sorties}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Total : {size}</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>ચિત્ર લોડ કરી શક્યા નહીં</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>પાછલી ચિત્ર</value></data>
   <data name="gallery.next" xml:space="preserve"><value>આગલી ચિત્ર</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>બધા</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>અસંચાલિત</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>સંચાલિત</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>અપલોડ થઈ રહ્યું છે</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>આલ્બમ</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>કલાકાર</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>બંધારણ</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>સંગ્રહ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ફાઈલો</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>કદ</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# પ્રકાશન} other {# પ્રકાશનો}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>કુલ: {size}</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>לא ניתן היה לטעון את התמונה</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>תמונה קודמת</value></data>
   <data name="gallery.next" xml:space="preserve"><value>תמונה הבאה</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>הכול</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>לא מנוהל</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>מנוהל</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>מעלה</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>אלבום</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>אמן</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>פורמט</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>אחסון</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>קבצים</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>גודל</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {הוצאה #} two {# הוצאות} many {# הוצאות} other {# הוצאות}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>סה״כ: {size}</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>छवि लोड नहीं कर सके</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>पिछली छवि</value></data>
   <data name="gallery.next" xml:space="preserve"><value>अगली छवि</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>सभी</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>अप्रबंधित</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>प्रबंधित</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>अपलोड हो रहा है</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>एल्बम</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>कलाकार</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>प्रारूप</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>स्टोरेज</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>फ़ाइलें</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>आकार</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# रिलीज} other {# रिलीज}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>कुल: {size}</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>nije moguće učitati sliku</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>prethodna slika</value></data>
   <data name="gallery.next" xml:space="preserve"><value>sljedeća slika</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Sve</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Neupravljano</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Upravljano</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Učitavanje</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Izvođač</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Format</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Pohrana</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Datoteke</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Veličina</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# izdanje} few {# izdanja} other {# izdanja}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Ukupno: {size}</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>impossibile caricare l'immagine</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>immagine precedente</value></data>
   <data name="gallery.next" xml:space="preserve"><value>immagine seguente</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Tutti</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Non gestito</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Gestito</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Caricamento</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Artista</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Formato</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Archiviazione</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>File</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Dimensione</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# pubblicazione} other {# pubblicazioni}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Totale: {size}</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>画像を読み込めませんでした</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>前の画像</value></data>
   <data name="gallery.next" xml:space="preserve"><value>次の画像</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>すべて</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>管理対象外</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>管理対象</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>アップロード中</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>アルバム</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>アーティスト</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>フォーマット</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>ストレージ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ファイル</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>サイズ</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# 件のリリース}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>合計：{size}</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>ಚಿತ್ರವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>ಹಿಂದಿನ ಚಿತ್ರ</value></data>
   <data name="gallery.next" xml:space="preserve"><value>ಮುಂದಿನ ಚಿತ್ರ</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>ಎಲ್ಲಾ</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>ನಿರ್ವಹಿಸದ</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>ನಿರ್ವಹಿತ</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>ಅಪ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>ಆಲ್ಬಮ್</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>ಕಲಾವಿದ</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>ಸ್ವರೂಪ</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>ಸಂಗ್ರಹಣೆ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ಫೈಲ್‌ಗಳು</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>ಗಾತ್ರ</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# ಬಿಡುಗಡೆ} other {# ಬಿಡುಗಡೆಗಳು}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>ಒಟ್ಟು: {size}</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>이미지를 로드할 수 없음</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>이전 이미지</value></data>
   <data name="gallery.next" xml:space="preserve"><value>다음 이미지</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>전체</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>자체 관리형</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>관리형</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>업로드 중</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>앨범</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>아티스트</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>형식</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>저장소</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>파일</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>크기</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {#개 릴리스}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>합계: {size}</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>ചിത്രം ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>മുൻഗാമി ചിത്രം</value></data>
   <data name="gallery.next" xml:space="preserve"><value>അടുത്ത ചിത്രം</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>എല്ലാം</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>നിയന്ത്രണമില്ലാത്തത്</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>നിയന്ത്രിതം</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>അപ്ലോഡ് ചെയ്യുന്നു</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>ആൽബം</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>കലാകാരൻ</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>ഫോർമാറ്റ്</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>സംഭരണം</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ഫയലുകൾ</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>വലുപ്പം</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# പതിപ്പ്} other {# പതിപ്പുകൾ}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>ആകെ: {size}</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>प्रतिमा लोड करू शकलो नाही</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>मागील प्रतिमा</value></data>
   <data name="gallery.next" xml:space="preserve"><value>पुढील प्रतिमा</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>सर्व</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>अव्यवस्थापित</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>व्यवस्थापित</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>अपलोड होत आहे</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>अल्बम</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>कलाकार</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>स्वरूप</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>साठवण</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>फायली</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>आकार</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# प्रकाशन} other {# प्रकाशने}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>एकूण: {size}</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>afbeelding kon niet worden geladen</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>vorige afbeelding</value></data>
   <data name="gallery.next" xml:space="preserve"><value>volgende afbeelding</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Alle</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Onbeheerd</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Beheerd</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Uploaden</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Artiest</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Formaat</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Opslag</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Bestanden</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Grootte</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# release} other {# releases}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Totaal: {size}</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>ਤਸਵੀਰ ਲੋਡ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>ਪਿਛਲੀ ਤਸਵੀਰ</value></data>
   <data name="gallery.next" xml:space="preserve"><value>ਅਗਲੀ ਤਸਵੀਰ</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>ਸਭ</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>ਅਪਰਬੰਧਿਤ</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>ਪਰਬੰਧਿਤ</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>ਅੱਪਲੋਡ ਹੋ ਰਿਹਾ ਹੈ</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>ਐਲਬਮ</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>ਕਲਾਕਾਰ</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>ਫਾਰਮੈਟ</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>ਸਟੋਰੇਜ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ਫਾਈਲਾਂ</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>ਆਕਾਰ</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# ਰਿਲੀਜ਼} other {# ਰਿਲੀਜ਼ਾਂ}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>ਕੁੱਲ: {size}</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>nie udało się załadować obrazu</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>poprzedni obraz</value></data>
   <data name="gallery.next" xml:space="preserve"><value>następny obraz</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Wszystkie</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Niezarządzane</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Zarządzane</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Przesyłanie</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Wykonawca</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Format</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Magazyn</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Pliki</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Rozmiar</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# wydanie} few {# wydania} many {# wydań} other {# wydania}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Łącznie: {size}</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>não foi possível carregar a imagem</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>imagem anterior</value></data>
   <data name="gallery.next" xml:space="preserve"><value>próxima imagem</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Todos</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Não gerenciado</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Gerenciado</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Enviando</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Álbum</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Artista</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Formato</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Armazenamento</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Arquivos</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Tamanho</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# lançamento} other {# lançamentos}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Total: {size}</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>படத்தைப் பதிவிறக்க முடியவில்லை</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>முந்தைய படம்</value></data>
   <data name="gallery.next" xml:space="preserve"><value>அடுத்த படம்</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>அனைத்தும்</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>நிர்வகிக்கப்படாதது</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>நிர்வகிக்கப்படுகிறது</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>பதிவேற்றுகிறது</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>ஆல்பம்</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>கலைஞர்</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>வடிவம்</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>சேமிப்பு</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>கோப்புகள்</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>அளவு</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# வெளியீடு} other {# வெளியீடுகள்}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>மொத்தம்: {size}</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>చిత్రాన్ని లోడ్ చేయలేకపోయాను</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>మునుపటి చిత్రం</value></data>
   <data name="gallery.next" xml:space="preserve"><value>తదుపరి చిత్రం</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>అన్నీ</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>నిర్వహించబడలేదు</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>నిర్వహించబడుతోంది</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>అప్‌లోడ్ అవుతోంది</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>ఆల్బమ్</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>కళాకారుడు</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>ఫార్మాట్</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>నిల్వ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ఫైల్‌లు</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>పరిమాణం</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# విడుదల} other {# విడుదలలు}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>మొత్తం: {size}</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>ไม่สามารถโหลดรูปภาพได้</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>รูปภาพก่อนหน้า</value></data>
   <data name="gallery.next" xml:space="preserve"><value>รูปภาพถัดไป</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>ทั้งหมด</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>ไม่ได้จัดการ</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>จัดการแล้ว</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>กำลังอัปโหลด</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>อัลบั้ม</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>ศิลปิน</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>รูปแบบ</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>พื้นที่จัดเก็บ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>ไฟล์</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>ขนาด</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# รีลีส}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>รวม: {size}</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>görüntü yüklenemedi</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>önceki görüntü</value></data>
   <data name="gallery.next" xml:space="preserve"><value>sonraki görüntü</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Tümü</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Yönetilmeyen</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Yönetilen</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Yükleniyor</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Albüm</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Sanatçı</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Biçim</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Depolama</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Dosyalar</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Boyut</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# yayın} other {# yayın}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Toplam: {size}</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>не вдалося завантажити зображення</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>попереднє зображення</value></data>
   <data name="gallery.next" xml:space="preserve"><value>наступне зображення</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Усі</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Некероване</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Кероване</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Вивантаження</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Альбом</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Виконавець</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Формат</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Сховище</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Файли</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Розмір</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# реліз} few {# релізи} many {# релізів} other {# релізу}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Усього: {size}</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>تصویر لوڈ نہیں کی جا سکی</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>پچھلی تصویر</value></data>
   <data name="gallery.next" xml:space="preserve"><value>اگلی تصویر</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>تمام</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>غیر منظم</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>منظم</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>اپ لوڈ ہو رہا ہے</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>البم</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>فنکار</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>ساخت</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>اسٹوریج</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>فائلیں</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>سائز</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# اشاعت} other {# اشاعتیں}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>کل: {size}</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>không thể tải hình ảnh</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>hình ảnh trước</value></data>
   <data name="gallery.next" xml:space="preserve"><value>hình ảnh tiếp theo</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>Tất cả</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>Không được quản lý</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>Được quản lý</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>Đang tải lên</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>Album</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>Nghệ sĩ</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>Định dạng</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>Lưu trữ</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>Tệp</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>Kích thước</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# bản phát hành}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>Tổng: {size}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>无法加载图像</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>上一张图像</value></data>
   <data name="gallery.next" xml:space="preserve"><value>下一张图像</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>全部</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>未托管</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>已托管</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>上传中</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>专辑</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>艺术家</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>格式</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>存储</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>文件</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>大小</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# 个发行}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>总计：{size}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -387,4 +387,16 @@
   <data name="gallery.image_load_failed" xml:space="preserve"><value>無法載入圖像</value></data>
   <data name="gallery.previous" xml:space="preserve"><value>上一個圖像</value></data>
   <data name="gallery.next" xml:space="preserve"><value>下一個圖像</value></data>
+  <data name="storage.tab.all" xml:space="preserve"><value>全部</value></data>
+  <data name="storage.tab.unmanaged" xml:space="preserve"><value>未受管理</value></data>
+  <data name="storage.tab.managed" xml:space="preserve"><value>受管理</value></data>
+  <data name="storage.tab.uploading" xml:space="preserve"><value>上傳中</value></data>
+  <data name="storage.column.album" xml:space="preserve"><value>專輯</value></data>
+  <data name="storage.column.artist" xml:space="preserve"><value>演出者</value></data>
+  <data name="storage.column.format" xml:space="preserve"><value>格式</value></data>
+  <data name="storage.column.storage" xml:space="preserve"><value>儲存空間</value></data>
+  <data name="storage.column.files" xml:space="preserve"><value>檔案</value></data>
+  <data name="storage.column.size" xml:space="preserve"><value>大小</value></data>
+  <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# 個發行}}</value></data>
+  <data name="storage.footer.total" xml:space="preserve"><value>總計：{size}</value></data>
 </root>

--- a/bae-windows/Views/AlbumDetailDialog.cs
+++ b/bae-windows/Views/AlbumDetailDialog.cs
@@ -25,19 +25,28 @@ internal sealed class AlbumDetailDialog
     private readonly Func<IntPtr> _windowHandle;
     private readonly Action<string> _setStatus;
     private readonly ReleaseActionDialogs _releaseActions;
+    private readonly StorageStore _storage;
+    private readonly TransferProgressStore _transfers;
+    private readonly ProjectionRegistry _projections;
 
     public AlbumDetailDialog(
         SessionStore session,
         Func<XamlRoot?> xamlRoot,
         Func<IntPtr> windowHandle,
         Action<string> setStatus,
-        ReleaseActionDialogs releaseActions)
+        ReleaseActionDialogs releaseActions,
+        StorageStore storage,
+        TransferProgressStore transfers,
+        ProjectionRegistry projections)
     {
         _session = session;
         _xamlRoot = xamlRoot;
         _windowHandle = windowHandle;
         _setStatus = setStatus;
         _releaseActions = releaseActions;
+        _storage = storage;
+        _transfers = transfers;
+        _projections = projections;
     }
 
     public async System.Threading.Tasks.Task Show(
@@ -149,10 +158,10 @@ internal sealed class AlbumDetailDialog
         moreButton.Flyout = moreMenu;
         header.Children.Add(moreButton);
 
-        // Export failures surface here, inside the dialog: the window-level banner
-        // is occluded by this modal album-detail dialog, so a banner error would be
-        // invisible until the dialog is dismissed.
-        var exportStatus = new TextBlock
+        // Export and storage-action failures surface here, inside the dialog: the
+        // window-level banner is occluded by this modal album-detail dialog, so a
+        // banner error would be invisible until the dialog is dismissed.
+        var statusLine = new TextBlock
         {
             TextWrapping = TextWrapping.Wrap,
             Visibility = Visibility.Collapsed,
@@ -223,13 +232,126 @@ internal sealed class AlbumDetailDialog
             var addQueueTrack = new MenuFlyoutItem { Text = Loc.Chrome("menu.add_to_queue") };
             addQueueTrack.Click += (_, _) => QueueTrack(track, next: false);
             var exportTrack = new MenuFlyoutItem { Text = Loc.Chrome("menu.export") };
-            exportTrack.Click += async (_, _) => await ExportTrack(track, exportStatus);
+            exportTrack.Click += async (_, _) => await ExportTrack(track, statusLine);
             menu.Items.Add(play);
             menu.Items.Add(playNextTrack);
             menu.Items.Add(addQueueTrack);
             menu.Items.Add(exportTrack);
             menu.ShowAt(element, new FlyoutShowOptions { Position = args.GetPosition(element) });
         };
+
+        // The storage band, mirroring macOS's StorageStatusBand: the selected
+        // release's storage status, and while a transfer is in flight an
+        // indeterminate bar with the verb plus a Cancel; otherwise its storage
+        // action buttons. `storageRelease` carries the live storage fields the
+        // band renders — seeded from the picked release, refreshed on the Release/
+        // Album invalidations and transfer events core emits together.
+        var storageBand = new StackPanel { Spacing = 4 };
+        var storageRelease = selectedRelease;
+
+        void RenderStorageBand()
+        {
+            storageBand.Children.Clear();
+            var release = storageRelease;
+            if (string.IsNullOrEmpty(release.ReleaseId))
+            {
+                return;
+            }
+
+            storageBand.Children.Add(new TextBlock
+            {
+                Text = DialogPrimitives.RestingStorageLabel(release.IsManaged, release.Pinned),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                FontSize = 12,
+            });
+
+            var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            var releaseId = release.ReleaseId;
+            var token = _transfers.TokenFor(releaseId)
+                ?? (release.TransferAction is { } transferAction
+                    ? NativeBae.TransferActionToken(transferAction)
+                    : null);
+            if (token is not null && NativeBae.TransferActionKey(token) is { } verbKey)
+            {
+                row.Children.Add(new ProgressBar
+                {
+                    IsIndeterminate = true,
+                    Width = 120,
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+                row.Children.Add(new TextBlock
+                {
+                    Text = Loc.Core(verbKey),
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+                var cancel = new Button { Content = Loc.Chrome("action.cancel") };
+                cancel.Click += async (_, _) =>
+                {
+                    statusLine.Visibility = Visibility.Collapsed;
+                    var (cancelCurrent, error) = await _session.RunForCurrentHandle(
+                        handle => NativeBae.CancelReleaseTransition(handle, releaseId));
+                    if (!cancelCurrent)
+                    {
+                        return;
+                    }
+                    if (error is not null)
+                    {
+                        statusLine.Text = error;
+                        statusLine.Visibility = Visibility.Visible;
+                    }
+                };
+                row.Children.Add(cancel);
+            }
+            else
+            {
+                foreach (var action in release.StorageActions)
+                {
+                    var act = action;
+                    var button = new Button { Content = DialogPrimitives.StorageActionLabel(act) };
+                    button.Click += async (_, _) =>
+                    {
+                        statusLine.Visibility = Visibility.Collapsed;
+                        var error = await _storage.RunStorageActionForReleases(
+                            act,
+                            new List<string> { releaseId },
+                            () => DialogPrimitives.PickUnmanageFolder(_windowHandle()));
+                        if (error is not null)
+                        {
+                            statusLine.Text = error;
+                            statusLine.Visibility = Visibility.Visible;
+                        }
+                    };
+                    row.Children.Add(button);
+                }
+            }
+            storageBand.Children.Add(row);
+        }
+
+        // Re-fetch the selected release's storage fields and re-render the band.
+        // Skips when the release changed under the await (a newer refresh handles
+        // the new one).
+        async System.Threading.Tasks.Task RefreshStorageBand()
+        {
+            var releaseId = selectedRelease.ReleaseId;
+            if (string.IsNullOrEmpty(releaseId))
+            {
+                RenderStorageBand();
+                return;
+            }
+            var (current2, result2) = await _session.RunForCurrentHandle(
+                handle => NativeBae.ReleaseStorage(handle, releaseId));
+            if (!current2 || selectedRelease.ReleaseId != releaseId)
+            {
+                return;
+            }
+            if (result2.Release is { } fresh)
+            {
+                storageRelease = fresh;
+            }
+            RenderStorageBand();
+        }
+
+        RenderStorageBand();
 
         var content = new StackPanel { Spacing = 8 };
         content.Children.Add(header);
@@ -249,12 +371,15 @@ internal sealed class AlbumDetailDialog
                 {
                     selectedRelease = release;
                     trackList.ItemsSource = selectedRelease.Tracks;
+                    storageRelease = release;
+                    RenderStorageBand();
                 }
             };
             content.Children.Add(releasePicker);
         }
+        content.Children.Add(storageBand);
         content.Children.Add(trackList);
-        content.Children.Add(exportStatus);
+        content.Children.Add(statusLine);
 
         var dialog = new ContentDialog
         {
@@ -308,7 +433,32 @@ internal sealed class AlbumDetailDialog
             dialog.Hide();
         };
 
-        var result = await dialog.ShowAsync();
+        // Keep the storage band live while the dialog is open: a transfer event
+        // re-renders it (overlay-driven), and the Release/Album invalidation core
+        // emits alongside re-fetches its storage fields. Disposed once ShowAsync
+        // returns, the storage-dialog pattern.
+        var registrations = new List<IDisposable>
+        {
+            _projections.Register(typeof(BridgeInvalidation.Release), () => _ = RefreshStorageBand()),
+            _projections.Register(typeof(BridgeInvalidation.Album), () => _ = RefreshStorageBand()),
+        };
+        void OnTransfersChanged() => RenderStorageBand();
+        _transfers.Changed += OnTransfersChanged;
+
+        ContentDialogResult result;
+        try
+        {
+            result = await dialog.ShowAsync();
+        }
+        finally
+        {
+            _transfers.Changed -= OnTransfersChanged;
+            foreach (var registration in registrations)
+            {
+                registration.Dispose();
+            }
+        }
+
         if (editRequested)
         {
             await _releaseActions.ShowEditMetadata(selectedRelease.ReleaseId);
@@ -352,9 +502,9 @@ internal sealed class AlbumDetailDialog
     // track-applicable preset), seed the filename from the configured template,
     // then export to the picked path. Errors surface in the album-detail status
     // line, which the modal doesn't occlude here (the pickers are OS dialogs).
-    private async System.Threading.Tasks.Task ExportTrack(Track track, TextBlock exportStatus)
+    private async System.Threading.Tasks.Task ExportTrack(Track track, TextBlock statusLine)
     {
-        exportStatus.Visibility = Visibility.Collapsed;
+        statusLine.Visibility = Visibility.Collapsed;
         var picker = new global::Windows.Storage.Pickers.FileSavePicker();
         WinRT.Interop.InitializeWithWindow.Initialize(picker, _windowHandle());
         var (settingsCurrent, settings) = await _session.RunForCurrentHandle(NativeBae.GetSettings);
@@ -374,8 +524,8 @@ internal sealed class AlbumDetailDialog
         }
         if (originalExtension is null)
         {
-            exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
-            exportStatus.Visibility = Visibility.Visible;
+            statusLine.Text = Loc.Chrome("track.export.prepare_failed");
+            statusLine.Visibility = Visibility.Visible;
             return;
         }
         var choices = new List<(string Label, string Extension, BridgeExportSelection Selection)>
@@ -406,8 +556,8 @@ internal sealed class AlbumDetailDialog
         }
         if (defaultIndex < 0)
         {
-            exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
-            exportStatus.Visibility = Visibility.Visible;
+            statusLine.Text = Loc.Chrome("track.export.prepare_failed");
+            statusLine.Visibility = Visibility.Visible;
             return;
         }
         formatPicker.SelectedIndex = defaultIndex;
@@ -426,8 +576,8 @@ internal sealed class AlbumDetailDialog
         }
         if (formatPicker.SelectedIndex < 0)
         {
-            exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
-            exportStatus.Visibility = Visibility.Visible;
+            statusLine.Text = Loc.Chrome("track.export.prepare_failed");
+            statusLine.Visibility = Visibility.Visible;
             return;
         }
         var selectedChoice = choices[formatPicker.SelectedIndex];
@@ -458,8 +608,8 @@ internal sealed class AlbumDetailDialog
         }
         if (stem is null)
         {
-            exportStatus.Text = Loc.Chrome("track.export.prepare_failed");
-            exportStatus.Visibility = Visibility.Visible;
+            statusLine.Text = Loc.Chrome("track.export.prepare_failed");
+            statusLine.Visibility = Visibility.Visible;
             return;
         }
         picker.SuggestedFileName = stem;
@@ -478,8 +628,8 @@ internal sealed class AlbumDetailDialog
         }
         if (error is not null)
         {
-            exportStatus.Text = error;
-            exportStatus.Visibility = Visibility.Visible;
+            statusLine.Text = error;
+            statusLine.Visibility = Visibility.Visible;
         }
     }
 

--- a/bae-windows/Views/DialogPrimitives.cs
+++ b/bae-windows/Views/DialogPrimitives.cs
@@ -1,13 +1,52 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using uniffi.bae_bridge;
 
 namespace Bae.Windows;
 
-// Shared dialog building blocks used across the library-lifecycle, import, and
-// album-detail screens.
+// Shared dialog building blocks used across the library-lifecycle, import,
+// album-detail, and storage screens.
 internal static class DialogPrimitives
 {
+    // The folder picker for a make-local (unmanage) transition, run in the app
+    // window. Returns the chosen path, or null when the user cancelled. Shared by
+    // the storage dialog and the album-detail storage band so both take the same
+    // destination for the transfer.
+    internal static async System.Threading.Tasks.Task<string?> PickUnmanageFolder(IntPtr windowHandle)
+    {
+        var picker = new global::Windows.Storage.Pickers.FolderPicker();
+        picker.FileTypeFilter.Add("*");
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, windowHandle);
+        var folder = await picker.PickSingleFolderAsync();
+        return folder?.Path;
+    }
+
+    // The user-facing label for a storage transition, matching the macOS
+    // "Storage…" sheet / context menu wording. Shared by the storage row menu and
+    // the album-detail storage band.
+    internal static string StorageActionLabel(BridgeReleaseStorageAction action) => action switch
+    {
+        BridgeReleaseStorageAction.MakeRemote => Loc.Chrome("storage.action.manage"),
+        BridgeReleaseStorageAction.MakeLocal => Loc.Chrome("storage.action.unmanage"),
+        BridgeReleaseStorageAction.Pin => Loc.Chrome("storage.action.pin"),
+        BridgeReleaseStorageAction.Unpin => Loc.Chrome("storage.action.unpin"),
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown storage action"),
+    };
+
+    // A release's resting storage state, mirroring macOS's precedence: unmanaged
+    // first, then pinned (kept offline), then managed (cloud). Shared by the
+    // storage row's Storage cell and the album-detail band's status line.
+    internal static string RestingStorageLabel(bool isManaged, bool pinned)
+    {
+        if (!isManaged)
+        {
+            return Loc.Chrome("storage.state.unmanaged");
+        }
+        return pinned ? Loc.Chrome("storage.pinned") : Loc.Chrome("storage.state.managed");
+    }
+
     // A dismiss-only error dialog: a title, an optional detail body, and a single
     // "OK" button that closes it.
     internal static async System.Threading.Tasks.Task ShowError(XamlRoot? xamlRoot, string title, string? message = null)

--- a/bae-windows/Views/StorageDialog.cs
+++ b/bae-windows/Views/StorageDialog.cs
@@ -16,24 +16,30 @@ namespace Bae.Windows;
 // running a transition, the action intersection) live on the storage store.
 internal sealed class StorageDialog
 {
+    private const string AscendingArrow = "↑";
+    private const string DescendingArrow = "↓";
+
     private readonly SessionStore _session;
     private readonly Func<XamlRoot?> _xamlRoot;
     private readonly Func<IntPtr> _windowHandle;
     private readonly StorageStore _storage;
     private readonly ProjectionRegistry _projections;
+    private readonly TransferProgressStore _transfers;
 
     public StorageDialog(
         SessionStore session,
         Func<XamlRoot?> xamlRoot,
         Func<IntPtr> windowHandle,
         StorageStore storage,
-        ProjectionRegistry projections)
+        ProjectionRegistry projections,
+        TransferProgressStore transfers)
     {
         _session = session;
         _xamlRoot = xamlRoot;
         _windowHandle = windowHandle;
         _storage = storage;
         _projections = projections;
+        _transfers = transfers;
     }
 
     public async System.Threading.Tasks.Task Show()
@@ -43,7 +49,6 @@ internal sealed class StorageDialog
             return;
         }
 
-        var listPanel = new StackPanel { Spacing = 4, MinWidth = 460 };
         var storageStatus = new TextBlock
         {
             Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
@@ -59,54 +64,110 @@ internal sealed class StorageDialog
         // The current rows, kept so the right-tap menu can resolve a release's
         // allowed actions (for the multi-select intersection) by id.
         var rowsById = new Dictionary<string, BridgeStorageRow>();
+        // The projected list the tab/sort re-render from, plus the per-release
+        // outbox progress the Storage cell reads for its upload badge. Both are
+        // refreshed by LoadStorageRows and read (without a refetch) by RenderRows.
+        var cachedRows = new List<StorageListRow>();
+        var outboxProgress = new Dictionary<string, BridgeUploadProgress>();
 
-        // Each row shows its summary; a left-click toggles its selection and a
-        // right-click opens a menu of the transitions the core says it allows
-        // (carried on the row, gated on cloud-home + pending uploads), plus
-        // cancel for any queued uploads. The same actions run on every selected
-        // release.
-        async System.Threading.Tasks.Task LoadStorageRows()
+        // Filter tab resets to All each open (macOS parity); the sort persists.
+        var activeTab = StorageTab.All;
+        var (sortField, sortDirection) = StorageSortStore.Load();
+
+        var listPanel = new StackPanel { Spacing = 4, MinWidth = 560 };
+        var headerRow = MakeStorageGrid();
+        var footer = new TextBlock
         {
-            var (current, result) = await _session.RunForCurrentHandle(NativeBae.StorageRows);
-            if (!current)
-            {
-                return;
-            }
-            if (result.Error is not null)
-            {
-                storageStatus.Text = result.Error;
-                storageStatus.Visibility = Visibility.Visible;
-                return;
-            }
-            if (result.Rows is null)
-            {
-                storageStatus.Text = Loc.Chrome("storage.load_failed");
-                storageStatus.Visibility = Visibility.Visible;
-                return;
-            }
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+            FontSize = 12,
+        };
 
-            storageStatus.Visibility = Visibility.Collapsed;
-            rowsById.Clear();
-            foreach (var row in result.Rows)
+        // The tab bar: All / Unmanaged / Managed / Uploading. Clicking a tab
+        // clears the selection and re-renders from the cached rows (no refetch).
+        var tabBar = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        var tabButtons = new List<(StorageTab Tab, Button Button)>();
+        foreach (var tab in new[] { StorageTab.All, StorageTab.Unmanaged, StorageTab.Managed, StorageTab.Uploading })
+        {
+            var value = tab;
+            var button = new Button { Content = Loc.Chrome(StorageListModel.TabLabelKey(tab)) };
+            button.Click += (_, _) =>
             {
-                rowsById[row.Release.Id] = row;
-            }
-            // Drop selections for releases no longer present after a transition.
-            selected.IntersectWith(rowsById.Keys);
-
-            listPanel.Children.Clear();
-            foreach (var row in result.Rows)
-            {
-                var text = new TextBlock
+                if (activeTab == value)
                 {
-                    Text = StorageRowSummary(row),
-                    VerticalAlignment = VerticalAlignment.Center,
-                    TextWrapping = TextWrapping.Wrap,
-                };
-                var releaseId = row.Release.Id;
+                    return;
+                }
+                activeTab = value;
+                selected.Clear();
+                RenderRows();
+            };
+            tabButtons.Add((value, button));
+            tabBar.Children.Add(button);
+        }
+
+        // The storage cell's precedence mirrors macOS: an in-flight transfer verb
+        // (from the overlay or the row's own transfer action) wins over the outbox
+        // upload badge, which wins over the resting state.
+        string StorageCellText(BridgeStorageRow row)
+        {
+            var releaseId = row.Release.Id;
+            var token = _transfers.TokenFor(releaseId)
+                ?? (row.Release.TransferAction is { } action ? NativeBae.TransferActionToken(action) : null);
+            if (token is not null && NativeBae.TransferActionKey(token) is { } verbKey)
+            {
+                return Loc.Core(verbKey);
+            }
+            if (outboxProgress.TryGetValue(releaseId, out var progress))
+            {
+                return UploadBadgeLabel(progress);
+            }
+            return DialogPrimitives.RestingStorageLabel(
+                row.Release.StorageState == BridgeReleaseStorageState.Remote, row.Release.Pinned);
+        }
+
+        void RefreshRowHighlights()
+        {
+            foreach (var child in listPanel.Children)
+            {
+                if (child is Border border && border.Tag is string id)
+                {
+                    border.Background = RowBackground(selected.Contains(id));
+                }
+            }
+        }
+
+        // Rebuild the header, list rows, and footer from the cached snapshot for
+        // the active tab and sort — no refetch. The tab buttons and the sortable
+        // column arrows reflect the current selection.
+        void RenderRows()
+        {
+            foreach (var (tab, button) in tabButtons)
+            {
+                StyleTab(button, tab == activeTab);
+            }
+
+            RenderHeader();
+
+            var displayed = StorageListModel.Displayed(cachedRows, activeTab, sortField, sortDirection);
+            listPanel.Children.Clear();
+            foreach (var listRow in displayed)
+            {
+                var releaseId = listRow.ReleaseId;
+                if (!rowsById.TryGetValue(releaseId, out var row))
+                {
+                    continue;
+                }
+
+                var grid = MakeStorageGrid();
+                AddCell(grid, 0, row.Album.Title);
+                AddCell(grid, 1, row.Album.ArtistNames);
+                AddCell(grid, 2, row.Release.Format ?? string.Empty);
+                AddCell(grid, 3, StorageCellText(row));
+                AddCell(grid, 4, Loc.Number(row.Release.FileCount), rightAligned: true);
+                AddCell(grid, 5, Loc.Bytes(row.Release.TotalSize), rightAligned: true);
+
                 var rowBorder = new Border
                 {
-                    Child = text,
+                    Child = grid,
                     // The release id rides on Tag so RefreshRowHighlights can
                     // recolor each row from the current selection.
                     Tag = releaseId,
@@ -151,16 +212,116 @@ internal sealed class StorageDialog
                 listPanel.Children.Add(rowBorder);
             }
 
-            void RefreshRowHighlights()
+            var (count, totalSize) = StorageListModel.Footer(cachedRows, activeTab);
+            footer.Text = $"{Loc.Chrome("storage.footer.releases", "count", count)} · {Loc.Chrome("storage.footer.total", "size", Loc.Bytes(totalSize))}";
+        }
+
+        // The sortable-column header: a button per column. The five data columns
+        // toggle the sort (persisting it) and show the ↑/↓ arrow when active; the
+        // Storage column is inert.
+        void RenderHeader()
+        {
+            headerRow.Children.Clear();
+
+            void AddSortHeader(int column, StorageSortField field, bool rightAligned = false)
             {
-                foreach (var child in listPanel.Children)
+                var active = sortField == field;
+                var arrow = sortDirection == SortDirection.Ascending ? AscendingArrow : DescendingArrow;
+                var label = Loc.Chrome(StorageListModel.ColumnLabelKey(field));
+                var button = new Button
                 {
-                    if (child is Border border && border.Tag is string id)
-                    {
-                        border.Background = RowBackground(selected.Contains(id));
-                    }
+                    Content = active ? $"{label} {arrow}" : label,
+                    Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+                    BorderThickness = new Thickness(0),
+                    Padding = new Thickness(2, 0, 2, 0),
+                    HorizontalAlignment = rightAligned ? HorizontalAlignment.Right : HorizontalAlignment.Left,
+                };
+                button.Click += (_, _) =>
+                {
+                    (sortField, sortDirection) = StorageListModel.Toggle(sortField, sortDirection, field);
+                    StorageSortStore.Save(sortField, sortDirection);
+                    RenderRows();
+                };
+                Grid.SetColumn(button, column);
+                headerRow.Children.Add(button);
+            }
+
+            AddSortHeader(0, StorageSortField.AlbumTitle);
+            AddSortHeader(1, StorageSortField.ArtistNames);
+            AddSortHeader(2, StorageSortField.Format);
+            var storageHeader = new TextBlock
+            {
+                Text = Loc.Chrome(StorageListModel.StorageColumnLabelKey),
+                Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+                VerticalAlignment = VerticalAlignment.Center,
+                Padding = new Thickness(2, 0, 2, 0),
+            };
+            Grid.SetColumn(storageHeader, 3);
+            headerRow.Children.Add(storageHeader);
+            AddSortHeader(4, StorageSortField.FileCount, rightAligned: true);
+            AddSortHeader(5, StorageSortField.TotalSize, rightAligned: true);
+        }
+
+        // Fetch the storage rows and the outbox snapshot, project the list model
+        // rows (with the per-release Uploading flag), cache both, and re-render.
+        async System.Threading.Tasks.Task LoadStorageRows()
+        {
+            var (current, result) = await _session.RunForCurrentHandle(NativeBae.StorageRows);
+            if (!current)
+            {
+                return;
+            }
+            if (result.Error is not null)
+            {
+                storageStatus.Text = result.Error;
+                storageStatus.Visibility = Visibility.Visible;
+                return;
+            }
+            if (result.Rows is null)
+            {
+                storageStatus.Text = Loc.Chrome("storage.load_failed");
+                storageStatus.Visibility = Visibility.Visible;
+                return;
+            }
+
+            // The per-release outbox progress drives both the Uploading tab flag
+            // and the Storage cell's upload badge. A failed outbox read leaves the
+            // rows without the badge rather than failing the whole list.
+            outboxProgress.Clear();
+            var (outboxCurrent, outbox) = await _session.RunForCurrentHandle(NativeBae.OutboxSnapshot);
+            if (!outboxCurrent)
+            {
+                return;
+            }
+            if (outbox.Snapshot is { } snapshot)
+            {
+                foreach (var entry in snapshot.PerRelease)
+                {
+                    outboxProgress[entry.Key] = entry.Value;
                 }
             }
+
+            storageStatus.Visibility = Visibility.Collapsed;
+            rowsById.Clear();
+            cachedRows.Clear();
+            foreach (var row in result.Rows)
+            {
+                rowsById[row.Release.Id] = row;
+                cachedRows.Add(new StorageListRow(
+                    row.Release.Id,
+                    row.Album.Title,
+                    row.Album.ArtistNames,
+                    row.Release.Format,
+                    row.Release.StorageState == BridgeReleaseStorageState.Remote,
+                    row.Release.Pinned,
+                    row.Release.FileCount,
+                    row.Release.TotalSize,
+                    outboxProgress.ContainsKey(row.Release.Id)));
+            }
+            // Drop selections for releases no longer present after a transition.
+            selected.IntersectWith(rowsById.Keys);
+
+            RenderRows();
         }
 
         await LoadStorageRows();
@@ -723,7 +884,10 @@ internal sealed class StorageDialog
         content.Children.Add(downloadsPanel);
         content.Children.Add(exportsPanel);
         content.Children.Add(outboxPanel);
+        content.Children.Add(tabBar);
+        content.Children.Add(headerRow);
         content.Children.Add(listPanel);
+        content.Children.Add(footer);
 
         var dialog = new ContentDialog
         {
@@ -752,28 +916,23 @@ internal sealed class StorageDialog
             _projections.Register(typeof(BridgeInvalidation.Album), () => _ = LoadStorageRows()),
             _projections.Register(typeof(BridgeInvalidation.Release), () => _ = LoadStorageRows()),
         };
+        // A transfer starting or ending re-renders the rows from cache (the row's
+        // Storage cell shows the in-flight verb); the Release invalidation core
+        // emits alongside it refetches the snapshot.
+        void OnTransfersChanged() => RenderRows();
+        _transfers.Changed += OnTransfersChanged;
         try
         {
             await dialog.ShowAsync();
         }
         finally
         {
+            _transfers.Changed -= OnTransfersChanged;
             foreach (var registration in registrations)
             {
                 registration.Dispose();
             }
         }
-    }
-
-    // The folder picker for a make-local (unmanage) transition, run in the app
-    // window. Returns the chosen path, or null when the user cancelled.
-    private async System.Threading.Tasks.Task<string?> PickUnmanageFolder()
-    {
-        var picker = new global::Windows.Storage.Pickers.FolderPicker();
-        picker.FileTypeFilter.Add("*");
-        WinRT.Interop.InitializeWithWindow.Initialize(picker, _windowHandle());
-        var folder = await picker.PickSingleFolderAsync();
-        return folder?.Path;
     }
 
     // Build the right-tap menu for the targeted releases: the intersected storage
@@ -790,18 +949,16 @@ internal sealed class StorageDialog
         // A release with a transition in flight offers only "Cancel" — the
         // storage actions (pin/unmanage/…) would race it. Each transition
         // surfaces differently: an upload sits in the outbox snapshot, a pin in
-        // the download queue snapshot, and an unmanage (a blocking foreground
-        // transfer with no queue) is tracked in the store while it runs. Core
-        // dispatches to whichever is running.
-        var (uploading, uploadError) = await _storage.UploadingReleases(releaseIds);
+        // the download queue snapshot, an unmanage (a blocking foreground
+        // transfer with no queue) is tracked in the store while it runs, and any
+        // event-reported transfer is in the overlay. Core dispatches to whichever
+        // is running.
+        var (transitioning, uploadError) = await _storage.TransitioningReleases(releaseIds);
         if (uploadError is not null)
         {
             storageStatus.Text = uploadError;
             storageStatus.Visibility = Visibility.Visible;
         }
-        var transitioning = new HashSet<string>(uploading);
-        transitioning.UnionWith(await _storage.DownloadingReleases(releaseIds));
-        transitioning.UnionWith(releaseIds.Where(_storage.IsUnmanaging));
         if (transitioning.Count > 0)
         {
             var cancel = new MenuFlyoutItem { Text = Loc.Chrome("action.cancel") };
@@ -832,10 +989,11 @@ internal sealed class StorageDialog
         foreach (var action in _storage.IntersectedStorageActions(releaseIds, rowsById))
         {
             var act = action;
-            var item = new MenuFlyoutItem { Text = StorageActionLabel(act) };
+            var item = new MenuFlyoutItem { Text = DialogPrimitives.StorageActionLabel(act) };
             item.Click += async (_, _) =>
             {
-                var error = await _storage.RunStorageActionForReleases(act, releaseIds, PickUnmanageFolder);
+                var error = await _storage.RunStorageActionForReleases(
+                    act, releaseIds, () => DialogPrimitives.PickUnmanageFolder(_windowHandle()));
                 if (error is not null)
                 {
                     storageStatus.Text = error;
@@ -859,24 +1017,50 @@ internal sealed class StorageDialog
             ? new SolidColorBrush(Microsoft.UI.Colors.SteelBlue) { Opacity = 0.25 }
             : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
 
-    // User-facing label for a storage transition, matching the macOS
-    // "Storage…" sheet / context menu wording.
-    private static string StorageRowSummary(BridgeStorageRow row)
+    // The six-column grid shared by the header and each row: Album and Artist
+    // stretch, Format / Storage auto-size, Files and Size auto-size (right-
+    // aligned in the cell).
+    private static Grid MakeStorageGrid()
     {
-        var format = string.IsNullOrEmpty(row.Release.Format) ? string.Empty : $" · {row.Release.Format}";
-        var files = Loc.Chrome("storage.files", "count", row.Release.FileCount);
-        return $"{row.Album.Title} — {row.Album.ArtistNames}{format} · {files} · {Loc.Bytes(row.Release.TotalSize)} · {StorageStateLabel(row.Release.StorageState)}{PinIndicator(row.Release)}";
+        var grid = new Grid { ColumnSpacing = 8 };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        return grid;
     }
 
-    private static string StorageStateLabel(BridgeReleaseStorageState state) => state switch
+    private static void AddCell(Grid grid, int column, string text, bool rightAligned = false)
     {
-        BridgeReleaseStorageState.Remote => Loc.Chrome("storage.state.managed"),
-        BridgeReleaseStorageState.Local => Loc.Chrome("storage.state.unmanaged"),
-        _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown storage state"),
-    };
+        var block = new TextBlock
+        {
+            Text = text,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+            HorizontalAlignment = rightAligned ? HorizontalAlignment.Right : HorizontalAlignment.Left,
+        };
+        Grid.SetColumn(block, column);
+        grid.Children.Add(block);
+    }
 
-    private static string PinIndicator(BridgeReleaseSummary release) =>
-        release.Pinned ? $" · {Loc.Chrome("storage.pinned")}" : string.Empty;
+    // Emphasize the active tab and gray the inactive ones, matching the import
+    // dialog's tab bar.
+    private static void StyleTab(Button tab, bool active)
+    {
+        tab.FontWeight = active
+            ? Microsoft.UI.Text.FontWeights.SemiBold
+            : Microsoft.UI.Text.FontWeights.Normal;
+        if (active)
+        {
+            tab.ClearValue(Control.ForegroundProperty);
+        }
+        else
+        {
+            tab.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray);
+        }
+    }
 
     private static BridgeDownloadTransferProgress? DownloadProgress(BridgeDownloadState state) =>
         state is BridgeDownloadState.Active active ? active.Progress : null;
@@ -969,13 +1153,4 @@ internal sealed class StorageDialog
 
     private static string DeleteLabel(BridgeDeleteOp delete) =>
         $"{delete.CloudKey} — {Loc.Chrome("outbox.delete.kind")}";
-
-    private static string StorageActionLabel(BridgeReleaseStorageAction action) => action switch
-    {
-        BridgeReleaseStorageAction.MakeRemote => Loc.Chrome("storage.action.manage"),
-        BridgeReleaseStorageAction.MakeLocal => Loc.Chrome("storage.action.unmanage"),
-        BridgeReleaseStorageAction.Pin => Loc.Chrome("storage.action.pin"),
-        BridgeReleaseStorageAction.Unpin => Loc.Chrome("storage.action.unpin"),
-        _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown storage action"),
-    };
 }

--- a/bae-windows/bae-windows.Tests/StorageListModelTests.cs
+++ b/bae-windows/bae-windows.Tests/StorageListModelTests.cs
@@ -1,0 +1,322 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+// The storage list model: tab membership over a mixed snapshot, the five sortable
+// fields in both directions (case-insensitive strings, null format as empty, raw
+// numeric, stable ties), the persisted sort-token round-trip and its degrade-to-
+// default, and the transfer overlay's apply/overwrite/clear/no-op behavior plus
+// terminal-event cleanup.
+public sealed class StorageListModelTests
+{
+    private static StorageListRow Row(
+        string id,
+        string album = "album",
+        string artist = "artist",
+        string? format = "FLAC",
+        bool managed = false,
+        bool pinned = false,
+        long fileCount = 1,
+        long totalSize = 1,
+        bool uploading = false) =>
+        new(id, album, artist, format, managed, pinned, fileCount, totalSize, uploading);
+
+    // ── Tab membership ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void InTab_MixedSnapshotLandsEachRowInTheRightTabs()
+    {
+        var unmanaged = Row("a", managed: false);
+        var managed = Row("b", managed: true);
+        var managedPinned = Row("c", managed: true, pinned: true);
+        var uploadingUnmanaged = Row("d", managed: false, uploading: true);
+
+        Assert.True(StorageListModel.InTab(unmanaged, StorageTab.Unmanaged));
+        Assert.False(StorageListModel.InTab(unmanaged, StorageTab.Managed));
+
+        Assert.True(StorageListModel.InTab(managed, StorageTab.Managed));
+        Assert.False(StorageListModel.InTab(managed, StorageTab.Unmanaged));
+
+        Assert.True(StorageListModel.InTab(managedPinned, StorageTab.Managed));
+
+        // Uploading is driven solely by the flag, regardless of storage state.
+        Assert.True(StorageListModel.InTab(uploadingUnmanaged, StorageTab.Uploading));
+        Assert.True(StorageListModel.InTab(uploadingUnmanaged, StorageTab.Unmanaged));
+        Assert.False(StorageListModel.InTab(managed, StorageTab.Uploading));
+
+        // All contains everything.
+        foreach (var row in new[] { unmanaged, managed, managedPinned, uploadingUnmanaged })
+        {
+            Assert.True(StorageListModel.InTab(row, StorageTab.All));
+        }
+    }
+
+    [Fact]
+    public void Displayed_AllTabContainsEveryRow()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("a", managed: false),
+            Row("b", managed: true),
+            Row("c", managed: true, uploading: true),
+        };
+        var displayed = StorageListModel.Displayed(
+            rows, StorageTab.All, StorageSortField.AlbumTitle, SortDirection.Ascending);
+        Assert.Equal(new[] { "a", "b", "c" }, displayed.Select(row => row.ReleaseId));
+    }
+
+    // ── Sort correctness ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Displayed_AlbumTitleSortIsCaseInsensitiveBothDirections()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("bravo", album: "Bravo"),
+            Row("alpha", album: "alpha"),
+        };
+        Assert.Equal(
+            new[] { "alpha", "bravo" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.AlbumTitle, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+        Assert.Equal(
+            new[] { "bravo", "alpha" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.AlbumTitle, SortDirection.Descending)
+                .Select(row => row.ReleaseId));
+    }
+
+    [Fact]
+    public void Displayed_ArtistNamesSortOrders()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("y", artist: "Yankee"),
+            Row("x", artist: "xray"),
+        };
+        Assert.Equal(
+            new[] { "x", "y" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.ArtistNames, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+    }
+
+    [Fact]
+    public void Displayed_NullFormatSortsAsEmpty()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("has", format: "FLAC"),
+            Row("none", format: null),
+        };
+        // Ascending: empty (null) sorts before "FLAC".
+        Assert.Equal(
+            new[] { "none", "has" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.Format, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+    }
+
+    [Fact]
+    public void Displayed_FileCountAndTotalSizeSortNumerically()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("big", fileCount: 100, totalSize: 9),
+            Row("small", fileCount: 9, totalSize: 100),
+        };
+        // A raw numeric compare, not lexicographic (9 < 100).
+        Assert.Equal(
+            new[] { "small", "big" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.FileCount, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+        Assert.Equal(
+            new[] { "big", "small" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.TotalSize, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+    }
+
+    [Fact]
+    public void Displayed_TiesPreserveSnapshotOrder()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("first", album: "same"),
+            Row("second", album: "SAME"),
+            Row("third", album: "same"),
+        };
+        // Equal titles keep input order in both directions (stable).
+        Assert.Equal(
+            new[] { "first", "second", "third" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.AlbumTitle, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+        Assert.Equal(
+            new[] { "first", "second", "third" },
+            StorageListModel.Displayed(rows, StorageTab.All, StorageSortField.AlbumTitle, SortDirection.Descending)
+                .Select(row => row.ReleaseId));
+    }
+
+    [Fact]
+    public void Toggle_FlipsActiveFieldAndResetsNewField()
+    {
+        // Same field flips direction.
+        Assert.Equal(
+            (StorageSortField.AlbumTitle, SortDirection.Descending),
+            StorageListModel.Toggle(StorageSortField.AlbumTitle, SortDirection.Ascending, StorageSortField.AlbumTitle));
+        Assert.Equal(
+            (StorageSortField.AlbumTitle, SortDirection.Ascending),
+            StorageListModel.Toggle(StorageSortField.AlbumTitle, SortDirection.Descending, StorageSortField.AlbumTitle));
+        // A new field selects it ascending, whatever the prior direction was.
+        Assert.Equal(
+            (StorageSortField.TotalSize, SortDirection.Ascending),
+            StorageListModel.Toggle(StorageSortField.AlbumTitle, SortDirection.Descending, StorageSortField.TotalSize));
+    }
+
+    // ── Persistence round-trip ───────────────────────────────────────────────
+
+    [Fact]
+    public void SerializeParse_RoundTripsEveryFieldAndDirection()
+    {
+        foreach (var field in new[]
+        {
+            StorageSortField.AlbumTitle,
+            StorageSortField.ArtistNames,
+            StorageSortField.Format,
+            StorageSortField.FileCount,
+            StorageSortField.TotalSize,
+        })
+        {
+            foreach (var direction in new[] { SortDirection.Ascending, SortDirection.Descending })
+            {
+                Assert.Equal(
+                    (field, direction),
+                    StorageListModel.ParseSort(StorageListModel.Serialize(field, direction)));
+            }
+        }
+    }
+
+    [Fact]
+    public void ParseSort_GarbageEmptyOrNullDegradesToDefault()
+    {
+        var expected = (StorageSortField.AlbumTitle, SortDirection.Ascending);
+        Assert.Equal(expected, StorageListModel.ParseSort(null));
+        Assert.Equal(expected, StorageListModel.ParseSort(""));
+        Assert.Equal(expected, StorageListModel.ParseSort("bogus"));
+        Assert.Equal(expected, StorageListModel.ParseSort("albumTitle"));
+        Assert.Equal(expected, StorageListModel.ParseSort("albumTitle:sideways"));
+        Assert.Equal(expected, StorageListModel.ParseSort("nope:ascending"));
+    }
+
+    // ── Progress overlay ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Overlay_ApplyTokenForOverwriteAndClear()
+    {
+        var overlay = new StorageTransferOverlay();
+        overlay.Apply("r1", "pin");
+        Assert.Equal("pin", overlay.TokenFor("r1"));
+
+        // A second apply for the same id overwrites.
+        overlay.Apply("r1", "unpin");
+        Assert.Equal("unpin", overlay.TokenFor("r1"));
+
+        Assert.Contains("r1", overlay.ActiveReleaseIds);
+
+        // Clear removes and returns true.
+        Assert.True(overlay.Clear("r1"));
+        Assert.Null(overlay.TokenFor("r1"));
+        Assert.DoesNotContain("r1", overlay.ActiveReleaseIds);
+    }
+
+    [Fact]
+    public void Overlay_ClearOfUnknownIdIsNoOpReturningFalse()
+    {
+        var overlay = new StorageTransferOverlay();
+        // A release id never applied — including one absent from every row of the
+        // current filter — clears to false and throws nothing.
+        Assert.False(overlay.Clear("never-applied"));
+        Assert.Null(overlay.TokenFor("never-applied"));
+        Assert.Empty(overlay.ActiveReleaseIds);
+    }
+
+    [Fact]
+    public void Overlay_TerminalEventCleanupLeavesDisplayedUnaffected()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("visible", managed: true),
+            Row("filtered", managed: false),
+        };
+
+        // A row filtered out of the Managed tab gets an in-flight transfer, then
+        // the ended path clears it. Displayed output stays constant throughout.
+        var overlay = new StorageTransferOverlay();
+        var managedBefore = StorageListModel.Displayed(
+            rows, StorageTab.Managed, StorageSortField.AlbumTitle, SortDirection.Ascending);
+
+        overlay.Apply("filtered", "manage");
+        Assert.True(overlay.Clear("filtered"));
+        Assert.Empty(overlay.ActiveReleaseIds);
+
+        foreach (var tab in new[] { StorageTab.All, StorageTab.Unmanaged, StorageTab.Managed, StorageTab.Uploading })
+        {
+            var before = StorageListModel.Displayed(rows, tab, StorageSortField.AlbumTitle, SortDirection.Ascending);
+            var after = StorageListModel.Displayed(rows, tab, StorageSortField.AlbumTitle, SortDirection.Ascending);
+            Assert.Equal(before.Select(row => row.ReleaseId), after.Select(row => row.ReleaseId));
+        }
+        Assert.Equal(
+            managedBefore.Select(row => row.ReleaseId),
+            StorageListModel.Displayed(rows, StorageTab.Managed, StorageSortField.AlbumTitle, SortDirection.Ascending)
+                .Select(row => row.ReleaseId));
+    }
+
+    // ── Garbage snapshot handling ────────────────────────────────────────────
+
+    [Fact]
+    public void Displayed_DuplicateReleaseIdsLastWins()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("dup", album: "first", totalSize: 10),
+            Row("dup", album: "second", totalSize: 40),
+        };
+        var displayed = StorageListModel.Displayed(
+            rows, StorageTab.All, StorageSortField.AlbumTitle, SortDirection.Ascending);
+        Assert.Single(displayed);
+        Assert.Equal("second", displayed[0].AlbumTitle);
+
+        var footer = StorageListModel.Footer(rows, StorageTab.All);
+        Assert.Equal(1, footer.Count);
+        Assert.Equal(40, footer.TotalSize);
+    }
+
+    [Fact]
+    public void Displayed_HandlesBlankFieldsAndNegativeNumbers()
+    {
+        var rows = new List<StorageListRow>
+        {
+            Row("blank", album: "  ", artist: "", fileCount: -5, totalSize: -20),
+            Row("plain", album: "plain", fileCount: 3, totalSize: 30),
+        };
+        // Negative numbers sum arithmetically, no throw.
+        var footer = StorageListModel.Footer(rows, StorageTab.All);
+        Assert.Equal(2, footer.Count);
+        Assert.Equal(10, footer.TotalSize);
+
+        // Sorting over blank titles/negatives doesn't throw.
+        var displayed = StorageListModel.Displayed(
+            rows, StorageTab.All, StorageSortField.FileCount, SortDirection.Ascending);
+        Assert.Equal(new[] { "blank", "plain" }, displayed.Select(row => row.ReleaseId));
+    }
+
+    [Fact]
+    public void Displayed_EmptySnapshotIsEmptyEveryTabFooterZero()
+    {
+        var rows = new List<StorageListRow>();
+        foreach (var tab in new[] { StorageTab.All, StorageTab.Unmanaged, StorageTab.Managed, StorageTab.Uploading })
+        {
+            Assert.Empty(StorageListModel.Displayed(rows, tab, StorageSortField.AlbumTitle, SortDirection.Ascending));
+            Assert.Equal((0, 0L), StorageListModel.Footer(rows, tab));
+        }
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="../Stores/ImportIdentityModel.cs" Link="ImportIdentityModel.cs" />
     <Compile Include="../Stores/ReidentifyResultsModel.cs" Link="ReidentifyResultsModel.cs" />
     <Compile Include="../Stores/ImportListModel.cs" Link="ImportListModel.cs" />
+    <Compile Include="../Stores/StorageListModel.cs" Link="StorageListModel.cs" />
     <Compile Include="../Stores/ExportQueueModel.cs" Link="ExportQueueModel.cs" />
     <Compile Include="../Stores/WindowBoundsModel.cs" Link="WindowBoundsModel.cs" />
     <Compile Include="../Stores/PersistPlaybackModel.cs" Link="PersistPlaybackModel.cs" />


### PR DESCRIPTION
The Windows storage dialog rendered a flat, fixed-order release table: one fetch of every release, always by album title ascending, with no way to narrow to unmanaged/managed/uploading releases and no way to re-sort. Windows album detail offered no per-release storage actions at all — pin/unpin/manage/unmanage were reachable only by finding the release inside the storage dialog. And Windows was the only platform rendering no in-flight indicator for a running transition: the `ReleaseTransferProgress` / `ReleaseTransferEnded` UiEvents were explicitly dropped, so a release mid-transition looked idle until it finished. All three gaps live in the same dialog/flow, so they ship together.

The list now carries four filter tabs (All / Unmanaged / Managed / Uploading) and five sortable columns, both driven by a new pure `StorageListModel` so the whole tab/sort/footer/overlay matrix is unit-tested apart from WinUI. Filtering and ordering run client-side over the one full snapshot the dialog already fetches, rather than round-tripping the server-side filter/sort parameters: ordering album titles and artist names is a locale-aware compare, and the locale never crosses the bridge, so bae-core cannot do it. The sort persists as a per-preference file (the `ImportSortStore` shape); the filter tab resets to All on each open and selection clears on tab switch, matching macOS's non-persisted state.

A `TransferProgressStore` — fed by the router's now-live `ReleaseTransferProgress`/`ReleaseTransferEnded` arms and cleared on library close/switch — holds the in-flight transitions. Each storage row's Storage cell shows the transfer verb (overlay or the row's own transfer action) over the outbox upload badge over the resting state, and a release mid-transition offers only Cancel. Album detail gains a compact storage band mirroring macOS's status band: the release's storage status, an indeterminate bar with the transfer verb plus Cancel while a transfer runs, else its storage-action buttons — each running the exact `StorageStore` path the dialog uses, so unmanage shares one folder picker hoisted into `DialogPrimitives`. No bae-core, bae-bridge, or non-Windows changes; the twelve new chrome keys are translated across all 31 locale catalogs.

## Test plan
- `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` (257 pass, incl. the new `StorageListModelTests`)
- `python3 scripts/loc-chrome-orphans.py` (0 Windows orphans of 388 keys)
- Windows dialog rendering, event routing, and the album-detail band are verified by compilation plus manual pass, per the split documented in the test csproj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)