### PR TITLE
Relocate shuffle-library into the Playback menu

### DIFF
--- a/BaeKit/Sources/BaeKit/Services/LibraryStore.swift
+++ b/BaeKit/Sources/BaeKit/Services/LibraryStore.swift
@@ -238,7 +238,21 @@ public final class LibraryStore {
     /// Cleared when a load for that release starts again or succeeds.
     public private(set) var releaseDetailErrors: [String: DisplayError] = [:]
 
+    /// Total albums in the open library, or `nil` before any album list has
+    /// reported a count. Written by the macOS library browser whenever its
+    /// album list's count loads or changes; read by menu chrome that has no
+    /// list of its own (the Playback menu's Shuffle Library item disables at
+    /// zero). Albums are the proxy the UI owns for "anything to play": core's
+    /// shuffle no-ops on zero *tracks*, but the UI never loads a track count.
+    public private(set) var albumTotal: Int?
+
     public nonisolated init() {}
+
+    /// Record the library-wide album total reported by an album-list count
+    /// load.
+    public func setAlbumTotal(_ count: Int) {
+        albumTotal = count
+    }
 
     // MARK: - Interning
 

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -79167,7 +79167,7 @@
       }
     },
     "Shuffle Library": {
-      "comment": "Library view: shuffle the whole library into a fresh session",
+      "comment": "Menu bar Playback menu: shuffle the whole library into a fresh session",
       "localizations": {
         "en": {
           "stringUnit": {

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -125,6 +125,15 @@ struct LibraryView: View {
         .task(id: albumList?.loadEpoch) {
             await pruneDeletedSelection()
         }
+        // Mirror the library-wide album count into the store: the menu bar's
+        // Shuffle Library item (MainAppMenuCommands) disables at zero, and the
+        // menu has no album list of its own to ask. `initial: true` publishes
+        // a count that was already loaded when this view (re)mounts.
+        .onChange(of: albumList?.totalCount, initial: true) { _, count in
+            if let count {
+                libraryStore.setAlbumTotal(count)
+            }
+        }
     }
 }
 
@@ -179,13 +188,6 @@ extension LibraryView {
             Spacer()
             switch uiStore.libraryBrowserMode {
             case .albums:
-                Button {
-                    playback.playLibraryShuffled()
-                } label: {
-                    Label("Shuffle Library", systemImage: "shuffle")
-                }
-                .buttonStyle(.borderless)
-                .help("Shuffle Library")
                 albumSortControls
             case .composers:
                 composerSortControls

--- a/bae-macos/bae/bae/Views/MainAppMenuCommands.swift
+++ b/bae-macos/bae/bae/Views/MainAppMenuCommands.swift
@@ -327,6 +327,13 @@ struct MainAppMenuCommands: Commands {
                     playback.setRepeatMode(mode)
                 }
             }
+
+            Divider()
+
+            Button("Shuffle Library") {
+                playback.playLibraryShuffled()
+            }
+            .disabled((libraryStore.albumTotal ?? 0) == 0)
         }
     }
 }

--- a/bae-macos/bae/baeTests/LibraryStoreTests.swift
+++ b/bae-macos/bae/baeTests/LibraryStoreTests.swift
@@ -302,6 +302,20 @@ struct InternAlbumSummaryTests {
     }
 }
 
+@Suite("LibraryStore.albumTotal")
+struct AlbumTotalTests {
+    @MainActor
+    @Test("nil before any count is recorded, then tracks recorded values")
+    func recordsAlbumTotal() {
+        let store = LibraryStore()
+        #expect(store.albumTotal == nil)
+        store.setAlbumTotal(3)
+        #expect(store.albumTotal == 3)
+        store.setAlbumTotal(0)
+        #expect(store.albumTotal == 0)
+    }
+}
+
 // MARK: - internReleaseSummary tests
 
 @Suite("LibraryStore.internReleaseSummary")

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -49,7 +49,18 @@
                            Foreground="Gray" TextWrapping="NoWrap" />
                 <ComboBox x:Name="BrowserModeBox" SelectionChanged="OnBrowserModeChanged" VerticalAlignment="Center" />
                 <StackPanel x:Name="SortControls" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center" />
