### PR TITLE
Add the artists browser mode to the Windows library

### DIFF
--- a/bae-windows/Album.cs
+++ b/bae-windows/Album.cs
@@ -14,20 +14,21 @@ public sealed class Album : INotifyPropertyChanged
     private readonly CoverImage.Binding _cover;
     private bool _isSelected;
 
-    internal Album(BridgeAlbumSearchResult album) : this(album.Id, album.Title, album.ArtistName, album.Cover)
+    internal Album(BridgeAlbumSearchResult album) : this(album.Id, album.Title, album.ArtistName, album.Year, album.Cover)
     {
     }
 
-    internal Album(BridgeAlbum album) : this(album.Id, album.Title, album.ArtistNames, album.Cover)
+    internal Album(BridgeAlbum album) : this(album.Id, album.Title, album.ArtistNames, album.Year, album.Cover)
     {
         PrimaryReleaseId = album.PrimaryReleaseId;
     }
 
-    private Album(string id, string title, string artist, BridgeImageRef? cover)
+    private Album(string id, string title, string artist, int? year, BridgeImageRef? cover)
     {
         _id = id;
         _title = title;
         _artist = artist;
+        Year = year;
         _cover = new CoverImage.Binding(cover);
         _cover.SourceChanged += () => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Cover)));
     }
@@ -37,6 +38,7 @@ public sealed class Album : INotifyPropertyChanged
     public string Id => _id;
     public string Title => _title;
     public string Artist => _artist;
+    public int? Year { get; }
 
     /// <summary>The album's canonical release — the default play/queue target.
     /// Null for search-result albums, whose bridge type doesn't carry it.</summary>

--- a/bae-windows/Artist.cs
+++ b/bae-windows/Artist.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Media;
+using uniffi.bae_bridge;
+
+namespace Bae.Windows;
+
+public sealed class ArtistSummary : INotifyPropertyChanged
+{
+    private readonly BridgeArtistSummary _artist;
+    private readonly CoverImage.Binding _cover;
+
+    internal ArtistSummary(BridgeArtistSummary artist)
+    {
+        _artist = artist;
+        _cover = new CoverImage.Binding(artist.Image);
+        _cover.SourceChanged += () => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Cover)));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string ArtistId => _artist.ArtistId;
+    public string Name => _artist.Name;
+    public long AlbumCount => _artist.AlbumCount;
+
+    internal void AttachCover(LibraryHandle handle, DispatcherQueue dispatcherQueue) =>
+        _cover.Attach(handle, dispatcherQueue);
+
+    public ImageSource? Cover => _cover.Source;
+    public string AlbumCountText => Loc.Chrome("album.count", "count", Loc.Number(AlbumCount));
+}
+
+public sealed class ArtistDetail
+{
+    internal ArtistDetail(BridgeArtistDetail detail)
+    {
+        Artist = new ArtistSummary(detail.Artist);
+        Albums = detail.Albums.Select(album => new Album(album)).ToList();
+    }
+
+    public ArtistSummary Artist { get; }
+    public List<Album> Albums { get; }
+}

--- a/bae-windows/MainWindow.xaml
+++ b/bae-windows/MainWindow.xaml
@@ -169,6 +169,45 @@
                 <StackPanel x:Name="ComposerDetailPane" Spacing="10" />
             </ScrollViewer>
         </Grid>
+        <Grid
+            x:Name="ArtistBrowser"
+            Grid.Row="1"
+            Margin="24"
+            ColumnSpacing="16"
+            Visibility="Collapsed">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <ListView
+                x:Name="ArtistList"
+                Grid.Column="0"
+                ItemsSource="{x:Bind Artists}"
+                IsItemClickEnabled="True"
+                SelectionMode="Single"
+                ItemClick="OnArtistClick">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local:ArtistSummary">
+                        <StackPanel Orientation="Horizontal" Spacing="10" Padding="4">
+                            <Border
+                                Width="42"
+                                Height="42"
+                                CornerRadius="6"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                                <Image Source="{x:Bind Cover, Mode=OneWay}" Stretch="UniformToFill" />
+                            </Border>
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="{x:Bind Name}" MaxLines="1" TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{x:Bind AlbumCountText}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <ScrollViewer Grid.Column="1">
+                <StackPanel x:Name="ArtistDetailPane" Spacing="10" />
+            </ScrollViewer>
+        </Grid>
         <ScrollViewer
             x:Name="SearchResultsScroll"
             Grid.Row="1"

--- a/bae-windows/MainWindow.xaml.cs
+++ b/bae-windows/MainWindow.xaml.cs
@@ -97,17 +97,18 @@ public sealed partial class MainWindow : Window
     [DllImport("user32.dll")]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
 
-    // x:Bind Albums/Composers in the shell resolve here; the collections live in
-    // the browser store (constructed before InitializeComponent so these are
-    // non-null when the bindings first evaluate).
+    // x:Bind Albums/Composers/Artists in the shell resolve here; the collections
+    // live in the browser store (constructed before InitializeComponent so
+    // these are non-null when the bindings first evaluate).
     public ObservableCollection<Album> Albums => _browser.Albums;
     public ObservableCollection<ComposerSummary> Composers => _browser.Composers;
