### PR TITLE
Windows: bae:// protocol, folder verb, and single-instancing

### DIFF
--- a/bae-windows/ActivationIntentModel.cs
+++ b/bae-windows/ActivationIntentModel.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// A typed action decoded from a process activation — a folder verb / dropped
+/// folder's command line, or a <c>bae://</c> link. Pure over plain BCL types
+/// (following <see cref="UpdateFlowState"/>'s pattern), so it compiles in the
+/// test project on any host; the WinRT activation plumbing that produces the
+/// raw arguments and dispatches the intent lives in <c>Program</c> and
+/// <c>MainWindow</c>.
+/// </summary>
+internal abstract record ActivationIntent
+{
+    /// <summary>Scan and, if it opens successfully, watch <paramref name="Path"/>
+    /// as an import source — the same action the window-drop target runs.</summary>
+    internal sealed record ImportFolder(string Path) : ActivationIntent;
+}
+
+/// <summary>
+/// Turns an activation's argument list into an <see cref="ActivationIntent"/>.
+/// Filesystem access never happens inside this class — every rootedness check
+/// is the model's own string rule (not <see cref="System.IO.Path"/>, whose
+/// rootedness semantics differ on the macOS host the unit tests run on), and
+/// every directory check goes through the caller-supplied <c>isDirectory</c>
+/// delegate.
+/// </summary>
+internal static class ActivationIntentModel
+{
+    /// <summary>
+    /// Scan <paramref name="args"/> in order; the first argument that yields an
+    /// intent wins. A folder-verb command line (or a folder dragged onto the
+    /// exe) and a redirected raw command line both arrive as <c>argv</c>, so a
+    /// single per-argument rule covers a bare folder path, the exe token that
+    /// leads a redirected command line (a file, not a directory — no match),
+    /// and Velopack's <c>--veloapp-*</c> flags (not a rooted path — no match).
+    /// </summary>
+    internal static ActivationIntent? Parse(IReadOnlyList<string> args, Func<string, bool> isDirectory)
+    {
+        foreach (var arg in args)
+        {
+            var intent = ParseArgument(arg, isDirectory);
+            if (intent is not null)
+            {
+                return intent;
+            }
+        }
+
+        return null;
+    }
+
+    private static ActivationIntent? ParseArgument(string arg, Func<string, bool> isDirectory)
+    {
+        if (Uri.TryCreate(arg, UriKind.Absolute, out var uri)
+            && string.Equals(uri.Scheme, "bae", StringComparison.OrdinalIgnoreCase))
+        {
+            return ParseBaeUri(uri, isDirectory);
+        }
+
+        return IsWindowsRootedPath(arg) && isDirectory(arg) ? new ActivationIntent.ImportFolder(arg) : null;
+    }
+
+    // The one recognized bae:// form: bae://import?path=<percent-encoded folder
+    // path>. Any other host, a missing/empty path, or a path that isn't a
+    // rooted existing directory is not an error — it's a focus-only activation,
+    // matching macOS, where every bae:// URL is a no-op beyond bringing the app
+    // forward.
+    private static ActivationIntent? ParseBaeUri(Uri uri, Func<string, bool> isDirectory)
+    {
+        if (!string.Equals(uri.Host, "import", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var rawPath = FirstQueryValue(uri.Query, "path");
+        if (string.IsNullOrEmpty(rawPath))
+        {
+            return null;
+        }
+
+        var path = Uri.UnescapeDataString(rawPath);
+        return IsWindowsRootedPath(path) && isDirectory(path) ? new ActivationIntent.ImportFolder(path) : null;
+    }
+
+    // Hand-rolled query parse (no System.Web dependency, so the model stays
+    // pure BCL): the first occurrence of `name` wins, matching the contract's
+    // "first path query parameter wins" — including when that first occurrence
+    // is present but empty, which is why an empty value is returned as-is
+    // rather than falling through to a later occurrence.
+    private static string? FirstQueryValue(string query, string name)
+    {
+        if (string.IsNullOrEmpty(query))
+        {
+            return null;
+        }
+
+        foreach (var pair in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = pair.IndexOf('=');
+            var key = separator < 0 ? pair : pair[..separator];
+            if (string.Equals(key, name, StringComparison.Ordinal))
+            {
+                return separator < 0 ? string.Empty : pair[(separator + 1)..];
+            }
+        }
+
+        return null;
+    }
+
+    // Windows-rooted per the model's own rule, not System.IO.Path (whose
+    // rootedness semantics differ on the macOS host these tests also run on):
+    // a drive letter (X:\ or X:/) or a UNC path (\\server\share...).
+    private static bool IsWindowsRootedPath(string value)
+    {
+        if (value.Length >= 3
+            && IsAsciiLetter(value[0])
+            && value[1] == ':'
+            && (value[2] == '\\' || value[2] == '/'))
+        {
+            return true;
+        }
+
+        return value.Length >= 3 && value[0] == '\\' && value[1] == '\\' && value[2] != '\\';
+    }
+
+    private static bool IsAsciiLetter(char c) => (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+
+    /// <summary>
+    /// Split a raw command-line string into argv tokens using Windows argv
+    /// quoting rules (the same convention <c>CommandLineToArgvW</c> documents):
+    /// whitespace separates tokens outside quotes; a double quote toggles
+    /// quoted mode; a run of backslashes immediately before a quote collapses
+    /// to half as many literal backslashes, and an odd run additionally escapes
+    /// the quote as a literal character instead of toggling quoted mode (so a
+    /// path ending in a backslash right before its closing quote, e.g. a UNC
+    /// share root, closes the quote rather than escaping it). Needed because a
+    /// redirected activation delivers <c>ILaunchActivatedEventArgs.Arguments</c>
+    /// as one raw string, unlike <see cref="Environment.GetCommandLineArgs"/>,
+    /// which the OS has already split for the initial launch.
+    /// </summary>
+    internal static IReadOnlyList<string> SplitCommandLine(string commandLine)
+    {
+        var tokens = new List<string>();
+        if (string.IsNullOrEmpty(commandLine))
+        {
+            return tokens;
+        }
+
+        var current = new StringBuilder();
+        var inQuotes = false;
+        var hasToken = false;
+        var i = 0;
+        while (i < commandLine.Length)
+        {
+            var c = commandLine[i];
+
+            if (c == '\\')
+            {
+                var backslashCount = 0;
+                while (i < commandLine.Length && commandLine[i] == '\\')
+                {
+                    backslashCount++;
+                    i++;
+                }
+
+                if (i < commandLine.Length && commandLine[i] == '"')
+                {
+                    current.Append('\\', backslashCount / 2);
+                    if (backslashCount % 2 == 1)
+                    {
+                        current.Append('"');
+                    }
+                    else
+                    {
+                        inQuotes = !inQuotes;
+                    }
+                    i++;
+                }
+                else
+                {
+                    current.Append('\\', backslashCount);
+                }
+
+                hasToken = true;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                hasToken = true;
+                i++;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(c))
+            {
+                if (hasToken)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                    hasToken = false;
+                }
+                i++;
+                continue;
+            }
+
+            current.Append(c);
+            hasToken = true;
+            i++;
+        }
+
+        if (hasToken)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens;
+    }
+}

--- a/bae-windows/App.xaml.cs
+++ b/bae-windows/App.xaml.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System.Linq;
+using Microsoft.UI.Xaml;
 
 namespace Bae.Windows;
 
 public partial class App : Application
 {
-    private Window? _window;
+    private MainWindow? _window;
 
     public App()
     {
@@ -25,7 +26,50 @@ public partial class App : Application
         // sign-in flows. Absent file: cloud sign-in stays unavailable.
         OAuthCreds.Register();
 
+        // Assert the bae:// protocol and folder-verb registration on every
+        // launch, gated to a real Velopack install so a dev run or loose-zip
+        // copy never points the user's registry at build output. Re-writing
+        // each launch keeps the command current and re-resolves the verb
+        // label after a locale change.
+        if (UpdateService.IsInstalled)
+        {
+            ProtocolRegistration.Register();
+        }
+
+        // The OS has already split this into argv for a normal launch, unlike
+        // a redirected activation's raw Arguments string (which needs
+        // ActivationIntentModel.SplitCommandLine first — see Program.OnActivated).
+        var intent = ActivationIntentModel.Parse(
+            Environment.GetCommandLineArgs().Skip(1).ToList(), Directory.Exists);
+
         _window = new MainWindow();
         _window.Activate();
+
+        if (intent is not null)
+        {
+            _window.SetPendingLaunchIntent(intent);
+        }
+    }
+
+    // Marshal a redirected activation (a second launch while this instance is
+    // already running) onto the window's dispatcher: bring it forward always,
+    // matching macOS, where every activation focuses the app even when the URL
+    // carries no action, then dispatch the parsed intent when there is one.
+    internal void HandleRedirectedActivation(ActivationIntent? intent)
+    {
+        var window = _window;
+        if (window is null)
+        {
+            return;
+        }
+
+        window.DispatcherQueue.TryEnqueue(() =>
+        {
+            window.BringToForeground();
+            if (intent is not null)
+            {
+                _ = window.HandleActivationIntent(intent);
+            }
+        });
     }
 }

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -83,6 +84,18 @@ public sealed partial class MainWindow : Window
     // relaunch lands on the user's chosen size rather than a display-sized rect.
     private PixelRect? _lastNormalBounds;
     private bool _maximized;
+
+    // The launch-time activation intent (a folder verb / bae://import command
+    // line, parsed by App.OnLaunched) latches here until the initial
+    // library-open attempt settles — a cold-start activation can arrive before
+    // an async unlock resolves, when CurrentHandleOrNull() would be null
+    // spuriously. A redirected activation (the app already warm) dispatches
+    // straight to HandleActivationIntent instead of going through this latch.
+    private bool _initialLibraryOpenSettled;
+    private ActivationIntent? _pendingLaunchIntent;
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
 
     // x:Bind Albums/Composers in the shell resolve here; the collections live in
     // the browser store (constructed before InitializeComponent so these are
@@ -450,6 +463,9 @@ public sealed partial class MainWindow : Window
         if (library is null)
         {
             _welcomeView.Show();
+            // Settled: no library exists to hand a launch-time intent to, so
+            // it applies now as the no-op HandleActivationIntent logs.
+            SettleInitialLibraryOpen();
             return;
         }
 
@@ -462,11 +478,14 @@ public sealed partial class MainWindow : Window
         {
             case OpenHandleResult.Failed:
                 StatusText.Text = Loc.Chrome("library.open_failed");
+                SettleInitialLibraryOpen();
                 return;
             case OpenHandleResult.NeedsUnlock:
                 // Encrypted library whose key isn't on this device: the session
                 // freed the handle it made; prompt for the key rather than show a
-                // half-open library. Unlocking re-opens with sync online.
+                // half-open library. Unlocking re-opens with sync online, which
+                // settles the latch below through this same method; until then
+                // a pending launch intent stays latched.
                 _ = _unlockDialog.Show(libraryId);
                 return;
         }
@@ -480,6 +499,76 @@ public sealed partial class MainWindow : Window
         _nowPlayingBar.SeedVolume();
         _sync.Refresh();
         _session.Subscribe();
+        SettleInitialLibraryOpen();
+    }
+
+    // Set by App.OnLaunched once the window exists. Applies immediately when
+    // the initial library-open attempt has already settled (the common case:
+    // LoadLibrary runs synchronously in the constructor, before this is
+    // called); otherwise latches until SettleInitialLibraryOpen runs.
+    internal void SetPendingLaunchIntent(ActivationIntent intent)
+    {
+        if (_initialLibraryOpenSettled)
+        {
+            _ = HandleActivationIntent(intent);
+        }
+        else
+        {
+            _pendingLaunchIntent = intent;
+        }
+    }
+
+    // Idempotent: called at every terminal point of the launch-time
+    // LoadLibrary/OpenLibrary flow (no library found, a failed open, or a
+    // successful open), including the one that runs after an async unlock
+    // resolves. Only the first call after a pending intent was set has an
+    // effect; later calls (a manual library switch, for instance) find nothing
+    // latched.
+    private void SettleInitialLibraryOpen()
+    {
+        _initialLibraryOpenSettled = true;
+        if (_pendingLaunchIntent is { } intent)
+        {
+            _pendingLaunchIntent = null;
+            _ = HandleActivationIntent(intent);
+        }
+    }
+
+    // Turn a parsed activation intent (the folder verb, a dropped-on-the-exe
+    // folder, or bae://import) into the same UI action OnWindowDrop runs for a
+    // dropped folder.
+    internal async System.Threading.Tasks.Task HandleActivationIntent(ActivationIntent intent)
+    {
+        switch (intent)
+        {
+            case ActivationIntent.ImportFolder importFolder:
+                if (CurrentHandleOrNull() == null)
+                {
+                    // No open library (welcome screen or an unresolved unlock):
+                    // a no-op, matching the macOS handler's folder add.
+                    BaeDiagnostics.Logger.Info(
+                        "Ignored a folder-import activation: no library is open.");
+                    return;
+                }
+                await ImportFolder(importFolder.Path);
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(intent), intent, "Unknown activation intent");
+        }
+    }
+
+    // Bring the window to the front for a redirected activation (a second
+    // launch while bae is already running): restore it first if minimized.
+    // The OS may downgrade this to a taskbar flash when foreground rights are
+    // denied to a background process — accepted, not worked around.
+    internal void BringToForeground()
+    {
+        if (AppWindow.Presenter is OverlappedPresenter { State: OverlappedPresenterState.Minimized } presenter)
+        {
+            presenter.Restore();
+        }
+
+        SetForegroundWindow(WinRT.Interop.WindowNative.GetWindowHandle(this));
     }
 
     // Render the toolbar sync indicator and the sync banner from the sync store's
