### PR TITLE
Add "remove this library from this PC" to bae-windows settings

### DIFF
--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -283,7 +283,8 @@ public sealed partial class MainWindow : Window
             _updateService,
             _projections,
             text => StatusText.Text = text,
-            OpenLibrary);
+            OpenLibrary,
+            CloseLibrary);
 
         RegisterProjections();
 

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -342,6 +342,9 @@ internal static class NativeBae
     internal static string? LockActiveLibrary(AppHandle handle) =>
         CaptureError(() => handle.LockActiveLibrary());
 
+    internal static string? ForgetLibrary(AppHandle handle) =>
+        CaptureError(() => handle.ForgetLibrary());
+
     internal static string? UnlockLibrary(string libraryId, string keyHex) =>
         CaptureError(() => BaeBridgeMethods.UnlockLibrary(libraryId, keyHex));
 

--- a/bae-windows/Stores/ForgetLibraryModel.cs
+++ b/bae-windows/Stores/ForgetLibraryModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Bae.Windows;
+
+// The pure decision layer behind the settings Remove section: which footer and
+// confirmation catalog keys to show, mirroring macOS's forgetConfirmationMessage.
+// Plain BCL types so it is unit-tested apart from the WinUI dialog that renders
+// it and the WithCurrentHandle-read BridgeOutboxSnapshot it derives from.
+public static class ForgetLibraryModel
+{
+    // The gray caption under the section title: which consequence to describe
+    // depends only on whether a cloud home is configured.
+    public static string FooterKey(bool hasCloudHome) =>
+        hasCloudHome ? "settings.remove.footer_synced" : "settings.remove.footer_unsynced";
+
+    // The confirmation body's ordered key list. A never-synced library ignores
+    // the pending-work flag (there is no cloud copy to lose work from); a synced
+    // library calls out queued-but-unlanded work before the final prompt.
+    public static List<string> ConfirmKeys(bool hasCloudHome, bool hasPendingCloudWork)
+    {
+        if (!hasCloudHome)
+        {
+            return ["settings.remove.confirm_unsynced", "settings.remove.confirm_again"];
+        }
+
+        return hasPendingCloudWork
+            ? ["settings.remove.confirm_synced", "settings.remove.confirm_pending", "settings.remove.confirm_again"]
+            : ["settings.remove.confirm_synced", "settings.remove.confirm_again"];
+    }
+
+    // Whether the outbox snapshot has cloud work that hasn't landed yet: queued
+    // uploads or deletes not yet applied to the cloud copy.
+    public static bool HasPendingCloudWork(int uploadGroupCount, long pendingDeletes) =>
+        uploadGroupCount > 0 || pendingDeletes > 0;
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>الحجم</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, zero {# إصدار} one {إصدار واحد} two {إصداران} few {# إصدارات} many {# إصدارًا} other {# إصدار}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>الإجمالي: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>إزالة</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>يؤدي هذا إلى إزالة هذه المكتبة وملفاتها التي تم تنزيلها من هذا الكمبيوتر. تبقى مكتبتك في السحابة كما هي — يمكنك استعادتها من هنا لاحقًا.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>هذه المكتبة غير متزامنة. ستؤدي إزالتها إلى حذف فهرسها نهائيًا — الألبومات وتعديلات البيانات الوصفية وسجل التشغيل. لن يتم حذف ملفات الصوت الموجودة في مجلداتك.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>إزالة هذه المكتبة من هذا الكمبيوتر</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>تبقى مكتبتك في السحابة كما هي — يمكنك استعادتها من شاشة الترحيب لاحقًا.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>لم تتم مزامنة هذه المكتبة قط. سيتم حذف فهرسها نهائيًا؛ لن يتم حذف ملفات الصوت الموجودة في مجلداتك.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>بعض التغييرات لم تنتهِ من الرفع وستُفقد.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>انقر على الزر مرة أخرى للتأكيد.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>تعذّرت إزالة المكتبة: {error}</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Размер</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# издание} other {# издания}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Общо: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Премахване</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Премахва тази библиотека и изтеглените ѝ файлове от този компютър. Библиотеката ви в облака остава непокътната — можете да я възстановите оттук по-късно.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Тази библиотека не е синхронизирана. Премахването ѝ изтрива завинаги каталога ѝ — албуми, редакции на метаданни и история на възпроизвеждане. Аудио файловете в папките ви няма да бъдат изтрити.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>премахване на тази библиотека от този компютър</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Библиотеката ви в облака остава непокътната — можете да я възстановите от началния екран по-късно.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Тази библиотека никога не е била синхронизирана. Каталогът ѝ ще бъде изтрит завинаги; аудио файловете в папките ви няма да бъдат изтрити.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Някои промени все още не са качени и ще бъдат загубени.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Натиснете бутона отново, за да потвърдите.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Библиотеката не можа да бъде премахната: {error}</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>আকার</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {#টি রিলিজ} other {#টি রিলিজ}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>মোট: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>সরান</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>এই লাইব্রেরি এবং এর ডাউনলোড করা ফাইলগুলো এই পিসি থেকে সরিয়ে দেয়। ক্লাউডে আপনার লাইব্রেরি অক্ষত থাকে — আপনি পরে এখান থেকে এটি পুনরুদ্ধার করতে পারবেন।</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>এই লাইব্রেরিটি সিঙ্ক করা নেই। এটি সরালে এর ক্যাটালগ — অ্যালবাম, মেটাডেটা সম্পাদনা এবং প্লে ইতিহাস — স্থায়ীভাবে মুছে যাবে। আপনার ফোল্ডারের অডিও ফাইলগুলো মুছে যাবে না।</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>এই লাইব্রেরিটি এই পিসি থেকে সরান</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>ক্লাউডে আপনার লাইব্রেরি অক্ষত থাকে — আপনি পরে স্বাগত স্ক্রিন থেকে এটি পুনরুদ্ধার করতে পারবেন।</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>এই লাইব্রেরিটি কখনও সিঙ্ক করা হয়নি। এর ক্যাটালগ স্থায়ীভাবে মুছে যাবে; আপনার ফোল্ডারের অডিও ফাইলগুলো মুছে যাবে না।</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>কিছু পরিবর্তন এখনও আপলোড শেষ হয়নি এবং সেগুলো হারিয়ে যাবে।</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>নিশ্চিত করতে বোতামটি আবার ক্লিক করুন।</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>লাইব্রেরি সরানো যায়নি: {error}</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Velikost</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# vydání} few {# vydání} many {# vydání} other {# vydání}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Celkem: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Odebrat</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Odebere tuto knihovnu a její stažené soubory z tohoto počítače. Vaše knihovna v cloudu zůstane nedotčena — později ji můžete odsud obnovit.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Tato knihovna není synchronizována. Jejím odebráním trvale smažete její katalog — alba, úpravy metadat a historii přehrávání. Zvukové soubory ve vašich složkách smazány nebudou.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>odebrat tuto knihovnu z tohoto počítače</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Vaše knihovna v cloudu zůstane nedotčena — později ji můžete obnovit z uvítací obrazovky.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Tato knihovna nebyla nikdy synchronizována. Její katalog bude trvale smazán; zvukové soubory ve vašich složkách smazány nebudou.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Některé změny se ještě nenahrály a budou ztraceny.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Potvrďte dalším kliknutím na tlačítko.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Knihovnu se nepodařilo odebrat: {error}</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Größe</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# Release} other {# Releases}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Gesamt: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Entfernen</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Entfernt diese Bibliothek und ihre heruntergeladenen Dateien von diesem PC. Ihre Bibliothek in der Cloud bleibt unberührt — Sie können sie später von hier aus wiederherstellen.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Diese Bibliothek ist nicht synchronisiert. Beim Entfernen wird ihr Katalog dauerhaft gelöscht — Alben, Metadaten-Änderungen und Wiedergabeverlauf. Audiodateien in Ihren Ordnern werden nicht gelöscht.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>diese Bibliothek von diesem PC entfernen</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Ihre Bibliothek in der Cloud bleibt unberührt — Sie können sie später vom Startbildschirm aus wiederherstellen.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Diese Bibliothek wurde nie synchronisiert. Ihr Katalog wird dauerhaft gelöscht; Audiodateien in Ihren Ordnern werden nicht gelöscht.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Einige Änderungen wurden noch nicht hochgeladen und gehen verloren.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Klicken Sie erneut auf die Schaltfläche, um zu bestätigen.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Bibliothek konnte nicht entfernt werden: {error}</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Size</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# release} other {# releases}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Total: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Remove</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Removes this library and its downloaded files from this PC. Your library in the cloud is untouched — you can restore it here later.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>This library isn't synced. Removing it permanently deletes its catalog — albums, metadata edits, and play history. Audio files in your folders aren't deleted.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>remove this library from this PC</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Your library in the cloud is untouched — you can restore it from the welcome screen later.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>This library has never been synced. Its catalog will be permanently deleted; audio files in your folders aren't deleted.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Some changes haven't finished uploading and will be lost.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Click the button again to confirm.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Couldn't remove library: {error}</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Tamaño</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# lanzamiento} other {# lanzamientos}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Total: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Eliminar</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Elimina esta biblioteca y sus archivos descargados de este equipo. Tu biblioteca en la nube permanece intacta — podrás restaurarla desde aquí más tarde.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Esta biblioteca no está sincronizada. Al eliminarla se borrará permanentemente su catálogo — álbumes, ediciones de metadatos e historial de reproducción. Los archivos de audio de tus carpetas no se eliminarán.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>eliminar esta biblioteca de este equipo</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Tu biblioteca en la nube permanece intacta — podrás restaurarla desde la pantalla de bienvenida más tarde.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Esta biblioteca nunca se ha sincronizado. Su catálogo se eliminará permanentemente; los archivos de audio de tus carpetas no se eliminarán.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Algunos cambios aún no han terminado de subirse y se perderán.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Haz clic en el botón de nuevo para confirmar.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>No se pudo eliminar la biblioteca: {error}</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Taille</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# sortie} other {# sorties}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Total : {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Supprimer</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Supprime cette bibliothèque et ses fichiers téléchargés de ce PC. Votre bibliothèque dans le cloud reste intacte — vous pourrez la restaurer d'ici plus tard.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Cette bibliothèque n'est pas synchronisée. La supprimer efface définitivement son catalogue — albums, modifications de métadonnées et historique de lecture. Les fichiers audio de vos dossiers ne seront pas supprimés.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>supprimer cette bibliothèque de ce PC</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Votre bibliothèque dans le cloud reste intacte — vous pourrez la restaurer depuis l'écran d'accueil plus tard.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Cette bibliothèque n'a jamais été synchronisée. Son catalogue sera définitivement supprimé ; les fichiers audio de vos dossiers ne seront pas supprimés.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Certaines modifications n'ont pas fini de se téléverser et seront perdues.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Cliquez de nouveau sur le bouton pour confirmer.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Impossible de supprimer la bibliothèque : {error}</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>કદ</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# પ્રકાશન} other {# પ્રકાશનો}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>કુલ: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>દૂર કરો</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>આ લાઇબ્રેરી અને તેની ડાઉનલોડ કરેલી ફાઇલોને આ પીસી પરથી દૂર કરે છે. ક્લાઉડમાં તમારી લાઇબ્રેરી અકબંધ રહે છે — તમે પછીથી અહીંથી તેને પુનઃસ્થાપિત કરી શકો છો.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>આ લાઇબ્રેરી સિંક થયેલી નથી. તેને દૂર કરવાથી તેની સૂચિ — આલ્બમ્સ, મેટાડેટા ફેરફારો અને પ્લે ઇતિહાસ — કાયમ માટે ડિલીટ થઈ જશે. તમારા ફોલ્ડર્સમાંની ઓડિયો ફાઇલો ડિલીટ થશે નહીં.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>આ લાઇબ્રેરીને આ પીસી પરથી દૂર કરો</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>ક્લાઉડમાં તમારી લાઇબ્રેરી અકબંધ રહે છે — તમે પછીથી સ્વાગત સ્ક્રીનથી તેને પુનઃસ્થાપિત કરી શકો છો.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>આ લાઇબ્રેરી ક્યારેય સિંક થઈ નથી. તેની સૂચિ કાયમ માટે ડિલીટ થઈ જશે; તમારા ફોલ્ડર્સમાંની ઓડિયો ફાઇલો ડિલીટ થશે નહીં.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>કેટલાક ફેરફારો હજુ અપલોડ થયા નથી અને ગુમ થઈ જશે.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>પુષ્ટિ કરવા માટે બટન પર ફરીથી ક્લિક કરો.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>લાઇબ્રેરી દૂર કરી શકાઈ નથી: {error}</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>גודל</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {הוצאה #} two {# הוצאות} many {# הוצאות} other {# הוצאות}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>סה״כ: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>הסרה</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>מסיר ספרייה זו ואת הקבצים שהורדו שלה ממחשב זה. הספרייה שלך בענן נשארת ללא פגע — תוכל לשחזר אותה מכאן מאוחר יותר.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ספרייה זו אינה מסונכרנת. הסרתה תמחק לצמיתות את הקטלוג שלה — אלבומים, עריכות מטא-נתונים והיסטוריית ניגון. קובצי השמע בתיקיות שלך לא יימחקו.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>הסר ספרייה זו ממחשב זה</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>הספרייה שלך בענן נשארת ללא פגע — תוכל לשחזר אותה ממסך הפתיחה מאוחר יותר.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ספרייה זו מעולם לא סונכרנה. הקטלוג שלה יימחק לצמיתות; קובצי השמע בתיקיות שלך לא יימחקו.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>חלק מהשינויים עדיין לא סיימו להעלות ויאבדו.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>לחץ שוב על הכפתור כדי לאשר.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>לא ניתן היה להסיר את הספרייה: {error}</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>आकार</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# रिलीज} other {# रिलीज}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>कुल: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>हटाएँ</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>यह इस लाइब्रेरी और इसकी डाउनलोड की गई फ़ाइलों को इस पीसी से हटा देता है। क्लाउड में आपकी लाइब्रेरी सुरक्षित रहती है — आप बाद में इसे यहां से पुनर्स्थापित कर सकते हैं।</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>यह लाइब्रेरी सिंक नहीं है। इसे हटाने से इसका कैटलॉग — एल्बम, मेटाडेटा संपादन और प्ले इतिहास — स्थायी रूप से मिट जाएगा। आपके फ़ोल्डरों की ऑडियो फ़ाइलें नहीं मिटेंगी।</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>इस लाइब्रेरी को इस पीसी से हटाएँ</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>क्लाउड में आपकी लाइब्रेरी सुरक्षित रहती है — आप बाद में इसे स्वागत स्क्रीन से पुनर्स्थापित कर सकते हैं।</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>यह लाइब्रेरी कभी सिंक नहीं हुई। इसका कैटलॉग स्थायी रूप से मिट जाएगा; आपके फ़ोल्डरों की ऑडियो फ़ाइलें नहीं मिटेंगी।</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>कुछ बदलाव अभी अपलोड होना बाकी हैं और वे खो जाएंगे।</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>पुष्टि करने के लिए बटन को फिर से क्लिक करें।</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>लाइब्रेरी हटाई नहीं जा सकी: {error}</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Veličina</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# izdanje} few {# izdanja} other {# izdanja}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Ukupno: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Ukloni</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Uklanja ovu fonoteku i njezine preuzete datoteke s ovog računala. Vaša fonoteka u oblaku ostaje netaknuta — kasnije je možete obnoviti odavde.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Ova fonoteka nije sinkronizirana. Njezinim uklanjanjem trajno se briše njezin katalog — albumi, izmjene metapodataka i povijest reprodukcije. Audiodatoteke u vašim mapama neće biti izbrisane.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ukloni ovu fonoteku s ovog računala</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Vaša fonoteka u oblaku ostaje netaknuta — kasnije je možete obnoviti s početnog zaslona.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Ova fonoteka nikada nije bila sinkronizirana. Njezin katalog bit će trajno izbrisan; audiodatoteke u vašim mapama neće biti izbrisane.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Neke se promjene još nisu dovršile prijenos i bit će izgubljene.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Ponovno kliknite gumb za potvrdu.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Fonoteku nije bilo moguće ukloniti: {error}</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Dimensione</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# pubblicazione} other {# pubblicazioni}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Totale: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Rimuovi</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Rimuove questa libreria e i suoi file scaricati da questo PC. La tua libreria nel cloud resta intatta — potrai ripristinarla da qui in seguito.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Questa libreria non è sincronizzata. Rimuoverla eliminerà definitivamente il suo catalogo — album, modifiche ai metadati e cronologia di riproduzione. I file audio nelle tue cartelle non verranno eliminati.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>rimuovi questa libreria da questo PC</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>La tua libreria nel cloud resta intatta — potrai ripristinarla dalla schermata di benvenuto in seguito.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Questa libreria non è mai stata sincronizzata. Il suo catalogo verrà eliminato definitivamente; i file audio nelle tue cartelle non verranno eliminati.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Alcune modifiche non hanno ancora terminato il caricamento e andranno perse.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Fai clic di nuovo sul pulsante per confermare.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Impossibile rimuovere la libreria: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>サイズ</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# 件のリリース}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>合計：{size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>削除</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>このライブラリとダウンロード済みファイルをこの PC から削除します。クラウド上のライブラリはそのまま残るため、後でここから復元できます。</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>このライブラリは同期されていません。削除すると、アルバム、メタデータの編集、再生履歴を含むカタログが完全に削除されます。フォルダー内のオーディオファイルは削除されません。</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>このライブラリをこの PC から削除</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>クラウド上のライブラリはそのまま残るため、後でようこそ画面から復元できます。</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>このライブラリは一度も同期されていません。カタログは完全に削除されます。フォルダー内のオーディオファイルは削除されません。</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>一部の変更のアップロードが完了しておらず、失われます。</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>確認するにはもう一度ボタンをクリックしてください。</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>ライブラリを削除できませんでした: {error}</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>ಗಾತ್ರ</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# ಬಿಡುಗಡೆ} other {# ಬಿಡುಗಡೆಗಳು}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>ಒಟ್ಟು: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>ತೆಗೆದುಹಾಕಿ</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>ಈ ಲೈಬ್ರರಿ ಮತ್ತು ಅದರ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಫೈಲ್‌ಗಳನ್ನು ಈ ಪಿಸಿಯಿಂದ ತೆಗೆದುಹಾಕುತ್ತದೆ. ಕ್ಲೌಡ್‌ನಲ್ಲಿರುವ ನಿಮ್ಮ ಲೈಬ್ರರಿ ಹಾಗೆಯೇ ಉಳಿಯುತ್ತದೆ — ನೀವು ನಂತರ ಇಲ್ಲಿಂದ ಅದನ್ನು ಪುನಃಸ್ಥಾಪಿಸಬಹುದು.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ಈ ಲೈಬ್ರರಿ ಸಿಂಕ್ ಆಗಿಲ್ಲ. ಇದನ್ನು ತೆಗೆದುಹಾಕುವುದರಿಂದ ಅದರ ಕ್ಯಾಟಲಾಗ್ — ಆಲ್ಬಮ್‌ಗಳು, ಮೆಟಾಡೇಟಾ ಬದಲಾವಣೆಗಳು ಮತ್ತು ಪ್ಲೇ ಇತಿಹಾಸ — ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಿಹೋಗುತ್ತದೆ. ನಿಮ್ಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿನ ಆಡಿಯೊ ಫೈಲ್‌ಗಳು ಅಳಿಸಲ್ಪಡುವುದಿಲ್ಲ.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ಈ ಲೈಬ್ರರಿಯನ್ನು ಈ ಪಿಸಿಯಿಂದ ತೆಗೆದುಹಾಕಿ</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>ಕ್ಲೌಡ್‌ನಲ್ಲಿರುವ ನಿಮ್ಮ ಲೈಬ್ರರಿ ಹಾಗೆಯೇ ಉಳಿಯುತ್ತದೆ — ನೀವು ನಂತರ ಸ್ವಾಗತ ಪರದೆಯಿಂದ ಅದನ್ನು ಪುನಃಸ್ಥಾಪಿಸಬಹುದು.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ಈ ಲೈಬ್ರರಿ ಎಂದಿಗೂ ಸಿಂಕ್ ಆಗಿಲ್ಲ. ಅದರ ಕ್ಯಾಟಲಾಗ್ ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಿಹೋಗುತ್ತದೆ; ನಿಮ್ಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿನ ಆಡಿಯೊ ಫೈಲ್‌ಗಳು ಅಳಿಸಲ್ಪಡುವುದಿಲ್ಲ.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>ಕೆಲವು ಬದಲಾವಣೆಗಳು ಇನ್ನೂ ಅಪ್‌ಲೋಡ್ ಮುಗಿಸಿಲ್ಲ ಮತ್ತು ಕಳೆದುಹೋಗುತ್ತವೆ.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>ದೃಢೀಕರಿಸಲು ಬಟನ್ ಅನ್ನು ಮತ್ತೆ ಕ್ಲಿಕ್ ಮಾಡಿ.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>ಲೈಬ್ರರಿಯನ್ನು ತೆಗೆದುಹಾಕಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>크기</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {#개 릴리스}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>합계: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>제거</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>이 PC에서 이 라이브러리와 다운로드된 파일을 제거합니다. 클라우드의 라이브러리는 그대로 유지되므로 나중에 여기서 복원할 수 있습니다.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>이 라이브러리는 동기화되지 않았습니다. 제거하면 앨범, 메타데이터 편집, 재생 기록을 포함한 카탈로그가 영구적으로 삭제됩니다. 폴더 안의 오디오 파일은 삭제되지 않습니다.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>이 PC에서 이 라이브러리 제거</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>클라우드의 라이브러리는 그대로 유지되므로 나중에 시작 화면에서 복원할 수 있습니다.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>이 라이브러리는 한 번도 동기화된 적이 없습니다. 카탈로그가 영구적으로 삭제됩니다. 폴더 안의 오디오 파일은 삭제되지 않습니다.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>일부 변경 사항이 아직 업로드되지 않았으며 손실됩니다.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>확인하려면 버튼을 다시 클릭하세요.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>라이브러리를 제거할 수 없습니다: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>വലുപ്പം</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# പതിപ്പ്} other {# പതിപ്പുകൾ}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>ആകെ: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>നീക്കം ചെയ്യുക</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>ഈ ലൈബ്രറിയും അതിന്റെ ഡൗൺലോഡ് ചെയ്ത ഫയലുകളും ഈ പിസിയിൽ നിന്ന് നീക്കം ചെയ്യുന്നു. ക്ലൗഡിലെ നിങ്ങളുടെ ലൈബ്രറി കേടുകൂടാതെയിരിക്കും — പിന്നീട് ഇവിടെ നിന്ന് അത് പുനഃസ്ഥാപിക്കാം.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ഈ ലൈബ്രറി സമന്വയിപ്പിച്ചിട്ടില്ല. ഇത് നീക്കം ചെയ്യുന്നത് അതിന്റെ കാറ്റലോഗ് — ആൽബങ്ങൾ, മെറ്റാഡാറ്റ എഡിറ്റുകൾ, പ്ലേ ചരിത്രം — ശാശ്വതമായി ഇല്ലാതാക്കും. നിങ്ങളുടെ ഫോൾഡറുകളിലെ ഓഡിയോ ഫയലുകൾ ഇല്ലാതാകില്ല.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ഈ ലൈബ്രറി ഈ പിസിയിൽ നിന്ന് നീക്കം ചെയ്യുക</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>ക്ലൗഡിലെ നിങ്ങളുടെ ലൈബ്രറി കേടുകൂടാതെയിരിക്കും — പിന്നീട് സ്വാഗത സ്ക്രീനിൽ നിന്ന് അത് പുനഃസ്ഥാപിക്കാം.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ഈ ലൈബ്രറി ഒരിക്കലും സമന്വയിപ്പിച്ചിട്ടില്ല. അതിന്റെ കാറ്റലോഗ് ശാശ്വതമായി ഇല്ലാതാകും; നിങ്ങളുടെ ഫോൾഡറുകളിലെ ഓഡിയോ ഫയലുകൾ ഇല്ലാതാകില്ല.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>ചില മാറ്റങ്ങൾ ഇതുവരെ അപ്‌ലോഡ് പൂർത്തിയായിട്ടില്ല, അവ നഷ്ടപ്പെടും.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>സ്ഥിരീകരിക്കാൻ ബട്ടൺ വീണ്ടും ക്ലിക്ക് ചെയ്യുക.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>ലൈബ്രറി നീക്കം ചെയ്യാനായില്ല: {error}</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>आकार</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# प्रकाशन} other {# प्रकाशने}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>एकूण: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>काढून टाका</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>ही लायब्ररी आणि तिच्या डाउनलोड केलेल्या फायली या पीसीवरून काढून टाकते. क्लाउडमधील तुमची लायब्ररी सुरक्षित राहते — तुम्ही नंतर येथून ती पुनर्संचयित करू शकता.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ही लायब्ररी सिंक केलेली नाही. ती काढून टाकल्याने तिचा कॅटलॉग — अल्बम, मेटाडेटा संपादने आणि प्ले इतिहास — कायमचा हटवला जाईल. तुमच्या फोल्डरमधील ऑडिओ फायली हटवल्या जाणार नाहीत.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ही लायब्ररी या पीसीवरून काढून टाका</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>क्लाउडमधील तुमची लायब्ररी सुरक्षित राहते — तुम्ही नंतर स्वागत स्क्रीनवरून ती पुनर्संचयित करू शकता.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ही लायब्ररी कधीही सिंक केलेली नाही. तिचा कॅटलॉग कायमचा हटवला जाईल; तुमच्या फोल्डरमधील ऑडिओ फायली हटवल्या जाणार नाहीत.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>काही बदल अद्याप अपलोड झालेले नाहीत आणि ते गमावले जातील.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>पुष्टी करण्यासाठी बटण पुन्हा क्लिक करा.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>लायब्ररी काढता आली नाही: {error}</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Grootte</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# release} other {# releases}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Totaal: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Verwijderen</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Verwijdert deze bibliotheek en de gedownloade bestanden ervan van deze pc. Je bibliotheek in de cloud blijft ongewijzigd — je kunt hem later vanaf hier herstellen.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Deze bibliotheek is niet gesynchroniseerd. Het verwijderen ervan wist de catalogus permanent — albums, metagegevenswijzigingen en afspeelgeschiedenis. Audiobestanden in je mappen worden niet verwijderd.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>deze bibliotheek van deze pc verwijderen</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Je bibliotheek in de cloud blijft ongewijzigd — je kunt hem later vanaf het welkomstscherm herstellen.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Deze bibliotheek is nooit gesynchroniseerd. De catalogus wordt permanent verwijderd; audiobestanden in je mappen worden niet verwijderd.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Sommige wijzigingen zijn nog niet volledig geüpload en gaan verloren.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Klik opnieuw op de knop om te bevestigen.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Kan bibliotheek niet verwijderen: {error}</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>ਆਕਾਰ</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# ਰਿਲੀਜ਼} other {# ਰਿਲੀਜ਼ਾਂ}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>ਕੁੱਲ: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>ਹਟਾਓ</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>ਇਹ ਲਾਇਬ੍ਰੇਰੀ ਅਤੇ ਇਸ ਦੀਆਂ ਡਾਊਨਲੋਡ ਕੀਤੀਆਂ ਫਾਈਲਾਂ ਨੂੰ ਇਸ ਪੀਸੀ ਤੋਂ ਹਟਾਉਂਦਾ ਹੈ। ਕਲਾਊਡ ਵਿੱਚ ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ ਸੁਰੱਖਿਅਤ ਰਹਿੰਦੀ ਹੈ — ਤੁਸੀਂ ਬਾਅਦ ਵਿੱਚ ਇੱਥੋਂ ਇਸਨੂੰ ਮੁੜ-ਬਹਾਲ ਕਰ ਸਕਦੇ ਹੋ।</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ਇਹ ਲਾਇਬ੍ਰੇਰੀ ਸਿੰਕ ਨਹੀਂ ਹੈ। ਇਸਨੂੰ ਹਟਾਉਣ ਨਾਲ ਇਸਦਾ ਕੈਟਾਲਾਗ — ਐਲਬਮਾਂ, ਮੈਟਾਡੇਟਾ ਸੋਧਾਂ ਅਤੇ ਪਲੇ ਇਤਿਹਾਸ — ਸਥਾਈ ਤੌਰ 'ਤੇ ਮਿਟ ਜਾਵੇਗਾ। ਤੁਹਾਡੇ ਫੋਲਡਰਾਂ ਦੀਆਂ ਆਡੀਓ ਫਾਈਲਾਂ ਨਹੀਂ ਮਿਟਣਗੀਆਂ।</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ਇਹ ਲਾਇਬ੍ਰੇਰੀ ਇਸ ਪੀਸੀ ਤੋਂ ਹਟਾਓ</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>ਕਲਾਊਡ ਵਿੱਚ ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ ਸੁਰੱਖਿਅਤ ਰਹਿੰਦੀ ਹੈ — ਤੁਸੀਂ ਬਾਅਦ ਵਿੱਚ ਸੁਆਗਤ ਸਕ੍ਰੀਨ ਤੋਂ ਇਸਨੂੰ ਮੁੜ-ਬਹਾਲ ਕਰ ਸਕਦੇ ਹੋ।</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ਇਹ ਲਾਇਬ੍ਰੇਰੀ ਕਦੇ ਵੀ ਸਿੰਕ ਨਹੀਂ ਹੋਈ। ਇਸਦਾ ਕੈਟਾਲਾਗ ਸਥਾਈ ਤੌਰ 'ਤੇ ਮਿਟ ਜਾਵੇਗਾ; ਤੁਹਾਡੇ ਫੋਲਡਰਾਂ ਦੀਆਂ ਆਡੀਓ ਫਾਈਲਾਂ ਨਹੀਂ ਮਿਟਣਗੀਆਂ।</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>ਕੁਝ ਬਦਲਾਅ ਅਜੇ ਅੱਪਲੋਡ ਹੋਣੇ ਬਾਕੀ ਹਨ ਅਤੇ ਗੁਆਚ ਜਾਣਗੇ।</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>ਪੁਸ਼ਟੀ ਕਰਨ ਲਈ ਬਟਨ ਨੂੰ ਦੁਬਾਰਾ ਕਲਿੱਕ ਕਰੋ।</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਹਟਾਈ ਨਹੀਂ ਜਾ ਸਕੀ: {error}</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Rozmiar</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# wydanie} few {# wydania} many {# wydań} other {# wydania}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Łącznie: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Usuń</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Usuwa tę bibliotekę i jej pobrane pliki z tego komputera. Twoja biblioteka w chmurze pozostaje nienaruszona — możesz ją później stąd przywrócić.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Ta biblioteka nie jest zsynchronizowana. Jej usunięcie trwale skasuje jej katalog — albumy, edycje metadanych i historię odtwarzania. Pliki audio w twoich folderach nie zostaną usunięte.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>usuń tę bibliotekę z tego komputera</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Twoja biblioteka w chmurze pozostaje nienaruszona — możesz ją później przywrócić z ekranu powitalnego.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Ta biblioteka nigdy nie była zsynchronizowana. Jej katalog zostanie trwale usunięty; pliki audio w twoich folderach nie zostaną usunięte.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Niektóre zmiany nie zostały jeszcze przesłane i zostaną utracone.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Kliknij przycisk ponownie, aby potwierdzić.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Nie udało się usunąć biblioteki: {error}</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Tamanho</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# lançamento} other {# lançamentos}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Total: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Remover</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Remove esta biblioteca e seus arquivos baixados deste computador. Sua biblioteca na nuvem permanece intacta — você poderá restaurá-la a partir daqui depois.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Esta biblioteca não está sincronizada. Removê-la excluirá permanentemente seu catálogo — álbuns, edições de metadados e histórico de reprodução. Os arquivos de áudio em suas pastas não serão excluídos.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>remover esta biblioteca deste computador</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Sua biblioteca na nuvem permanece intacta — você poderá restaurá-la a partir da tela de boas-vindas depois.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Esta biblioteca nunca foi sincronizada. Seu catálogo será excluído permanentemente; os arquivos de áudio em suas pastas não serão excluídos.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Algumas alterações ainda não terminaram de ser enviadas e serão perdidas.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Clique no botão novamente para confirmar.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Não foi possível remover a biblioteca: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>அளவு</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# வெளியீடு} other {# வெளியீடுகள்}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>மொத்தம்: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>அகற்று</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>இந்த நூலகத்தையும் அதன் பதிவிறக்கம் செய்யப்பட்ட கோப்புகளையும் இந்த பிசியிலிருந்து அகற்றுகிறது. மேகக்கணிப்பில் உள்ள உங்கள் நூலகம் அப்படியே இருக்கும் — நீங்கள் பின்னர் இங்கிருந்து அதை மீட்டெடுக்கலாம்.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>இந்த நூலகம் ஒத்திசைக்கப்படவில்லை. இதை அகற்றுவது அதன் பட்டியலை — ஆல்பங்கள், மேலான்ம தரவு திருத்தங்கள் மற்றும் இயக்க வரலாறு — நிரந்தரமாக நீக்கிவிடும். உங்கள் கோப்புறைகளில் உள்ள ஆடியோ கோப்புகள் நீக்கப்படாது.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>இந்த நூலகத்தை இந்த பிசியிலிருந்து அகற்று</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>மேகக்கணிப்பில் உள்ள உங்கள் நூலகம் அப்படியே இருக்கும் — நீங்கள் பின்னர் வரவேற்பு திரையிலிருந்து அதை மீட்டெடுக்கலாம்.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>இந்த நூலகம் ஒருபோதும் ஒத்திசைக்கப்படவில்லை. அதன் பட்டியல் நிரந்தரமாக நீக்கப்படும்; உங்கள் கோப்புறைகளில் உள்ள ஆடியோ கோப்புகள் நீக்கப்படாது.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>சில மாற்றங்கள் இன்னும் பதிவேற்றம் முடிக்கவில்லை, அவை இழக்கப்படும்.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>உறுதிப்படுத்த பொத்தானை மீண்டும் கிளிக் செய்யவும்.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>நூலகத்தை அகற்ற முடியவில்லை: {error}</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>పరిమాణం</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# విడుదల} other {# విడుదలలు}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>మొత్తం: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>తీసివేయి</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>ఈ లైబ్రరీని మరియు దాని డౌన్‌లోడ్ చేసిన ఫైళ్లను ఈ పీసీ నుండి తీసివేస్తుంది. క్లౌడ్‌లో మీ లైబ్రరీ చెక్కుచెదరకుండా ఉంటుంది — మీరు తర్వాత దీన్ని ఇక్కడి నుండి పునరుద్ధరించవచ్చు.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ఈ లైబ్రరీ సింక్ చేయబడలేదు. దీన్ని తీసివేయడం వల్ల దాని కేటలాగ్ — ఆల్బమ్‌లు, మెటాడేటా మార్పులు మరియు ప్లే చరిత్ర — శాశ్వతంగా తొలగించబడుతుంది. మీ ఫోల్డర్‌లలోని ఆడియో ఫైళ్లు తొలగించబడవు.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ఈ లైబ్రరీని ఈ పీసీ నుండి తీసివేయి</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>క్లౌడ్‌లో మీ లైబ్రరీ చెక్కుచెదరకుండా ఉంటుంది — మీరు తర్వాత స్వాగత స్క్రీన్ నుండి దీన్ని పునరుద్ధరించవచ్చు.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ఈ లైబ్రరీ ఎప్పుడూ సింక్ చేయబడలేదు. దాని కేటలాగ్ శాశ్వతంగా తొలగించబడుతుంది; మీ ఫోల్డర్‌లలోని ఆడియో ఫైళ్లు తొలగించబడవు.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>కొన్ని మార్పులు ఇంకా అప్‌లోడ్ పూర్తి చేయలేదు, అవి పోతాయి.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>నిర్ధారించడానికి బటన్‌ను మళ్లీ క్లిక్ చేయండి.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>లైబ్రరీని తీసివేయలేకపోయింది: {error}</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>ขนาด</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# รีลีส}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>รวม: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>ลบ</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>ลบไลบรารีนี้และไฟล์ที่ดาวน์โหลดไว้ออกจากพีซีเครื่องนี้ ไลบรารีของคุณบนคลาวด์ยังคงอยู่ครบถ้วน — คุณสามารถกู้คืนจากที่นี่ได้ในภายหลัง</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>ไลบรารีนี้ไม่ได้ซิงค์ การลบจะลบแคตตาล็อกของไลบรารีอย่างถาวร — อัลบั้ม การแก้ไขข้อมูลเมตา และประวัติการเล่น ไฟล์เสียงในโฟลเดอร์ของคุณจะไม่ถูกลบ</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>ลบไลบรารีนี้ออกจากพีซีเครื่องนี้</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>ไลบรารีของคุณบนคลาวด์ยังคงอยู่ครบถ้วน — คุณสามารถกู้คืนจากหน้าจอต้อนรับได้ในภายหลัง</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>ไลบรารีนี้ไม่เคยซิงค์มาก่อน แคตตาล็อกของไลบรารีจะถูกลบอย่างถาวร ไฟล์เสียงในโฟลเดอร์ของคุณจะไม่ถูกลบ</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>การเปลี่ยนแปลงบางอย่างยังอัปโหลดไม่เสร็จและจะสูญหาย</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>คลิกปุ่มอีกครั้งเพื่อยืนยัน</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>ไม่สามารถลบไลบรารีได้: {error}</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Boyut</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# yayın} other {# yayın}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Toplam: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Kaldır</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Bu kitaplığı ve indirilen dosyalarını bu bilgisayardan kaldırır. Buluttaki kitaplığınız olduğu gibi kalır — daha sonra buradan geri yükleyebilirsiniz.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Bu kitaplık eşitlenmemiş. Kaldırmak, kataloğunu — albümleri, meta veri düzenlemelerini ve çalma geçmişini — kalıcı olarak siler. Klasörlerinizdeki ses dosyaları silinmez.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>bu kitaplığı bu bilgisayardan kaldır</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Buluttaki kitaplığınız olduğu gibi kalır — daha sonra karşılama ekranından geri yükleyebilirsiniz.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Bu kitaplık hiç eşitlenmedi. Kataloğu kalıcı olarak silinecek; klasörlerinizdeki ses dosyaları silinmez.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Bazı değişikliklerin yüklenmesi tamamlanmadı ve kaybolacak.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Onaylamak için düğmeye tekrar tıklayın.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Kitaplık kaldırılamadı: {error}</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Розмір</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# реліз} few {# релізи} many {# релізів} other {# релізу}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Усього: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Вилучити</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Вилучає цю бібліотеку та її завантажені файли з цього комп'ютера. Ваша бібліотека в хмарі залишається недоторканою — пізніше ви зможете відновити її звідси.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Ця бібліотека не синхронізована. Її вилучення остаточно видалить каталог — альбоми, редагування метаданих і історію відтворення. Аудіофайли у ваших папках не будуть видалені.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>вилучити цю бібліотеку з цього комп'ютера</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Ваша бібліотека в хмарі залишається недоторканою — пізніше ви зможете відновити її з екрана привітання.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Ця бібліотека ніколи не синхронізувалася. Її каталог буде остаточно видалено; аудіофайли у ваших папках не будуть видалені.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Деякі зміни ще не завершили завантаження і будуть втрачені.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Натисніть кнопку ще раз, щоб підтвердити.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Не вдалося вилучити бібліотеку: {error}</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>سائز</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, one {# اشاعت} other {# اشاعتیں}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>کل: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>ہٹائیں</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>یہ لائبریری اور اس کی ڈاؤن لوڈ شدہ فائلیں اس پی سی سے ہٹا دیتا ہے۔ کلاؤڈ میں آپ کی لائبریری محفوظ رہتی ہے — آپ بعد میں یہاں سے اسے بحال کر سکتے ہیں۔</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>یہ لائبریری سنک نہیں ہے۔ اسے ہٹانے سے اس کا کیٹلاگ — البمز، میٹا ڈیٹا میں ترامیم اور پلے کی تاریخ — مستقل طور پر حذف ہو جائے گا۔ آپ کے فولڈرز میں موجود آڈیو فائلیں حذف نہیں ہوں گی۔</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>اس لائبریری کو اس پی سی سے ہٹائیں</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>کلاؤڈ میں آپ کی لائبریری محفوظ رہتی ہے — آپ بعد میں خوش آمدید اسکرین سے اسے بحال کر سکتے ہیں۔</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>یہ لائبریری کبھی سنک نہیں ہوئی۔ اس کا کیٹلاگ مستقل طور پر حذف ہو جائے گا؛ آپ کے فولڈرز میں موجود آڈیو فائلیں حذف نہیں ہوں گی۔</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>کچھ تبدیلیاں ابھی اپ لوڈ مکمل نہیں کر پائیں اور ضائع ہو جائیں گی۔</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>تصدیق کے لیے بٹن دوبارہ دبائیں۔</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>لائبریری ہٹائی نہیں جا سکی: {error}</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>Kích thước</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# bản phát hành}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>Tổng: {size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>Xóa</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>Xóa thư viện này và các tệp đã tải xuống của nó khỏi máy tính này. Thư viện của bạn trên đám mây vẫn còn nguyên vẹn — bạn có thể khôi phục từ đây sau.</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>Thư viện này chưa được đồng bộ hóa. Xóa thư viện sẽ xóa vĩnh viễn danh mục của nó — album, chỉnh sửa siêu dữ liệu và lịch sử phát. Các tệp âm thanh trong thư mục của bạn sẽ không bị xóa.</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>xóa thư viện này khỏi máy tính này</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>Thư viện của bạn trên đám mây vẫn còn nguyên vẹn — bạn có thể khôi phục từ màn hình chào mừng sau.</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>Thư viện này chưa từng được đồng bộ hóa. Danh mục của nó sẽ bị xóa vĩnh viễn; các tệp âm thanh trong thư mục của bạn sẽ không bị xóa.</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Một số thay đổi vẫn chưa tải lên xong và sẽ bị mất.</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>Nhấp lại vào nút để xác nhận.</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>Không thể xóa thư viện: {error}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>大小</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# 个发行}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>总计：{size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>移除</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>从此电脑移除此库及其已下载的文件。云端的库保持不变——您以后可以从这里恢复它。</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>此库未同步。移除它将永久删除其目录——专辑、元数据编辑和播放历史。您文件夹中的音频文件不会被删除。</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>从此电脑移除此库</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>云端的库保持不变——您以后可以从欢迎屏幕恢复它。</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>此库从未同步过。其目录将被永久删除；您文件夹中的音频文件不会被删除。</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>部分更改尚未上传完成，将会丢失。</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>再次点击按钮以确认。</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>无法移除库：{error}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -399,4 +399,13 @@
   <data name="storage.column.size" xml:space="preserve"><value>大小</value></data>
   <data name="storage.footer.releases" xml:space="preserve"><value>{count, plural, other {# 個發行}}</value></data>
   <data name="storage.footer.total" xml:space="preserve"><value>總計：{size}</value></data>
+  <data name="settings.remove.title" xml:space="preserve"><value>移除</value></data>
+  <data name="settings.remove.footer_synced" xml:space="preserve"><value>從此電腦移除此資料庫及其已下載的檔案。雲端中的資料庫保持不變——您稍後可以從這裡還原它。</value></data>
+  <data name="settings.remove.footer_unsynced" xml:space="preserve"><value>此資料庫尚未同步。移除它將永久刪除其目錄——專輯、元資料編輯和播放紀錄。您資料夾中的音訊檔案不會被刪除。</value></data>
+  <data name="settings.remove.button" xml:space="preserve"><value>從此電腦移除此資料庫</value></data>
+  <data name="settings.remove.confirm_synced" xml:space="preserve"><value>雲端中的資料庫保持不變——您稍後可以從歡迎畫面還原它。</value></data>
+  <data name="settings.remove.confirm_unsynced" xml:space="preserve"><value>此資料庫從未同步過。其目錄將被永久刪除；您資料夾中的音訊檔案不會被刪除。</value></data>
+  <data name="settings.remove.confirm_pending" xml:space="preserve"><value>部分變更尚未上傳完成，將會遺失。</value></data>
+  <data name="settings.remove.confirm_again" xml:space="preserve"><value>再次點擊按鈕以確認。</value></data>
+  <data name="settings.remove.failed" xml:space="preserve"><value>無法移除資料庫：{error}</value></data>
 </root>

--- a/bae-windows/Views/SettingsDialog.cs
+++ b/bae-windows/Views/SettingsDialog.cs
@@ -14,12 +14,12 @@ using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 namespace Bae.Windows;
 
 // The settings dialog: Discogs key, cloud sync (disconnect / S3 / OAuth), export
-// template and presets, MCP automation, devices, recovery code, updates, and
-// lock. Reads the current settings through the settings store and re-renders when
-// a config invalidation (or an in-dialog connect/disconnect) reloads them; those
-// registrations live only while the dialog is open. The lock, add-device, and
-// apply-update flows close the dialog and run after it returns (a nested
-// ContentDialog can't open over it).
+// template and presets, MCP automation, devices, recovery code, updates, lock,
+// and remove. Reads the current settings through the settings store and
+// re-renders when a config invalidation (or an in-dialog connect/disconnect)
+// reloads them; those registrations live only while the dialog is open. The
+// lock, remove, add-device, and apply-update flows close the dialog and run
+// after it returns (a nested ContentDialog can't open over it).
 internal sealed class SettingsDialog
 {
     private readonly SessionStore _session;
@@ -33,6 +33,7 @@ internal sealed class SettingsDialog
     private readonly ProjectionRegistry _projections;
     private readonly Action<string> _setStatus;
     private readonly Action<string> _openLibrary;
+    private readonly Func<System.Threading.Tasks.Task> _closeToWelcome;
 
     public SettingsDialog(
         SessionStore session,
@@ -45,7 +46,8 @@ internal sealed class SettingsDialog
         UpdateService updateService,
         ProjectionRegistry projections,
         Action<string> setStatus,
-        Action<string> openLibrary)
+        Action<string> openLibrary,
+        Func<System.Threading.Tasks.Task> closeToWelcome)
     {
         _session = session;
         _xamlRoot = xamlRoot;
@@ -58,6 +60,7 @@ internal sealed class SettingsDialog
         _projections = projections;
         _setStatus = setStatus;
         _openLibrary = openLibrary;
+        _closeToWelcome = closeToWelcome;
     }
 
     public async System.Threading.Tasks.Task Show()
@@ -1280,6 +1283,39 @@ internal sealed class SettingsDialog
         var lockButton = new Button { Content = Loc.Chrome("settings.lock_library") };
         content.Children.Add(lockButton);
 
+        // Remove this library from this device: delete its local data directory,
+        // clear the active-library pointer, and drop its encryption key, leaving
+        // any cloud copy untouched. Two-step armed confirm, like disconnect: the
+        // first click reads the outbox snapshot off the UI thread to decide
+        // whether to call out unlanded cloud work, renders the confirmation body
+        // inline, and arms; the second click requests the forget and closes the
+        // dialog — the destructive work runs after ShowAsync returns (the
+        // post-close dance, like lock), because a nested ContentDialog can't
+        // open over this one.
+        var forgetRequested = false;
+        var removeArmed = false;
+        content.Children.Add(new TextBlock
+        {
+            Text = Loc.Chrome("settings.remove.title"),
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+        });
+        var removeFooter = new TextBlock
+        {
+            Text = Loc.Chrome(ForgetLibraryModel.FooterKey(s.HasCloudHome)),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        };
+        content.Children.Add(removeFooter);
+        var removeButton = new Button { Content = Loc.Chrome("settings.remove.button") };
+        content.Children.Add(removeButton);
+        var removeConfirmText = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Salmon),
+            Visibility = Visibility.Collapsed,
+        };
+        content.Children.Add(removeConfirmText);
+
         var dialog = new ContentDialog
         {
             Title = Loc.Chrome("settings.title"),
@@ -1290,6 +1326,37 @@ internal sealed class SettingsDialog
         lockButton.Click += (_, _) =>
         {
             lockRequested = true;
+            dialog.Hide();
+        };
+        removeButton.Click += async (_, _) =>
+        {
+            if (!removeArmed)
+            {
+                var (snapshotCurrent, snapshotResult) = await _session.RunForCurrentHandle(NativeBae.OutboxSnapshot);
+                if (!snapshotCurrent)
+                {
+                    return;
+                }
+                if (snapshotResult.Error is not null)
+                {
+                    // The outbox read only informs the confirmation copy; a
+                    // failure here doesn't block the confirm from arming, it
+                    // just can't call out pending cloud work.
+                    BaeDiagnostics.Logger.Warning(
+                        $"Could not read the outbox snapshot for the remove confirmation: {snapshotResult.Error}");
+                }
+                var hasPendingCloudWork = snapshotResult.Snapshot is { } snapshot
+                    && ForgetLibraryModel.HasPendingCloudWork(snapshot.UploadGroups.Length, snapshot.PendingDeletes);
+                var hasCloudHome = _settings.Current?.HasCloudHome ?? s.HasCloudHome;
+                removeConfirmText.Text = string.Join(
+                    " ",
+                    ForgetLibraryModel.ConfirmKeys(hasCloudHome, hasPendingCloudWork).Select(key => Loc.Chrome(key)));
+                removeConfirmText.Visibility = Visibility.Visible;
+                removeArmed = true;
+                return;
+            }
+
+            forgetRequested = true;
             dialog.Hide();
         };
 
@@ -1334,6 +1401,7 @@ internal sealed class SettingsDialog
             RenderExport(fresh);
             RenderMcp(fresh);
             RenderDiscogs(fresh);
+            removeFooter.Text = Loc.Chrome(ForgetLibraryModel.FooterKey(fresh.HasCloudHome));
         }
         _settings.Changed += Refresh;
         // A config invalidation reloads the store while the dialog is open; the
@@ -1384,6 +1452,25 @@ internal sealed class SettingsDialog
             await _session.ShutdownAndFreeCurrentHandle();
 
             _openLibrary(s.LibraryId);
+            return;
+        }
+
+        if (forgetRequested)
+        {
+            var (forgetCurrent, error) = await _session.RunForCurrentHandle(NativeBae.ForgetLibrary);
+            if (!forgetCurrent)
+            {
+                return;
+            }
+            if (error is not null)
+            {
+                _setStatus(Loc.Chrome("settings.remove.failed", "error", error));
+                return;
+            }
+
+            // The local directory is gone; tear the handle down and return to
+            // the welcome chooser, mirroring macOS's closeLibrary().
+            await _closeToWelcome();
             return;
         }
 

--- a/bae-windows/bae-windows.Tests/ForgetLibraryModelTests.cs
+++ b/bae-windows/bae-windows.Tests/ForgetLibraryModelTests.cs
@@ -1,0 +1,66 @@
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+// The settings Remove section's pure decision layer: which footer and
+// confirmation-body catalog keys to show, and the pending-cloud-work
+// derivation from the outbox snapshot's plain counts.
+public sealed class ForgetLibraryModelTests
+{
+    [Fact]
+    public void FooterKey_SplitsOnCloudHome()
+    {
+        Assert.Equal("settings.remove.footer_synced", ForgetLibraryModel.FooterKey(hasCloudHome: true));
+        Assert.Equal("settings.remove.footer_unsynced", ForgetLibraryModel.FooterKey(hasCloudHome: false));
+    }
+
+    [Fact]
+    public void ConfirmKeys_NeverSynced_IgnoresPendingFlag()
+    {
+        Assert.Equal(
+            new[] { "settings.remove.confirm_unsynced", "settings.remove.confirm_again" },
+            ForgetLibraryModel.ConfirmKeys(hasCloudHome: false, hasPendingCloudWork: false));
+        Assert.Equal(
+            new[] { "settings.remove.confirm_unsynced", "settings.remove.confirm_again" },
+            ForgetLibraryModel.ConfirmKeys(hasCloudHome: false, hasPendingCloudWork: true));
+    }
+
+    [Fact]
+    public void ConfirmKeys_Synced_NoPending()
+    {
+        Assert.Equal(
+            new[] { "settings.remove.confirm_synced", "settings.remove.confirm_again" },
+            ForgetLibraryModel.ConfirmKeys(hasCloudHome: true, hasPendingCloudWork: false));
+    }
+
+    [Fact]
+    public void ConfirmKeys_Synced_WithPending()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "settings.remove.confirm_synced",
+                "settings.remove.confirm_pending",
+                "settings.remove.confirm_again",
+            },
+            ForgetLibraryModel.ConfirmKeys(hasCloudHome: true, hasPendingCloudWork: true));
+    }
+
+    [Fact]
+    public void HasPendingCloudWork_False_AtZero()
+    {
+        Assert.False(ForgetLibraryModel.HasPendingCloudWork(uploadGroupCount: 0, pendingDeletes: 0));
+    }
+
+    [Fact]
+    public void HasPendingCloudWork_True_WithUploadGroupsOnly()
+    {
+        Assert.True(ForgetLibraryModel.HasPendingCloudWork(uploadGroupCount: 1, pendingDeletes: 0));
+    }
+
+    [Fact]
+    public void HasPendingCloudWork_True_WithPendingDeletesOnly()
+    {
+        Assert.True(ForgetLibraryModel.HasPendingCloudWork(uploadGroupCount: 0, pendingDeletes: 1));
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -39,6 +39,12 @@
       button gating, version-string normalization), over plain BCL types with no
       WinUI or Velopack dependency (the Velopack shell that produces its states
       lives in UpdateService and is verified by compilation).
