### PR TITLE
Windows: album-grid multi-select with bulk actions

### DIFF
--- a/bae-windows/Album.cs
+++ b/bae-windows/Album.cs
@@ -12,6 +12,7 @@ public sealed class Album : INotifyPropertyChanged
     private readonly string _title;
     private readonly string _artist;
     private readonly CoverImage.Binding _cover;
+    private bool _isSelected;
 
     internal Album(BridgeAlbumSearchResult album) : this(album.Id, album.Title, album.ArtistName, album.Cover)
     {
@@ -45,4 +46,21 @@ public sealed class Album : INotifyPropertyChanged
         _cover.Attach(handle, dispatcherQueue);
 
     public ImageSource? Cover => _cover.Source;
+
+    /// <summary>Whether the grid's multi-selection contains this album. The
+    /// window syncs this from <see cref="AlbumGridSelectionModel"/> after every
+    /// selection mutation; the card's tint binds to it OneWay.</summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected == value)
+            {
+                return;
+            }
+            _isSelected = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+        }
+    }
 }

--- a/bae-windows/BoolToOpacityConverter.cs
+++ b/bae-windows/BoolToOpacityConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.UI.Xaml.Data;
+
+namespace Bae.Windows;
+
+// x:Bind has no built-in bool -> double conversion, so the album card's
+// always-present selection tint (opacity 1/0, never added/removed from the
+// layout tree) needs this to bind its Opacity straight to Album.IsSelected.
+public sealed class BoolToOpacityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language) =>
+        value is true ? 1.0 : 0.0;
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -5,6 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Bae.Windows"
     Title="bae">
+    <Window.Resources>
+        <local:BoolToOpacityConverter x:Key="BoolToOpacityConverter" />
+    </Window.Resources>
     <!-- Background="Transparent" makes the whole window a hit-testable drop target,
          so a folder can be dropped over empty areas (e.g. the empty-library state),
          not just over the grid. -->
@@ -82,25 +85,37 @@
             RightTapped="OnAlbumGridRightTapped">
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="local:Album">
-                    <StackPanel Width="180" Margin="8" Spacing="6">
+                    <Grid>
+                        <!-- The multi-selection tint: always in the layout tree, toggled by
+                             Opacity (not Visibility), so a selection change never re-measures
+                             the row — required in a virtualized, container-recycling GridView. -->
                         <Border
-                            Width="180"
-                            Height="180"
-                            CornerRadius="6"
-                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
-                            <Image Source="{x:Bind Cover, Mode=OneWay}" Stretch="UniformToFill" />
+                            CornerRadius="10"
+                            Opacity="{x:Bind IsSelected, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}">
+                            <Border.Background>
+                                <SolidColorBrush Color="{ThemeResource SystemAccentColor}" Opacity="0.18" />
+                            </Border.Background>
                         </Border>
-                        <TextBlock
-                            Text="{x:Bind Title}"
-                            MaxLines="1"
-                            TextTrimming="CharacterEllipsis"
-                            Style="{StaticResource BodyStrongTextBlockStyle}" />
-                        <TextBlock
-                            Text="{x:Bind Artist}"
-                            MaxLines="1"
-                            TextTrimming="CharacterEllipsis"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                    </StackPanel>
+                        <StackPanel Width="180" Margin="8" Spacing="6">
+                            <Border
+                                Width="180"
+                                Height="180"
+                                CornerRadius="6"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                                <Image Source="{x:Bind Cover, Mode=OneWay}" Stretch="UniformToFill" />
+                            </Border>
+                            <TextBlock
+                                Text="{x:Bind Title}"
+                                MaxLines="1"
+                                TextTrimming="CharacterEllipsis"
+                                Style="{StaticResource BodyStrongTextBlockStyle}" />
+                            <TextBlock
+                                Text="{x:Bind Artist}"
+                                MaxLines="1"
+                                TextTrimming="CharacterEllipsis"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                    </Grid>
                 </DataTemplate>
             </GridView.ItemTemplate>
         </GridView>

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -33,6 +33,11 @@ public sealed partial class MainWindow : Window
     // The library session (handle + event subscription) and the stores it drives.
     private readonly SessionStore _session;
     private readonly LibraryBrowserStore _browser;
+    // The album grid's multi-selection, a browsing-session concern owned here
+    // like the browser store itself. Modifier clicks/Esc/Ctrl+A mutate it; the
+    // window syncs Album.IsSelected over the loaded collection after every
+    // mutation so the card tint (bound OneWay) stays current.
+    private readonly AlbumGridSelectionModel _albumSelection = new();
     private readonly LibrarySortControls _sortControls;
     private readonly BrowserPanes _browserPanes;
     private readonly WelcomeView _welcomeView;
@@ -375,6 +380,12 @@ public sealed partial class MainWindow : Window
         {
             return;
         }
+        // A reload replaces Albums wholesale (sort/mode change, invalidation,
+        // library open), so the prior selection's ids no longer resolve to
+        // anything on screen — clear it rather than prune, which also
+        // subsumes macOS's per-id deleted-album pruning.
+        _albumSelection.Clear();
+        SyncAlbumSelectionTint();
         ShowAlbumBrowser();
         RenderGridStatus(load);
     }
@@ -544,6 +555,7 @@ public sealed partial class MainWindow : Window
         _queuePane.Hide();
         _import.Reset();
         _browser.Reset();
+        _albumSelection.Clear();
         _transferProgress.Reset();
         SearchBox.Text = string.Empty;
         StatusText.Text = string.Empty;
@@ -692,7 +704,9 @@ public sealed partial class MainWindow : Window
     }
 
     // Start a drag from an album card: carry the album ids as the newline-joined
-    // payload the queue pane decodes. Cancelled when no library is open.
+    // payload the queue pane decodes — the whole multi-selection (visible order)
+    // when the pressed card is part of it, else just that card. Cancelled when no
+    // library is open. Never mutates the selection.
     private void OnAlbumDragStarting(object sender, DragItemsStartingEventArgs e)
     {
         if (CurrentHandleOrNull() == null)
@@ -700,7 +714,10 @@ public sealed partial class MainWindow : Window
             e.Cancel = true;
             return;
         }
-        var ids = e.Items.OfType<Album>().Select(album => album.Id).ToList();
+        var pressed = e.Items.OfType<Album>().FirstOrDefault();
+        var ids = pressed is null
+            ? e.Items.OfType<Album>().Select(album => album.Id).ToList()
+            : _albumSelection.OrderedTargets(pressed.Id, AlbumPosition);
         e.Data.SetText(QueueDragPayload.Encode(ids));
         e.Data.RequestedOperation = DataPackageOperation.Copy;
     }
