### PR TITLE
Add the artists browser mode to the iOS library

### DIFF
--- a/BaeKit/Sources/BaeKit/Services/Library.swift
+++ b/BaeKit/Sources/BaeKit/Services/Library.swift
@@ -247,6 +247,17 @@ public final class Library: Sendable, Observable {
                     try await handle.getComposerDetail(artistId: $0)
                 },
                 getWorkDetail: { try await handle.getWorkDetail(workId: $0) },
+                getArtistCount: { try await handle.getArtistCount() },
+                getArtistPage: {
+                    try await handle.getArtistPage(
+                        sortCriterion: $0,
+                        offset: $1,
+                        limit: $2
+                    )
+                },
+                getArtistDetail: {
+                    try await handle.getArtistDetail(artistId: $0)
+                },
                 searchLibrary: { try await handle.searchLibrary(query: $0) },
                 findReleaseDetail: {
                     try await handle.findReleaseDetail(releaseId: $0)

--- a/bae-ios/bae/bae/Localizable.xcstrings
+++ b/bae-ios/bae/bae/Localizable.xcstrings
@@ -23054,6 +23054,769 @@
           }
         }
       }
+    },
+    "Artists": {
+      "comment": "Library artists mode label",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفنانون"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изпълнители"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শিল্পীরা"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interpreti"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Künstler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artists"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artistas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artistes"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "કલાકારો"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אמנים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izvođači"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artisti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーティスト"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಕಲಾವಿದರು"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아티스트"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "കലാകാരന്മാർ"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artiesten"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਕਲਾਕਾਰ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wykonawcy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artistas"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைஞர்கள்"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "కళాకారులు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ศิลปิน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanatçılar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виконавці"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فنکار"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nghệ sĩ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "艺人"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "藝人"
+          }
+        }
+      }
+    },
+    "No artists": {
+      "comment": "Empty artist library message",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يوجد فنانون"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Няма изпълнители"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "কোনো শিল্পী নেই"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Žádní interpreti"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Künstler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No artists"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay artistas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun artiste"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "કોઈ કલાકારો નથી"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אין אמנים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई कलाकार नहीं"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nema izvođača"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun artista"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーティストがいません"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಕಲಾವಿದರು ಇಲ್ಲ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아티스트 없음"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "കലാകാരന്മാരില്ല"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार नाहीत"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen artiesten"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਕੋਈ ਕਲਾਕਾਰ ਨਹੀਂ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak wykonawców"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum artista"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைஞர்கள் இல்லை"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "కళాకారులు లేరు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีศิลปิน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanatçı yok"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає виконавців"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کوئی فنکار نہیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có nghệ sĩ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有艺人"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有藝人"
+          }
+        }
+      }
+    },
+    "Artist detail not found": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على تفاصيل الفنان"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Данните за изпълнителя не са намерени"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "শিল্পীর বিবরণ পাওয়া যায়নি"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detail interpreta nebyl nalezen"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Künstlerdetails nicht gefunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artist detail not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron los detalles del artista"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails de l'artiste introuvables"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "કલાકારની વિગત મળી નથી"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פרטי האמן לא נמצאו"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार विवरण नहीं मिला"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalji izvođača nisu pronađeni"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dettaglio artista non trovato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーティストの詳細が見つかりません"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಕಲಾವಿದರ ವಿವರ ಸಿಕ್ಕಿಲ್ಲ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아티스트 세부 정보를 찾을 수 없음"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "കലാകാരന്റെ വിശദാംശം കണ്ടെത്തിയില്ല"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कलाकार तपशील सापडला नाही"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artiestdetails niet gevonden"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਕਲਾਕਾਰ ਵੇਰਵਾ ਨਹੀਂ ਮਿਲਿਆ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono szczegółów wykonawcy"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes do artista não encontrados"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "கலைஞர் விவரம் கிடைக்கவில்லை"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "కళాకారుని వివరాలు కనబడలేదు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบรายละเอียดศิลปิน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanatçı ayrıntısı bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відомості про виконавця не знайдено"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فنکار کی تفصیل نہیں ملی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy chi tiết nghệ sĩ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到艺人详情"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到藝人詳細資料"
+          }
+        }
+      }
+    },
+    "Name": {
+      "comment": "Sort menu: name field",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاسم"
+          }
+        },
+        "bg": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Име"
+          }
+        },
+        "bn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "নাম"
+          }
+        },
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Název"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom"
+          }
+        },
+        "gu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "નામ"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שם"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नाम"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naziv"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ಹೆಸರು"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름"
+          }
+        },
+        "ml": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "പേര്"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नाव"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naam"
+          }
+        },
+        "pa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ਨਾਂ"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "பெயர்"
+          }
+        },
+        "te": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "పేరు"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ad"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名稱"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/bae-ios/bae/bae/Views/LibraryView.swift
+++ b/bae-ios/bae/bae/Views/LibraryView.swift
@@ -7,6 +7,7 @@ private let pageSize = 60
 private enum LibraryBrowserMode {
     case albums
     case composers
+    case artists
 }
 
 private enum LibraryRoute: Hashable {
@@ -17,6 +18,7 @@ private enum LibraryRoute: Hashable {
     )
     case composer(String)
     case work(String)
+    case artist(String)
 }
 
 /// Maps a `LibraryRoute` to its pushed screen, threading navigation callbacks