+    - The Remove-library decision layer (ForgetLibraryModel) — the settings
+      Remove section's footer and confirmation-body catalog keys and the
+      pending-cloud-work derivation from the outbox snapshot's plain counts,
+      over plain BCL types (the armed two-step confirm and the post-close
+      forget dance that render it live in SettingsDialog and are verified by
+      compilation).
 
     The rest of bae-windows' pure logic (ReleaseCandidateChoice.Summary,
     ImportCandidate status/ToString, BridgeDisplay) depends on the generated
@@ -79,6 +85,7 @@
     <Compile Include="../Stores/ExportQueueModel.cs" Link="ExportQueueModel.cs" />
     <Compile Include="../Stores/WindowBoundsModel.cs" Link="WindowBoundsModel.cs" />
     <Compile Include="../Stores/PersistPlaybackModel.cs" Link="PersistPlaybackModel.cs" />
+    <Compile Include="../Stores/ForgetLibraryModel.cs" Link="ForgetLibraryModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

macOS lets a user remove the open library's local presence from Settings — a confirmed, destructive action that deletes the library's data directory, clears the active-library pointer, and drops its encryption key on that device, leaving any cloud copy untouched, then returns to the welcome chooser. bae-windows had no equivalent: once a library existed on a device there was no way to remove its local presence from the app.

