### PR TITLE
Add the artists browser mode to the macOS library

### DIFF
--- a/BaeKit/Sources/BaeKit/BridgeArtistSortField+CaseIterable.swift
+++ b/BaeKit/Sources/BaeKit/BridgeArtistSortField+CaseIterable.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension BridgeArtistSortField: CaseIterable {
+    public static var allCases: [BridgeArtistSortField] {
+        [.name, .albumCount]
+    }
+
+    public var displayName: String {
+        switch self {
+        case .name: String(localized: "Name")
+        case .albumCount: String(localized: "Albums")
+        }
+    }
+}

--- a/BaeKit/Sources/BaeKit/Services/Library.swift
+++ b/BaeKit/Sources/BaeKit/Services/Library.swift
@@ -24,6 +24,14 @@ public final class Library: Sendable, Observable {
         @Sendable (_ artistId: String) async throws -> BridgeComposerDetail?
     public let getWorkDetail:
         @Sendable (_ workId: String) async throws -> BridgeWorkDetail?
+    public let getArtistCount: @Sendable () async throws -> UInt64
+    public let getArtistPage:
+        @Sendable (
+            _ sortCriterion: BridgeArtistSortCriterion, _ offset: UInt64,
+            _ limit: UInt64
+        ) async throws -> [BridgeArtistSummary]
+    public let getArtistDetail:
+        @Sendable (_ artistId: String) async throws -> BridgeArtistDetail?
     public let searchLibrary:
         @Sendable (_ query: String) async throws -> BridgeSearchResults
     public let storageCount:
@@ -75,6 +83,20 @@ public final class Library: Sendable, Observable {
                 _ in
                 throw StubError.notImplemented
             },
+        getArtistCount: @escaping @Sendable () async throws -> UInt64 = {
+            throw StubError.notImplemented
+        },
+        getArtistPage:
+            @escaping @Sendable (BridgeArtistSortCriterion, UInt64, UInt64)
+            async throws
+            -> [BridgeArtistSummary] = { _, _, _ in
+                throw StubError.notImplemented
+            },
+        getArtistDetail:
+            @escaping @Sendable (String) async throws -> BridgeArtistDetail? =
+            {
+                _ in throw StubError.notImplemented
+            },
         searchLibrary:
             @escaping @Sendable (String) async throws -> BridgeSearchResults = {
                 _ in
@@ -112,6 +134,9 @@ public final class Library: Sendable, Observable {
         self.getComposerPage = getComposerPage
         self.getComposerDetail = getComposerDetail
         self.getWorkDetail = getWorkDetail
+        self.getArtistCount = getArtistCount
+        self.getArtistPage = getArtistPage
+        self.getArtistDetail = getArtistDetail
         self.searchLibrary = searchLibrary
         self.storageCount = storageCount
         self.storagePage = storagePage
@@ -126,6 +151,10 @@ public final class Library: Sendable, Observable {
     // desktop-only; the iOS `AppService` builds `Library` via the designated
     // initializer with just the iOS-available closures.
     #if !os(iOS)
+        // Flat 1:1 argument forwarding from `AppHandleProtocol` to `Library`'s
+        // closures; its length tracks the number of Library reads, not
+        // logical complexity.
+        // swiftlint:disable:next function_body_length
         public convenience init(handle: any AppHandleProtocol) {
             self.init(
                 getAlbumCount: { try await handle.getAlbumCount() },
@@ -154,6 +183,17 @@ public final class Library: Sendable, Observable {
                     try await handle.getComposerDetail(artistId: $0)
                 },
                 getWorkDetail: { try await handle.getWorkDetail(workId: $0) },
+                getArtistCount: { try await handle.getArtistCount() },
+                getArtistPage: {
+                    try await handle.getArtistPage(
+                        sortCriterion: $0,
+                        offset: $1,
+                        limit: $2
+                    )
+                },
+                getArtistDetail: {
+                    try await handle.getArtistDetail(artistId: $0)
+                },
                 searchLibrary: { try await handle.searchLibrary(query: $0) },
                 storageCount: { try await handle.storageCount(filter: $0) },
                 storagePage: {

--- a/BaeKit/Sources/BaeKit/Services/LibraryStore.swift
+++ b/BaeKit/Sources/BaeKit/Services/LibraryStore.swift
@@ -70,6 +70,30 @@ extension BridgeComposerSummary: Identifiable {
     public var id: String { artistId }
 }
 
+public struct LibraryArtistPageSource: PageSource {
+    public let library: Library
+    public let sort: BridgeArtistSortCriterion
+
+    public init(library: Library, sort: BridgeArtistSortCriterion) {
+        self.library = library
+        self.sort = sort
+    }
+
+    public func count() async throws -> Int {
+        Int(try await library.getArtistCount())
+    }
+
+    public func page(offset: Int, limit: Int) async throws
+        -> [BridgeArtistSummary]
+    {
+        try await library.getArtistPage(sort, UInt64(offset), UInt64(limit))
+    }
+}
+
+extension BridgeArtistSummary: Identifiable {
+    public var id: String { artistId }
+}
+
 // MARK: - Storage page source
 
 /// Page source backed by `AppHandle` for the Storage Manager table.
@@ -124,6 +148,7 @@ extension BridgeStorageRow: Identifiable {
 /// store. Views resolve slots by reading `libraryStore.albumSummaries[id]`.
 public typealias AlbumList = PaginatedList<BridgeAlbum>
 public typealias ComposerList = PaginatedList<BridgeComposerSummary>
+public typealias ArtistList = PaginatedList<BridgeArtistSummary>
 
 // MARK: - StorageList
 
@@ -231,6 +256,8 @@ public final class LibraryStore {
     public private(set) var releaseDetails: [String: ReleaseDetail] = [:]
     public private(set) var composerSummaries: [String: BridgeComposerSummary] =
         [:]
+    public private(set) var artistSummaries: [String: BridgeArtistSummary] =
+        [:]
 
     /// Per-release detail-load failures, keyed by release id. `loadReleaseDetail`
     /// records the failure here instead of swallowing it, so the album detail
@@ -275,6 +302,14 @@ public final class LibraryStore {
         -> BridgeComposerSummary
     {
         composerSummaries[bridge.artistId] = bridge
+        return bridge
+    }
+
+    @discardableResult
+    public func internArtistSummary(_ bridge: BridgeArtistSummary)
+        -> BridgeArtistSummary
+    {
+        artistSummaries[bridge.artistId] = bridge
         return bridge
     }
 
@@ -342,6 +377,7 @@ public final class LibraryStore {
             releaseSummaries.removeValue(forKey: releaseId)
             releaseDetails.removeValue(forKey: releaseId)
             composerSummaries.removeAll()
+            artistSummaries.removeAll()
             return
         }
         _ = internReleaseDetail(bridge)

--- a/bae-macos/bae/bae/Localizable.xcstrings
+++ b/bae-macos/bae/bae/Localizable.xcstrings
@@ -94355,6 +94355,578 @@
           }
         }
       }
+    },
+    "Artists": {
+      "comment": "Library artists mode label",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفنانون"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изпълнители"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শিল্পীরা"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interpreti"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Künstler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artists"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artistas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artistes"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "કલાકારો"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אמנים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izvođači"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artisti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーティスト"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಕಲಾವಿದರು"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아티스트"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "കലാകാരന്മാർ"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artiesten"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਕਲਾਕਾਰ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wykonawcy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artistas"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைஞர்கள்"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "కళాకారులు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ศิลปิน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanatçılar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виконавці"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فنکار"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nghệ sĩ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "艺人"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "藝人"
+          }
+        }
+      }
+    },
+    "No artists": {
+      "comment": "Empty artist library message title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يوجد فنانون"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Няма изпълнители"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কোনো শিল্পী নেই"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Žádní interpreti"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Künstler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No artists"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay artistas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun artiste"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "કોઈ કલાકારો નથી"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אין אמנים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई कलाकार नहीं"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nema izvođača"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun artista"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーティストがいません"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಕಲಾವಿದರು ಇಲ್ಲ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아티스트 없음"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "കലാകാരന്മാരില്ല"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार नाहीत"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen artiesten"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਕੋਈ ਕਲਾਕਾਰ ਨਹੀਂ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak wykonawców"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum artista"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைஞர்கள் இல்லை"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "కళాకారులు లేరు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีศิลปิน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanatçı yok"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає виконавців"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کوئی فنکار نہیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có nghệ sĩ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有艺人"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有藝人"
+          }
+        }
+      }
+    },
+    "Artist detail not found": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على تفاصيل الفنان"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Данните за изпълнителя не са намерени"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শিল্পীর বিবরণ পাওয়া যায়নি"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detail interpreta nebyl nalezen"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Künstlerdetails nicht gefunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artist detail not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron los detalles del artista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails de l'artiste introuvables"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "કલાકારની વિગત મળી નથી"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פרטי האמן לא נמצאו"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार विवरण नहीं मिला"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalji izvođača nisu pronađeni"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dettaglio artista non trovato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーティストの詳細が見つかりません"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಕಲಾವಿದರ ವಿವರ ಸಿಕ್ಕಿಲ್ಲ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아티스트 세부 정보를 찾을 수 없음"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "കലാകാരന്റെ വിശദാംശം കണ്ടെത്തിയില്ല"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार तपशील सापडला नाही"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artiestdetails niet gevonden"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਕਲਾਕਾਰ ਵੇਰਵਾ ਨਹੀਂ ਮਿਲਿਆ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono szczegółów wykonawcy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes do artista não encontrados"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைஞர் விவரம் கிடைக்கவில்லை"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "కళాకారుని వివరాలు కనబడలేదు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบรายละเอียดศิลปิน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanatçı ayrıntısı bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відомості про виконавця не знайдено"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فنکار کی تفصیل نہیں ملی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy chi tiết nghệ sĩ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到艺人详情"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到藝人詳細資料"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-macos/bae/bae/Services/UiStore.swift
+++ b/bae-macos/bae/bae/Services/UiStore.swift
@@ -11,11 +11,13 @@ enum MainSection {
 enum LibraryBrowserMode: CaseIterable {
     case albums
     case composers
+    case artists
 
     var displayName: String {
         switch self {
         case .albums: String(localized: "Albums")
         case .composers: String(localized: "Composers")
+        case .artists: String(localized: "Artists")
         }
     }
 }

--- a/bae-macos/bae/bae/Views/LibraryView.swift
+++ b/bae-macos/bae/bae/Views/LibraryView.swift
@@ -1,7 +1,7 @@
 import BaeKit
 import SwiftUI
 
-private let composerLoadBatchSize = 50
+private let listLoadBatchSize = 50
 
 private enum ComposerPaneSelection: Equatable {
     case none
@@ -70,6 +70,17 @@ struct LibraryView: View {
     private var composerPaneDetail: ComposerPaneDetail = .empty
     @State
     private var detailSelection: ComposerPaneSelection = .none
+    @State
+    private var artistList: ArtistList?
+    @State
+    private var artistListRegistration: ProjectionRegistration?
+    @State
+    private var artistSortCriterion =
+        BridgeArtistSortCriterion(field: .name, direction: .ascending)
+    @State
+    private var selectedArtistId: String?
+    @State
+    private var artistDetail: BridgeArtistDetail?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -80,6 +91,8 @@ struct LibraryView: View {
                     albumContent
                 case .composers:
                     composerContent
+                case .artists:
+                    artistContent
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -90,8 +103,13 @@ struct LibraryView: View {
             await reloadAlbumList(sort: sortCriteria)
         }
         .task(id: uiStore.libraryBrowserMode) {
-            if uiStore.libraryBrowserMode == .composers {
+            switch uiStore.libraryBrowserMode {
+            case .albums:
+                break
+            case .composers:
                 await ensureComposerListLoaded()
+            case .artists:
+                await ensureArtistListLoaded()
             }
         }
         .task(id: detailSelection.composerId) {
@@ -104,6 +122,14 @@ struct LibraryView: View {
             if uiStore.libraryBrowserMode == .composers {
                 await reloadComposerList(sort: composerSortCriterion)
             }
+        }
+        .task(id: artistSortCriterion) {
+            if uiStore.libraryBrowserMode == .artists {
+                await reloadArtistList(sort: artistSortCriterion)
+            }
+        }
+        .task(id: selectedArtistId) {
+            await loadArtistDetail()
         }
         .task(id: uiStore.libraryNavigationRequest?.seq) {
             guard let request = uiStore.libraryNavigationRequest else {
@@ -191,6 +217,8 @@ extension LibraryView {
                 albumSortControls
             case .composers:
                 composerSortControls
+            case .artists:
+                artistSortControls
             }
         }
         .padding(.horizontal, 16)
@@ -315,6 +343,36 @@ extension LibraryView {
         }
     }
 
+    private var artistContent: some View {
+        Group {
+            if let artistList {
+                if let error = artistList.initialLoadError {
+                    LoadFailureView(line: error.line) {
+                        Task { await artistList.loadInitial() }
+                    }
+                }
+                else if artistList.totalCount == 0 {
+                    ContentUnavailableView(
+                        "No artists",
+                        systemImage: "music.mic",
+                        description: Text("Import some music to get started"),
+                    )
+                }
+                else {
+                    HSplitView {
+                        artistListView(artistList)
+                            .frame(minWidth: 260, idealWidth: 320)
+                        artistDetailView
+                            .frame(minWidth: 420)
+                    }
+                }
+            }
+            else {
+                ProgressView()
+            }
+        }
+    }
+
     private func applyLibraryNavigation(_ target: LibraryNavigationTarget) {
         switch target {
         case .composer(let artistId):
@@ -338,10 +396,10 @@ extension LibraryView {
                     ) {
                         let first = max(
                             0,
-                            index - composerLoadBatchSize / 2
+                            index - listLoadBatchSize / 2
                         )
                         let end = min(
-                            first + composerLoadBatchSize,
+                            first + listLoadBatchSize,
                             list.totalCount
                         )
                         await list.loadRange(
@@ -353,6 +411,44 @@ extension LibraryView {
         }
         .scrollContentBackground(.hidden)
         .background(Theme.background)
+    }
+
+    private func artistListView(_ list: ArtistList) -> some View {
+        List {
+            ForEach(0..<list.totalCount, id: \.self) { index in
+                artistRow(at: index, list: list)
+                    .task(
+                        id: RowLoadID(
+                            epoch: list.loadEpoch,
+                            index: index
+                        )
+                    ) {
+                        let first = max(0, index - listLoadBatchSize / 2)
+                        let end = min(
+                            first + listLoadBatchSize,
+                            list.totalCount
+                        )
+                        await list.loadRange(
+                            offset: first,
+                            limit: end - first
+                        )
+                    }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Theme.background)
+    }
+
+    private func artistRow(at index: Int, list: ArtistList) -> some View {
+        let id = list.idAt(index)
+        return ArtistListRow(
+            id: id,
+            isSelected: id != nil && selectedArtistId == id,
+            select: { id in
+                selectedArtistId = id
+                artistDetail = nil
+            }
+        )
     }
 
     private var composerSortControls: some View {
@@ -392,6 +488,49 @@ extension LibraryView {
             .background(Theme.surfaceElevated, in: Capsule())
             .help(
                 composerSortCriterion.direction == .ascending
+                    ? String(localized: "Sort Descending")
+                    : String(localized: "Sort Ascending")
+            )
+        }
+    }
+
+    private var artistSortControls: some View {
+        HStack(spacing: 8) {
+            Menu {
+                ForEach(BridgeArtistSortField.allCases, id: \.self) { field in
+                    Button(field.displayName) {
+                        artistSortCriterion = BridgeArtistSortCriterion(
+                            field: field,
+                            direction: artistSortCriterion.direction
+                        )
+                    }
+                }
+            } label: {
+                Text(artistSortCriterion.field.displayName)
+            }
+            .menuStyle(.borderlessButton)
+            Button {
+                let nextDirection: BridgeSortDirection =
+                    artistSortCriterion.direction == .ascending
+                    ? .descending : .ascending
+                artistSortCriterion = BridgeArtistSortCriterion(
+                    field: artistSortCriterion.field,
+                    direction: nextDirection
+                )
+            } label: {
+                Image(
+                    systemName: artistSortCriterion.direction == .ascending
+                        ? "arrow.up" : "arrow.down"
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(Theme.surfaceElevated, in: Capsule())
+            .help(
+                artistSortCriterion.direction == .ascending
                     ? String(localized: "Sort Descending")
                     : String(localized: "Sort Ascending")
             )
@@ -512,6 +651,41 @@ extension LibraryView {
         .background(Theme.surface)
     }
 
+    private var artistDetailView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                if let artistDetail {
+                    ArtistDetailHeader(summary: artistDetail.artist)
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.adaptive(minimum: 140), spacing: 12)
+                        ],
+                        alignment: .leading,
+                        spacing: 12
+                    ) {
+                        ForEach(artistDetail.albums) { album in
+                            ArtistAlbumCard(album: album) {
+                                uiStore.navigateToAlbum(album.id)
+                            }
+                        }
+                    }
+                }
+                else if selectedArtistId == nil {
+                    ContentUnavailableView(
+                        "Artists",
+                        systemImage: "music.mic"
+                    )
+                }
+                else {
+                    ProgressView()
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Theme.surface)
+    }
+
     private func ensureComposerListLoaded() async {
         guard composerList == nil else {
             return
@@ -519,6 +693,13 @@ extension LibraryView {
         let newList = makeComposerList(sort: composerSortCriterion)
         await newList.loadInitial()
         composerList = newList
+    }
+
+    private func ensureArtistListLoaded() async {
+        guard artistList == nil else {
+            return
+        }
+        await reloadArtistList(sort: artistSortCriterion)
     }
 
     private func loadComposerDetail() async {
@@ -549,6 +730,34 @@ extension LibraryView {
                     workId: defaultWorkId
                 )
             }
+        }
+        catch {
+            uiStore.showError(DisplayError(line: error.localizedDescription))
+        }
+    }
+
+    private func loadArtistDetail() async {
+        guard let requestedArtistId = selectedArtistId else {
+            return
+        }
+        do {
+            let getArtistDetail = library.getArtistDetail
+            let detail = try await getArtistDetail(requestedArtistId)
+            guard !Task.isCancelled else {
+                return
+            }
+            guard selectedArtistId == requestedArtistId else {
+                return
+            }
+            guard let detail else {
+                uiStore.showError(
+                    DisplayError(
+                        line: String(localized: "Artist detail not found")
+                    )
+                )
+                return
+            }
+            artistDetail = detail
         }
         catch {
             uiStore.showError(DisplayError(line: error.localizedDescription))
@@ -638,6 +847,23 @@ extension LibraryView {
         )
     }
 
+    private func makeArtistList(sort: BridgeArtistSortCriterion) -> ArtistList {
+        ArtistList(
+            pageSource: LibraryArtistPageSource(
+                library: library,
+                sort: sort
+            ),
+            ingest: { [libraryStore] rows in
+                for row in rows {
+                    _ = libraryStore.internArtistSummary(row)
+                }
+            },
+            onError: { [uiStore] error in
+                uiStore.showError(error)
+            },
+        )
+    }
+
     private func reloadComposerList(sort: BridgeComposerSortCriterion) async {
         let newList = makeComposerList(sort: sort)
         await newList.loadInitial()
@@ -649,6 +875,19 @@ extension LibraryView {
             domain: .composerList
         )
         composerList = newList
+    }
+
+    private func reloadArtistList(sort: BridgeArtistSortCriterion) async {
+        let newList = makeArtistList(sort: sort)
+        await newList.loadInitial()
+        guard !Task.isCancelled else {
+            return
+        }
+        artistListRegistration = projectionRegistry.registerList(
+            newList,
+            domain: .artistList
+        )
+        artistList = newList
     }
 
     private func reloadAlbumList(sort: [BridgeSortCriterion]) async {
@@ -705,7 +944,7 @@ private struct ComposerListRow: View {
             select(id)
         }) {
             ZStack(alignment: .leading) {
-                ComposerSummaryPlaceholder()
+                SummaryRowPlaceholder()
                     .opacity(summary == nil ? 1 : 0)
                     .allowsHitTesting(summary == nil)
                 ComposerSummaryRow(summary: summary, isSelected: isSelected)
@@ -756,6 +995,74 @@ private struct ComposerSummaryRow: View {
     }
 }
 
+private struct ArtistListRow: View {
+    @Environment(LibraryStore.self)
+    private var libraryStore
+
+    let id: String?
+    let isSelected: Bool
+    let select: (String) -> Void
+
+    var body: some View {
+        let summary = id.flatMap { libraryStore.artistSummaries[$0] }
+        Button(action: {
+            guard let id else {
+                return
+            }
+            select(id)
+        }) {
+            ZStack(alignment: .leading) {
+                SummaryRowPlaceholder()
+                    .opacity(summary == nil ? 1 : 0)
+                    .allowsHitTesting(summary == nil)
+                ArtistSummaryRow(summary: summary, isSelected: isSelected)
+                    .opacity(summary == nil ? 0 : 1)
+                    .allowsHitTesting(summary != nil)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(summary == nil)
+    }
+}
+
+private struct ArtistSummaryRow: View {
+    let summary: BridgeArtistSummary?
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: summary?.image, pointSize: 36)
+                .frame(width: 36, height: 36)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading, spacing: 3) {
+                OptionalLineText(
+                    text: summary?.name,
+                    font: .body,
+                    foreground: .primary
+                )
+                OptionalLineText(
+                    text: albumCountText,
+                    font: .caption,
+                    foreground: .secondary
+                )
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isSelected ? Color.accentColor.opacity(0.18) : .clear)
+        )
+    }
+
+    private var albumCountText: String? {
+        guard let summary else {
+            return nil
+        }
+        return "\(summary.albumCount) \(String(localized: "Albums"))"
+    }
+}
+
 private struct OptionalLineText: View {
     let text: String?
     let font: Font
@@ -781,7 +1088,7 @@ private struct OptionalLineText: View {
     }
 }
 
-private struct ComposerSummaryPlaceholder: View {
+private struct SummaryRowPlaceholder: View {
     var body: some View {
         HStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 6)
@@ -817,6 +1124,53 @@ private struct ComposerDetailHeader: View {
                     .foregroundStyle(.secondary)
             }
         }
+    }
+}
+
+private struct ArtistDetailHeader: View {
+    let summary: BridgeArtistSummary
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ImageView(imageRef: summary.image, pointSize: 72)
+                .frame(width: 72, height: 72)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            VStack(alignment: .leading, spacing: 6) {
+                Text(summary.name)
+                    .font(.title.bold())
+                    .lineLimit(2)
+                Text("\(summary.albumCount) \(String(localized: "Albums"))")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct ArtistAlbumCard: View {
+    let album: BridgeAlbum
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 6) {
+                ImageView(imageRef: album.cover, pointSize: 140)
+                    .aspectRatio(1, contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                Text(album.title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                StableOptionalText(
+                    text: album.year.map(String.init),
+                    font: .caption,
+                    foreground: .secondary,
+                    lineHeight: 12,
+                    lineLimit: 1
+                )
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -997,6 +1351,8 @@ private struct WorkDetailView: View {
                 getAlbumPage: { _, _, _ in [] },
                 getComposerCount: { 0 },
                 getComposerPage: { _, _, _ in [] },
+                getArtistCount: { 0 },
+                getArtistPage: { _, _, _ in [] },
             )
         }
     }
@@ -1017,6 +1373,21 @@ private struct WorkDetailView: View {
     #Preview("Composers \u{2014} Empty") {
         let uiStore = UiStore()
         uiStore.setLibraryBrowserMode(.composers)
+        return LibraryView()
+            .environment(Playback.stub)
+            .environment(Queue.stub)
+            .environment(Downloads.stub)
+            .environment(LibraryView.emptyLibrary)
+            .environment(LibraryStore())
+            .environment(uiStore)
+            .environment(ProjectionRegistry())
+            .frame(width: 1100, height: 700)
+            .windowBackground()
+    }
+
+    #Preview("Artists \u{2014} Empty") {
+        let uiStore = UiStore()
+        uiStore.setLibraryBrowserMode(.artists)
         return LibraryView()
             .environment(Playback.stub)
             .environment(Queue.stub)

--- a/bae-macos/bae/baeTests/UiStoreTests.swift
+++ b/bae-macos/bae/baeTests/UiStoreTests.swift
@@ -16,6 +16,9 @@ struct UiStoreLibraryBrowserModeTests {
         store.setLibraryBrowserMode(.composers)
         #expect(store.libraryBrowserMode == .composers)
 
+        store.setLibraryBrowserMode(.artists)
+        #expect(store.libraryBrowserMode == .artists)
+
         store.setLibraryBrowserMode(.albums)
         #expect(store.libraryBrowserMode == .albums)
     }
@@ -93,6 +96,15 @@ struct UiStoreLibraryBrowserModeTests {
         store.navigateToAlbum("album-1")
         #expect(store.libraryBrowserMode == .albums)
         #expect(store.activeSection == .library)
+        #expect(store.selectedAlbumId == "album-1")
+    }
+
+    @Test("navigateToAlbum from artists mode switches to albums mode")
+    func navigateToAlbumFromArtistsSwitchesToAlbumsMode() {
+        let store = UiStore()
+        store.setLibraryBrowserMode(.artists)
+        store.navigateToAlbum("album-1")
+        #expect(store.libraryBrowserMode == .albums)
         #expect(store.selectedAlbumId == "album-1")
     }
 


### PR DESCRIPTION
## Summary

The library heading and View menu gain an Artists mode: a paginated list of every album artist (name, album count, artist image where one was fetched) with a detail pane showing the artist's albums in discography order. Album cards navigate to the album in albums mode. The list refreshes via the `artistList` invalidation domain and pages like the composers list; sort (name / album count, in-memory like the composer sort) uses the pill direction control.

One structural choice worth calling out: the artists list registers itself with the projection registry on first load, not only on sort change — the composer list's registration only happens once a sort change runs `reloadComposerList`, leaving a window on first load where an invalidation wouldn't refresh it. The artists list closes that gap; the composer list is unchanged.

Three new catalog keys ("Artists", "No artists", "Artist detail not found") are translated across all 31 locales.

## Test plan

- [x] `./bae-bridge/build-macos.sh && ./bae-bridge/install-swift-bindings.sh macos`
- [x] macOS xcodegen + `xcodebuild build` (Debug)
- [x] macOS `xcodebuild test` (153 tests, including the new `UiStoreTests` cases)
- [x] `swift-format lint` over `bae-macos/bae/bae` and `BaeKit/Sources/BaeKit`
- [x] `swiftlint lint --strict` over `bae-macos/bae/bae` and `BaeKit/Sources/BaeKit`
- [x] `periphery scan --strict`
- [x] iOS bridge build + xcodegen + `xcodebuild build` (compile-only gate; BaeKit is shared)
- [x] `scripts/loc-chrome-orphans.py` and `scripts/loc-english-skeleton.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)