@@ -58,13 +60,25 @@ private struct LibraryRouteDestination: View {
                     )
                 }
             )
+        case .artist(let artistId):
+            ArtistDetailScreen(
+                artistId: artistId,
+                openAlbum: { albumId in
+                    routePath.appendAlbum(
+                        albumId: albumId,
+                        initialReleaseId: nil,
+                        context: nil
+                    )
+                }
+            )
         }
     }
 }
 
 /// Library browse root: a top bar with sync status, an album grid paged from
 /// the database, navigation into album detail, and a persistent now-playing
-/// bar. The grid re-queries when core invalidates the album or composer list.
+/// bar. The grid re-queries when core invalidates the album, artist, or
+/// composer list.
 struct LibraryView: View {
     @Environment(LibraryStore.self)
     private var libraryStore
@@ -90,9 +104,13 @@ struct LibraryView: View {
     @State
     private var composerList: ComposerList?
     @State
+    private var artistList: ArtistList?
+    @State
     private var albumListRegistration: ProjectionRegistration?
     @State
     private var composerListRegistration: ProjectionRegistration?
+    @State
+    private var artistListRegistration: ProjectionRegistration?
     @State
     private var routePath: [LibraryRoute] = []
     @State
@@ -110,6 +128,9 @@ struct LibraryView: View {
     @State
     private var composerSortCriterion =
         BridgeComposerSortCriterion(field: .name, direction: .ascending)
+    @State
+    private var artistSortCriterion =
+        BridgeArtistSortCriterion(field: .name, direction: .ascending)
 
     private var listSelection: LibraryListSelection {
         switch mode {
@@ -117,6 +138,8 @@ struct LibraryView: View {
             .albums(field: sortField, direction: sortDirection)
         case .composers:
             .composers(composerSortCriterion)
+        case .artists:
+            .artists(artistSortCriterion)
         }
     }
 
@@ -151,6 +174,8 @@ struct LibraryView: View {
                         )
                     case .composers:
                         ComposerSortMenu(criterion: $composerSortCriterion)
+                    case .artists:
+                        ArtistSortMenu(criterion: $artistSortCriterion)
                     }
                 }
                 ToolbarItem(placement: .topBarLeading) {
@@ -195,10 +220,14 @@ struct LibraryView: View {
                 await rebuildList()
             case .composers:
                 await rebuildComposerList()
+            case .artists:
+                await rebuildArtistList()
             }
         }
     }
+}
 
