### PR TITLE
Artist browsing data surface: core queries, resolvers, and bridge types

### DIFF
--- a/BaeKit/Sources/BaeKit/Services/Projection.swift
+++ b/BaeKit/Sources/BaeKit/Services/Projection.swift
@@ -22,6 +22,7 @@ public enum BridgeInvalidationDomain: Hashable {
     case release
     case composerList
     case composer
+    case artistList
     case queue
     case config
     case syncStatus
@@ -46,6 +47,8 @@ extension BridgeInvalidation {
             return .composerList
         case .composer:
             return .composer
+        case .artistList:
+            return .artistList
         case .queue:
             return .queue
         case .config:

--- a/bae-android/app/src/main/java/fm/bae/app/data/UiEventAdapter.kt
+++ b/bae-android/app/src/main/java/fm/bae/app/data/UiEventAdapter.kt
@@ -264,6 +264,7 @@ object UiEventAdapter {
             is BridgeInvalidation.ImportCandidate,
             BridgeInvalidation.WatchedFolders,
             is BridgeInvalidation.Composer,
+            BridgeInvalidation.ArtistList,
             -> {
                 logger.debug("ignoring ${invalidation::class.simpleName}")
             }

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -17,7 +17,8 @@ use crate::types::BridgeHomeStorage;
 #[cfg(feature = "desktop")]
 use crate::types::BridgeRemoteCover;
 use crate::types::{
-    BridgeAlbum, BridgeAlbumDetail, BridgeAlbumSearchResult, BridgeComposerDetail,
+    BridgeAlbum, BridgeAlbumDetail, BridgeAlbumSearchResult, BridgeArtistDetail,
+    BridgeArtistSortCriterion, BridgeArtistSummary, BridgeComposerDetail,
     BridgeComposerSortCriterion, BridgeComposerSummary, BridgeComposerWorkGroup, BridgeConfig,
     BridgeCoverSelection, BridgeError, BridgeFile, BridgeGalleryItem, BridgeGallerySource,
     BridgeMetadataSource, BridgeQueueSnapshot, BridgeRelease, BridgeReleaseRoleSummary,
@@ -161,6 +162,46 @@ impl AppHandle {
             .await
             .map_err(|e| BridgeError::database(format!("{e}")))?;
         Ok(detail.map(BridgeWorkDetail::from_core))
+    }
+
+    pub async fn get_artist_count(&self) -> Result<u64, BridgeError> {
+        self.services
+            .library_manager()
+            .get_artist_count()
+            .await
+            .map_err(|e| BridgeError::database(format!("{e}")))
+    }
+
+    pub async fn get_artist_page(
+        &self,
+        sort_criterion: BridgeArtistSortCriterion,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<BridgeArtistSummary>, BridgeError> {
+        let sort = sort_criterion.into_core();
+        let artists = self
+            .services
+            .library_manager()
+            .get_artist_page(sort, offset, limit)
+            .await
+            .map_err(|e| BridgeError::database(format!("{e}")))?;
+        Ok(artists
+            .into_iter()
+            .map(BridgeArtistSummary::from_core)
+            .collect())
+    }
+
+    pub async fn get_artist_detail(
+        &self,
+        artist_id: String,
+    ) -> Result<Option<BridgeArtistDetail>, BridgeError> {
+        let detail = self
+            .services
+            .library_manager()
+            .get_artist_detail(&artist_id)
+            .await
+            .map_err(|e| BridgeError::database(format!("{e}")))?;
+        Ok(detail.map(BridgeArtistDetail::from_core))
     }
 
     /// Filesystem path for the user's own external file behind a library file
@@ -1549,6 +1590,7 @@ async fn pump_ui_events(
                 for invalidation in [
                     BridgeInvalidation::AlbumList,
                     BridgeInvalidation::ComposerList,
+                    BridgeInvalidation::ArtistList,
                     BridgeInvalidation::Queue,
                     BridgeInvalidation::Config,
                     BridgeInvalidation::SyncStatus,
@@ -2680,6 +2722,42 @@ impl BridgeComposerSummary {
             linked_release_count,
             unlinked_credit_count,
             image: image.map(crate::types::BridgeImageRef::from_core),
+        }
+    }
+}
+
+impl BridgeArtistSummary {
+    fn from_core(s: bae_core::album_detail::ArtistSummary) -> Self {
+        let bae_core::album_detail::ArtistSummary { raw, image } = s;
+        let bae_core::db::DbArtistSummary {
+            artist,
+            album_count,
+        } = raw;
+        let bae_core::db::DbArtist {
+            id: artist_id,
+            name,
+            // The MB-only sort name, per-source dedup ids, and the row
+            // timestamp don't cross to the UI.
+            sort_name: _,
+            discogs_artist_id: _,
+            musicbrainz_artist_id: _,
+            created_at: _,
+        } = artist;
+        BridgeArtistSummary {
+            artist_id,
+            name,
+            album_count,
+            image: image.map(crate::types::BridgeImageRef::from_core),
+        }
+    }
+}
+
+impl BridgeArtistDetail {
+    fn from_core(d: bae_core::album_detail::ArtistDetail) -> Self {
+        let bae_core::album_detail::ArtistDetail { artist, albums } = d;
+        BridgeArtistDetail {
+            artist: BridgeArtistSummary::from_core(artist),
+            albums: albums.into_iter().map(BridgeAlbum::from_core).collect(),
         }
     }
 }

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -1498,6 +1498,7 @@ pub enum BridgeInvalidation {
     Release { release_id: String },
     ComposerList,
     Composer { composer_id: String },
+    ArtistList,
     Queue,
     Config,
     SyncStatus,
@@ -1519,6 +1520,7 @@ impl BridgeInvalidation {
             CoreInvalidation::Release { release_id } => Self::Release { release_id },
             CoreInvalidation::ComposerList => Self::ComposerList,
             CoreInvalidation::Composer { composer_id } => Self::Composer { composer_id },
+            CoreInvalidation::ArtistList => Self::ArtistList,
             CoreInvalidation::Queue => Self::Queue,
             CoreInvalidation::Config => Self::Config,
             CoreInvalidation::SyncStatus => Self::SyncStatus,
@@ -2269,6 +2271,36 @@ pub enum BridgeComposerSortField {
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct BridgeComposerSortCriterion {
     pub field: BridgeComposerSortField,
+    pub direction: BridgeSortDirection,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeArtistSummary {
+    pub artist_id: String,
+    pub name: String,
+    /// Distinct albums this artist is an album artist of (primary FK or
+    /// `album_artists` junction).
+    pub album_count: i64,
+    pub image: Option<BridgeImageRef>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeArtistDetail {
+    pub artist: BridgeArtistSummary,
+    /// The artist's albums in discography order: year ascending with unknown
+    /// years last, then title.
+    pub albums: Vec<BridgeAlbum>,
+}
+
+#[derive(Debug, Clone, Copy, uniffi::Enum)]
+pub enum BridgeArtistSortField {
+    Name,
+    AlbumCount,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct BridgeArtistSortCriterion {
+    pub field: BridgeArtistSortField,
     pub direction: BridgeSortDirection,
 }
 
@@ -3062,6 +3094,19 @@ impl BridgeComposerSortCriterion {
                 BridgeComposerSortField::LinkedReleaseCount => {
                     bae_core::db::ComposerSortField::LinkedReleaseCount
                 }
+            },
+            direction: direction.into_core(),
+        }
+    }
+}
+
+impl BridgeArtistSortCriterion {
+    pub(crate) fn into_core(self) -> bae_core::db::ArtistSortCriterion {
+        let BridgeArtistSortCriterion { field, direction } = self;
+        bae_core::db::ArtistSortCriterion {
+            field: match field {
+                BridgeArtistSortField::Name => bae_core::db::ArtistSortField::Name,
+                BridgeArtistSortField::AlbumCount => bae_core::db::ArtistSortField::AlbumCount,
             },
             direction: direction.into_core(),
         }

--- a/bae-core/src/album_detail/artist.rs
+++ b/bae-core/src/album_detail/artist.rs
@@ -1,0 +1,22 @@
+//! Resolved artist types and their pure projections from DB aggregates.
+
+use super::*;
+use crate::db::DbArtistSummary;
+
+#[derive(Debug, Clone)]
+pub struct ArtistSummary {
+    pub raw: DbArtistSummary,
+    pub image: Option<ImageRef>,
+}
+
+impl ArtistSummary {
+    pub(crate) fn from_raw(raw: DbArtistSummary, image: Option<ImageRef>) -> Self {
+        Self { raw, image }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtistDetail {
+    pub artist: ArtistSummary,
+    pub albums: Vec<AlbumSummary>,
+}

--- a/bae-core/src/album_detail/mod.rs
+++ b/bae-core/src/album_detail/mod.rs
@@ -48,12 +48,14 @@
 use crate::db::{DbArtist, LibraryImageType};
 
 mod album;
+mod artist;
 mod composer;
 mod release;
 mod search;
 mod storage;
 
 pub use album::*;
+pub use artist::*;
 pub use composer::*;
 pub use release::*;
 pub use search::*;

--- a/bae-core/src/db/client/artist.rs
+++ b/bae-core/src/db/client/artist.rs
@@ -167,6 +167,83 @@ impl Database {
         .await
     }
 
+    pub async fn get_artist_count(&self) -> Result<u64, DbError> {
+        self.call(move |conn| {
+            let query = format!(
+                "SELECT COUNT(*) FROM ({})",
+                artist_summary_query(None, None)
+            );
+            conn.query_row(&query, [], |row| row.get::<_, i64>(0))
+                .map(|count| count as u64)
+                .map_err(DbError::from)
+        })
+        .await
+    }
+
+    pub async fn get_artist_page(
+        &self,
+        sort: ArtistSortCriterion,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<DbArtistSummary>, DbError> {
+        let order_by = artist_order_by(sort);
+        let tail = format!("ORDER BY {order_by} LIMIT ? OFFSET ?");
+        let query = artist_summary_query(None, Some(&tail));
+        self.call(move |conn| {
+            let mut stmt = conn.prepare(&query)?;
+            let rows =
+                stmt.query_map(params![limit as i64, offset as i64], row_to_artist_summary)?;
+            rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+                .map_err(DbError::from)
+        })
+        .await
+    }
+
+    /// The artist's summary row plus every album it is an album artist of
+    /// (primary FK or `album_artists` junction), in discography order: year
+    /// ascending with unknown years last, then title (case-insensitive), then
+    /// id. `None` when the artist doesn't exist or has no album links —
+    /// exactly the artists `get_artist_page` never lists.
+    pub async fn find_artist_detail(
+        &self,
+        artist_id: &str,
+    ) -> Result<Option<DbArtistDetail>, DbError> {
+        let artist_id = artist_id.to_string();
+        self.call(move |conn| {
+            let artist = conn
+                .query_row(
+                    &artist_summary_query(Some("WHERE ar.id = ?"), None),
+                    params![artist_id],
+                    row_to_artist_summary,
+                )
+                .optional()?;
+            let Some(artist) = artist else {
+                return Ok(None);
+            };
+
+            let albums_query = format!(
+                "{select} \
+                 FROM albums a \
+                 WHERE a.artist_id = ?1 \
+                    OR EXISTS ( \
+                        SELECT 1 FROM album_artists aa \
+                        WHERE aa.album_id = a.id AND aa.artist_id = ?1 \
+                    ) \
+                 ORDER BY CASE WHEN a.year IS NULL THEN 1 ELSE 0 END, \
+                          a.year, a.title COLLATE NOCASE, a.id",
+                select = album_summary_select()
+            );
+            let mut stmt = conn.prepare(&albums_query)?;
+            let mut rows = stmt.query(params![artist_id])?;
+            let mut albums = Vec::new();
+            while let Some(row) = rows.next()? {
+                albums.push(parse_album_summary_row(row)?);
+            }
+            Ok(Some(DbArtistDetail { artist, albums }))
+        })
+        .await
+    }
+
     pub async fn find_composer_detail(
         &self,
         artist_id: &str,

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -259,6 +259,43 @@ fn composer_summary_query(filter: Option<&str>, tail: Option<&str>) -> String {
     query
 }
 
+/// The artist-browser summary query: every artist with at least one album
+/// link, with its distinct album count. Membership is album-artist links
+/// only — the primary `albums.artist_id` FK unioned with `album_artists`
+/// junction rows; track-level credits (`track_artists`) don't confer
+/// membership. No Various Artists special case: it is a real `artists` row
+/// that compilation albums point at, and it lists like any other artist.
+fn artist_summary_query(filter: Option<&str>, tail: Option<&str>) -> String {
+    let mut query = String::from(
+        "SELECT ar.id AS artist_id,
+                ar.name AS artist_name,
+                ar.sort_name AS artist_sort_name,
+                ar.discogs_artist_id AS artist_discogs_artist_id,
+                ar.musicbrainz_artist_id AS artist_musicbrainz_artist_id,
+                ar.created_at AS artist_created_at,
+                COUNT(DISTINCT link.album_id) AS album_count
+         FROM artists ar
+         JOIN (
+             SELECT artist_id, id AS album_id FROM albums
+             UNION
+             SELECT artist_id, album_id FROM album_artists
+         ) link ON link.artist_id = ar.id
+         ",
+    );
+    if let Some(filter) = filter {
+        query.push_str(filter);
+    }
+    query.push_str(
+        "
+         GROUP BY ar.id, ar.name, ar.sort_name, ar.discogs_artist_id, ar.musicbrainz_artist_id, ar.created_at",
+    );
+    if let Some(tail) = tail {
+        query.push('\n');
+        query.push_str(tail);
+    }
+    query
+}
+
 fn unlinked_release_composer_role_predicate(role_alias: &str) -> String {
     unlinked_composer_role_predicate(
         role_alias,
@@ -370,6 +407,13 @@ fn row_to_composer_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbComposerS
     })
 }
 
+fn row_to_artist_summary(row: &Row<'_>) -> coven::rusqlite::Result<DbArtistSummary> {
+    Ok(DbArtistSummary {
+        artist: row_to_joined_artist(row)?,
+        album_count: row.get("album_count")?,
+    })
+}
+
 fn work_summary_sort_key(work: &DbWorkSummary) -> String {
     work.work.title.to_lowercase()
 }
@@ -463,6 +507,19 @@ fn composer_order_by(sort: ComposerSortCriterion) -> String {
     };
     // Pagination needs a total order; composer.name is not unique.
     format!("{field} {direction}, composer.name ASC, composer.id ASC")
+}
+
+fn artist_order_by(sort: ArtistSortCriterion) -> String {
+    let field = match sort.field {
+        ArtistSortField::Name => "ar.name",
+        ArtistSortField::AlbumCount => "album_count",
+    };
+    let direction = match sort.direction {
+        SortDirection::Ascending => "ASC",
+        SortDirection::Descending => "DESC",
+    };
+    // Pagination needs a total order; ar.name is not unique.
+    format!("{field} {direction}, ar.name ASC, ar.id ASC")
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/bae-core/src/db/client/tests.rs
+++ b/bae-core/src/db/client/tests.rs
@@ -1984,6 +1984,233 @@ mod composer_mode_tests {
 }
 
 #[cfg(test)]
+mod artist_mode_tests {
+    use super::super::*;
+    use coven::SystemClock;
+
+    /// Artists covering every membership case: a primary-FK artist that is
+    /// also a junction artist elsewhere, a junction-only artist, the Various
+    /// Artists row as a compilation's primary, a work-only composer (no album
+    /// links), and a fully unlinked artist.
+    async fn seeded_db() -> (Database, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        db.call(|conn| {
+            conn.execute_batch(
+                "
+                INSERT INTO artists (id, name, sort_name, discogs_artist_id, musicbrainz_artist_id, _updated_at, created_at)
+                VALUES
+                    ('artist-primary', 'Artist Name B', NULL, NULL, NULL, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('artist-extra', 'Artist Name A', NULL, NULL, NULL, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('artist-various', 'Various Artists', NULL, '194', NULL, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('artist-work-only', 'Composer Name A', NULL, NULL, 'mb-artist-work-only', 'stamp', '2026-01-01T00:00:00Z'),
+                    ('artist-unlinked', 'Artist Name C', NULL, NULL, NULL, 'stamp', '2026-01-01T00:00:00Z');
+
+                INSERT INTO albums (id, title, artist_id, year, primary_release_id, is_compilation, _updated_at, created_at)
+                VALUES
+                    ('album-a', 'Album Title A', 'artist-primary', 2001, NULL, 0, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('album-b', 'Album Title B', 'artist-primary', 1999, NULL, 0, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('album-compilation', 'Compilation Title A', 'artist-various', 2005, NULL, 1, 'stamp', '2026-01-01T00:00:00Z');
+
+                INSERT INTO releases (id, album_id, metadata_source, remote, _updated_at, created_at)
+                VALUES
+                    ('release-a', 'album-a', 'file_tags', 1, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('release-b', 'album-b', 'file_tags', 1, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('release-compilation', 'album-compilation', 'file_tags', 1, 'stamp', '2026-01-01T00:00:00Z');
+
+                -- artist-extra joins album-b; artist-primary's junction row on
+                -- album-a duplicates its primary FK and must not double-count.
+                INSERT INTO album_artists (id, album_id, artist_id, position, _updated_at, created_at)
+                VALUES
+                    ('aa-extra-b', 'album-b', 'artist-extra', 1, 'stamp', '2026-01-01T00:00:00Z'),
+                    ('aa-primary-a', 'album-a', 'artist-primary', 1, 'stamp', '2026-01-01T00:00:00Z');
+
+                INSERT INTO works (id, title, disambiguation, work_type, _updated_at, created_at)
+                VALUES ('work-a', 'Work Title A', NULL, 'work', 'stamp', '2026-01-01T00:00:00Z');
+
+                INSERT INTO work_artists (id, work_id, artist_id, position, source, _updated_at, created_at)
+                VALUES ('work-artist-a', 'work-a', 'artist-work-only', 0, 'musicbrainz', 'stamp', '2026-01-01T00:00:00Z');
+                ",
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+        .unwrap();
+        (db, tmp)
+    }
+
+    #[tokio::test]
+    async fn artist_page_lists_album_artists_with_distinct_album_counts() {
+        let (db, _tmp) = seeded_db().await;
+
+        let sort = ArtistSortCriterion {
+            field: ArtistSortField::Name,
+            direction: SortDirection::Ascending,
+        };
+        let page = db.get_artist_page(sort, 0, 10).await.unwrap();
+
+        let ids: Vec<&str> = page.iter().map(|a| a.artist.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["artist-extra", "artist-primary", "artist-various"]
+        );
+
+        let counts: Vec<i64> = page.iter().map(|a| a.album_count).collect();
+        assert_eq!(counts, vec![1, 2, 1]);
+
+        assert_eq!(db.get_artist_count().await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn artist_page_sorts_by_album_count() {
+        let (db, _tmp) = seeded_db().await;
+
+        let sort = ArtistSortCriterion {
+            field: ArtistSortField::AlbumCount,
+            direction: SortDirection::Descending,
+        };
+        let page = db.get_artist_page(sort, 0, 10).await.unwrap();
+
+        let ids: Vec<&str> = page.iter().map(|a| a.artist.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["artist-primary", "artist-extra", "artist-various"]
+        );
+    }
+
+    #[tokio::test]
+    async fn artist_page_uses_id_tiebreaker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        db.call(|conn| {
+            conn.execute_batch(
+                "
+                INSERT INTO artists (id, name, sort_name, discogs_artist_id, musicbrainz_artist_id, _updated_at, created_at)
+                VALUES
+                    ('artist-c', 'Artist Name Shared', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('artist-a', 'Artist Name Shared', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('artist-b', 'Artist Name Shared', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO albums (id, title, artist_id, year, primary_release_id, is_compilation, _updated_at, created_at)
+                VALUES
+                    ('album-c', 'Album Title C', 'artist-c', 2026, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-a', 'Album Title A', 'artist-a', 2026, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-b', 'Album Title B', 'artist-b', 2026, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO releases (id, album_id, metadata_source, remote, _updated_at, created_at)
+                VALUES
+                    ('release-c', 'album-c', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-a', 'album-a', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-b', 'album-b', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                ",
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+        .unwrap();
+
+        let sort = ArtistSortCriterion {
+            field: ArtistSortField::AlbumCount,
+            direction: SortDirection::Descending,
+        };
+        let mut page_ids = Vec::new();
+        for offset in 0..3 {
+            let page = db.get_artist_page(sort, offset, 1).await.unwrap();
+            assert_eq!(page.len(), 1);
+            page_ids.push(page[0].artist.id.clone());
+        }
+
+        assert_eq!(page_ids, vec!["artist-a", "artist-b", "artist-c"]);
+    }
+
+    #[tokio::test]
+    async fn artist_detail_orders_albums_year_then_title_with_unknown_years_last() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
+            .await
+            .unwrap();
+        db.call(|conn| {
+            conn.execute_batch(
+                "
+                INSERT INTO artists (id, name, sort_name, discogs_artist_id, musicbrainz_artist_id, _updated_at, created_at)
+                VALUES
+                    ('artist-a', 'Artist Name A', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('artist-other', 'Artist Name B', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO albums (id, title, artist_id, year, primary_release_id, is_compilation, _updated_at, created_at)
+                VALUES
+                    ('album-null', 'Album Title Null', 'artist-a', NULL, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-2001-upper', 'Album Title B', 'artist-a', 2001, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-2001-lower', 'album title a', 'artist-a', 2001, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-1999', 'Album Title 1999', 'artist-a', 1999, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-junction', 'Album Title Junction', 'artist-other', 2005, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('album-unrelated', 'Album Title Unrelated', 'artist-other', 1990, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO releases (id, album_id, metadata_source, remote, _updated_at, created_at)
+                VALUES
+                    ('release-null', 'album-null', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-2001-upper', 'album-2001-upper', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-2001-lower', 'album-2001-lower', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-1999', 'album-1999', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-junction', 'album-junction', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                    ('release-unrelated', 'album-unrelated', 'file_tags', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+
+                INSERT INTO album_artists (id, album_id, artist_id, position, _updated_at, created_at)
+                VALUES ('aa-junction', 'album-junction', 'artist-a', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                ",
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+        .unwrap();
+
+        let detail = db.find_artist_detail("artist-a").await.unwrap();
+        let detail = detail.expect("artist-a has album links and must resolve");
+
+        assert_eq!(detail.artist.artist.id, "artist-a");
+        assert_eq!(detail.artist.album_count, 5);
+
+        let album_ids: Vec<&str> = detail.albums.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(
+            album_ids,
+            vec![
+                "album-1999",
+                "album-2001-lower",
+                "album-2001-upper",
+                "album-junction",
+                "album-null",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn artist_detail_absent_or_album_less_artist_is_none() {
+        let (db, _tmp) = seeded_db().await;
+
+        assert!(db
+            .find_artist_detail("artist-absent")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(db
+            .find_artist_detail("artist-work-only")
+            .await
+            .unwrap()
+            .is_none());
+    }
+}
+
+#[cfg(test)]
 mod playback_state_load_tests {
     use super::super::*;
     use coven::SystemClock;

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -1070,6 +1070,23 @@ pub struct DbComposerSummary {
     pub unlinked_credit_count: i64,
 }
 
+/// Raw artist-summary aggregate: the artist row plus its distinct album
+/// count over both album-artist links (the primary `albums.artist_id` FK
+/// and `album_artists` junction rows).
+#[derive(Debug, Clone)]
+pub struct DbArtistSummary {
+    pub artist: DbArtist,
+    pub album_count: i64,
+}
+
+/// Raw artist-detail aggregate. The resolver in `LibraryManager` produces
+/// the display-ready `crate::album_detail::ArtistDetail`.
+#[derive(Debug, Clone)]
+pub struct DbArtistDetail {
+    pub artist: DbArtistSummary,
+    pub albums: Vec<DbAlbumSummary>,
+}
+
 #[derive(Debug, Clone)]
 pub struct DbWorkSummary {
     pub work: DbWork,
@@ -1194,6 +1211,18 @@ pub enum ComposerSortField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ComposerSortCriterion {
     pub field: ComposerSortField,
+    pub direction: SortDirection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtistSortField {
+    Name,
+    AlbumCount,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtistSortCriterion {
+    pub field: ArtistSortField,
     pub direction: SortDirection,
 }
 

--- a/bae-core/src/library/manager/artist.rs
+++ b/bae-core/src/library/manager/artist.rs
@@ -93,6 +93,56 @@ impl LibraryManager {
         Ok(self.database.find_artist_by_id(artist_id).await?)
     }
 
+    pub async fn get_artist_count(&self) -> Result<u64, LibraryError> {
+        Ok(self.database.get_artist_count().await?)
+    }
+
+    pub async fn get_artist_page(
+        &self,
+        sort: crate::db::ArtistSortCriterion,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<ArtistSummary>, LibraryError> {
+        let raw = self.database.get_artist_page(sort, offset, limit).await?;
+        let artist_ids: Vec<String> = raw.iter().map(|a| a.artist.id.clone()).collect();
+        let images = self.artist_image_refs(&artist_ids).await?;
+        Ok(raw
+            .into_iter()
+            .map(|artist| {
+                let image = images.get(&artist.artist.id).cloned();
+                ArtistSummary::from_raw(artist, image)
+            })
+            .collect())
+    }
+
+    pub async fn get_artist_detail(
+        &self,
+        artist_id: &str,
+    ) -> Result<Option<ArtistDetail>, LibraryError> {
+        let Some(raw) = self.database.find_artist_detail(artist_id).await? else {
+            return Ok(None);
+        };
+        let images = self
+            .artist_image_refs(std::slice::from_ref(&raw.artist.artist.id))
+            .await?;
+        let release_ids: Vec<String> = raw
+            .albums
+            .iter()
+            .flat_map(|a| a.release_ids.iter().cloned())
+            .collect();
+        let covers = self.cover_refs(&release_ids).await?;
+        let albums = raw
+            .albums
+            .into_iter()
+            .map(|album| AlbumSummary::from_raw(album, |rid| covers.get(rid).cloned()))
+            .collect();
+        let image = images.get(&raw.artist.artist.id).cloned();
+        Ok(Some(ArtistDetail {
+            artist: ArtistSummary::from_raw(raw.artist, image),
+            albums,
+        }))
+    }
+
     /// Resolve each parsed artist to an existing DB row or a row to insert at
     /// finalize.
     ///

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -30,8 +30,8 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
 use crate::album_detail::{
-    join_artist_names, AlbumDetail, AlbumSummary, ComposerDetail, ComposerSummary,
-    ComposerWorkGroup, GallerySource, ImageRef, ReleaseDetail, ReleaseResolveCtx,
+    join_artist_names, AlbumDetail, AlbumSummary, ArtistDetail, ArtistSummary, ComposerDetail,
+    ComposerSummary, ComposerWorkGroup, GallerySource, ImageRef, ReleaseDetail, ReleaseResolveCtx,
     ReleaseStorageAction, ReleaseStorageState, ReleaseStorageSummary, SearchResults, StorageFilter,
     StoragePage, StorageRow, StorageSort, StorageSortDirection, StorageSortField, WorkDetail,
     WorkReleaseSummary, WorkSummary,

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -27,6 +27,7 @@ impl UiEventBus {
         for invalidation in [
             Invalidation::AlbumList,
             Invalidation::ComposerList,
+            Invalidation::ArtistList,
             Invalidation::SyncStatus,
             Invalidation::Outbox,
             Invalidation::DownloadQueue,
@@ -385,6 +386,7 @@ impl UiEventBus {
                         let album_id = album.album.id.clone();
                         bus.invalidate(Invalidation::AlbumList);
                         bus.invalidate(Invalidation::ComposerList);
+                        bus.invalidate(Invalidation::ArtistList);
                         bus.invalidate(Invalidation::Album { album_id });
                         tracing::info!("wire_library: AlbumAdded for album {}", album.album.id);
                     }
@@ -392,6 +394,7 @@ impl UiEventBus {
                         let album_id = album.album.id.clone();
                         bus.invalidate(Invalidation::AlbumList);
                         bus.invalidate(Invalidation::ComposerList);
+                        bus.invalidate(Invalidation::ArtistList);
                         bus.invalidate(Invalidation::Album { album_id });
                     }
                     Ok(LibraryEvent::AlbumRemoved {
@@ -400,6 +403,7 @@ impl UiEventBus {
                     }) => {
                         bus.invalidate(Invalidation::AlbumList);
                         bus.invalidate(Invalidation::ComposerList);
+                        bus.invalidate(Invalidation::ArtistList);
                         bus.invalidate(Invalidation::Album {
                             album_id: album_id.clone(),
                         });
@@ -412,6 +416,7 @@ impl UiEventBus {
                     Ok(LibraryEvent::ReleaseAdded { album, release }) => {
                         bus.invalidate(Invalidation::AlbumList);
                         bus.invalidate(Invalidation::ComposerList);
+                        bus.invalidate(Invalidation::ArtistList);
                         bus.invalidate(Invalidation::Album {
                             album_id: album.id.clone(),
                         });
@@ -422,6 +427,7 @@ impl UiEventBus {
                     Ok(LibraryEvent::ReleaseUpdated { album_id, release }) => {
                         bus.invalidate(Invalidation::AlbumList);
                         bus.invalidate(Invalidation::ComposerList);
+                        bus.invalidate(Invalidation::ArtistList);
                         bus.invalidate(Invalidation::Album {
                             album_id: album_id.clone(),
                         });
@@ -436,6 +442,7 @@ impl UiEventBus {
                     }) => {
                         bus.invalidate(Invalidation::AlbumList);
                         bus.invalidate(Invalidation::ComposerList);
+                        bus.invalidate(Invalidation::ArtistList);
                         bus.invalidate(Invalidation::Album {
                             album_id: album_id.clone(),
                         });
@@ -601,6 +608,7 @@ mod tests {
         let expected = [
             Invalidation::AlbumList,
             Invalidation::ComposerList,
+            Invalidation::ArtistList,
             Invalidation::SyncStatus,
             Invalidation::Outbox,
             Invalidation::DownloadQueue,
@@ -652,6 +660,7 @@ mod tests {
         let expected = [
             Invalidation::AlbumList,
             Invalidation::ComposerList,
+            Invalidation::ArtistList,
             Invalidation::Album {
                 album_id: "album-1".to_string(),
             },

--- a/bae-core/src/ui/types.rs
+++ b/bae-core/src/ui/types.rs
@@ -106,6 +106,7 @@ pub enum Invalidation {
     Release { release_id: String },
     ComposerList,
     Composer { composer_id: String },
+    ArtistList,
     Queue,
     Config,
     SyncStatus,


### PR DESCRIPTION
## Summary

Adds the data surface for browsing the library by artist: raw DB aggregates and queries in bae-core (`get_artist_count`, `get_artist_page`, `get_artist_detail`), resolved types with images/covers attached, an `ArtistList` invalidation emitted alongside `ComposerList` on every album/release mutation, and the matching bae-bridge records and handle methods.

Two decisions worth recording:

- Membership is album-artist links only — the primary `albums.artist_id` FK unioned with `album_artists` junction rows. Track-level credits (`track_artists`) don't confer membership.
- The Various Artists row is not special-cased: it's a real `artists` row that compilation albums point at, and it appears in the list like any other artist. Filtering it out would orphan compilations and require sentinel-ID handling everywhere else.

`BaeKit/Sources/BaeKit/Services/Projection.swift` and Android's `UiEventAdapter.kt` each gain one arm because the compiler forces it: adding `BridgeInvalidation::ArtistList` regenerates the Swift/Kotlin enums and breaks their exhaustive matches over `BridgeInvalidation`. No other UI or platform code changes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo clippy -p bae-core --tests --features bae-core/test-utils -- -D warnings`
- [x] `cargo clippy -p bae-bridge -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test -p bae-bridge --lib` (17 passed, including loc-key coverage)
- [x] `cargo test -p bae-core --features bae-core/test-utils -- --skip test_playback_cpu` (new `artist_mode_tests` module and both updated event-bus tests pass)
- [x] macOS chain: `build-macos.sh`, `install-swift-bindings.sh macos`, `xcodegen`, `xcodebuild` build
- [x] Android: `build-android.sh`, `gradlew assembleFullDebug`, `ktlint`
- [x] `scripts/loc-chrome-orphans.py` and `scripts/loc-english-skeleton.py` — no-ops
- [x] Rules self-review against the changed-path rule set

🤖 Generated with [Claude Code](https://claude.com/claude-code)