+    public ObservableCollection<ArtistSummary> Artists => _browser.Artists;
 
     public MainWindow()
     {
-        // The browser store owns the Albums/Composers collections the shell binds
-        // to with x:Bind, so it (and the session it reads) must exist before
-        // InitializeComponent evaluates those bindings.
+        // The browser store owns the Albums/Composers/Artists collections the
+        // shell binds to with x:Bind, so it (and the session it reads) must
+        // exist before InitializeComponent evaluates those bindings.
         _session = new SessionStore(DispatcherQueue);
         _browser = new LibraryBrowserStore(_session, DispatcherQueue);
 
@@ -145,6 +146,7 @@ public sealed partial class MainWindow : Window
 
         BrowserModeBox.Items.Add(Loc.Chrome("library.mode.albums"));
         BrowserModeBox.Items.Add(Loc.Chrome("library.mode.composers"));
+        BrowserModeBox.Items.Add(Loc.Chrome("library.mode.artists"));
         _sortControls = new LibrarySortControls(SortControls, _browser.Sort, ReloadBrowserForSortChange);
         _sortControls.Render();
         BrowserModeBox.SelectedIndex = 0;
@@ -241,8 +243,10 @@ public sealed partial class MainWindow : Window
             DispatcherQueue,
             SearchResultsPanel,
             ComposerDetailPane,
+            ArtistDetailPane,
             text => StatusText.Text = text,
             ShowComposerBrowser,
+            ShowArtistBrowser,
             _albumDetail.Show);
         _unlockDialog = new UnlockDialog(() => Content.XamlRoot, text => StatusText.Text = text, OpenLibrary);
         _joinDialog = new JoinLibraryDialog(
@@ -322,6 +326,7 @@ public sealed partial class MainWindow : Window
     {
         _projections.Register(typeof(BridgeInvalidation.AlbumList), ReloadBrowserFromInvalidation);
         _projections.Register(typeof(BridgeInvalidation.ComposerList), ReloadBrowserFromInvalidation);
+        _projections.Register(typeof(BridgeInvalidation.ArtistList), ReloadBrowserFromInvalidation);
         _projections.Register(typeof(BridgeInvalidation.SyncStatus), _sync.Refresh);
         _projections.Register(typeof(BridgeInvalidation.ImportCandidateList), _import.RefreshCandidates);
         _projections.Register(typeof(BridgeInvalidation.ImportCandidate), _import.RefreshCandidates);
@@ -338,7 +343,12 @@ public sealed partial class MainWindow : Window
 
     private void OnBrowserModeChanged(object sender, SelectionChangedEventArgs e)
     {
-        _browser.Sort.SetMode(BrowserModeBox.SelectedIndex == 1 ? BrowserMode.Composers : BrowserMode.Albums);
+        _browser.Sort.SetMode(BrowserModeBox.SelectedIndex switch
+        {
+            1 => BrowserMode.Composers,
+            2 => BrowserMode.Artists,
+            _ => BrowserMode.Albums,
+        });
         _sortControls.Render();
         ReloadBrowserForSortChange();
     }
@@ -357,6 +367,7 @@ public sealed partial class MainWindow : Window
     {
         AlbumGrid.Visibility = Visibility.Visible;
         ComposerBrowser.Visibility = Visibility.Collapsed;
+        ArtistBrowser.Visibility = Visibility.Collapsed;
         SearchResultsScroll.Visibility = Visibility.Collapsed;
     }
 
@@ -364,6 +375,15 @@ public sealed partial class MainWindow : Window
     {
         AlbumGrid.Visibility = Visibility.Collapsed;
         ComposerBrowser.Visibility = Visibility.Visible;
+        ArtistBrowser.Visibility = Visibility.Collapsed;
+        SearchResultsScroll.Visibility = Visibility.Collapsed;
+    }
+
+    private void ShowArtistBrowser()
+    {
+        AlbumGrid.Visibility = Visibility.Collapsed;
+        ComposerBrowser.Visibility = Visibility.Collapsed;
+        ArtistBrowser.Visibility = Visibility.Visible;
         SearchResultsScroll.Visibility = Visibility.Collapsed;
     }
 
@@ -371,6 +391,7 @@ public sealed partial class MainWindow : Window
     {
         AlbumGrid.Visibility = Visibility.Collapsed;
         ComposerBrowser.Visibility = Visibility.Collapsed;
+        ArtistBrowser.Visibility = Visibility.Collapsed;
         SearchResultsScroll.Visibility = Visibility.Visible;
     }
 
@@ -385,6 +406,14 @@ public sealed partial class MainWindow : Window
             ShowComposerBrowser();
             _browserPanes.ClearComposerDetail();
             RenderGridStatus(_browser.LoadComposers());
+            return;
+        }
+
+        if (_browser.Sort.Mode == BrowserMode.Artists)
+        {
+            ShowArtistBrowser();
+            _browserPanes.ClearArtistDetail();
+            RenderGridStatus(_browser.LoadArtists());
             return;
         }
 
@@ -428,7 +457,12 @@ public sealed partial class MainWindow : Window
                 return;
             default:
                 StatusText.Text = load.IsEmpty
-                    ? Loc.Chrome(load.Mode == BrowserMode.Composers ? "library.no_composers" : "library.empty")
+                    ? Loc.Chrome(load.Mode switch
+                    {
+                        BrowserMode.Composers => "library.no_composers",
+                        BrowserMode.Artists => "library.no_artists",
+                        _ => "library.empty",
+                    })
                     : string.Empty;
                 return;
         }
@@ -1053,6 +1087,16 @@ public sealed partial class MainWindow : Window
         }
 
         await _browserPanes.ShowComposerDetail(composer.ArtistId);
+    }
+
+    private async void OnArtistClick(object sender, ItemClickEventArgs e)
+    {
+        if (CurrentHandleOrNull() == null || e.ClickedItem is not ArtistSummary artist)
+        {
+            return;
+        }
+
+        await _browserPanes.ShowArtistDetail(artist.ArtistId);
     }
 
     // Dispatch by the modifiers held at click time: Ctrl toggles the clicked

--- a/bae-windows/NativeBae.cs
+++ b/bae-windows/NativeBae.cs
@@ -398,6 +398,14 @@ internal static class NativeBae
             .Select(composer => new ComposerSummary(composer))
             .ToList());
 
+    internal static long ArtistCount(AppHandle handle) =>
+        checked((long)Await(handle.GetArtistCount()));
+
+    internal static (List<ArtistSummary>? Artists, string? Error) ArtistPage(AppHandle handle, ulong offset, ulong limit, ArtistSortField field, SortDirection direction) =>
+        CaptureBridgeValue(() => Await(handle.GetArtistPage(ArtistSort(field, direction), offset, limit))
+            .Select(artist => new ArtistSummary(artist))
+            .ToList());
+
     internal static (BridgeGalleryItem[]? Items, string? Error) Gallery(AppHandle handle, string releaseId) =>
         CaptureBridgeValue(() =>
         {
@@ -487,6 +495,13 @@ internal static class NativeBae
         {
             var detail = Await(handle.GetComposerDetail(artistId));
             return detail is null ? null : new ComposerDetail(detail);
+        });
+
+    internal static (ArtistDetail? Detail, string? Error) GetArtistDetail(AppHandle handle, string artistId) =>
+        CaptureBridgeValue(() =>
+        {
+            var detail = Await(handle.GetArtistDetail(artistId));
+            return detail is null ? null : new ArtistDetail(detail);
         });
 
     internal static (WorkDetail? Detail, string? Error) GetWorkDetail(AppHandle handle, string workId) =>
@@ -849,6 +864,9 @@ internal static class NativeBae
     private static BridgeComposerSortCriterion ComposerSort(ComposerSortField field, SortDirection direction) =>
         new(ToBridge(field), ToBridge(direction));
 
+    private static BridgeArtistSortCriterion ArtistSort(ArtistSortField field, SortDirection direction) =>
+        new(ToBridge(field), ToBridge(direction));
+
     private static BridgeSortField ToBridge(AlbumSortField field) => field switch
     {
         AlbumSortField.DateAdded => BridgeSortField.DateAdded,
@@ -864,6 +882,13 @@ internal static class NativeBae
         ComposerSortField.WorkCount => BridgeComposerSortField.WorkCount,
         ComposerSortField.LinkedReleaseCount => BridgeComposerSortField.LinkedReleaseCount,
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown composer sort field"),
+    };
+
+    private static BridgeArtistSortField ToBridge(ArtistSortField field) => field switch
+    {
+        ArtistSortField.Name => BridgeArtistSortField.Name,
+        ArtistSortField.AlbumCount => BridgeArtistSortField.AlbumCount,
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown artist sort field"),
     };
 
     private static BridgeSortDirection ToBridge(SortDirection direction) => direction switch

--- a/bae-windows/Stores/LibraryBrowserStore.cs
+++ b/bae-windows/Stores/LibraryBrowserStore.cs
@@ -22,11 +22,11 @@ internal sealed record BrowserGridLoad(BrowserMode Mode, BrowserLoadResult Resul
 // HandleGone means the session closed mid-search; the window leaves the pane as-is.
 internal sealed record BrowserSearch(bool HandleGone, LibrarySearchResults? Results, string? Error);
 
-// Mirror of the library grid: the albums and composers on screen, plus the
-// per-mode sort selections. The window binds x:Bind Albums/Composers to these
-// collections (through forwarders) and drives loads on sort / mode / search
-// changes; the store fetches from the current handle, attaches covers, and
-// populates the collections, returning an outcome the window renders.
+// Mirror of the library grid: the albums, composers, and artists on screen,
+// plus the per-mode sort selections. The window binds x:Bind Albums/Composers to
+// these collections (through forwarders) and drives loads on sort / mode /
+// search changes; the store fetches from the current handle, attaches covers,
+// and populates the collections, returning an outcome the window renders.
 internal sealed class LibraryBrowserStore
 {
     private const ulong FirstPageSize = 500;
@@ -38,6 +38,7 @@ internal sealed class LibraryBrowserStore
 
     public ObservableCollection<Album> Albums { get; } = new();
     public ObservableCollection<ComposerSummary> Composers { get; } = new();
+    public ObservableCollection<ArtistSummary> Artists { get; } = new();
 
     public LibraryBrowserStore(SessionStore session, DispatcherQueue dispatcher)
     {
@@ -113,6 +114,38 @@ internal sealed class LibraryBrowserStore
         return new BrowserGridLoad(BrowserMode.Composers, BrowserLoadResult.Loaded, null, page.Composers.Count == 0);
     }
 
+    // Load the artist list (per the active artist sort) into Artists. Clears
+    // the list up front so a failed or empty load leaves nothing stale behind.
+    public BrowserGridLoad LoadArtists()
+    {
+        Artists.Clear();
+        var artistSort = Sort.Artist;
+        var (current, page) = _session.WithCurrentHandle(
+            handle => NativeBae.ArtistPage(handle, 0, FirstPageSize, artistSort.Field, artistSort.Direction));
+        if (!current)
+        {
+            return new BrowserGridLoad(BrowserMode.Artists, BrowserLoadResult.HandleGone, null, false);
+        }
+        if (page.Error is not null || page.Artists is null)
+        {
+            return new BrowserGridLoad(BrowserMode.Artists, BrowserLoadResult.Failed, page.Error, false);
+        }
+
+        var handle = _session.CurrentHandleOrNull();
+        if (handle == null)
+        {
+            return new BrowserGridLoad(BrowserMode.Artists, BrowserLoadResult.HandleGone, null, false);
+        }
+
+        foreach (var artist in page.Artists)
+        {
+            artist.AttachCover(handle, _dispatcher);
+            Artists.Add(artist);
+        }
+
+        return new BrowserGridLoad(BrowserMode.Artists, BrowserLoadResult.Loaded, null, page.Artists.Count == 0);
+    }
+
     // Run a library search and attach covers to the results, for the search pane to
     // render. Covers are attached only when the search returned no error; an
     // error result passes through untouched.
@@ -155,5 +188,6 @@ internal sealed class LibraryBrowserStore
     {
         Albums.Clear();
         Composers.Clear();
+        Artists.Clear();
     }
 }

--- a/bae-windows/Stores/LibrarySort.cs
+++ b/bae-windows/Stores/LibrarySort.cs
@@ -10,6 +10,7 @@ public enum BrowserMode
 {
     Albums,
     Composers,
+    Artists,
 }
 
 // The library album sort keys. Names match the bridge sort fields the album page
@@ -27,6 +28,12 @@ public enum ComposerSortField
     Name,
     WorkCount,
     LinkedReleaseCount,
+}
+
+public enum ArtistSortField
+{
+    Name,
+    AlbumCount,
 }
 
 public enum SortDirection
@@ -57,6 +64,12 @@ public static class LibrarySortVocab
         ComposerSortField.LinkedReleaseCount,
     };
 