This brings the same UX to bae-windows' `SettingsDialog`, reusing the two patterns already in that file rather than inventing a third: the disconnect-flow's two-step armed confirm (first click reads the outbox snapshot off the UI thread to decide whether to call out unlanded cloud work, renders the confirmation inline, and arms; second click requests the forget and closes the dialog) and the lock-library post-close dance (the destructive bridge call — the handle's last operation — runs after `ShowAsync` returns, since a nested `ContentDialog` can't open over this one). The message-gating logic (which footer and confirmation lines to show, given whether a cloud home is configured and whether cloud work is still pending) is a plain-typed, unit-tested static class mirroring macOS's `forgetConfirmationMessage`. No bridge/Rust changes — `forget_library` and `get_outbox_snapshot` were already exported; the only new native-call surface is a `NativeBae.ForgetLibrary` wrapper next to the existing `LockActiveLibrary`.

Per-row remove from the libraries switcher is out of scope, same as macOS — the bridge's `forget_library` only ever applies to the currently open library.

## Test plan

- [x] `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 304 passed, including the new `ForgetLibraryModelTests`
- [x] `python3 scripts/loc-chrome-orphans.py` — 0 orphans across all four platforms
- [ ] Manual pass on Windows: remove a never-synced library (welcome chooser appears, directory gone), remove a synced library (cloud copy restorable from welcome), arm-then-cancel (close the dialog while armed; nothing happens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)