@@ -834,7 +851,9 @@ public sealed partial class MainWindow : Window
     private void OnGlobalKeyDown(object sender, KeyRoutedEventArgs e)
     {
         // Escape closes the queue pane when it's open. Dialogs capture their own
-        // input layer, so their Escape never reaches this root handler.
+        // input layer, so their Escape never reaches this root handler. The
+        // queue pane keeps priority: the album-grid selection only clears once
+        // it isn't open.
         if (e.Key == VirtualKey.Escape && _queuePane.IsOpen)
         {
             _queuePane.Hide();
@@ -842,13 +861,29 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        if (e.Key != VirtualKey.Space)
+        if (e.Key == VirtualKey.Escape && AlbumGrid.Visibility == Visibility.Visible && !_albumSelection.IsEmpty)
         {
+            _albumSelection.Clear();
+            SyncAlbumSelectionTint();
+            e.Handled = true;
             return;
         }
 
         var focused = FocusManager.GetFocusedElement(Content.XamlRoot);
-        if (focused is TextBox || focused is AutoSuggestBox)
+        var focusedTextInput = focused is TextBox || focused is AutoSuggestBox;
+
+        // Ctrl+A selects every loaded album, guarded by the same focused-text-input
+        // check as Space so Ctrl+A in the search box still selects its text.
+        if (e.Key == VirtualKey.A && !focusedTextInput
+            && AlbumGrid.Visibility == Visibility.Visible && IsModifierDown(VirtualKey.Control))
+        {
+            _albumSelection.SelectAll(Albums.Select(album => album.Id).ToList());
+            SyncAlbumSelectionTint();
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key != VirtualKey.Space || focusedTextInput)
         {
             return;
         }
@@ -892,6 +927,9 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        // The album grid leaves the screen for the search results pane.
+        _albumSelection.Clear();
+        SyncAlbumSelectionTint();
         ShowSearchBrowser();
         _browserPanes.RenderSearchResults(search.Results, search.Error);
     }
@@ -906,6 +944,10 @@ public sealed partial class MainWindow : Window
         await _browserPanes.ShowComposerDetail(composer.ArtistId);
     }
 
+    // Dispatch by the modifiers held at click time: Ctrl toggles the clicked
+    // album, Shift extends the range from the anchor, and a plain click clears
+    // the multi-selection and opens the detail dialog. Modifier clicks never
+    // open the dialog.
     private async void OnAlbumClick(object sender, ItemClickEventArgs e)
     {
         if (CurrentHandleOrNull() == null || e.ClickedItem is not Album album)
@@ -913,11 +955,27 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        if (IsModifierDown(VirtualKey.Control))
+        {
+            _albumSelection.Toggle(album.Id);
+            SyncAlbumSelectionTint();
+            return;
+        }
+        if (IsModifierDown(VirtualKey.Shift))
+        {
+            _albumSelection.ExtendRange(album.Id, AlbumPosition, AlbumIdAt);
+            SyncAlbumSelectionTint();
+            return;
+        }
+
+        _albumSelection.Clear();
+        SyncAlbumSelectionTint();
         await _albumDetail.Show(album.Id);
     }
 