+    public static readonly ArtistSortField[] ArtistFields =
+    {
+        ArtistSortField.Name,
+        ArtistSortField.AlbumCount,
+    };
+
     public static string LabelKey(AlbumSortField field) => field switch
     {
         AlbumSortField.DateAdded => "sort.dateAdded",
@@ -72,6 +85,13 @@ public static class LibrarySortVocab
         ComposerSortField.WorkCount => "search.section.works",
         ComposerSortField.LinkedReleaseCount => "search.section.releases",
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown composer sort field"),
+    };
+
+    public static string LabelKey(ArtistSortField field) => field switch
+    {
+        ArtistSortField.Name => "sort.name",
+        ArtistSortField.AlbumCount => "search.section.albums",
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown artist sort field"),
     };
 
     // The chrome key naming the action of switching to a direction: the direction
@@ -301,6 +321,10 @@ public sealed class AlbumSortCriteria
 // criterion and is not persisted — it resets to name-ascending each launch.
 public sealed record ComposerSortCriterion(ComposerSortField Field, SortDirection Direction);
 
+// One artist sort key and direction. Like the composer sort: a single
+// criterion, not persisted — it resets to name-ascending each launch.
+public sealed record ArtistSortCriterion(ArtistSortField Field, SortDirection Direction);
+
 // The browser's whole sort state: the current mode, the persisted album sort
 // criteria, and the in-memory composer sort. No WinUI, no bridge types.
 public sealed class LibrarySort
@@ -311,6 +335,9 @@ public sealed class LibrarySort
 
     public ComposerSortCriterion Composer { get; private set; } =
         new(ComposerSortField.Name, SortDirection.Ascending);
+
+    public ArtistSortCriterion Artist { get; private set; } =
+        new(ArtistSortField.Name, SortDirection.Ascending);
 
     public LibrarySort()
         : this(new AlbumSortCriteria())
@@ -326,4 +353,7 @@ public sealed class LibrarySort
 
     public void SetComposer(ComposerSortField field, SortDirection direction) =>
         Composer = new ComposerSortCriterion(field, direction);
+
+    public void SetArtist(ArtistSortField field, SortDirection direction) =>
+        Artist = new ArtistSortCriterion(field, direction);
 }

--- a/bae-windows/Strings/ar/Resources.resw
+++ b/bae-windows/Strings/ar/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>تم تدوير الرمز ونسخه</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>الألبومات</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>المؤلفون</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>الفنانون</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>لا يوجد مؤلفون</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>لا يوجد فنانون</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>الألبومات</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>المقاطع</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>المؤلفون</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>الاعتمادات</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>التسجيلات</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>تعذر فتح تفاصيل المؤلف</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>تعذر فتح تفاصيل الفنان</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>تعذر فتح تفاصيل العمل</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} عمل</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} ألبومات</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>تصدير</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>صيغة المقطع الافتراضية</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>صيغة الإصدار الافتراضية</value></data>

--- a/bae-windows/Strings/bg/Resources.resw
+++ b/bae-windows/Strings/bg/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>токенът е сменен и копиран</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Албуми</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Композитори</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Изпълнители</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Няма композитори</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Няма изпълнители</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Албуми</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Песни</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Композитори</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Кредити</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Записи</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Данните за композитора не можаха да бъдат отворени</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Данните за изпълнителя не можаха да бъдат отворени</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Данните за произведението не можаха да бъдат отворени</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} произведения</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} албума</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Експорт</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Формат на песните по подразбиране</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Формат на изданията по подразбиране</value></data>

--- a/bae-windows/Strings/bn/Resources.resw
+++ b/bae-windows/Strings/bn/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>টোকেন ঘোরানো হয়েছে এবং কপি হয়েছে</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>অ্যালবাম</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>সুরকার</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>শিল্পীরা</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>কোনো সুরকার নেই</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>কোনো শিল্পী নেই</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>অ্যালবাম</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ট্র্যাক</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>সুরকার</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>ক্রেডিট</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>রেকর্ডিং</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>সুরকারের বিবরণ খোলা যায়নি</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>শিল্পীর বিবরণ খোলা যায়নি</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>কাজের বিবরণ খোলা যায়নি</value></data>
   <data name="work.count" xml:space="preserve"><value>{count}টি কাজ</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count}টি অ্যালবাম</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>এক্সপোর্ট</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>ডিফল্ট ট্র্যাক ফরম্যাট</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>ডিফল্ট রিলিজ ফরম্যাট</value></data>