+extension LibraryView {
     private var isSearching: Bool {
         !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -259,6 +288,32 @@ struct LibraryView: View {
         composerList = newList
     }
 
+    private func rebuildArtistList() async {
+        let newList = ArtistList(
+            pageSource: LibraryArtistPageSource(
+                library: library,
+                sort: artistSortCriterion
+            ),
+            ingest: { rows in
+                for row in rows {
+                    _ = libraryStore.internArtistSummary(row)
+                }
+            },
+            onError: { error in
+                configStore.showError(error)
+            },
+        )
+        artistListRegistration = projectionRegistry.registerList(
+            newList,
+            domain: .artistList
+        )
+        await newList.loadInitial()
+        guard !Task.isCancelled else {
+            return
+        }
+        artistList = newList
+    }
+
     @ViewBuilder
     private var content: some View {
         LibraryContentView(
@@ -266,6 +321,7 @@ struct LibraryView: View {
             mode: mode,
             albumList: albumList,
             composerList: composerList,
+            artistList: artistList,
             searchResults: searchResults,
             searchError: searchError,
             sync: sync,
@@ -277,6 +333,7 @@ struct LibraryView: View {
                 )
             },
             onSelectComposer: { routePath.append(.composer($0)) },
+            onSelectArtist: { routePath.append(.artist($0)) },
             onSelectWork: { routePath.append(.work($0)) }
         )
     }
@@ -411,6 +468,7 @@ private struct LibraryModePicker: View {
         Picker("Library", selection: $mode) {
             Text("Albums").tag(LibraryBrowserMode.albums)
             Text("Composers").tag(LibraryBrowserMode.composers)
+            Text("Artists").tag(LibraryBrowserMode.artists)
         }
         .pickerStyle(.segmented)
         .padding(.horizontal, 16)
@@ -501,16 +559,62 @@ private struct ComposerSortMenu: View {
     }
 }
 
+private struct ArtistSortMenu: View {
+    @Binding
+    var criterion: BridgeArtistSortCriterion
+
+    var body: some View {
+        Menu {
+            ForEach(BridgeArtistSortField.allCases, id: \.self) { field in
+                Button {
+                    criterion = BridgeArtistSortCriterion(
+                        field: field,
+                        direction: criterion.direction
+                    )
+                } label: {
+                    if field == criterion.field {
+                        Label(field.displayName, systemImage: "checkmark")
+                    }
+                    else {
+                        Text(field.displayName)
+                    }
+                }
+            }
+            Divider()
+            Button {
+                let direction: BridgeSortDirection =
+                    criterion.direction == .ascending ? .descending : .ascending
+                criterion = BridgeArtistSortCriterion(
+                    field: criterion.field,
+                    direction: direction
+                )
+            } label: {
+                Label(
+                    criterion.direction == .ascending
+                        ? String(localized: "Ascending")
+                        : String(localized: "Descending"),
+                    systemImage: criterion.direction == .ascending
+                        ? "arrow.up" : "arrow.down"
+                )
+            }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+        }
+    }
+}
+
 private struct LibraryContentView: View {
     let isSearching: Bool
     let mode: LibraryBrowserMode
     let albumList: AlbumList?
     let composerList: ComposerList?
+    let artistList: ArtistList?
     let searchResults: SearchResults?
     let searchError: String?
     let sync: Sync
     let onSelectAlbum: (String) -> Void
     let onSelectComposer: (String) -> Void
+    let onSelectArtist: (String) -> Void
     let onSelectWork: (String) -> Void
 
     var body: some View {
@@ -529,6 +633,8 @@ private struct LibraryContentView: View {
                 albumContent
             case .composers:
                 composerContent
+            case .artists:
+                artistContent
             }
         }
     }
@@ -563,6 +669,21 @@ private struct LibraryContentView: View {
         }
     }
 
+    @ViewBuilder
+    private var artistContent: some View {
+        if let artistList {
+            ArtistListView(list: artistList, onSelect: onSelectArtist)
+                .refreshable {
+                    sync.triggerSync()
+                    await settleAfterRefresh()
+                }
+        }
+        else {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
     private func settleAfterRefresh() async {
         do {
             try await Task.sleep(for: .seconds(0.9))
@@ -577,6 +698,7 @@ private struct LibraryContentView: View {
 private enum LibraryListSelection: Hashable {
     case albums(field: BridgeSortField, direction: BridgeSortDirection)
     case composers(BridgeComposerSortCriterion)
+    case artists(BridgeArtistSortCriterion)
 }
 
 private extension Array where Element == LibraryRoute {
@@ -793,6 +915,93 @@ private struct ComposerSummaryRow: View {
     }
 }
 
+private struct ArtistListView: View {
+    let list: ArtistList
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        if let error = list.initialLoadError {
+            LoadFailureView(line: error.line) {
+                Task { await list.loadInitial() }
+            }
+        }
+        else if list.totalCount == 0 {
+            Text("No artists")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(32)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        else {
+            List {
+                ForEach(0..<list.totalCount, id: \.self) { position in
+                    ArtistRowSlot(
+                        list: list,
+                        position: position,
+                        onSelect: onSelect
+                    )
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+private struct ArtistRowSlot: View {
+    let list: ArtistList
+    let position: Int
+    let onSelect: (String) -> Void
+
+    @Environment(LibraryStore.self)
+    private var libraryStore
+
+    var body: some View {
+        Group {
+            if let id = list.idAt(position),
+                let summary = libraryStore.artistSummaries[id]
+            {
+                Button {
+                    onSelect(id)
+                } label: {
+                    ArtistSummaryRow(summary: summary)
+                }
+                .buttonStyle(.plain)
+            }
+            else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .task(id: list.loadEpoch) {
+            let offset = (position / pageSize) * pageSize
+            await list.loadRange(offset: offset, limit: pageSize)
+        }
+    }
+}
+
+private struct ArtistSummaryRow: View {
+    let summary: BridgeArtistSummary
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ImageView(imageRef: summary.image, pointSize: 48)
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(summary.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Text("\(summary.albumCount) \(String(localized: "Albums"))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+}
+
 private struct ComposerDetailScreen: View {
     let artistId: String
     let openWork: (String) -> Void
@@ -909,6 +1118,106 @@ private struct ComposerDetailContent: View {
                             title: role.trackTitle,
                             subtitle: role.albumTitle
                         )
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+}
+
+private struct ArtistDetailScreen: View {
+    let artistId: String
+    let openAlbum: (String) -> Void
+
+    @Environment(Library.self)
+    private var library
+
+    @State
+    private var detail: BridgeArtistDetail?
+    @State
+    private var error: String?
+
+    var body: some View {
+        Group {
+            if let error {
+                Text(error)
+                    .foregroundStyle(.red)
+                    .padding(32)
+            }
+            else if let detail {
+                ArtistDetailContent(detail: detail, openAlbum: openAlbum)
+            }
+            else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(navigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: artistId) {
+            await load()
+        }
+    }
+
+    private var navigationTitle: String {
+        if let detail {
+            return detail.artist.name
+        }
+        if error != nil {
+            return String(localized: "Artists")
+        }
+        return ""
+    }
+
+    private func load() async {
+        error = nil
+        do {
+            let getArtistDetail = library.getArtistDetail
+            let loaded =
+                try await Task.detached {
+                    try await getArtistDetail(artistId)
+                }
+                .value
+            try Task.checkCancellation()
+            guard let loaded else {
+                error = String(localized: "Artist detail not found")
+                return
+            }
+            detail = loaded
+        }
+        catch is CancellationError {}
+        catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct ArtistDetailContent: View {
+    let detail: BridgeArtistDetail
+    let openAlbum: (String) -> Void
+
+    var body: some View {
+        List {
+            Section {
+                ArtistSummaryRow(summary: detail.artist)
+            }
+            if !detail.albums.isEmpty {
+                Section("Albums") {
+                    ForEach(detail.albums) { album in
+                        Button {
+                            openAlbum(album.id)
+                        } label: {
+                            HStack(spacing: 12) {
+                                ImageView(imageRef: album.cover, pointSize: 48)
+                                    .frame(width: 48, height: 48)
+                                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                                TwoLineRow(
+                                    title: album.title,
+                                    subtitle: album.year.map(String.init)
+                                )
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The library mode picker gains an Artists segment listing every album artist (image, name, album count) with pull-to-refresh and paging like the composers list; tapping an artist pushes a detail screen (artist header + albums in discography order) whose album rows push the existing album detail route. The list refreshes via the artistList invalidation domain, and sorts by name or album count from the toolbar menu.

The iOS `Library(handle:)` wiring gains the three artist reads — the only closures it was missing relative to the composer surface it already wired, since artists are a phone surface exactly like composers. That edit lives in the shared BaeKit `Library.swift`, so the macOS compile gate applies even though this PR adds no macOS views.

Four catalog keys land across all 31 locales: `Artists`, `No artists`, `Artist detail not found`, and `Name` — the last was previously missing from the iOS catalog entirely, which meant the composer sort menu's "Name" option was silently English-only on iOS; adding it here fixes that alongside the new artist sort menu that also needs it.

No new tests: the browser mode, routes, and list selection are private types inside `LibraryView.swift` with no extracted model, matching how the composers mode shipped. Correctness rides on the compile gates, the existing iOS test bundle, and the view code mirroring the composer branch one-for-one.

## Test plan

- [x] `./bae-bridge/build-ios.sh`, iOS xcodegen, iOS xcodebuild build
- [x] iOS unit-test bundle on a simulator (44 tests, 8 suites, all passing)
- [x] swift-format lint + swiftlint --strict over `bae-ios/bae/bae`, periphery scan
- [x] BaeKit lint (swift-format + swiftlint)
- [x] macOS compile gate (BaeKit shared): build-macos.sh, install-swift-bindings.sh macos, macOS xcodegen, macOS xcodebuild build
- [x] `scripts/loc-chrome-orphans.py` and `scripts/loc-english-skeleton.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)