-    // Right-click / long-press on an album card: play or queue the album's
-    // canonical release without opening the detail dialog.
+    // Right-click / long-press on an album card: the bulk-action menu for
+    // whatever the card targets — the whole multi-selection (visible order)
+    // for a member card, else just that card. Never mutates the selection.
     private void OnAlbumGridRightTapped(object sender, RightTappedRoutedEventArgs e)
     {
         if (CurrentHandleOrNull() == null
@@ -925,19 +983,126 @@ public sealed partial class MainWindow : Window
         {
             return;
         }
-        var releaseId = album.PrimaryReleaseId;
-        if (string.IsNullOrEmpty(releaseId))
+
+        var targets = _albumSelection.OrderedTargets(album.Id, AlbumPosition);
+        var menu = targets.Count == 1
+            ? BuildSingleAlbumCardMenu(album)
+            : BuildBulkAlbumCardMenu(targets);
+        if (menu is null)
         {
             return;
         }
+
         e.Handled = true;
         var element = (FrameworkElement)e.OriginalSource;
-        var menu = AlbumCardMenu.Build(
-            onPlay: () => WithCurrentHandle(handle => NativeBae.PlayRelease(handle, releaseId, -1, false)),
-            onPlayNext: () => WithCurrentHandle(handle => NativeBae.AddReleaseNext(handle, releaseId)),
-            onAddToQueue: () => WithCurrentHandle(handle => NativeBae.AddReleaseToQueue(handle, releaseId)));
         menu.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
     }
+
+    // The pre-existing single-album menu: release-based actions on the card's
+    // primary release. Null when the album carries none (defensive — every
+    // grid-loaded album has one; only a search-result album wouldn't).
+    private MenuFlyout? BuildSingleAlbumCardMenu(Album album)
+    {
+        var releaseId = album.PrimaryReleaseId;
+        if (string.IsNullOrEmpty(releaseId))
+        {
+            return null;
+        }
+        return AlbumCardMenu.Build(
+            targetCount: 1,
+            onPlay: () =>
+            {
+                WithCurrentHandle(handle => NativeBae.PlayRelease(handle, releaseId, -1, false));
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            onPlayNext: () =>
+            {
+                WithCurrentHandle(handle => NativeBae.AddReleaseNext(handle, releaseId));
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            onAddToQueue: () =>
+            {
+                WithCurrentHandle(handle => NativeBae.AddReleaseToQueue(handle, releaseId));
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            onPin: () => PinReleases(new[] { releaseId }));
+    }
+
+    // The bulk menu for a multi-selected card: batch actions over every
+    // targeted album, in visible grid order.
+    private MenuFlyout BuildBulkAlbumCardMenu(IReadOnlyList<string> targets)
+    {
+        var primaryReleaseIds = PrimaryReleaseIds(targets);
+        return AlbumCardMenu.Build(
+            targetCount: targets.Count,
+            onPlay: () =>
+            {
+                WithCurrentHandle(handle => NativeBae.PlayReleases(handle, primaryReleaseIds));
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            onPlayNext: () => _queuePane.AddAlbumsToQueue(targets, addNext: true),
+            onAddToQueue: () => _queuePane.AddAlbumsToQueue(targets, addNext: false),
+            onPin: () => PinReleases(primaryReleaseIds));
+    }
+
+    // Enqueue releases to pin for offline, surfacing a failure through the
+    // shell error banner. Runs off the UI thread: the pin enqueue awaits core's
+    // async library-manager call.
+    private async System.Threading.Tasks.Task PinReleases(IReadOnlyList<string> releaseIds)
+    {
+        var (current, error) = await _session.RunForCurrentHandle(handle => releaseIds.Count == 1
+            ? NativeBae.PinRelease(handle, releaseIds[0])
+            : NativeBae.PinReleases(handle, releaseIds));
+        if (current && error is not null)
+        {
+            _shell.ShowBanner(InfoBarSeverity.Error, Loc.Chrome("error.title"), error);
+        }
+    }
+
+    // The targeted albums' primary release ids, in target order, dropping any
+    // target with none (a search-result album would have none; grid albums
+    // always do).
+    private List<string> PrimaryReleaseIds(IReadOnlyList<string> albumIds)
+    {
+        var albumsById = Albums.ToDictionary(album => album.Id);
+        return albumIds
+            .Select(id => albumsById.TryGetValue(id, out var album) ? album.PrimaryReleaseId : null)
+            .Where(releaseId => !string.IsNullOrEmpty(releaseId))
+            .Select(releaseId => releaseId!)
+            .ToList();
+    }
+
+    // The clicked album's index in the loaded grid, or null if it isn't loaded —
+    // the position delegate AlbumGridSelectionModel needs for range-extend and
+    // ordered targets.
+    private int? AlbumPosition(string id)
+    {
+        for (var i = 0; i < Albums.Count; i++)
+        {
+            if (Albums[i].Id == id)
+            {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    private string? AlbumIdAt(int index) =>
+        index >= 0 && index < Albums.Count ? Albums[index].Id : null;
+
+    // Sync every loaded album's tint from the selection model. Called after
+    // every mutation; O(loaded count), which is at most the first page (500).
+    private void SyncAlbumSelectionTint()
+    {
+        foreach (var album in Albums)
+        {
+            album.IsSelected = _albumSelection.Contains(album.Id);
+        }
+    }
+
+    private static bool IsModifierDown(VirtualKey key) =>
+        Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(key)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 
     private async void OnStorageClick(object sender, RoutedEventArgs e)
     {

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -427,6 +427,11 @@ internal static class NativeBae
     internal static string? PinRelease(AppHandle handle, string releaseId) =>
         CaptureError(() => Await(handle.QueuePinReleases([releaseId])));
 
+    // The album grid's bulk pin: the same enqueue as PinRelease, over every
+    // targeted album's primary release.
+    internal static string? PinReleases(AppHandle handle, IReadOnlyList<string> releaseIds) =>
+        CaptureError(() => Await(handle.QueuePinReleases(releaseIds.ToArray())));
+
     internal static string? UnpinRelease(AppHandle handle, string releaseId) =>
         CaptureError(() => Await(handle.UnpinRelease(releaseId)));
 
@@ -706,6 +711,11 @@ internal static class NativeBae
 
     internal static void PlayRelease(AppHandle handle, string releaseId, long startTrackIndex, bool shuffle) =>
         handle.PlayRelease(releaseId, startTrackIndex < 0 ? null : checked((uint)startTrackIndex), shuffle);
+
+    // The album grid's bulk play: replaces the queue with every targeted
+    // album's primary release, in the given order.
+    internal static void PlayReleases(AppHandle handle, IReadOnlyList<string> releaseIds) =>
+        handle.PlayReleases(releaseIds.ToArray());
 
     internal static void PlayLibraryShuffled(AppHandle handle) => handle.PlayLibraryShuffled();
 

--- a/bae-windows/Stores/AlbumGridSelectionModel.cs
+++ b/bae-windows/Stores/AlbumGridSelectionModel.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bae.Windows;
+
+// Multi-selection state for the album grid: which albums are selected and the
+// anchor a shift-click extends from. Plain BCL port of macOS's
+// AlbumGridSelection — no WinUI, no bridge types — so it is linked into the
+// test project. Owned by MainWindow as a browsing-session concern; after every
+// mutation the window syncs Album.IsSelected over the loaded collection.
+//
+// "Selection" here is distinct from the one album whose detail dialog is open:
+// multi-select is modifier-driven (ctrl/shift-click), and a plain click clears
+// it.
+public sealed class AlbumGridSelectionModel
+{
+    private readonly HashSet<string> _selectedIds = new();
+
+    public IReadOnlySet<string> SelectedIds => _selectedIds;
+    public string? AnchorId { get; private set; }
+
+    public bool IsEmpty => _selectedIds.Count == 0;
+
+    public bool Contains(string id) => _selectedIds.Contains(id);
+
+    // Ctrl-click: toggle the id's membership and make it the new anchor.
+    public void Toggle(string id)
+    {
+        if (!_selectedIds.Remove(id))
+        {
+            _selectedIds.Add(id);
+        }
+        AnchorId = id;
+    }
+
+    // Shift-click: union the contiguous range between the anchor and targetId
+    // (in grid order) into the selection. Positions come from position; ids in
+    // the range that aren't loaded (idAt returns null) are skipped. The anchor
+    // is unchanged. If the anchor no longer resolves — a sort swapped the list
+    // and its segment isn't fetched — this degrades to toggling targetId.
+    public void ExtendRange(string targetId, Func<string, int?> position, Func<int, string?> idAt)
+    {
+        var anchorIndex = AnchorId is null ? null : position(AnchorId);
+        var targetIndex = position(targetId);
+        if (anchorIndex is not int anchor || targetIndex is not int target)
+        {
+            Toggle(targetId);
+            return;
+        }
+
+        for (var index = Math.Min(anchor, target); index <= Math.Max(anchor, target); index++)
+        {
+            var id = idAt(index);
+            if (id is not null)
+            {
+                _selectedIds.Add(id);
+            }
+        }
+    }
+
+    // Ctrl+A: select every loaded album id, anchored on the last.
+    public void SelectAll(IReadOnlyList<string> ids)
+    {
+        _selectedIds.Clear();
+        foreach (var id in ids)
+        {
+            _selectedIds.Add(id);
+        }
+        AnchorId = ids.Count > 0 ? ids[^1] : null;
+    }
+
+    public void Clear()
+    {
+        _selectedIds.Clear();
+        AnchorId = null;
+    }
+
+    // Drop ids that no longer exist (a reload replaced the list). Clears the
+    // anchor only if it was among them.
+    public void Remove(IEnumerable<string> ids)
+    {
+        var removed = ids as ICollection<string> ?? ids.ToList();
+        _selectedIds.ExceptWith(removed);
+        if (AnchorId is not null && removed.Contains(AnchorId))
+        {
+            AnchorId = null;
+        }
+    }
+
+    // The menu/drag target rule: a card that is part of a multi-selection
+    // targets the whole selection in visible grid order (ids that don't
+    // resolve to a position are dropped); any other card targets just itself.
+    // Never mutates the selection — merely opening a menu or starting a drag
+    // leaves it as is.
+    public IReadOnlyList<string> OrderedTargets(string clickedId, Func<string, int?> position)
+    {
+        if (!_selectedIds.Contains(clickedId) || _selectedIds.Count <= 1)
+        {
+            return new[] { clickedId };
+        }
+
+        return _selectedIds
+            .Select(id => (Id: id, Position: position(id)))
+            .Where(entry => entry.Position is not null)
+            .OrderBy(entry => entry.Position!.Value)
+            .Select(entry => entry.Id)
+            .ToList();
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>بعض التغييرات لم تنتهِ من الرفع وستُفقد.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>انقر على الزر مرة أخرى للتأكيد.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>تعذّرت إزالة المكتبة: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>تثبيت للاستخدام دون اتصال</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, zero {تشغيل # ألبوم} one {تشغيل ألبوم واحد} two {تشغيل ألبومين} few {تشغيل # ألبومات} many {تشغيل # ألبومًا} other {تشغيل # ألبوم}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, zero {تشغيل # ألبوم كالتالي} one {تشغيل ألبوم واحد كالتالي} two {تشغيل ألبومين كالتالي} few {تشغيل # ألبومات كالتالي} many {تشغيل # ألبومًا كالتالي} other {تشغيل # ألبوم كالتالي}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, zero {إضافة # ألبوم إلى قائمة الانتظار} one {إضافة ألبوم واحد إلى قائمة الانتظار} two {إضافة ألبومين إلى قائمة الانتظار} few {إضافة # ألبومات إلى قائمة الانتظار} many {إضافة # ألبومًا إلى قائمة الانتظار} other {إضافة # ألبوم إلى قائمة الانتظار}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, zero {تثبيت # ألبوم للاستخدام دون اتصال} one {تثبيت ألبوم واحد للاستخدام دون اتصال} two {تثبيت ألبومين للاستخدام دون اتصال} few {تثبيت # ألبومات للاستخدام دون اتصال} many {تثبيت # ألبومًا للاستخدام دون اتصال} other {تثبيت # ألبوم للاستخدام دون اتصال}}</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Някои промени все още не са качени и ще бъдат загубени.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Натиснете бутона отново, за да потвърдите.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Библиотеката не можа да бъде премахната: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Закачане за офлайн</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Възпроизведи # албум} other {Възпроизведи # албума}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Възпроизведи # албум като следващ} other {Възпроизведи # албума като следващи}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Добави # албум в опашката} other {Добави # албума в опашката}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Закачи # албум за офлайн} other {Закачи # албума за офлайн}}</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>কিছু পরিবর্তন এখনও আপলোড শেষ হয়নি এবং সেগুলো হারিয়ে যাবে।</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>নিশ্চিত করতে বোতামটি আবার ক্লিক করুন।</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>লাইব্রেরি সরানো যায়নি: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>অফলাইনের জন্য পিন করুন</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম চালান} other {#টি অ্যালবাম চালান}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম এরপর চালান} other {#টি অ্যালবাম এরপর চালান}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম সারিতে যোগ করুন} other {#টি অ্যালবাম সারিতে যোগ করুন}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম অফলাইনের জন্য পিন করুন} other {#টি অ্যালবাম অফলাইনের জন্য পিন করুন}}</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Některé změny se ještě nenahrály a budou ztraceny.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Potvrďte dalším kliknutím na tlačítko.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Knihovnu se nepodařilo odebrat: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Připnout pro offline</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Přehrát # album} few {Přehrát # alba} many {Přehrát # alba} other {Přehrát # alb}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Přehrát # album jako další} few {Přehrát # alba jako další} many {Přehrát # alba jako další} other {Přehrát # alb jako další}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Přidat # album do fronty} few {Přidat # alba do fronty} many {Přidat # alba do fronty} other {Přidat # alb do fronty}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Připnout # album pro offline} few {Připnout # alba pro offline} many {Připnout # alba pro offline} other {Připnout # alb pro offline}}</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Einige Änderungen wurden noch nicht hochgeladen und gehen verloren.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Klicken Sie erneut auf die Schaltfläche, um zu bestätigen.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Bibliothek konnte nicht entfernt werden: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Für Offline anheften</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# Album wiedergeben} other {# Alben wiedergeben}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# Album als Nächstes abspielen} other {# Alben als Nächstes abspielen}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# Album zur Warteschlange hinzufügen} other {# Alben zur Warteschlange hinzufügen}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# Album für Offline anheften} other {# Alben für Offline anheften}}</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Some changes haven't finished uploading and will be lost.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Click the button again to confirm.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Couldn't remove library: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Pin for Offline</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Play # Album} other {Play # Albums}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Play # Album Next} other {Play # Albums Next}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Add # Album to Queue} other {Add # Albums to Queue}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Pin # Album for Offline} other {Pin # Albums for Offline}}</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Algunos cambios aún no han terminado de subirse y se perderán.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Haz clic en el botón de nuevo para confirmar.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>No se pudo eliminar la biblioteca: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Fijar para sin conexión</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Reproducir # álbum} other {Reproducir # álbumes}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Reproducir # álbum a continuación} other {Reproducir # álbumes a continuación}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Añadir # álbum a la cola} other {Añadir # álbumes a la cola}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Fijar # álbum para sin conexión} other {Fijar # álbumes para sin conexión}}</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Certaines modifications n'ont pas fini de se téléverser et seront perdues.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Cliquez de nouveau sur le bouton pour confirmer.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Impossible de supprimer la bibliothèque : {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Épingler hors ligne</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Lire # album} other {Lire # albums}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Lire # album à la suite} other {Lire # albums à la suite}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Ajouter # album à la file} other {Ajouter # albums à la file}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Épingler # album hors ligne} other {Épingler # albums hors ligne}}</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>કેટલાક ફેરફારો હજુ અપલોડ થયા નથી અને ગુમ થઈ જશે.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>પુષ્ટિ કરવા માટે બટન પર ફરીથી ક્લિક કરો.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>લાઇબ્રેરી દૂર કરી શકાઈ નથી: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ઑફલાઇન માટે પિન કરો</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ ચાલુ કરો} other {# આલ્બમો ચાલુ કરો}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ આગળ વગાડો} other {# આલ્બમો આગળ વગાડો}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ કતારમાં ઉમેરો} other {# આલ્બમો કતારમાં ઉમેરો}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ ઑફલાઇન માટે પિન કરો} other {# આલ્બમો ઑફલાઇન માટે પિન કરો}}</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>חלק מהשינויים עדיין לא סיימו להעלות ויאבדו.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>לחץ שוב על הכפתור כדי לאשר.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>לא ניתן היה להסיר את הספרייה: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>נעץ לזמינות לא מקוונת</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {נגן אלבום #} two {נגן # אלבומים} many {נגן # אלבומים} other {נגן # אלבומים}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {נגן אלבום # כהבא בתור} two {נגן # אלבומים כהבא בתור} many {נגן # אלבומים כהבא בתור} other {נגן # אלבומים כהבא בתור}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {הוסף אלבום # לתור} two {הוסף # אלבומים לתור} many {הוסף # אלבומים לתור} other {הוסף # אלבומים לתור}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {נעץ אלבום # לזמינות לא מקוונת} two {נעץ # אלבומים לזמינות לא מקוונת} many {נעץ # אלבומים לזמינות לא מקוונת} other {נעץ # אלבומים לזמינות לא מקוונת}}</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>कुछ बदलाव अभी अपलोड होना बाकी हैं और वे खो जाएंगे।</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>पुष्टि करने के लिए बटन को फिर से क्लिक करें।</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>लाइब्रेरी हटाई नहीं जा सकी: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ऑफलाइन के लिए पिन करें</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# एल्बम चलाएँ} other {# एल्बम चलाएँ}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# एल्बम अगला चलाएं} other {# एल्बम अगला चलाएं}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# एल्बम कतार में जोड़ें} other {# एल्बम कतार में जोड़ें}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# एल्बम ऑफलाइन के लिए पिन करें} other {# एल्बम ऑफलाइन के लिए पिन करें}}</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Neke se promjene još nisu dovršile prijenos i bit će izgubljene.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Ponovno kliknite gumb za potvrdu.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Fonoteku nije bilo moguće ukloniti: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Prikvači za izvanmrežni rad</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Reproduciraj # album} few {Reproduciraj # albuma} other {Reproduciraj # albuma}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Reproduciraj # album sljedeće} few {Reproduciraj # albuma sljedeće} other {Reproduciraj # albuma sljedeće}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Dodaj # album u red} few {Dodaj # albuma u red} other {Dodaj # albuma u red}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Prikvači # album za izvanmrežni rad} few {Prikvači # albuma za izvanmrežni rad} other {Prikvači # albuma za izvanmrežni rad}}</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Alcune modifiche non hanno ancora terminato il caricamento e andranno perse.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Fai clic di nuovo sul pulsante per confermare.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Impossibile rimuovere la libreria: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Rendi disponibile offline</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Riproduci # album} other {Riproduci # album}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Riproduci # album dopo} other {Riproduci # album dopo}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Aggiungi # album alla coda} other {Aggiungi # album alla coda}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Rendi disponibile offline # album} other {Rendi disponibile offline # album}}</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>一部の変更のアップロードが完了しておらず、失われます。</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>確認するにはもう一度ボタンをクリックしてください。</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>ライブラリを削除できませんでした: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>オフライン用にピン留め</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {アルバム#件を再生} other {アルバム#件を再生}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {アルバム#件を次に再生} other {アルバム#件を次に再生}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {アルバム#件をキューに追加} other {アルバム#件をキューに追加}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {アルバム#件をオフライン用にピン留め} other {アルバム#件をオフライン用にピン留め}}</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>ಕೆಲವು ಬದಲಾವಣೆಗಳು ಇನ್ನೂ ಅಪ್‌ಲೋಡ್ ಮುಗಿಸಿಲ್ಲ ಮತ್ತು ಕಳೆದುಹೋಗುತ್ತವೆ.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>ದೃಢೀಕರಿಸಲು ಬಟನ್ ಅನ್ನು ಮತ್ತೆ ಕ್ಲಿಕ್ ಮಾಡಿ.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>ಲೈಬ್ರರಿಯನ್ನು ತೆಗೆದುಹಾಕಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ಆಫ್‌ಲೈನ್‌ಗಾಗಿ ಪಿನ್ ಮಾಡಿ</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಪ್ಲೇ ಮಾಡಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಪ್ಲೇ ಮಾಡಿ}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಮುಂದೆ ಪ್ಲೇ ಮಾಡಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಮುಂದೆ ಪ್ಲೇ ಮಾಡಿ}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಸಾಲಿಗೆ ಸೇರಿಸಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಸಾಲಿಗೆ ಸೇರಿಸಿ}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಆಫ್‌ಲೈನ್‌ಗಾಗಿ ಪಿನ್ ಮಾಡಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಆಫ್‌ಲೈನ್‌ಗಾಗಿ ಪಿನ್ ಮಾಡಿ}}</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>일부 변경 사항이 아직 업로드되지 않았으며 손실됩니다.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>확인하려면 버튼을 다시 클릭하세요.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>라이브러리를 제거할 수 없습니다: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>오프라인용으로 고정</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 재생} other {앨범 #개 재생}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 다음에 재생} other {앨범 #개 다음에 재생}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 대기열에 추가} other {앨범 #개 대기열에 추가}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 오프라인용으로 고정} other {앨범 #개 오프라인용으로 고정}}</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>ചില മാറ്റങ്ങൾ ഇതുവരെ അപ്‌ലോഡ് പൂർത്തിയായിട്ടില്ല, അവ നഷ്ടപ്പെടും.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>സ്ഥിരീകരിക്കാൻ ബട്ടൺ വീണ്ടും ക്ലിക്ക് ചെയ്യുക.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>ലൈബ്രറി നീക്കം ചെയ്യാനായില്ല: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ഓഫ്‌ലൈൻ ഉപയോഗത്തിന് പിൻ ചെയ്യുക</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം പ്ലേ ചെയ്യുക} other {# ആൽബങ്ങൾ പ്ലേ ചെയ്യുക}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം അടുത്തതായി പ്ലേ ചെയ്യുക} other {# ആൽബങ്ങൾ അടുത്തതായി പ്ലേ ചെയ്യുക}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം നിരയിലേക്ക് ചേർക്കുക} other {# ആൽബങ്ങൾ നിരയിലേക്ക് ചേർക്കുക}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം ഓഫ്‌ലൈൻ ഉപയോഗത്തിന് പിൻ ചെയ്യുക} other {# ആൽബങ്ങൾ ഓഫ്‌ലൈൻ ഉപയോഗത്തിന് പിൻ ചെയ്യുക}}</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>काही बदल अद्याप अपलोड झालेले नाहीत आणि ते गमावले जातील.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>पुष्टी करण्यासाठी बटण पुन्हा क्लिक करा.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>लायब्ररी काढता आली नाही: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ऑफलाइनसाठी पिन करा</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# अल्बम प्ले करा} other {# अल्बम प्ले करा}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# अल्बम पुढे वाजवा} other {# अल्बम पुढे वाजवा}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# अल्बम रांगेत जोडा} other {# अल्बम रांगेत जोडा}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# अल्बम ऑफलाइनसाठी पिन करा} other {# अल्बम ऑफलाइनसाठी पिन करा}}</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Sommige wijzigingen zijn nog niet volledig geüpload en gaan verloren.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Klik opnieuw op de knop om te bevestigen.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Kan bibliotheek niet verwijderen: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Vastzetten voor offline</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# album afspelen} other {# albums afspelen}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# album hierna afspelen} other {# albums hierna afspelen}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# album toevoegen aan wachtrij} other {# albums toevoegen aan wachtrij}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# album vastzetten voor offline} other {# albums vastzetten voor offline}}</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>ਕੁਝ ਬਦਲਾਅ ਅਜੇ ਅੱਪਲੋਡ ਹੋਣੇ ਬਾਕੀ ਹਨ ਅਤੇ ਗੁਆਚ ਜਾਣਗੇ।</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>ਪੁਸ਼ਟੀ ਕਰਨ ਲਈ ਬਟਨ ਨੂੰ ਦੁਬਾਰਾ ਕਲਿੱਕ ਕਰੋ।</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਹਟਾਈ ਨਹੀਂ ਜਾ ਸਕੀ: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ਆਫਲਾਈਨ ਲਈ ਪਿਨ ਕਰੋ</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਚਲਾਓ} other {# ਐਲਬਮਾਂ ਚਲਾਓ}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਅੱਗੇ ਚਲਾਓ} other {# ਐਲਬਮਾਂ ਅੱਗੇ ਚਲਾਓ}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਕਤਾਰ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ} other {# ਐਲਬਮਾਂ ਕਤਾਰ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਆਫਲਾਈਨ ਲਈ ਪਿਨ ਕਰੋ} other {# ਐਲਬਮਾਂ ਆਫਲਾਈਨ ਲਈ ਪਿਨ ਕਰੋ}}</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Niektóre zmiany nie zostały jeszcze przesłane i zostaną utracone.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Kliknij przycisk ponownie, aby potwierdzić.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Nie udało się usunąć biblioteki: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Przypnij do trybu offline</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Odtwórz # album} few {Odtwórz # albumy} many {Odtwórz # albumów} other {Odtwórz # albumu}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Odtwórz # album jako następny} few {Odtwórz # albumy jako następne} many {Odtwórz # albumów jako następne} other {Odtwórz # albumu jako następne}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Dodaj # album do kolejki} few {Dodaj # albumy do kolejki} many {Dodaj # albumów do kolejki} other {Dodaj # albumu do kolejki}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Przypnij # album do trybu offline} few {Przypnij # albumy do trybu offline} many {Przypnij # albumów do trybu offline} other {Przypnij # albumu do trybu offline}}</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Algumas alterações ainda não terminaram de ser enviadas e serão perdidas.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Clique no botão novamente para confirmar.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Não foi possível remover a biblioteca: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Fixar para offline</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Reproduzir # álbum} other {Reproduzir # álbuns}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Reproduzir # álbum a seguir} other {Reproduzir # álbuns a seguir}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Adicionar # álbum à fila} other {Adicionar # álbuns à fila}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Fixar # álbum para offline} other {Fixar # álbuns para offline}}</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>சில மாற்றங்கள் இன்னும் பதிவேற்றம் முடிக்கவில்லை, அவை இழக்கப்படும்.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>உறுதிப்படுத்த பொத்தானை மீண்டும் கிளிக் செய்யவும்.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>நூலகத்தை அகற்ற முடியவில்லை: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>இணையமில்லா பயன்பாட்டுக்கு நிலைநிறுத்து</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை இயக்கு} other {# ஆல்பங்களை இயக்கு}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை அடுத்து இயக்கு} other {# ஆல்பங்களை அடுத்து இயக்கு}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை வரிசையில் சேர்க்கவும்} other {# ஆல்பங்களை வரிசையில் சேர்க்கவும்}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை இணையமில்லா பயன்பாட்டுக்கு நிலைநிறுத்து} other {# ஆல்பங்களை இணையமில்லா பயன்பாட்டுக்கு நிலைநிறுத்து}}</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>కొన్ని మార్పులు ఇంకా అప్‌లోడ్ పూర్తి చేయలేదు, అవి పోతాయి.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>నిర్ధారించడానికి బటన్‌ను మళ్లీ క్లిక్ చేయండి.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>లైబ్రరీని తీసివేయలేకపోయింది: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ఆఫ్‌లైన్ కోసం పిన్ చేయి</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ ప్లే చేయి} other {# ఆల్బమ్‌లు ప్లే చేయి}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ తర్వాత ప్లే చేయి} other {# ఆల్బమ్‌లు తర్వాత ప్లే చేయి}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ క్యూలో జోడించు} other {# ఆల్బమ్‌లు క్యూలో జోడించు}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ ఆఫ్‌లైన్ కోసం పిన్ చేయి} other {# ఆల్బమ్‌లు ఆఫ్‌లైన్ కోసం పిన్ చేయి}}</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>การเปลี่ยนแปลงบางอย่างยังอัปโหลดไม่เสร็จและจะสูญหาย</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>คลิกปุ่มอีกครั้งเพื่อยืนยัน</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>ไม่สามารถลบไลบรารีได้: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>ปักหมุดเพื่อใช้ออฟไลน์</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {เล่น # อัลบั้ม} other {เล่น # อัลบั้ม}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {เล่น # อัลบั้มถัดไป} other {เล่น # อัลบั้มถัดไป}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {เพิ่ม # อัลบั้มในคิว} other {เพิ่ม # อัลบั้มในคิว}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {ปักหมุด # อัลบั้มเพื่อใช้ออฟไลน์} other {ปักหมุด # อัลบั้มเพื่อใช้ออฟไลน์}}</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Bazı değişikliklerin yüklenmesi tamamlanmadı ve kaybolacak.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Onaylamak için düğmeye tekrar tıklayın.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Kitaplık kaldırılamadı: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Çevrimdışı için sabitle</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# albümü çal} other {# albümü çal}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# albümü sırada çal} other {# albümü sırada çal}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# albümü kuyruğa ekle} other {# albümü kuyruğa ekle}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# albümü çevrimdışı için sabitle} other {# albümü çevrimdışı için sabitle}}</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Деякі зміни ще не завершили завантаження і будуть втрачені.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Натисніть кнопку ще раз, щоб підтвердити.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Не вдалося вилучити бібліотеку: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Закріпити для офлайн-доступу</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Відтворити # альбом} few {Відтворити # альбоми} many {Відтворити # альбомів} other {Відтворити # альбому}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Відтворити # альбом наступним} few {Відтворити # альбоми наступними} many {Відтворити # альбомів наступними} other {Відтворити # альбому наступним}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Додати # альбом в чергу} few {Додати # альбоми в чергу} many {Додати # альбомів в чергу} other {Додати # альбому в чергу}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Закріпити # альбом для офлайн-доступу} few {Закріпити # альбоми для офлайн-доступу} many {Закріпити # альбомів для офлайн-доступу} other {Закріпити # альбому для офлайн-доступу}}</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>کچھ تبدیلیاں ابھی اپ لوڈ مکمل نہیں کر پائیں اور ضائع ہو جائیں گی۔</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>تصدیق کے لیے بٹن دوبارہ دبائیں۔</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>لائبریری ہٹائی نہیں جا سکی: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>آف لائن کے لیے پن کریں</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {# البم چلائیں} other {# البمز چلائیں}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# البم اگلا چلائیں} other {# البمز اگلا چلائیں}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# البم قطار میں شامل کریں} other {# البمز قطار میں شامل کریں}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# البم آف لائن کے لیے پن کریں} other {# البمز آف لائن کے لیے پن کریں}}</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>Một số thay đổi vẫn chưa tải lên xong và sẽ bị mất.</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>Nhấp lại vào nút để xác nhận.</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>Không thể xóa thư viện: {error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>Ghim để dùng ngoại tuyến</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {Phát # album} other {Phát # album}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Phát # album tiếp theo} other {Phát # album tiếp theo}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Thêm # album vào hàng đợi} other {Thêm # album vào hàng đợi}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Ghim # album để dùng ngoại tuyến} other {Ghim # album để dùng ngoại tuyến}}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>部分更改尚未上传完成，将会丢失。</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>再次点击按钮以确认。</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>无法移除库：{error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>固定以离线使用</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {播放#张专辑} other {播放#张专辑}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {接下来播放#张专辑} other {接下来播放#张专辑}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {将#张专辑添加到队列} other {将#张专辑添加到队列}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {固定#张专辑以离线使用} other {固定#张专辑以离线使用}}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -408,4 +408,9 @@
   <data name="settings.remove.confirm_pending" xml:space="preserve"><value>部分變更尚未上傳完成，將會遺失。</value></data>
   <data name="settings.remove.confirm_again" xml:space="preserve"><value>再次點擊按鈕以確認。</value></data>
   <data name="settings.remove.failed" xml:space="preserve"><value>無法移除資料庫：{error}</value></data>
+  <data name="menu.pin" xml:space="preserve"><value>釘選供離線使用</value></data>
+  <data name="menu.play_count" xml:space="preserve"><value>{count, plural, one {播放#張專輯} other {播放#張專輯}}</value></data>
+  <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {接下來播放#張專輯} other {接下來播放#張專輯}}</value></data>
+  <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {將#張專輯加入佇列} other {將#張專輯加入佇列}}</value></data>
+  <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {釘選#張專輯供離線使用} other {釘選#張專輯供離線使用}}</value></data>
 </root>

--- a/bae-windows/Views/AlbumCardMenu.cs
+++ b/bae-windows/Views/AlbumCardMenu.cs
@@ -1,25 +1,40 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Bae.Windows;
 
-// The album card's context menu: play the album's canonical release, or queue
-// it next / at the end — the same release-level actions the album-detail
-// overflow menu offers, reachable without opening the album.
+// The album card's context menu: play, queue next / at the end, or pin for
+// offline — the release-level actions reachable without opening the album.
+// targetCount is how many albums the click resolved to (the whole
+// multi-selection for a member card, else just the clicked one, computed by
+// AlbumGridSelectionModel.OrderedTargets); labels carry the count only when
+// more than one album is targeted. Opening the menu never mutates the
+// selection.
 internal static class AlbumCardMenu
 {
-    internal static MenuFlyout Build(Action onPlay, Action onPlayNext, Action onAddToQueue)
+    internal static MenuFlyout Build(
+        int targetCount,
+        Func<Task> onPlay,
+        Func<Task> onPlayNext,
+        Func<Task> onAddToQueue,
+        Func<Task> onPin)
     {
         var menu = new MenuFlyout();
-        var play = new MenuFlyoutItem { Text = Loc.Chrome("menu.play") };
-        play.Click += (_, _) => onPlay();
-        var playNext = new MenuFlyoutItem { Text = Loc.Chrome("menu.play_next") };
-        playNext.Click += (_, _) => onPlayNext();
-        var addToQueue = new MenuFlyoutItem { Text = Loc.Chrome("menu.add_to_queue") };
-        addToQueue.Click += (_, _) => onAddToQueue();
-        menu.Items.Add(play);
-        menu.Items.Add(playNext);
-        menu.Items.Add(addToQueue);
+        menu.Items.Add(Item(Label("menu.play", "menu.play_count", targetCount), onPlay));
+        menu.Items.Add(Item(Label("menu.play_next", "menu.play_next_count", targetCount), onPlayNext));
+        menu.Items.Add(Item(Label("menu.add_to_queue", "menu.add_to_queue_count", targetCount), onAddToQueue));
+        menu.Items.Add(Item(Label("menu.pin", "menu.pin_count", targetCount), onPin));
         return menu;
+    }
+
+    private static string Label(string singularKey, string countKey, int targetCount) =>
+        targetCount > 1 ? Loc.Chrome(countKey, "count", targetCount) : Loc.Chrome(singularKey);
+
+    private static MenuFlyoutItem Item(string text, Func<Task> onClick)
+    {
+        var item = new MenuFlyoutItem { Text = text };
+        item.Click += async (_, _) => await onClick();
+        return item;
     }
 }

--- a/bae-windows/Views/QueuePane.cs
+++ b/bae-windows/Views/QueuePane.cs
@@ -402,6 +402,15 @@ internal sealed class QueuePane
         await ResolveAndApply(ids, (handle, trackIds) => NativeBae.AddToQueue(handle, trackIds));
     }
 
+    // The album grid's bulk Add to Queue / Play Next: resolves album ids to
+    // tracks and applies them, sharing the drag-drop resolve-then-apply route
+    // and its error banner (the same route macOS's QueueActions gives both the
+    // now-playing-bar drop and the grid's bulk menu).
+    public Task AddAlbumsToQueue(IReadOnlyList<string> albumIds, bool addNext) =>
+        ResolveAndApply(albumIds, (handle, trackIds) => addNext
+            ? NativeBae.AddNext(handle, trackIds)
+            : NativeBae.AddToQueue(handle, trackIds));
+
     // Read and decode the drag payload, releasing the drop as soon as the data is
     // read. Null when the payload carries no ids (a Text drag that isn't ours).
     private static async Task<IReadOnlyList<string>?> ReadDropPayload(DragEventArgs e)

--- a/bae-windows/bae-windows.Tests/AlbumGridSelectionModelTests.cs
+++ b/bae-windows/bae-windows.Tests/AlbumGridSelectionModelTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the album-grid multi-selection semantics: toggle re-anchoring, range
+/// extension (including the unresolvable-anchor degrade and unloaded-gap
+/// skip), select-all, clear, remove, and the ordered-targets menu/drag rule.
+/// Ports the macOS AlbumGridSelectionTests suite over the plain-BCL model.
+/// </summary>
+public sealed class AlbumGridSelectionModelTests
+{
+    [Fact]
+    public void Toggle_AddsRemovesAndReanchorsOnTheClickedId()
+    {
+        var selection = new AlbumGridSelectionModel();
+
+        selection.Toggle("a");
+        Assert.Equal(new HashSet<string> { "a" }, selection.SelectedIds);
+        Assert.Equal("a", selection.AnchorId);
+
+        selection.Toggle("b");
+        Assert.Equal(new HashSet<string> { "a", "b" }, selection.SelectedIds);
+        Assert.Equal("b", selection.AnchorId);
+
+        selection.Toggle("a");
+        Assert.Equal(new HashSet<string> { "b" }, selection.SelectedIds);
+        // A ctrl-click re-anchors even when it removes the id.
+        Assert.Equal("a", selection.AnchorId);
+    }
+
+    [Fact]
+    public void ExtendRange_UnionsBothDirectionsFromTheAnchor()
+    {
+        var ids = new[] { "a", "b", "c", "d", "e" };
+        int? Position(string id) => System.Array.IndexOf(ids, id) is var i && i >= 0 ? i : null;
+        string? IdAt(int index) => index >= 0 && index < ids.Length ? ids[index] : null;
+
+        var up = new AlbumGridSelectionModel();
+        up.Toggle("b");
+        up.ExtendRange("d", Position, IdAt);
+        Assert.Equal(new HashSet<string> { "b", "c", "d" }, up.SelectedIds);
+        // The anchor is unchanged by a range extend.
+        Assert.Equal("b", up.AnchorId);
+
+        var down = new AlbumGridSelectionModel();
+        down.Toggle("d");
+        down.ExtendRange("a", Position, IdAt);
+        Assert.Equal(new HashSet<string> { "a", "b", "c", "d" }, down.SelectedIds);
+        Assert.Equal("d", down.AnchorId);
+    }
+
+    [Fact]
+    public void ExtendRange_SkipsIdsInTheSpanThatArentLoaded()
+    {
+        // Index 2 is within the span but not loaded (idAt returns null).
+        var positions = new Dictionary<string, int> { ["a"] = 0, ["b"] = 1, ["d"] = 3 };
+        var loaded = new Dictionary<int, string> { [0] = "a", [1] = "b", [3] = "d" };
+        var selection = new AlbumGridSelectionModel();
+
+        selection.Toggle("a");
+        selection.ExtendRange(
+            "d",
+            id => positions.TryGetValue(id, out var p) ? p : null,
+            index => loaded.TryGetValue(index, out var id) ? id : null);
+
+        Assert.Equal(new HashSet<string> { "a", "b", "d" }, selection.SelectedIds);
+    }
+
+    [Fact]
+    public void ExtendRange_DegradesToToggleWhenTheAnchorNoLongerResolves()
+    {
+        var selection = new AlbumGridSelectionModel();
+        selection.Toggle("a");
+        selection.ExtendRange("c", _ => null, _ => null);
+
+        Assert.Equal(new HashSet<string> { "a", "c" }, selection.SelectedIds);
+        Assert.Equal("c", selection.AnchorId);
+    }
+
+    [Fact]
+    public void SelectAll_SelectsEveryIdAndAnchorsTheLast_ClearEmpties()
+    {
+        var selection = new AlbumGridSelectionModel();
+        selection.SelectAll(new[] { "a", "b", "c" });
+        Assert.Equal(new HashSet<string> { "a", "b", "c" }, selection.SelectedIds);
+        Assert.Equal("c", selection.AnchorId);
+
+        selection.Clear();
+        Assert.True(selection.IsEmpty);
+        Assert.Null(selection.AnchorId);
+    }
+
+    [Fact]
+    public void OrderedTargets_ReturnsVisibleOrderForAMemberOfAMultiSelection()
+    {
+        var positions = new Dictionary<string, int> { ["a"] = 0, ["b"] = 1, ["c"] = 2 };
+        var selection = new AlbumGridSelectionModel();
+        selection.Toggle("c");
+        selection.Toggle("a");
+
+        Assert.Equal(
+            new[] { "a", "c" },
+            selection.OrderedTargets("a", id => positions.TryGetValue(id, out var p) ? p : null));
+    }
+
+    [Fact]
+    public void OrderedTargets_DropsIdsThatDontResolveToAPosition()
+    {
+        var selection = new AlbumGridSelectionModel();
+        selection.Toggle("a");
+        selection.Toggle("b");
+
+        Assert.Equal(
+            new[] { "a" },
+            selection.OrderedTargets("a", id => id == "a" ? 0 : null));
+    }
+
+    [Fact]
+    public void OrderedTargets_ReturnsJustTheClickedIdForANonMemberClick()
+    {
+        var positions = new Dictionary<string, int> { ["a"] = 0, ["b"] = 1, ["c"] = 2 };
+        var selection = new AlbumGridSelectionModel();
+        selection.Toggle("a");
+        selection.Toggle("c");
+
+        Assert.Equal(
+            new[] { "b" },
+            selection.OrderedTargets("b", id => positions.TryGetValue(id, out var p) ? p : null));
+    }
+
+    [Fact]
+    public void OrderedTargets_ReturnsJustTheClickedIdForASingleSelection()
+    {
+        var selection = new AlbumGridSelectionModel();
+        selection.Toggle("a");
+
+        Assert.Equal(new[] { "a" }, selection.OrderedTargets("a", _ => 0));
+    }
+
+    [Fact]
+    public void Remove_DropsOnlyTheMissingIdsAndClearsARemovedAnchor()
+    {
+        var selection = new AlbumGridSelectionModel();
+        selection.SelectAll(new[] { "a", "b", "c" });
+
+        selection.Remove(new[] { "b" });
+        Assert.Equal(new HashSet<string> { "a", "c" }, selection.SelectedIds);
+        // The anchor (c) survives when it isn't among the removed ids.
+        Assert.Equal("c", selection.AnchorId);
+
+        selection.Remove(new[] { "c" });
+        Assert.Equal(new HashSet<string> { "a" }, selection.SelectedIds);
+        Assert.Null(selection.AnchorId);
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -17,18 +17,20 @@
       MediaControlService and is verified by compilation).
     - The store models (PlaybackPositionModel / LightboxModel / SyncIndicatorModel /
       ImportIdentityModel / ReidentifyResultsModel / ImportListModel /
-      LibrarySwitchModel / PersistPlaybackModel) — the now-playing-bar
-      seek/position math, the lightbox navigation/zoom/chrome logic, the sync-indicator
-      precedence, the import identity-claim state (exact vs metadata-only, its note and
-      pressing-field enablement), the re-identify results-list arbitration
-      between the auto-identify pipeline and a manual search, the import
-      candidate-list tab assignment / counts / sort orders / persisted-token
-      round-trip, the main-window bounds clamp (validation of the saved rect
-      plus the fit-onto-the-current-displays math that keeps a restored window
-      reachable), the Ctrl+1..9 library-switch digit → id mapping, and the
-      restore-on-launch playback preference's token round-trip, split out as
-      plain BCL types (the stores that hold bridge snapshots and the WinUI
-      views and dialogs that render them are verified by compilation).
+      LibrarySwitchModel / PersistPlaybackModel / AlbumGridSelectionModel) — the
+      now-playing-bar seek/position math, the lightbox navigation/zoom/chrome logic,
+      the sync-indicator precedence, the import identity-claim state (exact vs
+      metadata-only, its note and pressing-field enablement), the re-identify
+      results-list arbitration between the auto-identify pipeline and a manual
+      search, the import candidate-list tab assignment / counts / sort orders /
+      persisted-token round-trip, the main-window bounds clamp (validation of the
+      saved rect plus the fit-onto-the-current-displays math that keeps a restored
+      window reachable), the Ctrl+1..9 library-switch digit → id mapping, the
+      restore-on-launch playback preference's token round-trip, and the album-grid
+      multi-selection (toggle/range-extend/select-all/clear/remove and the ordered
+      bulk-action/drag targets), split out as plain BCL types (the stores that hold
+      bridge snapshots and the WinUI views and dialogs that render them are
+      verified by compilation).
     - The export-queue decision layer (ExportQueueModel) — the Exporting
       section's band/state catalog keys, count summary, retry/pause gating and
       percent clamping, plus the export destination and settings Location-row
@@ -86,6 +88,7 @@
     <Compile Include="../Stores/WindowBoundsModel.cs" Link="WindowBoundsModel.cs" />
     <Compile Include="../Stores/PersistPlaybackModel.cs" Link="PersistPlaybackModel.cs" />
     <Compile Include="../Stores/ForgetLibraryModel.cs" Link="ForgetLibraryModel.cs" />
+    <Compile Include="../Stores/AlbumGridSelectionModel.cs" Link="AlbumGridSelectionModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The macOS album grid supports multi-select (cmd-click toggle, shift-click range, cmd-A select-all-loaded, Esc/plain-click clear) with bulk Play / Add to Queue / Play Next / Pin for Offline actions from any selected card's menu, and drags that carry the whole selection. bae-windows had none of this — one album per click, a three-item single-album context menu, single-album drags.

WinUI's `GridView` offers a built-in `SelectionMode="Extended"`, but it conflicts with the settled semantics: a plain click must clear the selection and open the detail dialog (Extended would single-select it instead), and a modifier click must never open the dialog. So this keeps `SelectionMode="None"` and drives a custom, WinRT-free selection model — `Stores/AlbumGridSelectionModel.cs`, a plain-BCL port of macOS's `AlbumGridSelection` — dispatching on modifier state read at click time. Selection renders through an `Album.IsSelected` notify property bound OneWay to an always-present, opacity-toggled tint in the card `DataTemplate`, so it survives container recycling in the virtualized grid without re-measuring rows.

`AlbumCardMenu` now takes a target count and a pin action, switching to ICU-plural count labels above one target. The four actions route through batch `NativeBae` wrappers (`PlayReleases`, `PinReleases`, both new, over already-exported bridge calls) when the click targets more than one album; a single target keeps the pre-existing calls. Add to Queue / Play Next reuse `QueuePane`'s existing resolve-then-apply route (now exposed as `AddAlbumsToQueue`) rather than re-implementing the resolve/error-banner logic. The selection clears on every album-list reload, on search, on library teardown, and before a plain click opens detail — the same points macOS clears at, adapted to Windows's wholesale-reload store shape.

All 31 `Strings/<locale>/Resources.resw` catalogs get the 5 new keys (`menu.pin` plus 4 count-plural keys) with real, locale-correct-category translations.

## Test plan

- [x] `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 323 passed, including the new `AlbumGridSelectionModelTests` (toggle/range-extend/select-all/clear/remove/ordered-targets, ported from the macOS suite)
- [x] `python3 scripts/loc-chrome-orphans.py` — 0 orphans across all platforms
- [ ] Manual pass on Windows: ctrl-click/shift-click build a selection with visible tint; plain click clears and opens detail; Ctrl+A/Esc; right-click a selected card shows count labels and each bulk action lands; drag of a selected card appends all its albums to the queue; sort change and library switch drop the selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)