--- a/bae-windows/Strings/cs/Resources.resw
+++ b/bae-windows/Strings/cs/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token obměněn a zkopírován</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Alba</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Skladatelé</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Interpreti</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Žádní skladatelé</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Žádní interpreti</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Alba</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Stopy</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Skladatelé</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Kredity</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Nahrávky</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Nepodařilo se otevřít detail skladatele</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Nepodařilo se otevřít detail interpreta</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Nepodařilo se otevřít detail díla</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} děl</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} alb</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Export</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Výchozí formát stopy</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Výchozí formát vydání</value></data>

--- a/bae-windows/Strings/de/Resources.resw
+++ b/bae-windows/Strings/de/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>Token erneuert und kopiert</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Alben</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Komponisten</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Künstler</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Keine Komponisten</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Keine Künstler</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Alben</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Komponisten</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Aufnahmen</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Komponistendetails konnten nicht geöffnet werden</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Künstlerdetails konnten nicht geöffnet werden</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Werkdetails konnten nicht geöffnet werden</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} Werke</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} Alben</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Exportieren</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Standardformat für Tracks</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Standardformat für Releases</value></data>

--- a/bae-windows/Strings/en-US/Resources.resw
+++ b/bae-windows/Strings/en-US/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token rotated and copied</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Composers</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Artists</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>No composers</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>No artists</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Tracks</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Composers</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Recordings</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Could not open composer detail</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Could not open artist detail</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Could not open work detail</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} Works</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} Albums</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Export</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Default track format</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Default release format</value></data>

--- a/bae-windows/Strings/es/Resources.resw
+++ b/bae-windows/Strings/es/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token rotado y copiado</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Álbumes</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Compositores</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Artistas</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>No hay compositores</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>No hay artistas</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Álbumes</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Pistas</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Compositores</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Créditos</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Grabaciones</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>No se pudieron abrir los detalles del compositor</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>No se pudieron abrir los detalles del artista</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>No se pudieron abrir los detalles de la obra</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} obras</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} álbumes</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Exportar</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Formato de pista predeterminado</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Formato de lanzamiento predeterminado</value></data>

--- a/bae-windows/Strings/fr/Resources.resw
+++ b/bae-windows/Strings/fr/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>jeton renouvelé et copié</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Compositeurs</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Artistes</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Aucun compositeur</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Aucun artiste</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Pistes</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Compositeurs</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Crédits</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Enregistrements</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Impossible d’ouvrir les détails du compositeur</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Impossible d’ouvrir les détails de l’artiste</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Impossible d’ouvrir les détails de l’œuvre</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} œuvres</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} albums</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Exporter</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Format de piste par défaut</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Format de sortie par défaut</value></data>

--- a/bae-windows/Strings/gu/Resources.resw
+++ b/bae-windows/Strings/gu/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ટોકન ફેરવાયું અને કૉપિ થયું</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>આલ્બમો</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>સંગીતકારો</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>કલાકારો</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>સંગીતકારો નથી</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>કોઈ કલાકારો નથી</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>આલ્બમો</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ટ્રૅક્સ</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>સંગીતકારો</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>શ્રેય</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>રેકોર્ડિંગ્સ</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>સંગીતકારની વિગત ખોલી શકાયી નહીં</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>કલાકારની વિગત ખોલી શકાયી નહીં</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>કૃતિની વિગત ખોલી શકાયી નહીં</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} કૃતિઓ</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} આલ્બમ</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>નિકાસ</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>મૂળભૂત ટ્રૅક બંધારણ</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>મૂળભૂત પ્રકાશન બંધારણ</value></data>

--- a/bae-windows/Strings/he/Resources.resw
+++ b/bae-windows/Strings/he/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>האסימון הוחלף והועתק</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>אלבומים</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>מלחינים</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>אמנים</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>אין מלחינים</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>אין אמנים</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>אלבומים</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>רצועות</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>מלחינים</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>קרדיטים</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>הקלטות</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>לא ניתן לפתוח את פרטי המלחין</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>לא ניתן לפתוח את פרטי האמן</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>לא ניתן לפתוח את פרטי היצירה</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} יצירות</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} אלבומים</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>ייצוא</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>פורמט ברירת מחדל לרצועה</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>פורמט ברירת מחדל להוצאה</value></data>

--- a/bae-windows/Strings/hi/Resources.resw
+++ b/bae-windows/Strings/hi/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>टोकन बदला गया और कॉपी किया गया</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>एल्बम</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>संगीतकार</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>कलाकार</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>कोई संगीतकार नहीं</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>कोई कलाकार नहीं</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>एल्बम</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ट्रैक</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>संगीतकार</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>श्रेय</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>रिकॉर्डिंग</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>संगीतकार विवरण नहीं खोला जा सका</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>कलाकार विवरण नहीं खोला जा सका</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>कृति विवरण नहीं खोला जा सका</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} कृतियाँ</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} एल्बम</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>निर्यात</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>डिफॉल्ट ट्रैक प्रारूप</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>डिफॉल्ट रिलीज प्रारूप</value></data>

--- a/bae-windows/Strings/hr/Resources.resw
+++ b/bae-windows/Strings/hr/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token rotiran i kopiran</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Albumi</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Skladatelji</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Izvođači</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Nema skladatelja</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Nema izvođača</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Albumi</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Pjesme</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Skladatelji</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Zasluge</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Snimke</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Nije moguće otvoriti detalje skladatelja</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Nije moguće otvoriti detalje izvođača</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Nije moguće otvoriti detalje djela</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} djela</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} albuma</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Izvoz</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Zadani format pjesme</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Zadani format izdanja</value></data>

--- a/bae-windows/Strings/it/Resources.resw
+++ b/bae-windows/Strings/it/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token ruotato e copiato</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Album</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Compositori</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Artisti</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Nessun compositore</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Nessun artista</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Album</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Brani</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Compositori</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Crediti</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Registrazioni</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Impossibile aprire il dettaglio del compositore</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Impossibile aprire il dettaglio dell’artista</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Impossibile aprire il dettaglio dell'opera</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} opere</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} album</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Esporta</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Formato brano predefinito</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Formato pubblicazione predefinito</value></data>

--- a/bae-windows/Strings/ja/Resources.resw
+++ b/bae-windows/Strings/ja/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>トークンを更新してコピーしました</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>アルバム</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>作曲者</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>アーティスト</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>作曲者がありません</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>アーティストがいません</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>アルバム</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>トラック</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>作曲者</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>クレジット</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>録音</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>作曲者の詳細を開けませんでした</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>アーティストの詳細を開けませんでした</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>作品の詳細を開けませんでした</value></data>
   <data name="work.count" xml:space="preserve"><value>{count}作品</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count}枚のアルバム</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>エクスポート</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>デフォルトのトラック形式</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>デフォルトのリリース形式</value></data>

--- a/bae-windows/Strings/kn/Resources.resw
+++ b/bae-windows/Strings/kn/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ಟೋಕನ್ ಬದಲಿಸಿ ನಕಲಿಸಲಾಗಿದೆ</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>ಆಲ್ಬಮ್‌ಗಳು</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>ಸಂಗೀತ ಸಂಯೋಜಕರು</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>ಕಲಾವಿದರು</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>ಸಂಗೀತ ಸಂಯೋಜಕರು ಇಲ್ಲ</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>ಕಲಾವಿದರು ಇಲ್ಲ</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>ಆಲ್ಬಮ್‌ಗಳು</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ಟ್ರ್ಯಾಕ್‌ಗಳು</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>ಸಂಗೀತ ಸಂಯೋಜಕರು</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>ಕ್ರೆಡಿಟ್‌ಗಳು</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>ಸಂಗೀತ ಸಂಯೋಜಕರ ವಿವರ ತೆರೆಯಲಾಗಲಿಲ್ಲ</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>ಕಲಾವಿದರ ವಿವರ ತೆರೆಯಲಾಗಲಿಲ್ಲ</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>ಕೃತಿ ವಿವರ ತೆರೆಯಲಾಗಲಿಲ್ಲ</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} ಕೃತಿಗಳು</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} ಆಲ್ಬಮ್‌ಗಳು</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>ರಫ್ತು</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>ಪೂರ್ವನಿಯೋಜಿತ ಹಾಡು ಸ್ವರೂಪ</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>ಪೂರ್ವನಿಯೋಜಿತ ಬಿಡುಗಡೆ ಸ್ವರೂಪ</value></data>

