### PR TITLE
Escalate a stalled decoder to a PlaybackError instead of logging forever

### DIFF
--- a/bae-core/src/audio_codec/decode.rs
+++ b/bae-core/src/audio_codec/decode.rs
@@ -1288,7 +1288,6 @@ unsafe fn decode_audio_streaming_impl(
         );
     }
     sink.set_decode_error_count(error_count);
-    sink.set_samples_decoded(samples_output);
 
     if !sink.is_cancelled() {
         sink.mark_finished();

--- a/bae-core/src/playback/service/mod.rs
+++ b/bae-core/src/playback/service/mod.rs
@@ -67,6 +67,7 @@ mod preview;
 mod queue_commands;
 mod seek;
 mod slot;
+mod starvation;
 mod state;
 
 use crate::playback::stream_pipeline::{
@@ -76,6 +77,7 @@ use crate::playback::stream_pipeline::{
 use slot::{
     CurrentTrack, LoadGeneration, PausePhase, PlayIntent, PlayTarget, PlaybackSlot, TrackPhase,
 };
+use starvation::StarvationEpisode;
 
 #[cfg(test)]
 mod tests;
@@ -910,6 +912,10 @@ pub struct PlaybackService {
     /// reader; the current track is designated foreground via
     /// `mark_current_foreground` whenever it becomes current.
     fetch_arbiter: Arc<FetchArbiter>,
+    /// The in-progress starvation-watchdog episode, if the current track is
+    /// mid-starvation with no decode progress yet observed. `None` whenever
+    /// the track is flowing normally — see `reset_starvation_episode`.
+    starvation_episode: Option<StarvationEpisode>,
 }
 
 impl PlaybackService {
@@ -983,6 +989,9 @@ impl PlaybackService {
     }
 
     fn handle_position_event(&mut self, fmt: Arc<TrackFmt>, pos: std::time::Duration) {
+        // Samples are flowing normally: whatever starvation episode was in
+        // progress is over.
+        self.reset_starvation_episode();
         let actual_pos = fmt.position_offset + pos;
         *self.current_position_shared.lock().unwrap() = Some(actual_pos);
         let raw_pos_ms = actual_pos.as_millis() as u64;
@@ -1038,15 +1047,40 @@ impl PlaybackService {
     }
 
     async fn handle_audio_event(&mut self, event: AudioEvent) {
+        // Position/Completion/TrackCrossing carry their own logging (or none);
+        // every other event kind gets the shared diagnostic log both players
+        // share.
+        if !matches!(
+            event,
+            AudioEvent::Position(_) | AudioEvent::Completion(_) | AudioEvent::TrackCrossing(_)
+        ) {
+            log_stream_diagnostic("playback", &event);
+        }
         match event {
             AudioEvent::Position((fmt, pos)) => self.handle_position_event(fmt, pos),
             AudioEvent::Completion((fmt, error_count, samples_decoded)) => {
                 self.handle_completion_event(fmt, error_count, samples_decoded);
             }
             AudioEvent::TrackCrossing(crossing) => self.handle_track_crossed(crossing).await,
-            event => {
-                log_stream_diagnostic("playback", &event);
+            AudioEvent::Starved {
+                fmt,
+                starved_ms,
+                producer_finished,
+                samples_decoded,
+                ..
+            } => {
+                // `producer_finished` is the completion path (a drained track
+                // awaiting AutoAdvance) — never the stall this watchdog
+                // targets.
+                if !producer_finished {
+                    self.handle_starvation(&fmt.track_id, samples_decoded, starved_ms)
+                        .await;
+                }
             }
+            AudioEvent::StarvationEnded { .. } => {
+                self.reset_starvation_episode();
+            }
+            AudioEvent::SourceLockMissed { .. } | AudioEvent::SourceLockReacquired { .. } => {}
         }
     }
 
@@ -1232,6 +1266,7 @@ impl PlaybackService {
                     shared_file_buffers: HashMap::new(),
                     last_position_display,
                     fetch_arbiter: FetchArbiter::new(),
+                    starvation_episode: None,
                 };
                 match service.library_manager.load_playback_state().await {
                     Ok(Some(state)) => match PersistedPlayback::from_row(state) {

--- a/bae-core/src/playback/service/pipeline.rs
+++ b/bae-core/src/playback/service/pipeline.rs
@@ -41,6 +41,9 @@ impl PlaybackService {
         });
         self.mark_current_foreground();
         self.sync_audio_state();
+        // A fresh install starts this track's starvation clock over, whatever
+        // the outgoing track's watchdog state was.
+        self.reset_starvation_episode();
     }
 
     /// Spawn the in-core decoder for `prepared`, build the audio stream through
@@ -266,6 +269,7 @@ impl PlaybackService {
         }
         self.shared_file_buffers.clear();
         *self.current_position_shared.lock().unwrap() = None;
+        self.reset_starvation_episode();
         // The slot is Stopped; project that onto the atomic and emit Stopped.
         self.sync_audio_state();
         self.emit_state();

--- a/bae-core/src/playback/service/starvation.rs
+++ b/bae-core/src/playback/service/starvation.rs
@@ -1,0 +1,84 @@
+//! The starvation watchdog: escalates a decoder that has stalled forever to a
+//! `PlaybackError`, so it fails loud instead of logging a once-per-second
+//! `Starved` warning behind a frozen position bar (the failure shape of a
+//! decoder blocked on a byte buffer that will never produce — a cancelled
+//! fill task, a reader that's never woken).
+//!
+//! A `Starved` event alone doesn't distinguish a genuine stall from an
+//! ordinary slow producer (a cloud fetch still landing bytes): both look like
+//! "the ring is empty" from the callback's side. `samples_decoded` — live off
+//! every push into the ring — is what tells them apart: a slow producer keeps
+//! advancing it even while starved; a stalled one doesn't advance it at all.
+
+use super::*;
+
+/// How long a starvation episode with zero decode progress must persist
+/// before it's treated as a genuine stall — a decoder wedged for good, not a
+/// producer that's merely slow — and escalated to a `PlaybackError`.
+const STARVATION_FAIL_AFTER_MS: u64 = 30_000;
+
+/// One escalation episode: the `samples_decoded` count observed when the
+/// current starvation began, for the track it began on. As long as that count
+/// keeps advancing, the producer is alive; once it stalls flat past
+/// `STARVATION_FAIL_AFTER_MS`, playback has stalled for good.
+pub(super) struct StarvationEpisode {
+    track_id: String,
+    samples_decoded_at_start: u64,
+}
+
+impl PlaybackService {
+    /// Feed one `Starved` event (`producer_finished == false`) to the
+    /// watchdog. Establishes a fresh episode baseline on the first
+    /// observation of a track's stall (or re-baselines whenever
+    /// `samples_decoded` has advanced past the current baseline — the
+    /// producer is alive); only a flat baseline that persists past the fail
+    /// threshold escalates.
+    pub(super) async fn handle_starvation(
+        &mut self,
+        track_id: &str,
+        samples_decoded: u64,
+        starved_ms: u64,
+    ) {
+        let stalled = matches!(
+            &self.starvation_episode,
+            Some(episode)
+                if episode.track_id == track_id
+                    && samples_decoded <= episode.samples_decoded_at_start
+        );
+
+        if !stalled {
+            // A fresh track's first starvation, or the producer advanced
+            // since the episode began: (re)baseline at the current count.
+            self.starvation_episode = Some(StarvationEpisode {
+                track_id: track_id.to_string(),
+                samples_decoded_at_start: samples_decoded,
+            });
+            return;
+        }
+
+        if starved_ms >= STARVATION_FAIL_AFTER_MS {
+            error!(
+                track_id,
+                starved_ms, "starvation exceeded the fail threshold with no decode progress"
+            );
+            emit_progress(
+                &self.progress_tx,
+                PlaybackProgress::PlaybackError {
+                    reason: crate::ui::PlaybackErrorReason::internal(format!(
+                        "Playback stalled on track {track_id} for {starved_ms}ms with no progress"
+                    )),
+                },
+            );
+            self.starvation_episode = None;
+            self.stop().await;
+        }
+    }
+
+    /// Reset the watchdog clock: no starvation episode is in progress. Called
+    /// on `StarvationEnded`, on every `Position` tick, on any track install,
+    /// and on `stop()` — anywhere the current track is either flowing
+    /// normally or gone.
+    pub(super) fn reset_starvation_episode(&mut self) {
+        self.starvation_episode = None;
+    }
+}

--- a/bae-core/src/playback/service/tests.rs
+++ b/bae-core/src/playback/service/tests.rs
@@ -151,6 +151,7 @@ async fn seeded_playback_service(
         shared_file_buffers: HashMap::new(),
         last_position_display: Arc::new(std::sync::Mutex::new(None)),
         fetch_arbiter: FetchArbiter::new(),
+        starvation_episode: None,
     };
     (home, service, progress_rx)
 }
@@ -622,6 +623,172 @@ async fn pause_during_load_emits_paused_and_supersedes_track_ready() {
     assert!(
         progress_rx.try_recv().is_err(),
         "the collapsed load's TrackReady must not emit a second state"
+    );
+}
+
+fn starved_event(
+    track_id: &str,
+    starved_ms: u64,
+    samples_decoded: u64,
+    producer_finished: bool,
+) -> AudioEvent {
+    AudioEvent::Starved {
+        fmt: Arc::new(test_track_fmt(track_id)),
+        starved_ms,
+        position_ms: 0,
+        producer_finished,
+        samples_decoded,
+        decode_errors: 0,
+        has_next: false,
+    }
+}
+
+fn starvation_ended_event(track_id: &str) -> AudioEvent {
+    AudioEvent::StarvationEnded {
+        fmt: Arc::new(test_track_fmt(track_id)),
+        starved_ms: 0,
+        position_ms: 0,
+        samples_decoded: 0,
+        decode_errors: 0,
+    }
+}
+
+/// A starvation episode with zero decode progress that persists past the fail
+/// threshold is a genuine stall — a decoder wedged for good on a byte buffer
+/// that will never produce, not a producer that's merely slow — and must
+/// surface a `PlaybackError` and tear playback down rather than log forever
+/// with a frozen position bar.
+#[tokio::test]
+async fn starvation_past_fail_threshold_with_no_progress_escalates_to_error_and_stops() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    let buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(test_prepared_track("t", buffer), TrackPhase::Playing);
+
+    service
+        .handle_audio_event(starved_event("t", 500, 1_000, false))
+        .await;
+    service
+        .handle_audio_event(starved_event("t", 30_000, 1_000, false))
+        .await;
+
+    let mut saw_error = false;
+    while let Ok(progress) = progress_rx.try_recv() {
+        if matches!(progress, PlaybackProgress::PlaybackError { .. }) {
+            saw_error = true;
+        }
+    }
+    assert!(
+        saw_error,
+        "a stalled starvation episode must surface a PlaybackError"
+    );
+    assert!(
+        matches!(service.slot, PlaybackSlot::Stopped),
+        "the stalled track must stop"
+    );
+}
+
+/// `samples_decoded` advancing between `Starved` events proves the producer is
+/// alive (e.g. a slow cloud fetch) even though the ring is still starved —
+/// this must never escalate, however long the starvation drags on.
+#[tokio::test]
+async fn starvation_with_advancing_samples_decoded_never_escalates() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    let buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(test_prepared_track("t", buffer), TrackPhase::Playing);
+
+    service
+        .handle_audio_event(starved_event("t", 500, 1_000, false))
+        .await;
+    service
+        .handle_audio_event(starved_event("t", 30_000, 1_100, false))
+        .await;
+    service
+        .handle_audio_event(starved_event("t", 60_000, 1_200, false))
+        .await;
+
+    let mut saw_error = false;
+    while let Ok(progress) = progress_rx.try_recv() {
+        if matches!(progress, PlaybackProgress::PlaybackError { .. }) {
+            saw_error = true;
+        }
+    }
+    assert!(
+        !saw_error,
+        "advancing samples_decoded must never escalate, regardless of starved_ms"
+    );
+    assert!(
+        matches!(service.slot, PlaybackSlot::Active(_)),
+        "the track must stay active"
+    );
+}
+
+/// `producer_finished == true` is the completion path — a drained track
+/// awaiting `AutoAdvance` — never the stall this watchdog targets.
+#[tokio::test]
+async fn starvation_with_producer_finished_never_escalates() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    let buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(test_prepared_track("t", buffer), TrackPhase::Playing);
+
+    service
+        .handle_audio_event(starved_event("t", 500, 1_000, true))
+        .await;
+    service
+        .handle_audio_event(starved_event("t", 60_000, 1_000, true))
+        .await;
+
+    let mut saw_error = false;
+    while let Ok(progress) = progress_rx.try_recv() {
+        if matches!(progress, PlaybackProgress::PlaybackError { .. }) {
+            saw_error = true;
+        }
+    }
+    assert!(
+        !saw_error,
+        "producer_finished starvation is the completion path, never escalates"
+    );
+}
+
+/// A `StarvationEnded` between episodes resets the watchdog clock: the next
+/// episode starts fresh rather than inheriting the ended episode's duration.
+/// Sabotage — drop the reset on `StarvationEnded` — and the single event below
+/// (whose own `starved_ms` already exceeds the threshold) would be read as a
+/// continuation of the first episode's stalled baseline and escalate
+/// immediately.
+#[tokio::test]
+async fn starvation_ended_resets_the_episode_clock() {
+    let (_home, mut service, mut progress_rx) = test_playback_service().await;
+    let buffer = create_sparse_buffer(1_024);
+    service.slot = active_slot(test_prepared_track("t", buffer), TrackPhase::Playing);
+
+    // First episode starts, then ends (the producer resumed) before ever
+    // crossing the fail threshold.
+    service
+        .handle_audio_event(starved_event("t", 500, 1_000, false))
+        .await;
+    service
+        .handle_audio_event(starvation_ended_event("t"))
+        .await;
+
+    // A second, independent episode begins at the same samples_decoded count.
+    service
+        .handle_audio_event(starved_event("t", 30_000, 1_000, false))
+        .await;
+
+    let mut saw_error = false;
+    while let Ok(progress) = progress_rx.try_recv() {
+        if matches!(progress, PlaybackProgress::PlaybackError { .. }) {
+            saw_error = true;
+        }
+    }
+    assert!(
+        !saw_error,
+        "StarvationEnded must reset the episode; the first Starved event after \
+         it establishes a fresh baseline rather than escalating immediately"
+    );
+    assert!(
+        matches!(service.slot, PlaybackSlot::Active(_)),
+        "the track must stay active"
     );
 }
 

--- a/bae-core/src/playback/source.rs
+++ b/bae-core/src/playback/source.rs
@@ -262,10 +262,10 @@ mod tests {
         let (mut sink1, src1, _r1) = create_track_stream_pair(44100, 1);
         let (mut sink2, src2, _r2) = create_track_stream_pair(44100, 1);
 
-        // Track 1: three samples + decode stats, then EOF.
+        // Track 1: three samples + decode stats, then EOF. `samples_decoded`
+        // is live off the push itself now, not hand-set.
         assert_eq!(sink1.push_samples(&[1.0, 2.0, 3.0]), 3);
         sink1.set_decode_error_count(7);
-        sink1.set_samples_decoded(3);
         sink1.mark_finished();
         // Track 2: two samples, then EOF.
         assert_eq!(sink2.push_samples(&[10.0, 11.0]), 2);

--- a/bae-core/src/playback/track_stream.rs
+++ b/bae-core/src/playback/track_stream.rs
@@ -90,8 +90,12 @@ impl StreamingState {
         self.samples_decoded.load(Ordering::Relaxed)
     }
 
-    pub fn set_samples_decoded(&self, count: u64) {
-        self.samples_decoded.store(count, Ordering::Relaxed);
+    /// Count `n` more interleaved samples as pushed into the ring — the total
+    /// pushed so far, live as the decoder produces them (not a value set once
+    /// at decode-complete), so a `Starved` event fired mid-decode carries a
+    /// truthful count.
+    fn add_samples_decoded(&self, n: u64) {
+        self.samples_decoded.fetch_add(n, Ordering::Relaxed);
     }
 }
 
@@ -127,6 +131,7 @@ impl TrackSink {
                 Err(_) => break, // Buffer full
             }
         }
+        self.state.add_samples_decoded(pushed as u64);
         pushed
     }
 
@@ -159,6 +164,7 @@ impl TrackSink {
 
             offset += n;
             self.samples_pushed += n;
+            self.state.add_samples_decoded(n as u64);
 
             // Signal ready when buffer is 50% full
             if self.ready_tx.is_some() && self.samples_pushed >= self.capacity / 2 {
@@ -210,11 +216,6 @@ impl TrackSink {
     /// Set the decode error count (called at end of decode with FFmpeg error count)
     pub fn set_decode_error_count(&self, count: u32) {
         self.state.set_decode_error_count(count);
-    }
-
-    /// Set the total samples decoded (called at end of decode)
-    pub fn set_samples_decoded(&self, count: u64) {
-        self.state.set_samples_decoded(count);
     }
 
     /// Check if cancelled.


### PR DESCRIPTION
## Summary

Both recent streaming bugs (the shared-buffer ownership bug and the read-ahead-ceiling deadlock) presented the same way: the decoder starved forever, the UI showed a frozen position bar, and nothing ever surfaced to the user. Mid-flight read failures already emit a `PlaybackError` and tear playback down; a silently-stuck producer did not — it just logged a once-per-second `Starved` warning forever.

A `Starved` event alone can't distinguish a genuine stall from an ordinary slow producer (a cloud fetch still landing bytes) — both look like an empty ring from the callback's side. The fix makes `samples_decoded` live: `TrackSink::push_samples`/`push_samples_blocking` now increment it on every push into the ring (rather than the decoder writing it once at end-of-decode), so a `Starved` event fired mid-decode carries a truthful count instead of reading 0. `push_silence_frames_blocking` gets this for free since it delegates to `push_samples_blocking`. The now-redundant `set_samples_decoded` setter is deleted along with its only two callers (the end-of-decode write in `audio_codec/decode.rs`, and a hand-set in a `source.rs` test that the push itself now covers).

The service watches this per starvation episode (new `service/starvation.rs`): on each `Starved` event for a track with `producer_finished == false`, if `samples_decoded` advanced since the episode's baseline the producer is alive and the episode re-baselines; if it's flat past 30s the decoder is wedged for good, and the service emits `PlaybackProgress::PlaybackError` naming the track and stall duration, then stops. The episode resets on `StarvationEnded`, on every `Position` tick, on any track install, and on `stop()`, and uses the event's own carried `starved_ms` rather than a service-side clock, so the whole thing is testable by feeding events without any real timing.

## Test

Red first: `starvation_past_fail_threshold_with_no_progress_escalates_to_error_and_stops` (feed two `Starved` events, same `samples_decoded`, second past the threshold) failed against the pre-existing code — no watchdog existed, so no `PlaybackError` ever fired. It's green now. Three more lock in the boundaries: `samples_decoded` advancing between events never escalates regardless of `starved_ms`; `producer_finished: true` (the completion path) never escalates; and a `StarvationEnded` between two episodes resets the clock — proven by sabotage-testing that a fresh episode's first event, whose own `starved_ms` already exceeds the threshold, does not escalate immediately (it would if the reset were missing).

## Note on this branch's base

This branch (and the rest of the `playback/*` chain) is built on top of three commits already on the local `main` checkout but not yet pushed to `origin/main`: `2029e647` (the shared-buffer ownership fix) and `d0f0b8df` (the read-ahead-ceiling fix) that this plan's context section names as prerequisites, plus the `e945534b` test-fixture commit that introduced `MultiWindowPlayback`. This PR's diff will include those until they land on `origin/main`, at which point it'll shrink to just this branch's own commit.

## Test plan
- [x] `cargo test --features test-utils --lib` (1074 passed)
- [x] `cargo test --features test-utils --test test_playback_behavior --test test_playback_state --test test_playback_cpu --test test_cue_flac --test test_cue_ape` (all green)
- [x] `cargo clippy --features test-utils --lib --tests -- -D warnings` (clean)
- [x] pre-commit hook (fmt + clippy + loc-gen) passed