-                <Button x:Uid="ShuffleLibraryButton" Content="shuffle library" Click="OnShuffleLibraryClick" />
+                <DropDownButton x:Uid="PlaybackMenuButton" Content="playback">
+                    <DropDownButton.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem
+                                x:Name="ShuffleLibraryItem"
+                                x:Uid="ShuffleLibraryMenuItem"
+                                Text="shuffle library"
+                                IsEnabled="False"
+                                Click="OnShuffleLibraryClick" />
+                        </MenuFlyout>
+                    </DropDownButton.Flyout>
+                </DropDownButton>
                 <Button x:Uid="LibrariesButton" Content="libraries" Click="OnLibrariesClick" />
                 <Button x:Uid="CloseLibraryButton" Content="close" Click="OnCloseLibraryClick" ToolTipService.ToolTip="close library">
                     <Button.KeyboardAccelerators>

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -407,6 +407,18 @@ public sealed partial class MainWindow : Window
     // untouched. Visibility is the caller's concern.
     private void RenderGridStatus(BrowserGridLoad load)
     {
+        // Albums are the proxy the UI owns for "anything to shuffle": core's
+        // shuffle no-ops on zero tracks, and the album count is what this
+        // window already loads. Only an album-mode load speaks to it (a
+        // composer load says nothing about albums), and a handle-gone load
+        // leaves the view untouched, this included. A failed load disables —
+        // don't offer playback of unknown contents.
+        if (load.Result != BrowserLoadResult.HandleGone && load.Mode == BrowserMode.Albums)
+        {
+            ShuffleLibraryItem.IsEnabled =
+                load.Result == BrowserLoadResult.Loaded && !load.IsEmpty;
+        }
+
         switch (load.Result)
         {
             case BrowserLoadResult.HandleGone:
@@ -648,6 +660,7 @@ public sealed partial class MainWindow : Window
         _transferProgress.Reset();
         SearchBox.Text = string.Empty;
         StatusText.Text = string.Empty;
+        ShuffleLibraryItem.IsEnabled = false;
         _mediaControls.Deactivate();
         // The banners report the old library's sync / playback errors; clear them
         // so they don't describe state the next library (or none) doesn't have.

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>بحث</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>المكتبات</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>تشغيل المكتبة عشوائيًا</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>التشغيل</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>تشغيل المكتبة عشوائيًا</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>إغلاق</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>إغلاق المكتبة</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>استيراد</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>търсене</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>библиотеки</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>разбъркване на библиотеката</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>възпроизвеждане</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>разбъркване на библиотеката</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>затваряне</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>затваряне на библиотеката</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>внасяне</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>অনুসন্ধান</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>লাইব্রেরি</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>লাইব্রেরি শাফল করুন</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>প্লেব্যাক</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>লাইব্রেরি শাফল করুন</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>বন্ধ করুন</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>লাইব্রেরি বন্ধ করুন</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>আমদানি</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>hledat</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>knihovny</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>náhodně přehrát knihovnu</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>přehrávání</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>náhodně přehrát knihovnu</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>zavřít</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>zavřít knihovnu</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>suchen</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>Bibliotheken</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>Mediathek zufällig wiedergeben</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>Wiedergabe</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>Mediathek zufällig wiedergeben</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>schließen</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>Bibliothek schließen</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importieren</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>search</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>libraries</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>shuffle library</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>playback</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>shuffle library</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>close</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>close library</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>import</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>buscar</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliotecas</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>reproducir biblioteca al azar</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>reproducción</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>reproducir biblioteca al azar</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>cerrar</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>cerrar biblioteca</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importar</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>rechercher</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliothèques</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>lecture aléatoire de la bibliothèque</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>lecture</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>lecture aléatoire de la bibliothèque</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>fermer</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>fermer la bibliothèque</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importer</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>શોધ</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>લાઇબ્રેરીઓ</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>લાઇબ્રેરી શફલ કરો</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>વગાડવું</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>લાઇબ્રેરી શફલ કરો</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>બંધ કરો</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>લાઇબ્રેરી બંધ કરો</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>આયાત</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>חיפוש</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ספריות</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ערבוב הספרייה</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>השמעה</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>ערבוב הספרייה</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>סגור</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>סגור ספרייה</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>ייבוא</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>खोजें</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>लाइब्रेरी</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>लाइब्रेरी शफ़ल करें</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>प्लेबैक</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>लाइब्रेरी शफ़ल करें</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>बंद करें</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>लाइब्रेरी बंद करें</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>आयात</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>pretraživanje</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>fonoteke</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>nasumično reproduciraj biblioteku</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>reprodukcija</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>nasumično reproduciraj biblioteku</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>zatvori</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>zatvori fonoteku</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>uvoz</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>cerca</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>librerie</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>riproduci libreria in ordine casuale</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>riproduzione</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>riproduci libreria in ordine casuale</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>chiudi</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>chiudi libreria</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importa</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>検索</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ライブラリ</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ライブラリをシャッフル</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>再生</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>ライブラリをシャッフル</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>閉じる</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>ライブラリを閉じる</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>取り込む</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>ಹುಡುಕಿ</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ಲೈಬ್ರರಿಗಳು</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>ಪ್ಲೇಬ್ಯಾಕ್</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>ಲೈಬ್ರರಿಯನ್ನು ಶಫಲ್ ಮಾಡಿ</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>ಮುಚ್ಚಿ</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>ಗ್ರಂಥಾಲಯ ಮುಚ್ಚಿ</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>ಆಮದು</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>검색</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>라이브러리</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>라이브러리 셔플</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>재생</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>라이브러리 셔플</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>닫기</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>라이브러리 닫기</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>가져오기</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>തിരയൽ</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ശേഖരങ്ങൾ</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ലൈബ്രറി ഷഫിൾ ചെയ്യുക</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>പ്ലേബാക്ക്</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>ലൈബ്രറി ഷഫിൾ ചെയ്യുക</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>അടയ്ക്കുക</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>ലൈബ്രറി അടയ്ക്കുക</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>ഇറക്കുമതി</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>शोध</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>संग्रहालये</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>लायब्ररी शफल करा</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>वाजवणे</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>लायब्ररी शफल करा</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>बंद करा</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>लायब्ररी बंद करा</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>आयात</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>zoeken</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliotheken</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>bibliotheek shufflen</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>afspelen</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>bibliotheek shufflen</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>sluiten</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>bibliotheek sluiten</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importeren</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>ਖੋਜੋ</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀਆਂ</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>ਪਲੇਬੈਕ</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ ਕਰੋ</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>ਬੰਦ ਕਰੋ</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>ਲਾਇਬ੍ਰੇਰੀ ਬੰਦ ਕਰੋ</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>ਆਯਾਤ ਕਰੋ</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>szukaj</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>biblioteki</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>odtwarzaj bibliotekę losowo</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>odtwarzanie</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>odtwarzaj bibliotekę losowo</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>zamknij</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>zamknij bibliotekę</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importuj</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>buscar</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>bibliotecas</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>embaralhar biblioteca</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>reprodução</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>embaralhar biblioteca</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>fechar</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>fechar biblioteca</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>importar</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>தேடு</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>நூலகங்கள்</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>நூலகத்தை கலைத்து இயக்கு</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>இயக்கல்</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>நூலகத்தை கலைத்து இயக்கு</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>மூடு</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>நூலகத்தை மூடு</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>இறக்குமதி</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>శోధన</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>లైబ్రరీలు</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>లైబ్రరీని షఫుల్ చేయి</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>ప్లేబ్యాక్</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>లైబ్రరీని షఫుల్ చేయి</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>మూసివేయి</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>లైబ్రరీని మూసివేయండి</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>దిగుమతి</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>ค้นหา</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>คลัง</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>สุ่มเล่นคลังเพลง</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>การเล่น</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>สุ่มเล่นคลังเพลง</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>ปิด</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>ปิดคลัง</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>นำเข้า</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>ara</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>kitaplıklar</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>kitaplığı karıştır</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>çalma</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>kitaplığı karıştır</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>kapat</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>kitaplığı kapat</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>içe aktar</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>пошук</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>бібліотеки</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>перемішати фонотеку</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>відтворення</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>перемішати фонотеку</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>закрити</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>закрити бібліотеку</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>імпорт</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>تلاش</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>کتب خانے</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>لائبریری کو شفل کریں</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>چلانا</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>لائبریری کو شفل کریں</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>بند کریں</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>لائبریری بند کریں</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>درآمد</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>tìm kiếm</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>thư viện</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>phát ngẫu nhiên thư viện</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>phát lại</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>phát ngẫu nhiên thư viện</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>đóng</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>đóng thư viện</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>nhập</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>搜索</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>库</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>随机播放音乐库</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>播放</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>随机播放音乐库</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>关闭</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>关闭库</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>导入</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <data name="SearchBox.PlaceholderText" xml:space="preserve"><value>搜尋</value></data>
   <data name="LibrariesButton.Content" xml:space="preserve"><value>資料庫</value></data>
-  <data name="ShuffleLibraryButton.Content" xml:space="preserve"><value>隨機播放資料庫</value></data>
+  <data name="PlaybackMenuButton.Content" xml:space="preserve"><value>播放</value></data>
+  <data name="ShuffleLibraryMenuItem.Text" xml:space="preserve"><value>隨機播放資料庫</value></data>
   <data name="CloseLibraryButton.Content" xml:space="preserve"><value>關閉</value></data>
   <data name="CloseLibraryButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve"><value>關閉資料庫</value></data>
   <data name="ImportButton.Content" xml:space="preserve"><value>匯入</value></data>


### PR DESCRIPTION
## Summary

Shuffle-library starts playback of the whole library rather than controlling the currently-playing item, so it doesn't fit among the library header's per-item controls. This PR moves it into the platform's playback surface on macOS and Windows, disabled when there's nothing to shuffle. iOS and Android are untouched.

On macOS the action moves to the end of the `CommandMenu("Playback")`, after a divider, disabled when the open library has zero albums. Windows has no menu bar, and its now-playing bar stays `Visibility="Collapsed"` until something is already playing — exactly the state shuffle-library is meant to escape — so it's disqualified as a host. Instead the header button is replaced with an always-enabled "playback" dropdown holding a single flyout item, matching the convention that a disabled top-level chrome button reads as "app broken" while a disabled item inside an openable menu reads as "nothing to shuffle."

Both platforms gate on album count rather than track count, because neither UI loads a track count and album totals are already what each grid fetches for itself: on macOS, `LibraryView` mirrors its grid's `totalCount` into a new `LibraryStore.albumTotal` slice the menu-bar commands can read without owning a list of their own; on Windows, `RenderGridStatus` — the method that already renders empty-state status text — also flips the flyout item's `IsEnabled` off the same load result.

## Test plan

- [x] `xcodebuild ... build` — BUILD SUCCEEDED
- [x] `xcodebuild ... test` — 152 tests passed, including the new `LibraryStore.albumTotal` suite (`AlbumTotalTests`)
- [x] `swift-format lint -s` over `bae-macos/bae/bae` and `BaeKit/Sources/BaeKit` — clean
- [x] `swiftlint lint --strict` over `bae-macos/bae/bae` and `BaeKit/Sources/BaeKit` — 0 violations
- [x] `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 358 passed
- [x] `scripts/loc-chrome-orphans.py` — 0 orphans
- [x] `scripts/loc-english-skeleton.py` — 0 gating failures
- [x] BOM preserved (`EF BB BF`) on all 31 edited `.resw` files, verified on `de` and `ja`
- [x] Rules self-review against the full matched-rules list — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)