--- a/bae-windows/Strings/ko/Resources.resw
+++ b/bae-windows/Strings/ko/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>토큰이 교체되어 복사됨</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>앨범</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>작곡가</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>아티스트</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>작곡가 없음</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>아티스트 없음</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>앨범</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>트랙</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>작곡가</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>크레딧</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>녹음</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>작곡가 세부 정보를 열 수 없음</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>아티스트 세부 정보를 열 수 없음</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>작품 세부 정보를 열 수 없음</value></data>
   <data name="work.count" xml:space="preserve"><value>작품 {count}개</value></data>
+  <data name="album.count" xml:space="preserve"><value>앨범 {count}개</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>내보내기</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>기본 트랙 형식</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>기본 릴리스 형식</value></data>

--- a/bae-windows/Strings/ml/Resources.resw
+++ b/bae-windows/Strings/ml/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ടോക്കൺ മാറ്റി പകർത്തി</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>ആൽബങ്ങൾ</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>സംഗീതരചയിതാക്കൾ</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>കലാകാരന്മാർ</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>സംഗീതരചയിതാക്കളില്ല</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>കലാകാരന്മാരില്ല</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>ആൽബങ്ങൾ</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ട്രാക്കുകൾ</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>സംഗീതരചയിതാക്കൾ</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>ക്രെഡിറ്റുകൾ</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>റെക്കോർഡിംഗുകൾ</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>സംഗീതരചയിതാവിന്റെ വിശദാംശം തുറക്കാനായില്ല</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>കലാകാരന്റെ വിശദാംശം തുറക്കാനായില്ല</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>കൃതിയുടെ വിശദാംശം തുറക്കാനായില്ല</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} കൃതികൾ</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} ആൽബങ്ങൾ</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>കയറ്റുമതി</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>സ്ഥിര ട്രാക്ക് ഫോർമാറ്റ്</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>സ്ഥിര പതിപ്പ് ഫോർമാറ്റ്</value></data>

--- a/bae-windows/Strings/mr/Resources.resw
+++ b/bae-windows/Strings/mr/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>टोकन बदलून कॉपी केले</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>अल्बम</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>संगीतकार</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>कलाकार</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>संगीतकार नाहीत</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>कलाकार नाहीत</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>अल्बम</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>गाणी</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>संगीतकार</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>श्रेय</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>रेकॉर्डिंग्ज</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>संगीतकार तपशील उघडता आला नाही</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>कलाकार तपशील उघडता आला नाही</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>कृती तपशील उघडता आला नाही</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} कृती</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} अल्बम</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>निर्यात</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>मुलभूत गाणे स्वरूप</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>मुलभूत प्रकाशन स्वरूप</value></data>

--- a/bae-windows/Strings/nl/Resources.resw
+++ b/bae-windows/Strings/nl/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token vervangen en gekopieerd</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Albums</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Componisten</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Artiesten</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Geen componisten</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Geen artiesten</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Albums</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Nummers</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Componisten</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Credits</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Opnamen</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Kan componistdetails niet openen</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Kan artiestdetails niet openen</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Kan werkdetails niet openen</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} werken</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} albums</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Exporteer</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Standaardformaat voor nummers</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Standaardformaat voor releases</value></data>

--- a/bae-windows/Strings/pa/Resources.resw
+++ b/bae-windows/Strings/pa/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ਟੋਕਨ ਬਦਲਿਆ ਤੇ ਕਾਪੀ ਹੋਇਆ</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>ਐਲਬਮਾਂ</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>ਸੰਗੀਤਕਾਰ</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>ਕਲਾਕਾਰ</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>ਕੋਈ ਸੰਗੀਤਕਾਰ ਨਹੀਂ</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>ਕੋਈ ਕਲਾਕਾਰ ਨਹੀਂ</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>ਐਲਬਮਾਂ</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ਟ੍ਰੈਕ</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>ਸੰਗੀਤਕਾਰ</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>ਕ੍ਰੈਡਿਟ</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>ਰਿਕਾਰਡਿੰਗਾਂ</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>ਸੰਗੀਤਕਾਰ ਵੇਰਵਾ ਖੋਲ੍ਹਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>ਕਲਾਕਾਰ ਵੇਰਵਾ ਖੋਲ੍ਹਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>ਰਚਨਾ ਵੇਰਵਾ ਖੋਲ੍ਹਿਆ ਨਹੀਂ ਜਾ ਸਕਿਆ</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} ਰਚਨਾਵਾਂ</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} ਐਲਬਮਾਂ</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>ਨਿਰਯਾਤ</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>ਡਿਫਾਲਟ ਟ੍ਰੈਕ ਫਾਰਮੈਟ</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>ਡਿਫਾਲਟ ਰਿਲੀਜ਼ ਫਾਰਮੈਟ</value></data>

--- a/bae-windows/Strings/pl/Resources.resw
+++ b/bae-windows/Strings/pl/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token zmieniony i skopiowany</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Albumy</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Kompozytorzy</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Wykonawcy</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Brak kompozytorów</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Brak wykonawców</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Albumy</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Ścieżki</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Kompozytorzy</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Twórcy</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Nagrania</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Nie udało się otworzyć szczegółów kompozytora</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Nie udało się otworzyć szczegółów wykonawcy</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Nie udało się otworzyć szczegółów dzieła</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} dzieł</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} albumów</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Eksportuj</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Domyślny format ścieżki</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Domyślny format wydania</value></data>

--- a/bae-windows/Strings/pt-BR/Resources.resw
+++ b/bae-windows/Strings/pt-BR/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>token trocado e copiado</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Álbuns</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Compositores</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Artistas</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Nenhum compositor</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Nenhum artista</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Álbuns</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Faixas</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Compositores</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Créditos</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Gravações</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Não foi possível abrir os detalhes do compositor</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Não foi possível abrir os detalhes do artista</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Não foi possível abrir os detalhes da obra</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} obras</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} álbuns</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Exportar</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Formato padrão de faixa</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Formato padrão de lançamento</value></data>

--- a/bae-windows/Strings/ta/Resources.resw
+++ b/bae-windows/Strings/ta/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>டோக்கன் மாற்றப்பட்டு நகலெடுக்கப்பட்டது</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>ஆல்பங்கள்</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>இசையமைப்பாளர்கள்</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>கலைஞர்கள்</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>இசையமைப்பாளர்கள் இல்லை</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>கலைஞர்கள் இல்லை</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>ஆல்பங்கள்</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>பாடல்கள்</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>இசையமைப்பாளர்கள்</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>பங்களிப்புகள்</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>பதிவுகள்</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>இசையமைப்பாளர் விவரத்தைத் திறக்க முடியவில்லை</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>கலைஞர் விவரத்தைத் திறக்க முடியவில்லை</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>படைப்பு விவரத்தைத் திறக்க முடியவில்லை</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} படைப்புகள்</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} ஆல்பங்கள்</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>ஏற்றுமதி</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>இயல்புநிலை பாடல் வடிவம்</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>இயல்புநிலை வெளியீட்டு வடிவம்</value></data>