@@ -674,6 +763,17 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        await ImportFolder(folderPath);
+    }
+
+    // Scan a folder and open the import dialog on its candidates — candidates
+    // stream into the import store and the dialog (bound to that list) shows
+    // them, on a scan error too, matching macOS, which navigates to import
+    // regardless of the scan result. Shared by the window drop target and a
+    // folder activation intent (the folder verb or bae://import); the caller
+    // has already confirmed a library is open.
+    private async System.Threading.Tasks.Task ImportFolder(string folderPath)
+    {
         var (current, error) = await _import.ScanFolder(folderPath);
         if (!current)
         {
@@ -684,8 +784,6 @@ public sealed partial class MainWindow : Window
             ShowImportBanner(error);
         }
 
-        // Open the import dialog on the streamed candidates — on scan error too,
-        // matching macOS, which navigates to import regardless of the scan result.
         // Skip if one is already open (only one ContentDialog can open at a time).
         if (!_importDialog.IsOpen)
         {

--- a/bae-windows/Program.cs
+++ b/bae-windows/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
+using Microsoft.Windows.AppLifecycle;
 using Velopack;
+using Windows.ApplicationModel.Activation;
 
 namespace Bae.Windows;
 
@@ -8,22 +10,67 @@ namespace Bae.Windows;
 /// The app entry point, replacing the one WinUI generates
 /// (<c>DISABLE_XAML_GENERATED_MAIN</c> turns that off) so the Velopack hook runs
 /// before any UI. The body otherwise replicates the generated Main: XAML process
-/// checks, COM wrappers, and the dispatcher-bound <see cref="App"/>.
+/// checks, COM wrappers, and the dispatcher-bound <see cref="App"/> — with one
+/// addition, single-instancing: a second launch redirects its activation to the
+/// running instance and exits instead of starting a second window.
 /// </summary>
 public static class Program
 {
     [DllImport("Microsoft.ui.xaml.dll")]
     private static extern void XamlCheckProcessRequirements();
 
+    // The documented unpackaged-app redirect wait: CoWaitForMultipleObjects
+    // pumps COM messages while it blocks, unlike a bare Task.Wait() on the STA
+    // thread, which can deadlock RedirectActivationToAsync's own COM callback.
+    [DllImport("ole32.dll")]
+    private static extern int CoWaitForMultipleObjects(
+        uint dwFlags, uint dwMilliseconds, uint nHandles, IntPtr[] pHandles, out uint dwIndex);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateEvent(
+        IntPtr lpEventAttributes, bool bManualReset, bool bInitialState, string? lpName);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetEvent(IntPtr hEvent);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
     [STAThread]
     private static void Main(string[] args)
     {
         // Must run before anything else: handles the Velopack install / update /
-        // uninstall hook arguments and exits the process for them.
-        VelopackApp.Build().Run();
+        // uninstall hook arguments and exits the process for them. The
+        // pre-uninstall hook removes the registry state OnLaunched asserts on
+        // every normal run, before any UI/resource initialization.
+        VelopackApp.Build()
+            .WithBeforeUninstallFastCallback(_ => ProtocolRegistration.Unregister())
+            .Run();
+
+        // AppInstance is a WinRT API; the COM wrappers it needs must be up
+        // before the first call, strictly after the Velopack hook above (whose
+        // own callbacks must exit the process first) and before
+        // XamlCheckProcessRequirements below.
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+
+        // One key per edition, so bae and baeium never redirect into each
+        // other. Editions are otherwise interchangeable here: whichever one is
+        // running when a bae:// link or folder verb fires is the one that
+        // handles it.
+        var editionKey = NativeBae.SupportsOAuthProviders() ? "bae" : "baeium";
+        var activationArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
+        var keyInstance = AppInstance.FindOrRegisterForKey(editionKey);
+        if (!keyInstance.IsCurrent)
+        {
+            RedirectActivationTo(activationArgs, keyInstance);
+            return;
+        }
+
+        // The handler fires on a background thread; it marshals to the
+        // window's DispatcherQueue itself before touching any UI.
+        keyInstance.Activated += OnActivated;
 
         XamlCheckProcessRequirements();
-        WinRT.ComWrappersSupport.InitializeComWrappers();
         Microsoft.UI.Xaml.Application.Start(p =>
         {
             var context = new DispatcherQueueSynchronizationContext(
@@ -31,5 +78,45 @@ public static class Program
             SynchronizationContext.SetSynchronizationContext(context);
             _ = new App();
         });
+    }
+
+    // Redirect this launch's activation to the already-running instance and
+    // block until it has been received, without a bare .AsTask().Wait() on the
+    // STA thread: the work runs on a pool thread and signals a Win32 event,
+    // which this thread waits on through CoWaitForMultipleObjects so pending
+    // COM calls (including the redirect itself) still pump while it waits.
+    private static void RedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
+    {
+        var redirectComplete = CreateEvent(IntPtr.Zero, true, false, null);
+        _ = Task.Run(() =>
+        {
+            keyInstance.RedirectActivationToAsync(args).AsTask().Wait();
+            SetEvent(redirectComplete);
+        });
+
+        const uint CwmoDefault = 0;
+        const uint Infinite = 0xFFFFFFFF;
+        _ = CoWaitForMultipleObjects(CwmoDefault, Infinite, 1, new[] { redirectComplete }, out _);
+        CloseHandle(redirectComplete);
+    }
+
+    // Raised on a background thread by a redirected activation from a second
+    // launch. Only the Launch kind carries a command line (the only kind this
+    // app registers for); anything else is ignored.
+    private static void OnActivated(object? sender, AppActivationArguments args)
+    {
+        if (args.Kind != ExtendedActivationKind.Launch
+            || args.Data is not ILaunchActivatedEventArgs launchArgs)
+        {
+            return;
+        }
+
+        var commandLineArgs = ActivationIntentModel.SplitCommandLine(launchArgs.Arguments);
+        var intent = ActivationIntentModel.Parse(commandLineArgs, Directory.Exists);
+
+        if (Microsoft.UI.Xaml.Application.Current is App app)
+        {
+            app.HandleRedirectedActivation(intent);
+        }
     }
 }

--- a/bae-windows/ProtocolRegistration.cs
+++ b/bae-windows/ProtocolRegistration.cs
@@ -1,0 +1,85 @@
+using Microsoft.Win32;
+
+namespace Bae.Windows;
+
+/// <summary>
+/// Per-user (<c>HKCU\Software\Classes</c>) registration of the <c>bae://</c>
+/// protocol and the folder "open with bae" verb — the unpackaged-app
+/// equivalent of macOS's <c>CFBundleURLTypes</c> / <c>CFBundleDocumentTypes</c>
+/// declarations, written by hand because an unpackaged, unsigned app has no
+/// package identity to declare them through. No elevation and no signing:
+/// every key lives under the current user's hive.
+/// </summary>
+internal static class ProtocolRegistration
+{
+    private const string ProtocolKeyPath = @"Software\Classes\bae";
+    private const string FolderVerbKeyPath = @"Software\Classes\Directory\shell\bae";
+
+    /// <summary>
+    /// Write both key trees, overwriting whatever is already there. Called on
+    /// every launch (gated by the caller on this being a Velopack install) so
+    /// the command always points at the current <c>current\</c> exe path and
+    /// the verb label re-resolves after a locale change. A write failure (the
+    /// hive is unreadable, some policy blocks it) is logged and leaves
+    /// whatever registration already existed in place.
+    /// </summary>
+    internal static void Register()
+    {
+        var exePath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exePath))
+        {
+            BaeDiagnostics.Logger.Warning(
+                "Could not resolve the process path; skipping bae:// protocol registration.");
+            return;
+        }
+
+        var quotedExe = $"\"{exePath}\"";
+        var command = $"{quotedExe} \"%1\"";
+        var icon = $"{quotedExe},0";
+        var editionName = NativeBae.SupportsOAuthProviders() ? "bae" : "baeium";
+
+        try
+        {
+            using var protocolKey = Registry.CurrentUser.CreateSubKey(ProtocolKeyPath);
+            protocolKey.SetValue(null, "URL:bae");
+            protocolKey.SetValue("URL Protocol", string.Empty);
+            using (var defaultIconKey = protocolKey.CreateSubKey("DefaultIcon"))
+            {
+                defaultIconKey.SetValue(null, icon);
+            }
+            using (var commandKey = protocolKey.CreateSubKey(@"shell\open\command"))
+            {
+                commandKey.SetValue(null, command);
+            }
+
+            using var folderVerbKey = Registry.CurrentUser.CreateSubKey(FolderVerbKeyPath);
+            folderVerbKey.SetValue(null, Loc.Chrome("shell.open_with_folder", "name", editionName));
+            folderVerbKey.SetValue("Icon", icon);
+            using (var folderCommandKey = folderVerbKey.CreateSubKey("command"))
+            {
+                folderCommandKey.SetValue(null, command);
+            }
+        }
+        catch (Exception exception)
+        {
+            BaeDiagnostics.Logger.Warning("Could not register the bae:// protocol / folder verb.", exception);
+        }
+    }
+
+    /// <summary>Remove both key trees. Run from the Velopack pre-uninstall
+    /// callback, before any UI/resource initialization — needs no localized
+    /// strings, so it is safe there.</summary>
+    internal static void Unregister()
+    {
+        try
+        {
+            Registry.CurrentUser.DeleteSubKeyTree(ProtocolKeyPath, throwOnMissingSubKey: false);
+            Registry.CurrentUser.DeleteSubKeyTree(FolderVerbKeyPath, throwOnMissingSubKey: false);
+        }
+        catch (Exception exception)
+        {
+            BaeDiagnostics.Logger.Warning(
+                "Could not remove the bae:// protocol / folder verb registration.", exception);
+        }
+    }
+}

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, zero {تشغيل # ألبوم كالتالي} one {تشغيل ألبوم واحد كالتالي} two {تشغيل ألبومين كالتالي} few {تشغيل # ألبومات كالتالي} many {تشغيل # ألبومًا كالتالي} other {تشغيل # ألبوم كالتالي}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, zero {إضافة # ألبوم إلى قائمة الانتظار} one {إضافة ألبوم واحد إلى قائمة الانتظار} two {إضافة ألبومين إلى قائمة الانتظار} few {إضافة # ألبومات إلى قائمة الانتظار} many {إضافة # ألبومًا إلى قائمة الانتظار} other {إضافة # ألبوم إلى قائمة الانتظار}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, zero {تثبيت # ألبوم للاستخدام دون اتصال} one {تثبيت ألبوم واحد للاستخدام دون اتصال} two {تثبيت ألبومين للاستخدام دون اتصال} few {تثبيت # ألبومات للاستخدام دون اتصال} many {تثبيت # ألبومًا للاستخدام دون اتصال} other {تثبيت # ألبوم للاستخدام دون اتصال}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>افتح باستخدام {name}</value></data>
 </root>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Възпроизведи # албум като следващ} other {Възпроизведи # албума като следващи}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Добави # албум в опашката} other {Добави # албума в опашката}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Закачи # албум за офлайн} other {Закачи # албума за офлайн}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>отвори с {name}</value></data>
 </root>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম এরপর চালান} other {#টি অ্যালবাম এরপর চালান}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম সারিতে যোগ করুন} other {#টি অ্যালবাম সারিতে যোগ করুন}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {#টি অ্যালবাম অফলাইনের জন্য পিন করুন} other {#টি অ্যালবাম অফলাইনের জন্য পিন করুন}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} দিয়ে খুলুন</value></data>
 </root>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Přehrát # album jako další} few {Přehrát # alba jako další} many {Přehrát # alba jako další} other {Přehrát # alb jako další}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Přidat # album do fronty} few {Přidat # alba do fronty} many {Přidat # alba do fronty} other {Přidat # alb do fronty}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Připnout # album pro offline} few {Připnout # alba pro offline} many {Připnout # alba pro offline} other {Připnout # alb pro offline}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>otevřít pomocí {name}</value></data>
 </root>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# Album als Nächstes abspielen} other {# Alben als Nächstes abspielen}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# Album zur Warteschlange hinzufügen} other {# Alben zur Warteschlange hinzufügen}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# Album für Offline anheften} other {# Alben für Offline anheften}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>mit {name} öffnen</value></data>
 </root>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Play # Album Next} other {Play # Albums Next}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Add # Album to Queue} other {Add # Albums to Queue}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Pin # Album for Offline} other {Pin # Albums for Offline}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>open with {name}</value></data>
 </root>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Reproducir # álbum a continuación} other {Reproducir # álbumes a continuación}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Añadir # álbum a la cola} other {Añadir # álbumes a la cola}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Fijar # álbum para sin conexión} other {Fijar # álbumes para sin conexión}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>abrir con {name}</value></data>
 </root>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Lire # album à la suite} other {Lire # albums à la suite}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Ajouter # album à la file} other {Ajouter # albums à la file}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Épingler # album hors ligne} other {Épingler # albums hors ligne}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>ouvrir avec {name}</value></data>
 </root>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ આગળ વગાડો} other {# આલ્બમો આગળ વગાડો}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ કતારમાં ઉમેરો} other {# આલ્બમો કતારમાં ઉમેરો}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# આલ્બમ ઑફલાઇન માટે પિન કરો} other {# આલ્બમો ઑફલાઇન માટે પિન કરો}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} વડે ખોલો</value></data>
 </root>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {נגן אלבום # כהבא בתור} two {נגן # אלבומים כהבא בתור} many {נגן # אלבומים כהבא בתור} other {נגן # אלבומים כהבא בתור}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {הוסף אלבום # לתור} two {הוסף # אלבומים לתור} many {הוסף # אלבומים לתור} other {הוסף # אלבומים לתור}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {נעץ אלבום # לזמינות לא מקוונת} two {נעץ # אלבומים לזמינות לא מקוונת} many {נעץ # אלבומים לזמינות לא מקוונת} other {נעץ # אלבומים לזמינות לא מקוונת}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>פתח באמצעות {name}</value></data>
 </root>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# एल्बम अगला चलाएं} other {# एल्बम अगला चलाएं}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# एल्बम कतार में जोड़ें} other {# एल्बम कतार में जोड़ें}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# एल्बम ऑफलाइन के लिए पिन करें} other {# एल्बम ऑफलाइन के लिए पिन करें}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} से खोलें</value></data>
 </root>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Reproduciraj # album sljedeće} few {Reproduciraj # albuma sljedeće} other {Reproduciraj # albuma sljedeće}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Dodaj # album u red} few {Dodaj # albuma u red} other {Dodaj # albuma u red}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Prikvači # album za izvanmrežni rad} few {Prikvači # albuma za izvanmrežni rad} other {Prikvači # albuma za izvanmrežni rad}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>otvori s aplikacijom {name}</value></data>
 </root>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Riproduci # album dopo} other {Riproduci # album dopo}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Aggiungi # album alla coda} other {Aggiungi # album alla coda}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Rendi disponibile offline # album} other {Rendi disponibile offline # album}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>apri con {name}</value></data>
 </root>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {アルバム#件を次に再生} other {アルバム#件を次に再生}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {アルバム#件をキューに追加} other {アルバム#件をキューに追加}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {アルバム#件をオフライン用にピン留め} other {アルバム#件をオフライン用にピン留め}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} で開く</value></data>
 </root>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಮುಂದೆ ಪ್ಲೇ ಮಾಡಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಮುಂದೆ ಪ್ಲೇ ಮಾಡಿ}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಸಾಲಿಗೆ ಸೇರಿಸಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಸಾಲಿಗೆ ಸೇರಿಸಿ}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ಆಲ್ಬಮ್ ಆಫ್‌ಲೈನ್‌ಗಾಗಿ ಪಿನ್ ಮಾಡಿ} other {# ಆಲ್ಬಮ್‌ಗಳು ಆಫ್‌ಲೈನ್‌ಗಾಗಿ ಪಿನ್ ಮಾಡಿ}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} ನೊಂದಿಗೆ ತೆರೆಯಿರಿ</value></data>
 </root>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 다음에 재생} other {앨범 #개 다음에 재생}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 대기열에 추가} other {앨범 #개 대기열에 추가}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {앨범 #개 오프라인용으로 고정} other {앨범 #개 오프라인용으로 고정}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name}(으)로 열기</value></data>
 </root>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം അടുത്തതായി പ്ലേ ചെയ്യുക} other {# ആൽബങ്ങൾ അടുത്തതായി പ്ലേ ചെയ്യുക}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം നിരയിലേക്ക് ചേർക്കുക} other {# ആൽബങ്ങൾ നിരയിലേക്ക് ചേർക്കുക}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ആൽബം ഓഫ്‌ലൈൻ ഉപയോഗത്തിന് പിൻ ചെയ്യുക} other {# ആൽബങ്ങൾ ഓഫ്‌ലൈൻ ഉപയോഗത്തിന് പിൻ ചെയ്യുക}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} ഉപയോഗിച്ച് തുറക്കുക</value></data>
 </root>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# अल्बम पुढे वाजवा} other {# अल्बम पुढे वाजवा}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# अल्बम रांगेत जोडा} other {# अल्बम रांगेत जोडा}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# अल्बम ऑफलाइनसाठी पिन करा} other {# अल्बम ऑफलाइनसाठी पिन करा}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} सह उघडा</value></data>
 </root>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# album hierna afspelen} other {# albums hierna afspelen}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# album toevoegen aan wachtrij} other {# albums toevoegen aan wachtrij}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# album vastzetten voor offline} other {# albums vastzetten voor offline}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>openen met {name}</value></data>
 </root>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਅੱਗੇ ਚਲਾਓ} other {# ਐਲਬਮਾਂ ਅੱਗੇ ਚਲਾਓ}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਕਤਾਰ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ} other {# ਐਲਬਮਾਂ ਕਤਾਰ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ਐਲਬਮ ਆਫਲਾਈਨ ਲਈ ਪਿਨ ਕਰੋ} other {# ਐਲਬਮਾਂ ਆਫਲਾਈਨ ਲਈ ਪਿਨ ਕਰੋ}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} ਨਾਲ ਖੋਲ੍ਹੋ</value></data>
 </root>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Odtwórz # album jako następny} few {Odtwórz # albumy jako następne} many {Odtwórz # albumów jako następne} other {Odtwórz # albumu jako następne}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Dodaj # album do kolejki} few {Dodaj # albumy do kolejki} many {Dodaj # albumów do kolejki} other {Dodaj # albumu do kolejki}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Przypnij # album do trybu offline} few {Przypnij # albumy do trybu offline} many {Przypnij # albumów do trybu offline} other {Przypnij # albumu do trybu offline}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>otwórz za pomocą {name}</value></data>
 </root>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Reproduzir # álbum a seguir} other {Reproduzir # álbuns a seguir}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Adicionar # álbum à fila} other {Adicionar # álbuns à fila}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Fixar # álbum para offline} other {Fixar # álbuns para offline}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>abrir com {name}</value></data>
 </root>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை அடுத்து இயக்கு} other {# ஆல்பங்களை அடுத்து இயக்கு}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை வரிசையில் சேர்க்கவும்} other {# ஆல்பங்களை வரிசையில் சேர்க்கவும்}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ஆல்பத்தை இணையமில்லா பயன்பாட்டுக்கு நிலைநிறுத்து} other {# ஆல்பங்களை இணையமில்லா பயன்பாட்டுக்கு நிலைநிறுத்து}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} மூலம் திற</value></data>
 </root>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ తర్వాత ప్లే చేయి} other {# ఆల్బమ్‌లు తర్వాత ప్లే చేయి}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ క్యూలో జోడించు} other {# ఆల్బమ్‌లు క్యూలో జోడించు}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# ఆల్బమ్ ఆఫ్‌లైన్ కోసం పిన్ చేయి} other {# ఆల్బమ్‌లు ఆఫ్‌లైన్ కోసం పిన్ చేయి}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name}తో తెరువు</value></data>
 </root>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {เล่น # อัลบั้มถัดไป} other {เล่น # อัลบั้มถัดไป}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {เพิ่ม # อัลบั้มในคิว} other {เพิ่ม # อัลบั้มในคิว}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {ปักหมุด # อัลบั้มเพื่อใช้ออฟไลน์} other {ปักหมุด # อัลบั้มเพื่อใช้ออฟไลน์}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>เปิดด้วย {name}</value></data>
 </root>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# albümü sırada çal} other {# albümü sırada çal}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# albümü kuyruğa ekle} other {# albümü kuyruğa ekle}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# albümü çevrimdışı için sabitle} other {# albümü çevrimdışı için sabitle}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} ile aç</value></data>
 </root>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Відтворити # альбом наступним} few {Відтворити # альбоми наступними} many {Відтворити # альбомів наступними} other {Відтворити # альбому наступним}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Додати # альбом в чергу} few {Додати # альбоми в чергу} many {Додати # альбомів в чергу} other {Додати # альбому в чергу}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Закріпити # альбом для офлайн-доступу} few {Закріпити # альбоми для офлайн-доступу} many {Закріпити # альбомів для офлайн-доступу} other {Закріпити # альбому для офлайн-доступу}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>відкрити за допомогою {name}</value></data>
 </root>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {# البم اگلا چلائیں} other {# البمز اگلا چلائیں}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {# البم قطار میں شامل کریں} other {# البمز قطار میں شامل کریں}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {# البم آف لائن کے لیے پن کریں} other {# البمز آف لائن کے لیے پن کریں}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>{name} کے ساتھ کھولیں</value></data>
 </root>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {Phát # album tiếp theo} other {Phát # album tiếp theo}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {Thêm # album vào hàng đợi} other {Thêm # album vào hàng đợi}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {Ghim # album để dùng ngoại tuyến} other {Ghim # album để dùng ngoại tuyến}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>mở bằng {name}</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {接下来播放#张专辑} other {接下来播放#张专辑}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {将#张专辑添加到队列} other {将#张专辑添加到队列}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {固定#张专辑以离线使用} other {固定#张专辑以离线使用}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>用 {name} 打开</value></data>
 </root>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -413,4 +413,5 @@
   <data name="menu.play_next_count" xml:space="preserve"><value>{count, plural, one {接下來播放#張專輯} other {接下來播放#張專輯}}</value></data>
   <data name="menu.add_to_queue_count" xml:space="preserve"><value>{count, plural, one {將#張專輯加入佇列} other {將#張專輯加入佇列}}</value></data>
   <data name="menu.pin_count" xml:space="preserve"><value>{count, plural, one {釘選#張專輯供離線使用} other {釘選#張專輯供離線使用}}</value></data>
+  <data name="shell.open_with_folder" xml:space="preserve"><value>用 {name} 打開</value></data>
 </root>

--- a/bae-windows/UpdateService.cs
+++ b/bae-windows/UpdateService.cs
@@ -20,8 +20,11 @@ internal sealed class UpdateService
 {
     // The public repository's GitHub releases are the feed. Anonymous access is
     // one API call per check; the installed package's channel selects its own
-    // releases.<channel>.json, so no edition branching is needed here.
-    private readonly UpdateManager _manager = new(
+    // releases.<channel>.json, so no edition branching is needed here. Static:
+    // IsInstalled is also the Velopack-install gate App.OnLaunched asserts the
+    // protocol registration behind, before a MainWindow (and its UpdateService)
+    // exists.
+    private static readonly UpdateManager Manager = new(
         new GithubSource("https://github.com/bae-fm/bae", null, false));
 
     // The checked-and-downloaded update awaiting apply-on-restart, set once a
@@ -39,12 +42,18 @@ internal sealed class UpdateService
     /// <summary>Whether this process is a Velopack install (as opposed to a dev
     /// run or a loose-zip copy). Gates every affordance: the throwing Velopack
     /// calls are only valid on an install.</summary>
-    internal bool IsAvailable => _manager.IsInstalled;
+    internal bool IsAvailable => Manager.IsInstalled;
+
+    /// <summary>Static form of <see cref="IsAvailable"/> for callers that run
+    /// before a <see cref="UpdateService"/> instance exists — the protocol
+    /// registration assert in <c>App.OnLaunched</c>, which runs before the
+    /// <see cref="MainWindow"/> that owns one.</summary>
+    internal static bool IsInstalled => Manager.IsInstalled;
 
     /// <summary>The installed package version, or null when this isn't an
     /// install.</summary>
     internal string? InstalledVersion =>
-        _manager.IsInstalled ? _manager.CurrentVersion?.ToString() : null;
+        Manager.IsInstalled ? Manager.CurrentVersion?.ToString() : null;
 
     private void SetState(UpdateFlowState state)
     {
@@ -66,15 +75,15 @@ internal sealed class UpdateService
 
         try
         {
-            var info = await _manager.CheckForUpdatesAsync();
+            var info = await Manager.CheckForUpdatesAsync();
             if (info is null)
             {
                 return;
             }
 
-            await _manager.DownloadUpdatesAsync(info);
+            await Manager.DownloadUpdatesAsync(info);
             _pending = info;
-            _manager.WaitExitThenApplyUpdates(info.TargetFullRelease, silent: true, restart: false);
+            Manager.WaitExitThenApplyUpdates(info.TargetFullRelease, silent: true, restart: false);
             SetState(new UpdateFlowState.Ready(info.TargetFullRelease.Version.ToString()));
         }
         catch (Exception exception)
@@ -107,14 +116,14 @@ internal sealed class UpdateService
         try
         {
             SetState(new UpdateFlowState.Checking());
-            var info = await _manager.CheckForUpdatesAsync();
+            var info = await Manager.CheckForUpdatesAsync();
             if (info is null)
             {
                 SetState(new UpdateFlowState.UpToDate());
                 return;
             }
 
-            await _manager.DownloadUpdatesAsync(
+            await Manager.DownloadUpdatesAsync(
                 info, percent => SetState(new UpdateFlowState.Downloading(percent)));
             _pending = info;
             SetState(new UpdateFlowState.Ready(info.TargetFullRelease.Version.ToString()));
@@ -132,5 +141,5 @@ internal sealed class UpdateService
 
     /// <summary>Apply the staged update and relaunch. This exits the process, so
     /// the caller must persist playback state first.</summary>
-    internal void ApplyAndRestart() => _manager.ApplyUpdatesAndRestart(_pending!.TargetFullRelease);
+    internal void ApplyAndRestart() => Manager.ApplyUpdatesAndRestart(_pending!.TargetFullRelease);
 }

--- a/bae-windows/bae-windows.Tests/ActivationIntentModelTests.cs
+++ b/bae-windows/bae-windows.Tests/ActivationIntentModelTests.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using Bae.Windows;
+using Xunit;
+
+namespace Bae.Windows.Tests;
+
+/// <summary>
+/// Locks the activation-intent grammar: the folder-verb / dropped-folder argv
+/// rule (its own Windows-rooted-path check, not System.IO.Path — this test
+/// project also runs on the macOS host, where Path's rootedness semantics
+/// differ), the bae://import URI form, and the argv tokenizer for a
+/// redirected activation's raw command line. Filesystem access is stubbed
+/// through isDirectory; the registry writes and AppInstance plumbing that
+/// produce and dispatch an intent live outside this pure model and are
+/// verified by compilation.
+/// </summary>
+public sealed class ActivationIntentModelTests
+{
+    private static System.Func<string, bool> Dirs(params string[] directories)
+    {
+        var set = new HashSet<string>(directories);
+        return path => set.Contains(path);
+    }
+
+    private static IReadOnlyList<string> Args(params string[] args) => args;
+
+    // --- Folder argument -----------------------------------------------
+
+    [Fact]
+    public void RootedExistingDirectory_ReturnsImportFolder()
+    {
+        var intent = ActivationIntentModel.Parse(Args(@"C:\Music"), Dirs(@"C:\Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\Music"), intent);
+    }
+
+    [Fact]
+    public void RootedPathThatIsNotADirectory_ReturnsNull()
+    {
+        var intent = ActivationIntentModel.Parse(Args(@"C:\Music"), Dirs());
+        Assert.Null(intent);
+    }
+
+    [Fact]
+    public void RelativePath_ReturnsNull_EvenWhenItWouldBeADirectory()
+    {
+        var intent = ActivationIntentModel.Parse(Args("Music"), path => true);
+        Assert.Null(intent);
+    }
+
+    [Fact]
+    public void UncPathDirectory_ReturnsImportFolder()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args(@"\\storage\share\Music"), Dirs(@"\\storage\share\Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"\\storage\share\Music"), intent);
+    }
+
+    // --- Argument scan ----------------------------------------------------
+
+    [Fact]
+    public void LeadingExeToken_IsSkipped_NotADirectory()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args(@"C:\Program Files\bae\bae.exe", @"C:\Music"), Dirs(@"C:\Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\Music"), intent);
+    }
+
+    [Fact]
+    public void VeloappFlags_AreSkipped_NotARootedPath()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args("--veloapp-updated", "1.2.3", @"C:\Music"), Dirs(@"C:\Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\Music"), intent);
+    }
+
+    [Fact]
+    public void FirstMatchingArgument_Wins()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args(@"C:\First", @"C:\Second"), Dirs(@"C:\First", @"C:\Second"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\First"), intent);
+    }
+
+    // --- bae://import?path=... ---------------------------------------------
+
+    [Fact]
+    public void PercentEncodedBackslashPath_Decodes()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args("bae://import?path=C%3A%5CUsers%5Cme%5CMusic"), Dirs(@"C:\Users\me\Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\Users\me\Music"), intent);
+    }
+
+    [Fact]
+    public void PercentEncodedForwardSlashPath_Decodes()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args("bae://import?path=C%3A/Users/me/Music"), Dirs("C:/Users/me/Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder("C:/Users/me/Music"), intent);
+    }
+
+    [Fact]
+    public void SchemeAndHost_AreCaseInsensitive()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args("BAE://IMPORT?path=C%3A%5CMusic"), Dirs(@"C:\Music"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\Music"), intent);
+    }
+
+    [Fact]
+    public void MissingPathParam_ReturnsNull()
+    {
+        var intent = ActivationIntentModel.Parse(Args("bae://import"), path => true);
+        Assert.Null(intent);
+    }
+
+    [Fact]
+    public void EmptyPathParam_ReturnsNull()
+    {
+        var intent = ActivationIntentModel.Parse(Args("bae://import?path="), path => true);
+        Assert.Null(intent);
+    }
+
+    [Fact]
+    public void DecodedPathNotADirectory_ReturnsNull()
+    {
+        var intent = ActivationIntentModel.Parse(Args("bae://import?path=C%3A%5CMusic"), Dirs());
+        Assert.Null(intent);
+    }
+
+    [Fact]
+    public void ExtraQueryParams_AreIgnored_FirstPathWins()
+    {
+        var intent = ActivationIntentModel.Parse(
+            Args("bae://import?other=1&path=C%3A%5CFirst&path=C%3A%5CSecond"),
+            Dirs(@"C:\First", @"C:\Second"));
+        Assert.Equal(new ActivationIntent.ImportFolder(@"C:\First"), intent);
+    }
+
+    // --- Unknown hosts / paths -> null --------------------------------------
+
+    [Theory]
+    [InlineData("bae://album/anything")]
+    [InlineData("bae://invite?code=x")]
+    [InlineData("bae://")]
+    [InlineData("bae:import")]
+    public void UnknownHostsAndPaths_ReturnNull(string arg)
+    {
+        var intent = ActivationIntentModel.Parse(Args(arg), path => true);
+        Assert.Null(intent);
+    }
+
+    // --- Garbage -> null -----------------------------------------------------
+
+    [Fact]
+    public void EmptyArgs_ReturnsNull()
+    {
+        var intent = ActivationIntentModel.Parse(Args(), path => true);
+        Assert.Null(intent);
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("not a uri")]
+    [InlineData("http://example.com")]
+    [InlineData("bae://[invalid")]
+    public void GarbageArguments_ReturnNull(string arg)
+    {
+        var intent = ActivationIntentModel.Parse(Args(arg), path => true);
+        Assert.Null(intent);
+    }
+
+    // --- SplitCommandLine ------------------------------------------------
+
+    [Fact]
+    public void SplitCommandLine_EmptyString_ReturnsEmptyList()
+    {
+        Assert.Empty(ActivationIntentModel.SplitCommandLine(string.Empty));
+    }
+
+    [Fact]
+    public void SplitCommandLine_UnquotedTokens_SplitOnWhitespace()
+    {
+        var tokens = ActivationIntentModel.SplitCommandLine("bae.exe --veloapp-updated 1.2.3");
+        Assert.Equal(new[] { "bae.exe", "--veloapp-updated", "1.2.3" }, tokens);
+    }
+
+    [Fact]
+    public void SplitCommandLine_QuotedPathWithSpaces_RoundTrips()
+    {
+        var tokens = ActivationIntentModel.SplitCommandLine(
+            "\"C:\\Program Files\\bae\\bae.exe\" \"C:\\Users\\me\\My Music\"");
+        Assert.Equal(new[] { @"C:\Program Files\bae\bae.exe", @"C:\Users\me\My Music" }, tokens);
+    }
+
+    [Fact]
+    public void SplitCommandLine_EmbeddedEscapedQuote_IsLiteral()
+    {
+        var tokens = ActivationIntentModel.SplitCommandLine("\"a \\\"quoted\\\" value\"");
+        Assert.Equal(new[] { "a \"quoted\" value" }, tokens);
+    }
+
+    [Fact]
+    public void SplitCommandLine_DoubledTrailingBackslashBeforeClosingQuote_CollapsesAndCloses()
+    {
+        // A UNC share root ending in one visible backslash is quoted with that
+        // backslash doubled (the standard argv-escaping convention): an even
+        // backslash run before the quote collapses to half as many literal
+        // backslashes and the quote is a real delimiter, not an escape.
+        var commandLine = "\"" + @"\\storage\share\\" + "\"";
+        var tokens = ActivationIntentModel.SplitCommandLine(commandLine);
+        Assert.Equal(new[] { @"\\storage\share\" }, tokens);
+    }
+}

--- a/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
+++ b/bae-windows/bae-windows.Tests/bae-windows.Tests.csproj
@@ -47,6 +47,15 @@
       over plain BCL types (the armed two-step confirm and the post-close
       forget dance that render it live in SettingsDialog and are verified by
       compilation).
+    - The activation-intent model (ActivationIntentModel) — the bae:// URI
+      grammar, the folder-verb / dropped-folder argv rule (its own
+      Windows-rooted-path check, not System.IO.Path, whose rootedness
+      semantics differ on this host), and the argv tokenizer for a redirected
+      activation's raw command line, over plain BCL types with a caller-
+      supplied isDirectory delegate standing in for the filesystem (the
+      registry writes and AppInstance redirection that produce and dispatch an
+      intent live in ProtocolRegistration / Program / MainWindow and are
+      verified by compilation).
 
     The rest of bae-windows' pure logic (ReleaseCandidateChoice.Summary,
     ImportCandidate status/ToString, BridgeDisplay) depends on the generated
@@ -89,6 +98,7 @@
     <Compile Include="../Stores/PersistPlaybackModel.cs" Link="PersistPlaybackModel.cs" />
     <Compile Include="../Stores/ForgetLibraryModel.cs" Link="ForgetLibraryModel.cs" />
     <Compile Include="../Stores/AlbumGridSelectionModel.cs" Link="AlbumGridSelectionModel.cs" />
+    <Compile Include="../ActivationIntentModel.cs" Link="ActivationIntentModel.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The macOS app registers the `bae://` URL scheme and a folder document type: a link focuses the app, and choosing bae in Finder's "Open With" on a folder adds it as a watched folder and takes the user to import. Windows registered neither, and running the exe a second time opened a second window instead of focusing the running one.

This adds per-user (`HKCU\Software\Classes`) registry writes for the protocol and the `Directory\shell` folder verb — the only option available to an unpackaged, unsigned app (no MSIX identity, no signing certificate) — asserted idempotently on every launch and removed by the Velopack pre-uninstall hook. Single-instancing uses Windows App SDK's `AppInstance.FindOrRegisterForKey`/`RedirectActivationToAsync`, waited on synchronously through the documented `CreateEvent` + `CoWaitForMultipleObjects` pattern rather than a bare `.AsTask().Wait()`, which can deadlock the STA thread. Both the folder verb and the protocol deliver a plain command line (`argv[1]` = the folder path or the `bae://` URI), so one pure parser (`ActivationIntentModel`, tested on macOS and Windows hosts alike) turns either into a typed `ActivationIntent` — for now, a single `ImportFolder` case, since folder import is the only behavior the macOS URL/association surface has ever had. A cold-start activation (a folder verb double-clicked while bae is closed) can race the async unlock flow, so `MainWindow` latches the parsed launch intent until the initial library-open attempt settles; a redirected activation (the app already warm) dispatches straight through. The folder-import action itself is the exact tail `OnWindowDrop` already ran, pulled into a shared helper so the drop target, the folder verb, and `bae://import` all run the same scan-and-open-dialog flow.

## Test plan

- [x] `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 348 passed, including the new `ActivationIntentModelTests` (folder/UNC rooting, argv scan order, the `bae://import` grammar with percent-decoding and case-insensitivity, unknown hosts, garbage input, and the `SplitCommandLine` argv tokenizer)
- [x] `python3 scripts/loc-chrome-orphans.py` — 0 orphans, including the new `shell.open_with_folder` key
- [ ] Manual, on a Windows machine with an installed (Setup.exe) build: `bae://import?path=...` from Win+R with the app closed, and again with it running (must focus the existing window and open the import dialog)
- [ ] Manual: folder right-click → "open with bae" under "Show more options"
- [ ] Manual: uninstall removes both registry key trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)