--- a/bae-windows/Strings/te/Resources.resw
+++ b/bae-windows/Strings/te/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>టోకెన్ మార్చి కాపీ చేయబడింది</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>ఆల్బమ్‌లు</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>సంగీతరచయితలు</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>కళాకారులు</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>సంగీతరచయితలు లేరు</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>కళాకారులు లేరు</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>ఆల్బమ్‌లు</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>ట్రాక్‌లు</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>సంగీతరచయితలు</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>క్రెడిట్‌లు</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>రికార్డింగ్‌లు</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>సంగీతరచయిత వివరాన్ని తెరవలేకపోయింది</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>కళాకారుని వివరాన్ని తెరవలేకపోయింది</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>కృతి వివరాన్ని తెరవలేకపోయింది</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} కృతులు</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} ఆల్బమ్‌లు</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>ఎగుమతి</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>డిఫాల్ట్ ట్రాక్ ఫార్మాట్</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>డిఫాల్ట్ విడుదల ఫార్మాట్</value></data>

--- a/bae-windows/Strings/th/Resources.resw
+++ b/bae-windows/Strings/th/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>หมุนเวียนและคัดลอกโทเค็นแล้ว</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>อัลบั้ม</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>ผู้ประพันธ์</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>ศิลปิน</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>ไม่มีผู้ประพันธ์</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>ไม่มีศิลปิน</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>อัลบั้ม</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>แทร็ก</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>ผู้ประพันธ์</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>เครดิต</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>การบันทึกเสียง</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>ไม่สามารถเปิดรายละเอียดผู้ประพันธ์ได้</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>ไม่สามารถเปิดรายละเอียดศิลปินได้</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>ไม่สามารถเปิดรายละเอียดผลงานได้</value></data>
   <data name="work.count" xml:space="preserve"><value>ผลงาน {count} รายการ</value></data>
+  <data name="album.count" xml:space="preserve"><value>อัลบั้ม {count} รายการ</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>ส่งออก</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>รูปแบบแทร็กเริ่มต้น</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>รูปแบบรีลีสเริ่มต้น</value></data>

--- a/bae-windows/Strings/tr/Resources.resw
+++ b/bae-windows/Strings/tr/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>belirteç değiştirildi ve kopyalandı</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Albümler</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Besteciler</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Sanatçılar</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Besteci yok</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Sanatçı yok</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Albümler</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Parçalar</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Besteciler</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Katkılar</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Kayıtlar</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Besteci ayrıntısı açılamadı</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Sanatçı ayrıntısı açılamadı</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Eser ayrıntısı açılamadı</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} Eser</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} Albüm</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Dışa aktar</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Varsayılan parça biçimi</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Varsayılan yayın biçimi</value></data>

--- a/bae-windows/Strings/uk/Resources.resw
+++ b/bae-windows/Strings/uk/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>токен змінено й скопійовано</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Альбоми</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Композитори</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Виконавці</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Немає композиторів</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Немає виконавців</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Альбоми</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Треки</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Композитори</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Автори</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Записи</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Не вдалося відкрити відомості про композитора</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Не вдалося відкрити відомості про виконавця</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Не вдалося відкрити відомості про твір</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} творів</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} альбомів</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Експорт</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Формат треку за замовчуванням</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Формат релізу за замовчуванням</value></data>

--- a/bae-windows/Strings/ur/Resources.resw
+++ b/bae-windows/Strings/ur/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>ٹوکن تبدیل کر کے کاپی ہو گیا</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>البمز</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>موسیقار</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>فنکار</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>کوئی موسیقار نہیں</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>کوئی فنکار نہیں</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>البمز</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>نغمے</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>موسیقار</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>اعزازات</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>ریکارڈنگز</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>موسیقار کی تفصیل نہیں کھل سکی</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>فنکار کی تفصیل نہیں کھل سکی</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>کام کی تفصیل نہیں کھل سکی</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} کام</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} البمز</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>برآمد</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>طے شدہ نغمہ ساخت</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>طے شدہ اشاعت ساخت</value></data>

--- a/bae-windows/Strings/vi/Resources.resw
+++ b/bae-windows/Strings/vi/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>đã đổi và sao chép mã thông báo</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>Album</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>Nhà soạn nhạc</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>Nghệ sĩ</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>Không có nhà soạn nhạc</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>Không có nghệ sĩ</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>Album</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>Bản nhạc</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>Nhà soạn nhạc</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>Công trạng</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>Bản thu</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>Không thể mở chi tiết nhà soạn nhạc</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>Không thể mở chi tiết nghệ sĩ</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>Không thể mở chi tiết tác phẩm</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} tác phẩm</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} album</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>Xuất</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>Định dạng bản nhạc mặc định</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>Định dạng bản phát hành mặc định</value></data>

--- a/bae-windows/Strings/zh-Hans/Resources.resw
+++ b/bae-windows/Strings/zh-Hans/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>令牌已轮换并复制</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>专辑</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>作曲家</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>艺人</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>没有作曲家</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>没有艺人</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>专辑</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>曲目</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>作曲家</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>鸣谢</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>录音</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>无法打开作曲家详情</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>无法打开艺人详情</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>无法打开作品详情</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} 部作品</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} 张专辑</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>导出</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>默认曲目格式</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>默认发行格式</value></data>

--- a/bae-windows/Strings/zh-Hant/Resources.resw
+++ b/bae-windows/Strings/zh-Hant/Resources.resw
@@ -283,7 +283,9 @@
   <data name="settings.automation.token_rotated" xml:space="preserve"><value>權杖已輪替並複製</value></data>
   <data name="library.mode.albums" xml:space="preserve"><value>專輯</value></data>
   <data name="library.mode.composers" xml:space="preserve"><value>作曲者</value></data>
+  <data name="library.mode.artists" xml:space="preserve"><value>藝人</value></data>
   <data name="library.no_composers" xml:space="preserve"><value>沒有作曲者</value></data>
+  <data name="library.no_artists" xml:space="preserve"><value>沒有藝人</value></data>
   <data name="search.section.albums" xml:space="preserve"><value>專輯</value></data>
   <data name="search.section.tracks" xml:space="preserve"><value>曲目</value></data>
   <data name="search.section.composers" xml:space="preserve"><value>作曲者</value></data>
@@ -292,8 +294,10 @@
   <data name="search.section.credits" xml:space="preserve"><value>製作名單</value></data>
   <data name="search.section.recordings" xml:space="preserve"><value>錄音</value></data>
   <data name="composer.open_failed" xml:space="preserve"><value>無法開啟作曲者詳細資料</value></data>
+  <data name="artist.open_failed" xml:space="preserve"><value>無法開啟藝人詳細資料</value></data>
   <data name="work.open_failed" xml:space="preserve"><value>無法開啟作品詳細資料</value></data>
   <data name="work.count" xml:space="preserve"><value>{count} 部作品</value></data>
+  <data name="album.count" xml:space="preserve"><value>{count} 張專輯</value></data>
   <data name="settings.export.label" xml:space="preserve"><value>匯出</value></data>
   <data name="settings.export.default_track_format" xml:space="preserve"><value>預設曲目格式</value></data>
   <data name="settings.export.default_release_format" xml:space="preserve"><value>預設發行格式</value></data>

--- a/bae-windows/Views/BrowserPanes.cs
+++ b/bae-windows/Views/BrowserPanes.cs
@@ -8,19 +8,22 @@ using uniffi.bae_bridge;
 
 namespace Bae.Windows;
 
-// Renders the two library panes that aren't the album grid: the search-results
-// list and the composer/work detail column. Both read the current handle for
-// their fetches (composer/work detail) and covers; the window owns pane
-// visibility and the status line, passed in as callbacks. Opening an album is
-// injected because the album-detail dialog lives on the window.
+// Renders the three library panes that aren't the album grid: the
+// search-results list and the composer/work and artist detail columns. Both
+// read the current handle for their fetches (composer/work/artist detail) and
+// covers; the window owns pane visibility and the status line, passed in as
+// callbacks. Opening an album is injected because the album-detail dialog
+// lives on the window.
 internal sealed class BrowserPanes
 {
     private readonly SessionStore _session;
     private readonly DispatcherQueue _dispatcher;
     private readonly StackPanel _searchResultsPanel;
     private readonly StackPanel _composerDetailPane;
+    private readonly StackPanel _artistDetailPane;
     private readonly Action<string> _setStatus;
     private readonly Action _showComposerBrowser;
+    private readonly Action _showArtistBrowser;
     private readonly Func<string, string?, string?, System.Threading.Tasks.Task> _openAlbum;
 
     public BrowserPanes(
@@ -28,20 +31,26 @@ internal sealed class BrowserPanes
         DispatcherQueue dispatcher,
         StackPanel searchResultsPanel,
         StackPanel composerDetailPane,
+        StackPanel artistDetailPane,
         Action<string> setStatus,
         Action showComposerBrowser,
+        Action showArtistBrowser,
         Func<string, string?, string?, System.Threading.Tasks.Task> openAlbum)
     {
         _session = session;
         _dispatcher = dispatcher;
         _searchResultsPanel = searchResultsPanel;
         _composerDetailPane = composerDetailPane;
+        _artistDetailPane = artistDetailPane;
         _setStatus = setStatus;
         _showComposerBrowser = showComposerBrowser;
+        _showArtistBrowser = showArtistBrowser;
         _openAlbum = openAlbum;
     }
 
     public void ClearComposerDetail() => _composerDetailPane.Children.Clear();
+
+    public void ClearArtistDetail() => _artistDetailPane.Children.Clear();
 
     // Render the search-results list from the store's cover-attached results. The
     // window has already flipped to the search pane; this fills the panel and sets
@@ -160,7 +169,7 @@ internal sealed class BrowserPanes
         });
         if (detail.WorkGroups.Count > 0)
         {
-            AddPaneHeader(Loc.Chrome("search.section.works"));
+            AddPaneHeader(_composerDetailPane, Loc.Chrome("search.section.works"));
             foreach (var group in detail.WorkGroups)
             {
                 if (group.Parent is not null)
@@ -175,7 +184,7 @@ internal sealed class BrowserPanes
         }
         if (detail.UnlinkedReleaseRoles.Count > 0)
         {
-            AddPaneHeader(Loc.Chrome("search.section.credits"));
+            AddPaneHeader(_composerDetailPane, Loc.Chrome("search.section.credits"));
             foreach (var role in detail.UnlinkedReleaseRoles)
             {
                 _composerDetailPane.Children.Add(PaneButton(role.AlbumTitle, role.SourceCredit ?? string.Empty, () =>
@@ -184,7 +193,7 @@ internal sealed class BrowserPanes
         }
         if (detail.UnlinkedTrackRoles.Count > 0)
         {
-            AddPaneHeader(Loc.Chrome("search.section.recordings"));
+            AddPaneHeader(_composerDetailPane, Loc.Chrome("search.section.recordings"));
             foreach (var role in detail.UnlinkedTrackRoles)
             {
                 _composerDetailPane.Children.Add(PaneButton(role.TrackTitle, role.AlbumTitle, () => _openAlbum(role.AlbumId, null, null)));
@@ -196,12 +205,63 @@ internal sealed class BrowserPanes
         }
     }
 
+    public async System.Threading.Tasks.Task ShowArtistDetail(string artistId)
+    {
+        var (current, response) = await _session.RunForCurrentHandle(
+            handle => NativeBae.GetArtistDetail(handle, artistId));
+        if (!current)
+        {
+            return;
+        }
+        if (response.Error is not null || response.Detail is null)
+        {
+            _setStatus(response.Error ?? Loc.Chrome("artist.open_failed"));
+            return;
+        }
+
+        var detail = response.Detail;
+        var handle = _session.CurrentHandleOrNull();
+        if (handle == null)
+        {
+            return;
+        }
+        detail.Artist.AttachCover(handle, _dispatcher);
+        foreach (var album in detail.Albums)
+        {
+            album.AttachCover(handle, _dispatcher);
+        }
+
+        _showArtistBrowser();
+        _artistDetailPane.Children.Clear();
+        _artistDetailPane.Children.Add(new TextBlock
+        {
+            Text = detail.Artist.Name,
+            Style = (Style)Application.Current.Resources["TitleTextBlockStyle"],
+        });
+        _artistDetailPane.Children.Add(new TextBlock
+        {
+            Text = detail.Artist.AlbumCountText,
+            Foreground = new SolidColorBrush(Microsoft.UI.Colors.Gray),
+        });
+        if (detail.Albums.Count > 0)
+        {
+            AddPaneHeader(_artistDetailPane, Loc.Chrome("search.section.albums"));
+            foreach (var album in detail.Albums)
+            {
+                _artistDetailPane.Children.Add(PaneButton(
+                    album.Title,
+                    album.Year?.ToString() ?? string.Empty,
+                    () => _openAlbum(album.Id, null, null)));
+            }
+        }
+    }
+
     private Button WorkButton(WorkSummary work) =>
         PaneButton(work.Title, work.ComposerNames ?? string.Empty, () => ShowWorkDetail(work.WorkId));
 
-    private void AddPaneHeader(string title)
+    private void AddPaneHeader(StackPanel pane, string title)
     {
-        _composerDetailPane.Children.Add(new TextBlock
+        pane.Children.Add(new TextBlock
         {
             Text = title,
             Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"],
@@ -274,7 +334,7 @@ internal sealed class BrowserPanes
         });
         if (detail.ChildWorks.Count > 0)
         {
-            AddPaneHeader(Loc.Chrome("search.section.works"));
+            AddPaneHeader(_composerDetailPane, Loc.Chrome("search.section.works"));
             foreach (var work in detail.ChildWorks)
             {
                 _composerDetailPane.Children.Add(WorkButton(work));
@@ -282,7 +342,7 @@ internal sealed class BrowserPanes
         }
         if (detail.Releases.Count > 0)
         {
-            AddPaneHeader(Loc.Chrome("search.section.releases"));
+            AddPaneHeader(_composerDetailPane, Loc.Chrome("search.section.releases"));
             foreach (var release in detail.Releases)
             {
                 _composerDetailPane.Children.Add(PaneButton(release.AlbumTitle, release.DisplaySubtitle, () =>
@@ -291,7 +351,7 @@ internal sealed class BrowserPanes
         }
         if (detail.Tracks.Count > 0)
         {
-            AddPaneHeader(Loc.Chrome("search.section.recordings"));
+            AddPaneHeader(_composerDetailPane, Loc.Chrome("search.section.recordings"));
             foreach (var track in detail.Tracks)
             {
                 _composerDetailPane.Children.Add(PaneButton(track.TrackTitle, track.AlbumTitle, () => _openAlbum(track.AlbumId, null, null)));

--- a/bae-windows/Views/LibrarySortControls.cs
+++ b/bae-windows/Views/LibrarySortControls.cs
@@ -7,11 +7,11 @@ namespace Bae.Windows;
 // Renders the library sort surface into the toolbar: for albums, a pill per sort
 // criterion (a button that inverts that field's direction, plus an "x" button
 // that removes it) and a "+" button whose flyout adds an unused field; for
-// composers, a field-picker button and a direction-invert button. Field
-// switching and reordering are gone by design — the sort is built by adding and
-// removing pills. Every action mutates the LibrarySort model and asks the window
-// to reload. The window owns visibility and reload; this only builds controls,
-// so it stays a thin renderer of the model.
+// composers and artists, a field-picker button and a direction-invert button.
+// Field switching and reordering are gone by design — the sort is built by
+// adding and removing pills. Every action mutates the LibrarySort model and
+// asks the window to reload. The window owns visibility and reload; this only
+// builds controls, so it stays a thin renderer of the model.
 internal sealed class LibrarySortControls
 {
     private const string CheckmarkGlyph = "";
@@ -35,13 +35,17 @@ internal sealed class LibrarySortControls
     public void Render()
     {
         _host.Children.Clear();
-        if (_sort.Mode == BrowserMode.Composers)
+        switch (_sort.Mode)
         {
-            RenderComposer();
-        }
-        else
-        {
-            RenderAlbums();
+            case BrowserMode.Composers:
+                RenderComposer();
+                break;
+            case BrowserMode.Artists:
+                RenderArtist();
+                break;
+            default:
+                RenderAlbums();
+                break;
         }
     }
 
@@ -154,12 +158,41 @@ internal sealed class LibrarySortControls
     private void RenderComposer()
     {
         var composer = _sort.Composer;
+        RenderSingleCriterion(
+            LibrarySortVocab.ComposerFields,
+            composer.Field,
+            composer.Direction,
+            LibrarySortVocab.LabelKey,
+            (field, direction) => _sort.SetComposer(field, direction));
+    }
 
+    private void RenderArtist()
+    {
+        var artist = _sort.Artist;
+        RenderSingleCriterion(
+            LibrarySortVocab.ArtistFields,
+            artist.Field,
+            artist.Direction,
+            LibrarySortVocab.LabelKey,
+            (field, direction) => _sort.SetArtist(field, direction));
+    }
+
+    // The single-criterion sort surface shared by the composer and artist
+    // modes: a field-picker button whose flyout checkmarks the active field,
+    // and a capsule direction button that sets the opposite direction.
+    private void RenderSingleCriterion<TField>(
+        TField[] fields,
+        TField selected,
+        SortDirection direction,
+        Func<TField, string> labelKey,
+        Action<TField, SortDirection> set)
+        where TField : struct, Enum
+    {
         var fieldMenu = new MenuFlyout();
-        foreach (var field in LibrarySortVocab.ComposerFields)
+        foreach (var field in fields)
         {
-            var item = new MenuFlyoutItem { Text = Loc.Chrome(LibrarySortVocab.LabelKey(field)) };
-            if (field == composer.Field)
+            var item = new MenuFlyoutItem { Text = Loc.Chrome(labelKey(field)) };
+            if (field.Equals(selected))
             {
                 item.Icon = new FontIcon { Glyph = CheckmarkGlyph };
             }
@@ -167,7 +200,7 @@ internal sealed class LibrarySortControls
             var target = field;
             item.Click += (_, _) =>
             {
-                _sort.SetComposer(target, composer.Direction);
+                set(target, direction);
                 Mutated();
             };
             fieldMenu.Items.Add(item);
@@ -175,13 +208,13 @@ internal sealed class LibrarySortControls
 
         _host.Children.Add(new Button
         {
-            Content = Loc.Chrome(LibrarySortVocab.LabelKey(composer.Field)),
+            Content = Loc.Chrome(labelKey(selected)),
             VerticalAlignment = VerticalAlignment.Center,
             Flyout = fieldMenu,
         });
 
-        var opposite = LibrarySortVocab.Opposite(composer.Direction);
-        var arrow = composer.Direction == SortDirection.Ascending ? AscendingArrow : DescendingArrow;
+        var opposite = LibrarySortVocab.Opposite(direction);
+        var arrow = direction == SortDirection.Ascending ? AscendingArrow : DescendingArrow;
         var directionButton = new Button
         {
             Content = arrow,
@@ -191,7 +224,7 @@ internal sealed class LibrarySortControls
         ToolTipService.SetToolTip(directionButton, Loc.Chrome(LibrarySortVocab.DirectionActionKey(opposite)));
         directionButton.Click += (_, _) =>
         {
-            _sort.SetComposer(composer.Field, opposite);
+            set(selected, opposite);
             Mutated();
         };
         _host.Children.Add(directionButton);

--- a/bae-windows/bae-windows.Tests/LibrarySortTests.cs
+++ b/bae-windows/bae-windows.Tests/LibrarySortTests.cs
@@ -7,7 +7,8 @@ namespace Bae.Windows.Tests;
 /// <summary>
 /// Locks the library sort model: the album criteria's defaults, invariants
 /// (unique fields, never empty), add/remove/direction manipulation, the composer
-/// sort, and the JSON round-trip that persists the album sort like macOS does.
+/// and artist sorts, and the JSON round-trip that persists the album sort like
+/// macOS does.
 /// </summary>
 public sealed class LibrarySortTests
 {
@@ -162,6 +163,23 @@ public sealed class LibrarySortTests
         sort.SetComposer(ComposerSortField.WorkCount, SortDirection.Descending);
         Assert.Equal(ComposerSortField.WorkCount, sort.Composer.Field);
         Assert.Equal(SortDirection.Descending, sort.Composer.Direction);
+    }
+
+    [Fact]
+    public void LibrarySort_DefaultsArtistToNameAscending()
+    {
+        var sort = new LibrarySort();
+        Assert.Equal(ArtistSortField.Name, sort.Artist.Field);
+        Assert.Equal(SortDirection.Ascending, sort.Artist.Direction);
+    }
+
+    [Fact]
+    public void SetArtist_ReplacesTheWholeCriterion()
+    {
+        var sort = new LibrarySort();
+        sort.SetArtist(ArtistSortField.AlbumCount, SortDirection.Descending);
+        Assert.Equal(ArtistSortField.AlbumCount, sort.Artist.Field);
+        Assert.Equal(SortDirection.Descending, sort.Artist.Direction);
     }
 
     [Fact]

--- a/scripts/loc-skeleton-allowlist.txt
+++ b/scripts/loc-skeleton-allowlist.txt
@@ -218,6 +218,7 @@ nl	signal.kind.disc_id
 nl	download.title
 nl	settings.automation.status.running
 nl	library.mode.albums
+nl	album.count
 nl	search.section.albums
 nl	search.section.releases
 nl	search.section.credits


### PR DESCRIPTION
The browser mode box gains an Artists entry listing every album artist (image, name, album count) in a 320px list with a detail pane (artist header + albums in discography order) whose album rows open the album-detail dialog; the list reloads on the ArtistList invalidation like the composer list; sorting by name or album count with the pill direction button, in-memory like the composer sort (the field-picker/direction renderer is now shared between the two single-criterion modes); the Album wrapper gains the year both bridge shapes already carried; four chrome keys added across all 31 resw catalogs.

## Test plan

- [x] `dotnet test bae-windows/bae-windows.Tests/bae-windows.Tests.csproj` — 356 passed (354 baseline + 2 new facts)
- [x] `python3 scripts/loc-chrome-orphans.py` — 0 orphans
- [x] `python3 scripts/loc-english-skeleton.py` — 0 gating failures
- [x] BOM spot-check on edited resw files
- [x] Rules self-review against the changed-path rule set
- [ ] CI Windows build (WinUI app code compiles only in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)