### PR TITLE
Make the library's durable state correct

### DIFF
--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -916,55 +916,6 @@ impl AppHandle {
     pub fn retry_downloads(&self) {
         self.services.library_manager().retry_downloads();
     }
-
-    // ── Export queue ─────────────────────────────────────────────────
-
-    /// The current export-queue snapshot. Export invalidations tell the
-    /// Exporting pane to read it again.
-    pub fn get_export_snapshot(&self) -> crate::types::BridgeExportSnapshot {
-        crate::types::BridgeExportSnapshot::from_core(
-            self.services.library_manager().export_snapshot(),
-        )
-    }
-
-    /// Enqueue a release export to `target_dir`. It joins
-    /// the in-memory serial export queue; the worker drains it one release at a
-    /// time. The storage-summary lookup (resolving the pane row's title/size)
-    /// happens here; the deep cloud read + copy runs on the queue worker.
-    pub async fn enqueue_export(
-        &self,
-        release_id: String,
-        target_dir: String,
-        selection: crate::types::BridgeExportSelection,
-    ) -> Result<(), BridgeError> {
-        self.services
-            .library_manager()
-            .enqueue_export(
-                &release_id,
-                std::path::PathBuf::from(target_dir),
-                crate::types::BridgeExportSelection::into_core(selection),
-            )
-            .await
-            .map_err(BridgeError::export)
-    }
-
-    /// Pause or resume the export queue. The in-flight export finishes; the queue
-    /// stops starting new ones until resumed.
-    pub fn set_exports_paused(&self, paused: bool) {
-        self.services.library_manager().set_exports_paused(paused);
-    }
-
-    /// Cancel a release's export — drops a queued/failed entry or aborts the
-    /// in-flight one (a partial copy never lands its destination file).
-    pub fn cancel_export(&self, release_id: String) {
-        self.services.library_manager().cancel_export(&release_id);
-    }
-
-    /// Retry every failed export now (flips them back to queued and wakes the
-    /// worker).
-    pub fn retry_exports(&self) {
-        self.services.library_manager().retry_exports();
-    }
 }
 
 #[cfg(feature = "desktop")]
@@ -1534,6 +1485,57 @@ impl AppHandle {
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 #[uniffi::export(async_runtime = "tokio")]
 impl AppHandle {
+    // ── Export queue ─────────────────────────────────────────────────
+
+    /// The current export-queue snapshot. Export invalidations tell the
+    /// Exporting pane to read it again.
+    pub fn get_export_snapshot(&self) -> crate::types::BridgeExportSnapshot {
+        crate::types::BridgeExportSnapshot::from_core(
+            self.services.library_manager().export_snapshot(),
+        )
+    }
+
+    /// Enqueue a release export to `target_dir`. It joins
+    /// the in-memory serial export queue; the worker drains it one release at a
+    /// time. The storage-summary lookup (resolving the pane row's title/size)
+    /// happens here; the deep cloud read + copy runs on the queue worker.
+    pub async fn enqueue_export(
+        &self,
+        release_id: String,
+        target_dir: String,
+        selection: crate::types::BridgeExportSelection,
+    ) -> Result<(), BridgeError> {
+        self.services
+            .library_manager()
+            .enqueue_export(
+                &release_id,
+                std::path::PathBuf::from(target_dir),
+                crate::types::BridgeExportSelection::into_core(selection),
+            )
+            .await
+            .map_err(BridgeError::export)
+    }
+
+    /// Pause or resume the export queue. The in-flight export finishes; the queue
+    /// stops starting new ones until resumed.
+    pub fn set_exports_paused(&self, paused: bool) {
+        self.services.library_manager().set_exports_paused(paused);
+    }
+
+    /// Cancel a release's export — drops a queued/failed entry or aborts the
+    /// in-flight one (a partial copy never lands its destination file).
+    pub fn cancel_export(&self, release_id: String) {
+        self.services.library_manager().cancel_export(&release_id);
+    }
+
+    /// Retry every failed export now (flips them back to queued and wakes the
+    /// worker).
+    pub fn retry_exports(&self) {
+        self.services.library_manager().retry_exports();
+    }
+
+    // ── Track export ─────────────────────────────────────────────────
+
     pub async fn export_track(
         &self,
         track_id: String,
@@ -1909,6 +1911,7 @@ impl crate::types::BridgeDownloadProgress {
     }
 }
 
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl crate::types::BridgeExportState {
     fn from_core(state: bae_core::library::ExportState) -> Self {
         use crate::types::BridgeExportState;
@@ -1921,6 +1924,7 @@ impl crate::types::BridgeExportState {
     }
 }
 
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl crate::types::BridgeExportOp {
     fn from_core(op: bae_core::library::ExportOp) -> Self {
         let bae_core::library::release_queue::ReleaseQueueOp {
@@ -1949,6 +1953,7 @@ impl crate::types::BridgeExportOp {
     }
 }
 
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl crate::types::BridgeExportSnapshot {
     fn from_core(snapshot: bae_core::library::ExportSnapshot) -> Self {
         let (exports, total, paused) = project_release_queue_snapshot(
@@ -1964,6 +1969,7 @@ impl crate::types::BridgeExportSnapshot {
     }
 }
 
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl crate::types::BridgeExportProgress {
     fn from_core(p: bae_core::library::ExportProgress) -> Self {
         let (queued, active, failed) = release_queue_progress_counts(p);

--- a/bae-bridge/src/handle.rs
+++ b/bae-bridge/src/handle.rs
@@ -3214,9 +3214,14 @@ mod tests {
         key_service
             .set_discogs_key("test-discogs-token")
             .expect("seed test Discogs key");
+        // One id source for the whole test app: the database mints the ids it
+        // owns (identity rows, copied album artists) from the same provider the
+        // manager mints everything else from.
+        let ids: coven::IdRef = Arc::new(coven::SequentialIdProvider::new(test_name));
         let database = bae_core::db::Database::open(
             config.to_coven(),
             Arc::new(coven::SystemClock),
+            Arc::clone(&ids),
             coven::StoreKeys::new(library_id),
             bae_core::sync::synced_tables(),
             None,
@@ -3229,7 +3234,7 @@ mod tests {
             config_handle,
             key_service,
             Arc::new(coven::SystemClock),
-            Arc::new(coven::SequentialIdProvider::new(test_name)),
+            ids,
             bae_core::diagnostics::Diagnostics::noop(),
             runtime.handle().clone(),
         );

--- a/bae-bridge/src/types.rs
+++ b/bae-bridge/src/types.rs
@@ -2782,6 +2782,9 @@ impl BridgeError {
     pub(crate) fn import(detail: impl std::fmt::Display) -> Self {
         Self::diagnostic(BridgeErrorCategory::Import, detail)
     }
+    /// Desktop-only with the export surface it reports on: iOS/Android compile
+    /// out the export queue and the track exporter entirely.
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub(crate) fn export(detail: impl std::fmt::Display) -> Self {
         Self::diagnostic(BridgeErrorCategory::Export, detail)
     }

--- a/bae-core/src/db/client/identity.rs
+++ b/bae-core/src/db/client/identity.rs
@@ -13,11 +13,12 @@ impl Database {
         let release_id = release_id.to_string();
         let identities = identities.to_vec();
         let now = self.inner.clock.now().to_rfc3339();
+        let ids = Arc::clone(&self.inner.ids);
         self.call_sql(move |sql| {
             let reg = sql.stamp();
             let conn = sql.tx();
             for identity in &identities {
-                insert_release_identity_row(conn, &release_id, identity, &reg, &now)?;
+                insert_release_identity_row(conn, &release_id, identity, ids.new_id(), &reg, &now)?;
             }
             Ok(())
         })
@@ -238,6 +239,7 @@ impl Database {
         let new_metadata = new_metadata.to_vec();
         let now_dt = self.inner.clock.now();
         let now = now_dt.to_rfc3339();
+        let ids = Arc::clone(&self.inner.ids);
 
         self.call_sql(move |sql| {
             let tx = sql.tx();
@@ -251,8 +253,8 @@ impl Database {
                 insert_album_row(tx, album, &reg)?;
 
                 // Copy album_artists from the source. Each row gets a fresh
-                // PK (generated in Rust to match the rest of the codebase)
-                // and is rebound to the new album. The UNIQUE(album_id,
+                // PK from the injected id provider, like every other id in the
+                // codebase, and is rebound to the new album. The UNIQUE(album_id,
                 // artist_id) constraint is satisfied because we're inserting
                 // into a different album. If the source is about to be
                 // deleted (sole release moved), the SELECT still sees the
@@ -272,13 +274,8 @@ impl Database {
                     rows.collect::<coven::rusqlite::Result<Vec<_>>>()?
                 };
                 for (artist_id, position) in source_artists {
-                    let album_artist = DbAlbumArtist::new(
-                        &album.id,
-                        &artist_id,
-                        position,
-                        uuid::Uuid::new_v4().to_string(),
-                        now_dt,
-                    );
+                    let album_artist =
+                        DbAlbumArtist::new(&album.id, &artist_id, position, ids.new_id(), now_dt);
                     insert_album_artist_row(tx, &album_artist, &reg)?;
                 }
             }
@@ -289,7 +286,7 @@ impl Database {
                 params![release_id],
             )?;
             for identity in &new_identities {
-                insert_release_identity_row(tx, &release_id, identity, &reg, &now)?;
+                insert_release_identity_row(tx, &release_id, identity, ids.new_id(), &reg, &now)?;
             }
 
             // 3. Update release: album, metadata source.

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -1556,7 +1556,18 @@ fn insert_album_artist_row(
     .map_err(DbError::from)
 }
 
+/// `source_folder_name` is the folder an export reconstructs under the user's
+/// target directory, so it is held to the same fragment policy as a file's name
+/// (see [`insert_file_row`]).
 fn insert_release_row(conn: &Connection, release: &DbRelease, reg: &str) -> Result<(), DbError> {
+    if let Some(folder) = &release.source_folder_name {
+        crate::storage::path_fragment::validate_path_fragment(
+            &release.id,
+            "source_folder_name",
+            folder,
+        )
+        .map_err(|e| DbError(e.to_string()))?;
+    }
     conn.execute(
         r#"
         INSERT INTO releases (
@@ -1789,7 +1800,18 @@ fn insert_artist_role_row(
         .map_err(DbError::from)
 }
 
+/// The one row-write for `release_files`, so the one place `original_filename`
+/// enters durable state. Export and make-Local join that column onto a directory
+/// the user chose, and it syncs to every other device, so a name that can't be
+/// materialized there is refused here — inside the caller's transaction, which
+/// rolls back whole rather than committing a release nobody can copy out.
 fn insert_file_row(conn: &Connection, file: &DbFile, reg: &str) -> Result<(), DbError> {
+    crate::storage::path_fragment::validate_path_fragment(
+        &file.release_id,
+        &format!("original_filename for file {}", file.id),
+        &file.original_filename,
+    )
+    .map_err(|e| DbError(e.to_string()))?;
     conn.execute(
         r#"
         INSERT INTO release_files (

--- a/bae-core/src/db/client/mod.rs
+++ b/bae-core/src/db/client/mod.rs
@@ -5,7 +5,7 @@ use crate::queue::QueueItem;
 use crate::util::content_type::ContentType;
 use chrono::{DateTime, Utc};
 use coven::rusqlite::{params, Connection, OptionalExtension, Params, Row};
-use coven::{ClockRef, Coven, CovenError, CovenHandle, DbError, SqlContext};
+use coven::{ClockRef, Coven, CovenError, CovenHandle, DbError, IdRef, SqlContext};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -793,6 +793,12 @@ struct DatabaseInner {
     /// Wall clock for `created_at` and status timestamps bound into write SQL.
     /// Synced-table `_updated_at` is stamped from coven's SQL context.
     clock: ClockRef,
+    /// The id source for the few rows this layer mints itself — the ones whose
+    /// count is only known inside the transaction that writes them (a release's
+    /// identity rows, an album's copied `album_artists`). Every other id is minted
+    /// by the caller from the same provider and passed in, so the DB holding one
+    /// keeps every id in the process coming from the one injected source.
+    ids: IdRef,
 }
 
 /// An external user-owned file a blob id resolves to.
@@ -916,9 +922,9 @@ impl Database {
             .map_err(Self::coven_error)
     }
 
-    pub fn from_handle(handle: CovenHandle, clock: ClockRef) -> Self {
+    pub fn from_handle(handle: CovenHandle, clock: ClockRef, ids: IdRef) -> Self {
         Database {
-            inner: Arc::new(DatabaseInner { handle, clock }),
+            inner: Arc::new(DatabaseInner { handle, clock, ids }),
         }
     }
 
@@ -927,6 +933,7 @@ impl Database {
     pub fn open(
         config: impl Into<coven::CovenConfig>,
         clock: ClockRef,
+        ids: IdRef,
         key_service: coven::StoreKeys,
         synced_tables: Vec<coven::SyncedTable>,
         observer: Option<Arc<dyn coven::BlobTransitionObserver>>,
@@ -942,13 +949,17 @@ impl Database {
             .migrations(crate::migrations::all())
             .open()
             .map_err(Self::coven_error)?;
-        Ok(Self::from_handle(handle, clock))
+        Ok(Self::from_handle(handle, clock, ids))
     }
 
     /// Test convenience: open over `path` with a fresh device id and bae's real
     /// synced-table set, so unit/integration tests don't repeat the wiring.
     #[cfg(any(test, feature = "test-utils"))]
-    pub async fn new_test(database_path: &str, clock: ClockRef) -> Result<Self, DbError> {
+    pub async fn new_test(
+        database_path: &str,
+        clock: ClockRef,
+        ids: IdRef,
+    ) -> Result<Self, DbError> {
         tracing::info!("Opening database at {}", database_path);
         let path = Path::new(database_path);
         let library_root = path
@@ -989,6 +1000,7 @@ impl Database {
         Self::open(
             config,
             clock,
+            ids,
             key_service,
             crate::sync::synced_tables(),
             None,
@@ -2033,6 +2045,7 @@ fn insert_release_identity_row(
     conn: &Connection,
     release_id: &str,
     identity: &crate::import::ReleaseIdentity,
+    id: String,
     reg: &str,
     now: &str,
 ) -> Result<(), DbError> {
@@ -2044,7 +2057,7 @@ fn insert_release_identity_row(
         ) VALUES (?, ?, ?, ?, ?, ?, ?)
         "#,
         params![
-            uuid::Uuid::new_v4().to_string(),
+            id,
             release_id,
             identity.source.as_str(),
             identity.source_group_id,

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -577,6 +577,7 @@ impl Database {
         let now_dt = self.inner.clock.now();
         let now = now_dt.to_rfc3339();
         let now_ts = now_dt.timestamp();
+        let ids = Arc::clone(&self.inner.ids);
         let replacement_outcomes = Arc::new(Mutex::new(Vec::new()));
         let replacement_outcomes_for_write = Arc::clone(&replacement_outcomes);
         self.inner
@@ -652,7 +653,14 @@ impl Database {
                     // `release_identities` is uniquely keyed on `(release_id,
                     // source)`, so a release never carries two rows for one source.
                     for identity in &identities {
-                        insert_release_identity_row(tx, &release.id, identity, &reg, &now)?;
+                        insert_release_identity_row(
+                            tx,
+                            &release.id,
+                            identity,
+                            ids.new_id(),
+                            &reg,
+                            &now,
+                        )?;
                     }
 
                     // Works are globally identified; they go in before their links.

--- a/bae-core/src/db/client/release.rs
+++ b/bae-core/src/db/client/release.rs
@@ -1131,6 +1131,50 @@ impl Database {
         Ok(())
     }
 
+    /// Test-only: write a path fragment onto an existing row directly, the way a
+    /// changeset from another device does. coven applies a pulled row straight into
+    /// SQLite, so the validation on the row-write never sees it — which is why
+    /// export and make-Local validate the fragment again before joining it onto a
+    /// local directory, and what these seams let a test exercise.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn set_original_filename_for_test(
+        &self,
+        file_id: &str,
+        original_filename: &str,
+    ) -> Result<(), DbError> {
+        let file_id = file_id.to_string();
+        let original_filename = original_filename.to_string();
+        self.call(move |conn| {
+            conn.execute(
+                "UPDATE release_files SET original_filename = ?1 WHERE id = ?2",
+                params![original_filename, file_id],
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+    }
+
+    /// Test-only. See [`set_original_filename_for_test`](Self::set_original_filename_for_test).
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn set_source_folder_name_for_test(
+        &self,
+        release_id: &str,
+        source_folder_name: &str,
+    ) -> Result<(), DbError> {
+        let release_id = release_id.to_string();
+        let source_folder_name = source_folder_name.to_string();
+        self.call(move |conn| {
+            conn.execute(
+                "UPDATE releases SET source_folder_name = ?1 WHERE id = ?2",
+                params![source_folder_name, release_id],
+            )
+            .map(|_| ())
+            .map_err(DbError::from)
+        })
+        .await
+    }
+
     pub async fn count_pending_uploads_for_release(
         &self,
         release_id: &str,

--- a/bae-core/src/db/client/tests.rs
+++ b/bae-core/src/db/client/tests.rs
@@ -61,9 +61,13 @@ mod in_clause_chunking_tests {
     async fn chunked_track_db() -> (Database, tempfile::TempDir, Vec<String>) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let track_count = SQL_MAX_IN_VARS * 45;
         let track_ids: Vec<String> = (0..track_count)
             .map(|index| format!("track-{index}"))
@@ -116,9 +120,13 @@ mod in_clause_chunking_tests {
     async fn cover_versions_merges_chunks() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
 
         let cover_count = SQL_MAX_IN_VARS * 3;
         db.call(move |conn| {
@@ -217,9 +225,13 @@ mod aggregate_ordering_tests {
     async fn aggregate_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -337,9 +349,13 @@ mod aggregate_ordering_tests {
     async fn album_and_storage_pages_allow_missing_primary_artist() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -401,9 +417,13 @@ mod aggregate_ordering_tests {
     async fn queue_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -459,9 +479,13 @@ mod aggregate_ordering_tests {
     async fn release_detail_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -537,9 +561,13 @@ mod connection_boundary_tests {
     async fn coven_connection_enforces_foreign_keys_for_bae_schema() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
 
         let track = DbTrack::new_test("missing-release", "track-a", "Track Title A", Some(1));
         let error = db
@@ -771,9 +799,13 @@ mod cloud_outbox_tests {
     async fn empty_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         (db, tmp)
     }
 
@@ -975,9 +1007,13 @@ mod composer_mode_tests {
     async fn seeded_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -1022,9 +1058,13 @@ mod composer_mode_tests {
     async fn finalize_import_persists_composer_work_and_role_rows() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1210,9 +1250,13 @@ mod composer_mode_tests {
     async fn fail_import_and_delete_release_removes_finalized_import_state_atomically() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1351,9 +1395,13 @@ mod composer_mode_tests {
     async fn finalize_replacement_in_surviving_album_clears_dangling_primary() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1385,9 +1433,13 @@ mod composer_mode_tests {
     async fn finalize_replacement_of_last_release_deletes_prior_album() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1413,9 +1465,13 @@ mod composer_mode_tests {
     async fn fail_import_and_delete_release_in_surviving_album_clears_dangling_primary() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1543,9 +1599,13 @@ mod composer_mode_tests {
     async fn fail_import_and_delete_release_returns_orphaned_image_blobs_to_evict() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1747,9 +1807,13 @@ mod composer_mode_tests {
     async fn complete_import_for_release_marks_active_release_import_complete() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
@@ -1896,9 +1960,13 @@ mod composer_mode_tests {
     async fn search_library_treats_like_metacharacters_as_literals() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2017,9 +2085,13 @@ mod composer_mode_tests {
     async fn composer_page_uses_id_tiebreaker() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2070,9 +2142,13 @@ mod composer_mode_tests {
     async fn composer_page_applies_secondary_criterion() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2136,9 +2212,13 @@ mod artist_mode_tests {
     async fn seeded_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2227,9 +2307,13 @@ mod artist_mode_tests {
     async fn artist_page_uses_id_tiebreaker() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2280,9 +2364,13 @@ mod artist_mode_tests {
     async fn artist_page_applies_secondary_criterion() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2337,9 +2425,13 @@ mod artist_mode_tests {
     async fn artist_detail_orders_albums_year_then_title_with_unknown_years_last() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         db.call(|conn| {
             conn.execute_batch(
                 "
@@ -2420,9 +2512,13 @@ mod playback_state_load_tests {
     async fn empty_db() -> (Database, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.db");
-        let db = Database::new_test(path.to_str().unwrap(), Arc::new(SystemClock))
-            .await
-            .unwrap();
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         (db, tmp)
     }
 
@@ -2454,5 +2550,136 @@ mod playback_state_load_tests {
             db.load_playback_state().await.unwrap(),
             LoadedPlaybackState::Corrupt
         ));
+    }
+}
+
+/// The ids this layer mints itself — a release's `release_identities` rows, and
+/// the `album_artists` rows copied when a `set_identity` moves a release to a new
+/// album — come from the injected [`coven::IdProvider`], like every other id in
+/// the process. Minting them with a raw `Uuid::new_v4()` would put an id source
+/// nobody injected inside the DB, and a test running a deterministic provider
+/// would still get random ones.
+#[cfg(test)]
+mod injected_ids_tests {
+    use super::super::*;
+    use crate::db::{DbAlbum, DbAlbumArtist, DbArtist, DbRelease, ReleaseMetadataSource};
+    use crate::import::{MetadataSource, ReleaseIdentity};
+    use chrono::Utc;
+    use coven::SystemClock;
+    use std::sync::Arc;
+
+    async fn db_with_sequential_ids() -> (Database, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("test.db");
+        let db = Database::new_test(
+            path.to_str().unwrap(),
+            Arc::new(SystemClock),
+            Arc::new(coven::SequentialIdProvider::new("db-ids")),
+        )
+        .await
+        .unwrap();
+        (db, tmp)
+    }
+
+    fn identity(source: MetadataSource, release_id: &str) -> ReleaseIdentity {
+        ReleaseIdentity {
+            source,
+            source_group_id: format!("group-{release_id}"),
+            source_release_id: Some(release_id.to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn identity_rows_take_their_ids_from_the_injected_provider() {
+        let (db, _tmp) = db_with_sequential_ids().await;
+        let now = Utc::now();
+
+        let artist = DbArtist {
+            id: "artist-1".to_string(),
+            name: "Artist".to_string(),
+            sort_name: None,
+            discogs_artist_id: None,
+            musicbrainz_artist_id: None,
+            created_at: now,
+        };
+        db.insert_artist(&artist).await.unwrap();
+
+        let mut album = DbAlbum::new_test("Album", &artist.id);
+        album.id = "album-1".to_string();
+        db.insert_album(&album).await.unwrap();
+        db.insert_album_artist(&DbAlbumArtist::new(
+            &album.id,
+            &artist.id,
+            0,
+            "album-artist-1".to_string(),
+            now,
+        ))
+        .await
+        .unwrap();
+
+        let release = DbRelease::new_test(&album.id, "release-1");
+        db.insert_release(&release).await.unwrap();
+
+        db.insert_release_identities(
+            &release.id,
+            &[identity(MetadataSource::Discogs, "discogs-release-1")],
+        )
+        .await
+        .unwrap();
+
+        let ids: Vec<String> = db
+            .read(|conn| {
+                let mut stmt = conn.prepare("SELECT id FROM release_identities")?;
+                let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+                rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+                    .map_err(DbError::from)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(ids.len(), 1, "one identity row was written, got {ids:?}",);
+        assert!(
+            ids[0].starts_with("db-ids"),
+            "the identity row's id comes from the injected provider, got {:?}",
+            ids[0],
+        );
+
+        // Moving the release to a fresh album copies its album_artists rows; those
+        // PKs are minted here too.
+        let target = DbAlbum::new_test("Target Album", &artist.id);
+        db.set_identity_atomic(
+            &release.id,
+            &[identity(MetadataSource::MusicBrainz, "mb-release-1")],
+            ReleaseMetadataSource::MusicBrainz,
+            Some("mb-release-1"),
+            &album.id,
+            &target.id,
+            Some(&target),
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let copied: Vec<String> = db
+            .read(move |conn| {
+                let mut stmt =
+                    conn.prepare("SELECT id FROM album_artists WHERE album_id != 'album-1'")?;
+                let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+                rows.collect::<coven::rusqlite::Result<Vec<_>>>()
+                    .map_err(DbError::from)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            copied.len(),
+            1,
+            "the album_artists row was copied, got {copied:?}"
+        );
+        assert!(
+            copied[0].starts_with("db-ids"),
+            "the copied album_artists row's id comes from the injected provider, got {:?}",
+            copied[0],
+        );
     }
 }

--- a/bae-core/src/db/models.rs
+++ b/bae-core/src/db/models.rs
@@ -972,6 +972,42 @@ pub struct DbLibraryImage {
     pub created_at: DateTime<Utc>,
 }
 
+impl DbLibraryImage {
+    /// A release's cover row, describing the bytes that will be stored as its
+    /// blob. `bytes` is [`crate::util::cover::resize_cover`]'s output — the
+    /// thumbnail itself, never the image it was made from — so `file_size`,
+    /// `content_hash` and `content_type` are all derived from it here and cannot
+    /// disagree with the blob. coven verifies the blob against `content_hash` on
+    /// every cloud fetch, so a hash of any other bytes makes the cover
+    /// unreadable on every other device.
+    ///
+    /// `content_type` is JPEG because the resize only ever emits JPEG.
+    /// `cloud_path` is left `None`: it depends on the home's storage mode, and is
+    /// set by whoever writes the row (the finalize transaction at import,
+    /// `change_cover` from the row's own content type).
+    pub fn cover(
+        release_id: &str,
+        source: &str,
+        source_url: Option<String>,
+        bytes: &[u8],
+        now: DateTime<Utc>,
+    ) -> Self {
+        DbLibraryImage {
+            id: release_id.to_string(),
+            image_type: LibraryImageType::Cover,
+            content_type: ContentType::Jpeg,
+            file_size: bytes.len() as i64,
+            width: None,
+            height: None,
+            source: source.to_string(),
+            source_url,
+            cloud_path: None,
+            content_hash: Some(crate::util::fs::hash_bytes(bytes)),
+            created_at: now,
+        }
+    }
+}
+
 /// Raw combined search-result aggregate. No formatting — the resolver in
 /// `LibraryManager` produces the display-ready `crate::album_detail::SearchResults`.
 #[derive(Debug, Clone)]

--- a/bae-core/src/identify/service.rs
+++ b/bae-core/src/identify/service.rs
@@ -362,9 +362,13 @@ mod tests {
     async fn setup_inner() -> (Arc<IdentifyServiceInner>, tempfile::TempDir) {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-            .await
-            .unwrap();
+        let database = Database::new_test(
+            db_path.to_str().unwrap(),
+            Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
         let library_dir = coven::StoreDir::new(temp_dir.path());
         let library_id = format!("test-{}", temp_dir.path().display());
         let config = Config::with_defaults(

--- a/bae-core/src/import/folder_scanner.rs
+++ b/bae-core/src/import/folder_scanner.rs
@@ -32,6 +32,11 @@ pub struct ScannedFile {
     /// as the HashMap key throughout the import pipeline and as
     /// `DbFile.original_filename`. Two files may share a bare filename; they
     /// never share a relative_path within one release.
+    ///
+    /// Always `/`-separated, on every platform: it is stored, synced, and joined
+    /// back onto a local directory by whichever device exports or unmanages the
+    /// release, so it cannot carry the writing platform's separator (see
+    /// [`crate::storage::path_fragment`], which refuses one that does).
     pub relative_path: String,
     /// File size in bytes
     pub size: u64,
@@ -756,7 +761,15 @@ fn categorize_files_from_tree(
                 .to_path_buf()
         };
 
-        let relative_path = relative_from_release.to_string_lossy().to_string();
+        // Joined from the path's components rather than displayed, so the result is
+        // `/`-separated on Windows too. A displayed `Path` uses the host's
+        // separator, and this string is stored on the row and joined back onto a
+        // directory by every other device in the library.
+        let relative_path = relative_from_release
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
 
         // The absolute path is fs_root + entry.path.
         let absolute_path = fs_root.join(&entry.path);

--- a/bae-core/src/import/handle/tests.rs
+++ b/bae-core/src/import/handle/tests.rs
@@ -33,6 +33,7 @@ async fn setup_test_manager() -> (LibraryManager, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-core/src/import/service/cover_image.rs
+++ b/bae-core/src/import/service/cover_image.rs
@@ -1,25 +1,34 @@
-//! Pick and read an import's cover image from the folder's own files, building
-//! the `DbLibraryImage` record and its bytes. Folder images are ranked so that
-//! `cover`/`front` wins when the user made no explicit pick.
+//! Pick an import's cover image from the folder's own files. Folder images are
+//! ranked so that `cover`/`front` wins when the user made no explicit pick.
 
 use crate::import::folder_scanner::ScannedFile;
 use crate::util::content_type_hint::ContentTypeHint;
 
-use super::format_prep::resolve_file_content_type;
 use super::ImportService;
 
+/// A candidate cover's bytes as they came from their source, with the provenance
+/// the `covers` row records. The bytes here are NOT the stored ones: the import
+/// funnel resizes the winning candidate and builds the row from that output, so
+/// nothing describing a candidate can be mistaken for a description of the blob.
+#[derive(Debug)]
+pub(super) struct CoverCandidate {
+    pub bytes: Vec<u8>,
+    /// `covers.source`: "local" for a folder image, "embedded" for a picture
+    /// pulled out of the audio, else the metadata source that supplied the URL.
+    pub source: String,
+    /// `covers.source_url`: "release://{path}" for a folder image, the download
+    /// URL for a remote one, `None` for an embedded picture.
+    pub source_url: Option<String>,
+}
+
 impl ImportService {
-    /// Read the chosen cover file's bytes and build its `DbLibraryImage` record.
-    /// Nothing is written here: the caller hands the bytes to coven's local store
-    /// and the record to finalize.
-    #[allow(clippy::type_complexity)]
-    pub(super) fn build_cover_image_record(
+    /// Read the chosen cover file's bytes. Nothing is written here, and no row is
+    /// built: the caller resizes the winning candidate and records the result.
+    pub(super) fn pick_folder_cover(
         &self,
-        release_id: &str,
         discovered_files: &[ScannedFile],
         selected_cover_path: Option<&str>,
-    ) -> Result<Option<(crate::db::DbLibraryImage, Vec<u8>)>, crate::import::ImportError> {
-        use crate::db::{DbLibraryImage, LibraryImageType};
+    ) -> Result<Option<CoverCandidate>, crate::import::ImportError> {
         use crate::import::ImportError;
 
         let mut image_files: Vec<(&ScannedFile, &str)> = Vec::new();
@@ -51,9 +60,6 @@ impl ImportService {
             return Ok(None);
         };
 
-        let content_type = resolve_file_content_type(&cover_file.path)?;
-        let source_url = format!("release://{}", relative_path);
-
         let bytes = std::fs::read(&cover_file.path).map_err(|e| ImportError::CoverArt {
             detail: format!(
                 "Failed to read cover art {}: {e}",
@@ -61,23 +67,11 @@ impl ImportService {
             ),
         })?;
 
-        let now = self.library_manager.clock().now();
-        let db_image = DbLibraryImage {
-            id: release_id.to_string(),
-            image_type: LibraryImageType::Cover,
-            content_type,
-            file_size: bytes.len() as i64,
-            width: None,
-            height: None,
+        Ok(Some(CoverCandidate {
+            bytes,
             source: "local".to_string(),
-            source_url: Some(source_url),
-            // Computed in the finalize transaction under a browsable home.
-            cloud_path: None,
-            content_hash: Some(crate::util::fs::hash_bytes(&bytes)),
-            created_at: now,
-        };
-
-        Ok(Some((db_image, bytes)))
+            source_url: Some(format!("release://{}", relative_path)),
+        }))
     }
 
     pub(super) fn image_cover_priority(filename: &str) -> u8 {

--- a/bae-core/src/import/service/mod.rs
+++ b/bae-core/src/import/service/mod.rs
@@ -43,7 +43,7 @@ struct PreparedMetadata {
     db_album: DbAlbum,
     db_release: DbRelease,
     db_tracks: Vec<DbTrack>,
-    remote_cover_image: Option<(crate::db::DbLibraryImage, Vec<u8>)>,
+    remote_cover_image: Option<cover_image::CoverCandidate>,
     /// Raw (source, json) pairs from the metadata resolver, wrapped into
     /// DbReleaseMetadata at commit.
     resolved_metadata: Vec<(String, String)>,
@@ -577,7 +577,9 @@ impl ImportService {
         prepared.db_release.content_hash = Some(content_hash);
 
         // The content type comes from the HTTP response, so no magic-byte
-        // sniffing is needed here.
+        // sniffing is needed to reject a non-image download. It describes the
+        // download, not the stored blob — the resize below re-encodes those bytes
+        // — so it is checked and dropped, never recorded.
         let remote_cover_data = if let Some(CoverSelection::Remote(ref url, source)) =
             selected_cover
         {
@@ -597,7 +599,11 @@ impl ImportService {
                         .to_string(),
                 });
             }
-            Some((bytes, content_type, url.clone(), source))
+            Some(cover_image::CoverCandidate {
+                bytes,
+                source: source.as_str().to_string(),
+                source_url: Some(url.clone()),
+            })
         } else {
             None
         };
@@ -663,30 +669,7 @@ impl ImportService {
 
         // No storage yet: the winning cover's bytes go to coven's local store below
         // and its row is written by finalize.
-        prepared.remote_cover_image =
-            if let Some((bytes, content_type, url, source)) = remote_cover_data {
-                let now = library_manager.clock().now();
-                Some((
-                    crate::db::DbLibraryImage {
-                        id: prepared.db_release.id.clone(),
-                        image_type: crate::db::LibraryImageType::Cover,
-                        content_type,
-                        file_size: bytes.len() as i64,
-                        width: None,
-                        height: None,
-                        source: source.as_str().to_string(),
-                        source_url: Some(url),
-                        // finalize computes the readable cloud_path on a browsable
-                        // home; NULL (hashed) on an opaque one.
-                        cloud_path: None,
-                        content_hash: Some(crate::util::fs::hash_bytes(&bytes)),
-                        created_at: now,
-                    },
-                    bytes,
-                ))
-            } else {
-                None
-            };
+        prepared.remote_cover_image = remote_cover_data;
 
         step_times.push(("save_to_database", last_step_start.elapsed()));
         last_step_start = std::time::Instant::now();
@@ -966,45 +949,33 @@ impl ImportService {
 
         // Cover priority: Remote > local folder image > embedded. Finalize writes
         // the winner's bytes and row in one coven batch.
-        let cover_winner = match remote_cover_image.take() {
+        let cover_candidate = match remote_cover_image.take() {
             Some(remote) => Some(remote),
-            None => match self.build_cover_image_record(
-                &db_release.id,
-                discovered_files,
-                selected_cover_path,
-            )? {
+            None => match self.pick_folder_cover(discovered_files, selected_cover_path)? {
                 Some(local) => Some(local),
-                None => embedded_cover.map(|(bytes, content_type)| {
-                    let now = library_manager.clock().now();
-                    (
-                        crate::db::DbLibraryImage {
-                            id: db_release.id.clone(),
-                            image_type: crate::db::LibraryImageType::Cover,
-                            content_type,
-                            file_size: bytes.len() as i64,
-                            width: None,
-                            height: None,
-                            source: "embedded".to_string(),
-                            source_url: None,
-                            cloud_path: None,
-                            content_hash: Some(crate::util::fs::hash_bytes(&bytes)),
-                            created_at: now,
-                        },
-                        bytes,
-                    )
+                None => embedded_cover.map(|(bytes, _content_type)| cover_image::CoverCandidate {
+                    bytes,
+                    source: "embedded".to_string(),
+                    source_url: None,
                 }),
             },
         };
-        // Resize the winner to a ≤600px thumbnail — one funnel for all three
-        // sources — and patch the record to describe the stored bytes. The resize
-        // always emits JPEG, so the row (and the `cloud_path` extension
-        // `finalize_import_atomic` derives from it) must say JPEG too.
-        let cover_winner = match cover_winner {
-            Some((mut image, bytes)) => {
-                let bytes = crate::util::cover::resize_cover(&bytes)
+        // Resize the winner to a ≤600px JPEG thumbnail — one funnel for all three
+        // sources — and build the row from that output, so its hash, size and
+        // content type describe the blob that gets stored rather than the image it
+        // was made from. `finalize_import_atomic` derives the readable
+        // `cloud_path` extension from the same row.
+        let cover_winner = match cover_candidate {
+            Some(candidate) => {
+                let bytes = crate::util::cover::resize_cover(&candidate.bytes)
                     .map_err(|detail| crate::import::ImportError::CoverArt { detail })?;
-                image.content_type = crate::util::content_type::ContentType::Jpeg;
-                image.file_size = bytes.len() as i64;
+                let image = crate::db::DbLibraryImage::cover(
+                    &db_release.id,
+                    &candidate.source,
+                    candidate.source_url,
+                    &bytes,
+                    library_manager.clock().now(),
+                );
                 Some((image, bytes))
             }
             None => None,

--- a/bae-core/src/import/service/tests.rs
+++ b/bae-core/src/import/service/tests.rs
@@ -10,9 +10,13 @@ use tempfile::TempDir;
 async fn setup_import_service() -> (ImportService, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
-    let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-        .await
-        .unwrap();
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
+    )
+    .await
+    .unwrap();
     let library_dir = coven::StoreDir::new(temp_dir.path());
     let library_id = format!("test-{}", temp_dir.path().display());
     let config = Config::with_defaults(

--- a/bae-core/src/import/service/tests.rs
+++ b/bae-core/src/import/service/tests.rs
@@ -134,17 +134,14 @@ async fn explicit_bmp_cover_is_selected() {
         ScannedFile::new(jpg, "front.jpg".to_string(), 9),
     ];
 
-    let (image, bytes) = service
-        .build_cover_image_record("release-1", &discovered, Some("cover.bmp"))
+    let candidate = service
+        .pick_folder_cover(&discovered, Some("cover.bmp"))
         .unwrap()
-        .expect("selected cover should build a record");
+        .expect("selected cover should be picked");
 
-    assert_eq!(
-        image.content_type,
-        crate::util::content_type::ContentType::Bmp
-    );
-    assert_eq!(image.source_url.as_deref(), Some("release://cover.bmp"));
-    assert_eq!(bytes, b"bmp bytes");
+    assert_eq!(candidate.source, "local");
+    assert_eq!(candidate.source_url.as_deref(), Some("release://cover.bmp"));
+    assert_eq!(candidate.bytes, b"bmp bytes");
 }
 
 #[tokio::test]
@@ -155,7 +152,7 @@ async fn explicit_local_cover_missing_from_discovered_images_is_an_error() {
     let discovered = vec![ScannedFile::new(fallback, "front.jpg".to_string(), 9)];
 
     let err = service
-        .build_cover_image_record("release-1", &discovered, Some("cover.bmp"))
+        .pick_folder_cover(&discovered, Some("cover.bmp"))
         .unwrap_err();
 
     assert!(
@@ -169,7 +166,7 @@ async fn explicit_local_cover_with_no_discovered_images_is_an_error() {
     let (service, _tmp) = setup_import_service().await;
 
     let err = service
-        .build_cover_image_record("release-1", &[], Some("cover.bmp"))
+        .pick_folder_cover(&[], Some("cover.bmp"))
         .unwrap_err();
 
     assert!(
@@ -282,7 +279,7 @@ async fn unreadable_selected_cover_is_an_error() {
     std::fs::set_permissions(&cover, std::fs::Permissions::from_mode(0o000)).unwrap();
     let discovered = vec![ScannedFile::new(cover.clone(), "cover.jpg".to_string(), 9)];
 
-    let result = service.build_cover_image_record("release-1", &discovered, Some("cover.jpg"));
+    let result = service.pick_folder_cover(&discovered, Some("cover.jpg"));
 
     std::fs::set_permissions(&cover, std::fs::Permissions::from_mode(0o600)).unwrap();
     let err = result.unwrap_err();

--- a/bae-core/src/library/app_services.rs
+++ b/bae-core/src/library/app_services.rs
@@ -193,9 +193,13 @@ mod tests {
     async fn playing_app_services(track_count: usize) -> (AppServices, Vec<String>, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-            .await
-            .unwrap();
+        let database = Database::new_test(
+            db_path.to_str().unwrap(),
+            Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
 
         let artist = DbArtist {
             id: "test-artist-id".to_string(),

--- a/bae-core/src/library/export.rs
+++ b/bae-core/src/library/export.rs
@@ -249,10 +249,10 @@ impl ExportService {
         let mut sample_rate = None;
         let mut channels = None;
         let source_bits_per_sample = plans[0].audio_meta.audio_format.bits_per_sample;
-        let release_title = plans[0].tags.album.clone();
-        let release_performer = plans[0].tags.artist.clone();
+        let release_title = plans[0].resolved.tags.album.clone();
+        let release_performer = plans[0].resolved.tags.artist.clone();
         let cover_image_bytes = plans[0].cover_image_bytes.clone();
-        let is_digital = plans[0].is_digital;
+        let is_digital = plans[0].resolved.is_digital;
         let mut current_sample_frame = 0u64;
 
         for (index, plan) in plans.iter_mut().enumerate() {
@@ -306,8 +306,8 @@ impl ExportService {
             cue_tracks.push(CueTrack {
                 number: u8::try_from(index + 1)
                     .map_err(|_| "CUE track number exceeds 99".to_string())?,
-                title: plan.tags.title.clone(),
-                performer: plan.tags.artist.clone(),
+                title: plan.resolved.tags.title.clone(),
+                performer: plan.resolved.tags.artist.clone(),
                 index_00_sample_frame: (pregap_sample_frames > 0).then_some(current_sample_frame),
                 index_01_sample_frame: current_sample_frame
                     .checked_add(pregap_sample_frames)
@@ -342,7 +342,7 @@ impl ExportService {
                 .as_deref()
                 .map(str::trim)
                 .filter(|catalog| !catalog.is_empty()),
-            plans[0].tags.year,
+            plans[0].resolved.tags.year,
             &audio_filename,
             cue_file_type(&preset.codec)?,
             sample_rate,
@@ -358,7 +358,7 @@ impl ExportService {
             title: release_title.clone(),
             artist: release_performer,
             album: release_title,
-            year: plans[0].tags.year,
+            year: plans[0].resolved.tags.year,
             disc: None,
         };
         let total_tracks = plans.len() as u32;
@@ -463,10 +463,10 @@ impl ExportService {
             write_tags(
                 &output_path_owned,
                 tag_type,
-                &plan.tags,
-                plan.track_number.map(|n| n as u32),
-                plan.total_tracks as u32,
-                plan.is_digital,
+                &plan.resolved.tags,
+                plan.resolved.track_number.map(|n| n as u32),
+                plan.resolved.total_tracks as u32,
+                plan.resolved.is_digital,
                 cover_data,
             )?;
 
@@ -839,7 +839,6 @@ mod tests {
             track_number,
             total_tracks,
             is_digital: true,
-            primary_release_id: None,
         }
     }
 

--- a/bae-core/src/library/manager/coven_blobs.rs
+++ b/bae-core/src/library/manager/coven_blobs.rs
@@ -184,13 +184,20 @@ impl LibraryManager {
     /// `storage/pinned/` (from the evictable cache if already there, else the
     /// cloud). Idempotent. Pinned-ness is coven cache state — there is no bae flag.
     /// The low-level cache op behind the "Pin" transition.
+    ///
+    /// Pinned one blob at a time so the Downloads pane advances as each file lands:
+    /// coven's `pin` is a per-blob loop with no cross-blob state, so a file at a
+    /// time is the same work in the same order as handing it the whole set — and it
+    /// is the only granularity coven reports at, since a single `pin` call over the
+    /// set returns nothing until every file is in.
     pub(crate) async fn pin_release_blobs_with_progress(
         &self,
         release_id: &str,
         mut on_progress: impl FnMut(crate::library::DownloadTransferProgress),
     ) -> Result<(), LibraryError> {
         let files = self.database.get_files_for_release(release_id).await?;
-        let bytes_total = download_total_bytes(release_id, &files)?;
+        let sizes = download_file_sizes(release_id, &files)?;
+        let bytes_total = total_bytes(release_id, &sizes)?;
         let mut emit_progress = |bytes_done| {
             on_progress(crate::library::DownloadTransferProgress::new(
                 release_id,
@@ -201,12 +208,17 @@ impl LibraryManager {
         };
         emit_progress(0)?;
 
-        let blobs: Vec<_> = files.iter().map(Self::release_file_blob_ref).collect();
-        self.handle
-            .pin(&blobs)
-            .await
-            .map_err(|e| LibraryError::Storage(format!("pin release {release_id}: {e}")))?;
-        emit_progress(bytes_total)?;
+        let mut bytes_done = 0u64;
+        for (file, size) in files.iter().zip(&sizes) {
+            let blob = Self::release_file_blob_ref(file);
+            self.handle
+                .pin(std::slice::from_ref(&blob))
+                .await
+                .map_err(|e| LibraryError::Storage(format!("pin release {release_id}: {e}")))?;
+            // Never exceeds `bytes_total`: it is the sum of these same sizes.
+            bytes_done += size;
+            emit_progress(bytes_done)?;
+        }
 
         Ok(())
     }
@@ -281,11 +293,13 @@ fn download_file_sizes(release_id: &str, files: &[DbFile]) -> Result<Vec<u64>, L
 }
 
 fn download_total_bytes(release_id: &str, files: &[DbFile]) -> Result<u64, LibraryError> {
-    download_file_sizes(release_id, files)?
-        .iter()
-        .try_fold(0u64, |total, file_size| {
-            total.checked_add(*file_size).ok_or_else(|| {
-                LibraryError::Storage(format!("pin release {release_id}: byte total overflow"))
-            })
+    total_bytes(release_id, &download_file_sizes(release_id, files)?)
+}
+
+fn total_bytes(release_id: &str, sizes: &[u64]) -> Result<u64, LibraryError> {
+    sizes.iter().try_fold(0u64, |total, file_size| {
+        total.checked_add(*file_size).ok_or_else(|| {
+            LibraryError::Storage(format!("pin release {release_id}: byte total overflow"))
         })
+    })
 }

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -1,6 +1,7 @@
 //! Export domain operations for [`LibraryManager`].
 
 use super::*;
+use crate::storage::path_fragment::validate_path_fragment;
 use tracing::info;
 
 const EXPORT_MARKER_FILE: &str = ".bae-export";
@@ -210,7 +211,7 @@ impl LibraryManager {
                 "release {release_id} has no source folder name; cannot reconstruct its folder"
             ))
         })?;
-        validate_export_path(release_id, "source_folder_name", &folder)?;
+        validate_path_fragment(release_id, "source_folder_name", &folder)?;
 
         let final_dir = request.target_dir.join(&folder);
         // Stage under the target dir (not a temp dir elsewhere) so the final rename
@@ -266,7 +267,7 @@ impl LibraryManager {
         file: &DbFile,
         staging_dir: &std::path::Path,
     ) -> Result<(), LibraryError> {
-        validate_export_path(
+        validate_path_fragment(
             &file.release_id,
             &format!("original_filename for file {}", file.id),
             &file.original_filename,
@@ -756,42 +757,6 @@ fn unique_export_path(
     }
 }
 
-/// Reject a stored path fragment (`source_folder_name`, `original_filename`) that
-/// would escape the staging directory when joined onto it. A local-filesystem-join
-/// guard is bae's concern, not coven's.
-///
-/// The rule is closed: every [`Component`] must be [`Component::Normal`]. That one
-/// condition subsumes an absolute path (`RootDir`), a Windows drive/UNC prefix
-/// (`Prefix` — this compiles for the Windows desktop, where `Path::join` onto a
-/// drive-absolute path like `C:/evil` *replaces* the base entirely), a `..`
-/// (`ParentDir`), and a `.` (`CurDir`). Empty, NUL, and backslash are rejected up
-/// front: a backslash is a separator on Windows and a literal character elsewhere,
-/// so it never belongs in one of these fragments.
-fn validate_export_path(release_id: &str, label: &str, value: &str) -> Result<(), LibraryError> {
-    use std::path::Component;
-    let reject = |reason: &str| {
-        Err(LibraryError::Import(format!(
-            "invalid export path for release {release_id} {label} {value:?}: {reason}"
-        )))
-    };
-    if value.is_empty() {
-        return reject("path is empty");
-    }
-    if value.contains('\0') {
-        return reject("path contains a NUL byte");
-    }
-    if value.contains('\\') {
-        return reject("path contains a backslash");
-    }
-    if Path::new(value)
-        .components()
-        .any(|component| !matches!(component, Component::Normal(_)))
-    {
-        return reject("path is absolute or contains a non-normal (.. / . / drive) component");
-    }
-    Ok(())
-}
-
 fn write_export_marker(
     staging_dir: &std::path::Path,
     release_id: &str,
@@ -988,44 +953,5 @@ mod tests {
         );
         assert!(!final_dir.join("prior.txt").exists());
         assert!(!temp.path().join(".album.replace-release-1").exists());
-    }
-
-    #[test]
-    fn validate_export_path_accepts_normal_relative_fragments() {
-        for ok in ["track.flac", "CD1/track.flac", "Disc 1/01 - Song.flac"] {
-            validate_export_path("r", "l", ok).unwrap_or_else(|e| panic!("{ok:?}: {e}"));
-        }
-    }
-
-    #[test]
-    fn validate_export_path_rejects_empty_nul_and_backslash() {
-        // `C:\evil` and any other backslash fragment is refused on every
-        // platform — a separator on Windows, a stray literal elsewhere.
-        for bad in ["", "a\0b", "CD1\\track.flac", r"C:\evil", r"..\evil"] {
-            validate_export_path("r", "l", bad).expect_err(bad);
-        }
-    }
-
-    #[test]
-    fn validate_export_path_rejects_absolute_and_traversal() {
-        // Non-`Normal` components: an absolute `RootDir`, a `..` `ParentDir`
-        // (leading or interior), and a leading `.` `CurDir` the old
-        // leading-`/` + `..` checks let through.
-        for bad in ["/etc/passwd", "..", "../evil", "a/../etc/passwd", "./evil"] {
-            validate_export_path("r", "l", bad).expect_err(bad);
-        }
-    }
-
-    // On Windows a drive-absolute (`C:/evil`) or UNC (`\\server\share`) value
-    // parses to a `Prefix`/`RootDir` component, and `Path::join` onto it would
-    // discard the staging directory entirely; the all-`Normal` rule rejects it.
-    // On Unix `C:` is just an ordinary directory name, so this case is
-    // Windows-specific and cannot run on the macOS/Linux CI host.
-    #[cfg(windows)]
-    #[test]
-    fn validate_export_path_rejects_windows_drive_and_unc() {
-        for bad in ["C:/evil", r"C:\evil", r"\\server\share\evil"] {
-            validate_export_path("r", "l", bad).expect_err(bad);
-        }
     }
 }

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -267,10 +267,13 @@ impl LibraryManager {
     /// track number, the release's track total, and whether the media is digital.
     /// Reads no audio and no cover, so both the filename-suggestion path (which
     /// must not download a whole file) and the full export plan share it.
+    /// Returns the tag data and, separately, the album's primary release id — the
+    /// release whose cover a track export embeds. That id is a cover-lookup key,
+    /// not tag data, so it rides beside the tags rather than inside them.
     async fn resolve_export_tags(
         &self,
         meta: &TrackAudioMeta,
-    ) -> Result<ResolvedExportTags, LibraryError> {
+    ) -> Result<(ResolvedExportTags, Option<String>), LibraryError> {
         let album = self.database.get_album_for_release(&meta.release).await?;
 
         let album_artists = self.database.get_artists_for_album(&album.id).await?;
@@ -305,13 +308,15 @@ impl LibraryManager {
             disc,
         };
 
-        Ok(ResolvedExportTags {
-            tags,
-            track_number: meta.track.track_number,
-            total_tracks,
-            is_digital,
-            primary_release_id: album.primary_release_id,
-        })
+        Ok((
+            ResolvedExportTags {
+                tags,
+                track_number: meta.track.track_number,
+                total_tracks,
+                is_digital,
+            },
+            album.primary_release_id,
+        ))
     }
 
     /// Assemble everything `ExportService::export_track` needs for a
@@ -324,7 +329,7 @@ impl LibraryManager {
         track_id: &str,
     ) -> Result<ExportTrackPlan, LibraryError> {
         let meta = TrackAudioMeta::resolve(&self.database, track_id).await?;
-        let resolved = self.resolve_export_tags(&meta).await?;
+        let (resolved, primary_release_id) = self.resolve_export_tags(&meta).await?;
 
         let mut audio_bytes = Vec::new();
         for audio_file in &meta.audio_files {
@@ -342,7 +347,7 @@ impl LibraryManager {
             });
         }
 
-        let cover_image_bytes = match resolved.primary_release_id.as_deref() {
+        let cover_image_bytes = match primary_release_id.as_deref() {
             Some(rid) => match self.cover_ref(rid).await? {
                 Some(image) => self.read_image_blob(&image).await?,
                 None => None,
@@ -350,21 +355,10 @@ impl LibraryManager {
             None => None,
         };
 
-        let ResolvedExportTags {
-            tags,
-            track_number,
-            total_tracks,
-            is_digital,
-            primary_release_id: _,
-        } = resolved;
-
         Ok(ExportTrackPlan {
             audio_bytes,
-            tags,
+            resolved,
             cover_image_bytes,
-            track_number,
-            total_tracks,
-            is_digital,
             audio_window: export_window_from_meta(&meta),
             audio_meta: meta,
         })
@@ -379,7 +373,7 @@ impl LibraryManager {
         track_id: &str,
     ) -> Result<String, LibraryError> {
         let meta = TrackAudioMeta::resolve(&self.database, track_id).await?;
-        let resolved = self.resolve_export_tags(&meta).await?;
+        let (resolved, _primary_release_id) = self.resolve_export_tags(&meta).await?;
         Ok(crate::library::export::render_export_filename(
             &self.export_filename_template(),
             &resolved,
@@ -519,7 +513,7 @@ impl LibraryManager {
 
             let stem = crate::library::export::render_export_filename(
                 &preset.filename_template,
-                &resolved_tags_from_plan(&plan),
+                &plan.resolved,
             );
             let output_path = unique_export_path(
                 staging_dir,
@@ -680,22 +674,6 @@ fn non_negative_samples(samples: Option<i64>) -> u64 {
     samples.map_or(0, |sample| {
         u64::try_from(sample).expect("audio_format pregap samples are non-negative")
     })
-}
-
-fn resolved_tags_from_plan(plan: &ExportTrackPlan) -> ResolvedExportTags {
-    ResolvedExportTags {
-        tags: ExportTags {
-            title: plan.tags.title.clone(),
-            artist: plan.tags.artist.clone(),
-            album: plan.tags.album.clone(),
-            year: plan.tags.year,
-            disc: plan.tags.disc,
-        },
-        track_number: plan.track_number,
-        total_tracks: plan.total_tracks,
-        is_digital: plan.is_digital,
-        primary_release_id: None,
-    }
 }
 
 fn unique_export_path(

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -1,10 +1,8 @@
 //! Export domain operations for [`LibraryManager`].
 
 use super::*;
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 use tracing::info;
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 const EXPORT_MARKER_FILE: &str = ".bae-export";
 
 impl LibraryManager {
@@ -103,7 +101,6 @@ impl LibraryManager {
     /// The serial export worker loop. Parks on the queue's `Notify` whenever the
     /// queue is paused or holds nothing queued; otherwise takes the next queued
     /// release and copies it out. Processes strictly one release at a time.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub(super) async fn run_export_worker(&self) {
         loop {
             let Some(op) = self.export_queue.next_queued() else {
@@ -123,7 +120,6 @@ impl LibraryManager {
     /// `cancel_export` aborts the in-flight task via the registered handle and
     /// removes the queue entry; on its way out we check whether the entry is still
     /// present before recording a failure — a cancelled export isn't a failure.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn run_queued_export(&self, op: crate::library::ExportOp) {
         let release_id = op.release_id.clone();
         let request = op.payload.clone();
@@ -200,7 +196,6 @@ impl LibraryManager {
     /// partial output at the final path. Updates the queue's per-release percent (by
     /// file index) and re-emits the snapshot after each file. Fails loudly when the
     /// release has no source folder name.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn export_release_to_dir(
         &self,
         release_id: &str,
@@ -266,7 +261,6 @@ impl LibraryManager {
     /// parent is created first. No per-file temp is needed: the whole staging
     /// directory is the atomic unit, renamed into place only once every file is
     /// written.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn export_one_file(
         &self,
         file: &DbFile,
@@ -289,10 +283,7 @@ impl LibraryManager {
     /// Export a release verbatim to `target_dir`, bypassing the export
     /// queue. Production always goes through `enqueue_export`; only a test
     /// helper for exercising the copy directly.
-    #[cfg(all(
-        not(any(target_os = "ios", target_os = "android")),
-        any(test, feature = "test-utils")
-    ))]
+    #[cfg(any(test, feature = "test-utils"))]
     pub async fn export_release(
         &self,
         release_id: &str,
@@ -313,7 +304,6 @@ impl LibraryManager {
     /// track number, the release's track total, and whether the media is digital.
     /// Reads no audio and no cover, so both the filename-suggestion path (which
     /// must not download a whole file) and the full export plan share it.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn resolve_export_tags(
         &self,
         meta: &TrackAudioMeta,
@@ -366,7 +356,6 @@ impl LibraryManager {
     /// neighbour counts, and the raw audio-format aggregate for decoding.
     /// Cloud-only tracks download + decrypt here — export never requires a
     /// local copy.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub async fn get_export_track_plan(
         &self,
         track_id: &str,
@@ -422,7 +411,6 @@ impl LibraryManager {
     /// suggests for `track_id`, rendered from the configured template and the
     /// track's tag data. Reads no audio and no cover — only the database — so
     /// seeding a save panel never touches a whole file or the cloud.
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub async fn export_track_suggested_name(
         &self,
         track_id: &str,
@@ -435,7 +423,6 @@ impl LibraryManager {
         ))
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub async fn export_track_extension(
         &self,
         track_id: &str,
@@ -461,7 +448,6 @@ impl LibraryManager {
         }
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub async fn export_track(
         &self,
         track_id: &str,
@@ -529,7 +515,6 @@ impl LibraryManager {
         }
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn export_release_tracks_to_dir(
         &self,
         release_id: &str,
@@ -589,7 +574,6 @@ impl LibraryManager {
         Ok(())
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     fn set_export_progress(&self, release_id: &str, percent: u8) {
         if self.export_queue.contains(release_id) {
             self.export_queue.set_active_percent(release_id, percent);
@@ -597,7 +581,6 @@ impl LibraryManager {
         }
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn export_release_image_with_cue_to_dir(
         &self,
         release_id: &str,
@@ -644,7 +627,6 @@ impl LibraryManager {
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn export_window_from_meta(meta: &TrackAudioMeta) -> super::ExportAudioWindow {
     super::ExportAudioWindow {
         segments: export_segment_windows(meta, true),
@@ -653,7 +635,6 @@ fn export_window_from_meta(meta: &TrackAudioMeta) -> super::ExportAudioWindow {
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn export_window_for_track_file(
     meta: &TrackAudioMeta,
     next_meta: Option<&TrackAudioMeta>,
@@ -697,7 +678,6 @@ fn export_window_for_track_file(
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn export_segment_windows(
     meta: &TrackAudioMeta,
     include_audio_pregap: bool,
@@ -711,7 +691,6 @@ fn export_segment_windows(
         .collect()
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn export_segment_windows_for_role(
     meta: &TrackAudioMeta,
     role: crate::db::DbAudioSegmentRole,
@@ -723,7 +702,6 @@ fn export_segment_windows_for_role(
         .collect()
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn export_segment_window(segment: &crate::db::DbAudioSegment) -> super::ExportAudioSegmentWindow {
     super::ExportAudioSegmentWindow {
         file_id: segment.file_id.clone(),
@@ -735,14 +713,12 @@ fn export_segment_window(segment: &crate::db::DbAudioSegment) -> super::ExportAu
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn non_negative_samples(samples: Option<i64>) -> u64 {
     samples.map_or(0, |sample| {
         u64::try_from(sample).expect("audio_format pregap samples are non-negative")
     })
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn resolved_tags_from_plan(plan: &ExportTrackPlan) -> ResolvedExportTags {
     ResolvedExportTags {
         tags: ExportTags {
@@ -759,7 +735,6 @@ fn resolved_tags_from_plan(plan: &ExportTrackPlan) -> ResolvedExportTags {
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn unique_export_path(
     dir: &std::path::Path,
     stem: &str,
@@ -792,7 +767,6 @@ fn unique_export_path(
 /// (`ParentDir`), and a `.` (`CurDir`). Empty, NUL, and backslash are rejected up
 /// front: a backslash is a separator on Windows and a literal character elsewhere,
 /// so it never belongs in one of these fragments.
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn validate_export_path(release_id: &str, label: &str, value: &str) -> Result<(), LibraryError> {
     use std::path::Component;
     let reject = |reason: &str| {
@@ -818,7 +792,6 @@ fn validate_export_path(release_id: &str, label: &str, value: &str) -> Result<()
     Ok(())
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn write_export_marker(
     staging_dir: &std::path::Path,
     release_id: &str,
@@ -827,7 +800,6 @@ fn write_export_marker(
     Ok(())
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 fn replace_export_dir(
     staging_dir: &std::path::Path,
     final_dir: &std::path::Path,
@@ -898,13 +870,11 @@ fn replace_export_dir(
 /// a read/write error (`?`), a panic, or the worker task being aborted on cancel
 /// (which drops this future) — drops the guard, which removes the directory. That
 /// is what keeps a failed or cancelled export from leaving partial output behind.
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 struct StagingDir {
     path: std::path::PathBuf,
     armed: bool,
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl StagingDir {
     /// Create the staging directory fresh. A leftover directory at this path (from
     /// a prior crash that skipped the drop cleanup) is removed first so the export
@@ -928,7 +898,6 @@ impl StagingDir {
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "android")))]
 impl Drop for StagingDir {
     fn drop(&mut self) {
         if !self.armed {

--- a/bae-core/src/library/manager/export.rs
+++ b/bae-core/src/library/manager/export.rs
@@ -99,92 +99,54 @@ impl LibraryManager {
         self.emit_export_queue_changed();
     }
 
-    /// The serial export worker loop. Parks on the queue's `Notify` whenever the
-    /// queue is paused or holds nothing queued; otherwise takes the next queued
-    /// release and copies it out. Processes strictly one release at a time.
-    pub(super) async fn run_export_worker(&self) {
-        loop {
-            let Some(op) = self.export_queue.next_queued() else {
-                self.export_queue.wait().await;
-                continue;
-            };
-            self.run_queued_export(op).await;
-        }
-    }
-
-    /// Run one queued release's export: spawn the copy task, flip the entry to
-    /// `Active` and register its abort handle atomically, then await the task. The
-    /// task updates the queue's per-release percent and re-emits the snapshot as
-    /// it copies each file. On success drop the entry; on failure mark it `Failed`
-    /// (it stays in the queue for retry).
+    /// The serial export worker: drains the export queue one release at a time
+    /// through [`run_serial_worker`], which owns the queue protocol (the
+    /// activate/cancel race, cancel-is-not-a-failure, remove vs mark-failed).
     ///
-    /// `cancel_export` aborts the in-flight task via the registered handle and
-    /// removes the queue entry; on its way out we check whether the entry is still
-    /// present before recording a failure — a cancelled export isn't a failure.
-    async fn run_queued_export(&self, op: crate::library::ExportOp) {
-        let release_id = op.release_id.clone();
-        let request = op.payload.clone();
+    /// All this supplies is how an export runs — spawn the copy task and yield its
+    /// outcome, mapping a panicked task to a failure that names the panic — and the
+    /// diagnostics event for the outcome. The copy itself updates the queue's
+    /// per-release percent and re-emits the snapshot as it writes each file.
+    pub(super) async fn run_export_worker(&self) {
+        use crate::library::release_queue::{run_serial_worker, RunningOp};
 
-        let worker = self.clone();
-        let task_release_id = release_id.clone();
-        let task = self.runtime_handle.spawn(async move {
-            worker
-                .export_release_to_dir(&task_release_id, request)
-                .await
-        });
-        let abort = task.abort_handle();
-
-        // Flip to Active and register the abort handle atomically. If a cancel
-        // removed the entry in the gap since we picked it, abort the task we just
-        // spawned and bail — nothing was written.
-        if !self.export_queue.activate(&release_id, abort.clone(), 0) {
-            abort.abort();
-            debug!("Export for {release_id} cancelled before it started; aborting");
-            return;
-        }
-        self.emit_export_queue_changed();
-
-        let outcome = task.await;
-        self.export_queue.clear_active_abort();
-
-        // A cancel removed the entry while the copy was in flight. This isn't a
-        // failure — don't re-add the entry or mark it Failed.
-        if !self.export_queue.contains(&release_id) {
-            debug!("Export for {release_id} ended after cancel; leaving queue as-is");
-            return;
-        }
-
-        match outcome {
-            Ok(Ok(())) => {
-                self.diagnostics().event(TelemetryEvent::ExportCompleted {
-                    release_id: crate::diagnostics::LocalId(release_id.clone()),
+        run_serial_worker(
+            &self.export_queue,
+            "Export",
+            |op| async move {
+                let release_id = op.release_id.clone();
+                let worker = self.clone();
+                let task = self.runtime_handle.spawn(async move {
+                    worker
+                        .export_release_to_dir(&op.release_id, op.payload)
+                        .await
                 });
-                self.export_queue.remove(&release_id);
-                self.emit_export_queue_changed();
-            }
-            Ok(Err(error)) => {
-                error!("Export failed for release {release_id}: {error}");
-                self.diagnostics().event(TelemetryEvent::ExportFailed {
-                    release_id: crate::diagnostics::LocalId(release_id.clone()),
+                let abort = task.abort_handle();
+                let outcome = async move {
+                    match task.await {
+                        Ok(result) => result,
+                        // Aborted by a cancel, which also removed the entry — the
+                        // driver's `contains` check is what reads that as a cancel.
+                        Err(join_error) if join_error.is_cancelled() => Err(LibraryError::Import(
+                            format!("export of {release_id} was cancelled"),
+                        )),
+                        Err(join_error) => Err(LibraryError::Import(format!(
+                            "export task for {release_id} panicked: {join_error}"
+                        ))),
+                    }
+                };
+                Ok((0, RunningOp { abort, outcome }))
+            },
+            || self.emit_export_queue_changed(),
+            |release_id, result| {
+                let release_id = crate::diagnostics::LocalId(release_id.to_string());
+                self.diagnostics().event(match result {
+                    Ok(()) => TelemetryEvent::ExportCompleted { release_id },
+                    Err(_) => TelemetryEvent::ExportFailed { release_id },
                 });
-                self.export_queue
-                    .mark_failed(&release_id, error.to_string());
-                self.emit_export_queue_changed();
-            }
-            Err(join_error) if join_error.is_cancelled() => {
-                // Aborted by a cancel that also removed the entry — handled above.
-                debug!("Export task for {release_id} aborted");
-            }
-            Err(join_error) => {
-                error!("Export task for {release_id} panicked: {join_error}");
-                self.diagnostics().event(TelemetryEvent::ExportFailed {
-                    release_id: crate::diagnostics::LocalId(release_id.clone()),
-                });
-                self.export_queue
-                    .mark_failed(&release_id, join_error.to_string());
-                self.emit_export_queue_changed();
-            }
-        }
+            },
+        )
+        .await
     }
 
     /// Copy a release's files verbatim to `<target_dir>/<source_folder_name>/`,

--- a/bae-core/src/library/manager/image.rs
+++ b/bae-core/src/library/manager/image.rs
@@ -113,36 +113,23 @@ impl LibraryManager {
             }
         };
 
-        // Resize to a ≤600px JPEG thumbnail before deriving the storage key and the
-        // record: the stored bytes, their format, and size describe the thumbnail,
-        // not the source. The resize always emits JPEG.
+        // Resize to a ≤600px JPEG thumbnail, then build the row from that output:
+        // the stored bytes, their format, size and hash all describe the thumbnail,
+        // not the source.
         let bytes = crate::util::cover::resize_cover(&bytes)
             .map_err(|e| LibraryError::Import(format!("Failed to resize cover: {e}")))?;
-        let content_type = crate::util::content_type::ContentType::Jpeg;
+        let mut library_image =
+            DbLibraryImage::cover(release_id, &source, source_url, &bytes, self.clock.now());
 
         // Record the cover blob and row in one coven write; the cover's `id` IS the
         // release id. On a browsable home the blob lands at a readable
         // `{album_id}/{release_id}/cover.{ext}` key, computed and stored here; an
         // opaque home leaves `cloud_path` NULL (hashed-by-id).
-        let now = self.clock.now();
         let storage = self.config_handle.config().cloud_home.storage;
-        let cloud_path = self
+        library_image.cloud_path = self
             .database
-            .cover_cloud_path_for_storage(storage, release_id, &content_type)
+            .cover_cloud_path_for_storage(storage, release_id, &library_image.content_type)
             .await?;
-        let library_image = DbLibraryImage {
-            id: release_id.to_string(),
-            image_type: LibraryImageType::Cover,
-            content_type,
-            file_size: bytes.len() as i64,
-            width: None,
-            height: None,
-            source,
-            source_url,
-            cloud_path,
-            content_hash: Some(crate::util::fs::hash_bytes(&bytes)),
-            created_at: now,
-        };
         self.store_library_image_blob(&library_image, &bytes)
             .await?;
 

--- a/bae-core/src/library/manager/locality.rs
+++ b/bae-core/src/library/manager/locality.rs
@@ -57,21 +57,30 @@ impl LibraryManager {
     /// The make-Local destination map: each release file's blob id → the user path
     /// (`new_path/original_filename`) its bytes go back to. Host-provided blobs (the
     /// cover) take no dest — coven restores them to its local store.
-    async fn make_local_dest(
+    ///
+    /// `original_filename` is a synced column another device wrote, and coven writes
+    /// wherever this map points, so each fragment is validated before it is joined
+    /// onto the user's folder: a release carrying one bad name copies out no files
+    /// at all, rather than one of them landing outside the folder the user chose.
+    pub(super) async fn make_local_dest(
         &self,
         release_id: &str,
         new_path: &str,
     ) -> Result<HashMap<String, PathBuf>, LibraryError> {
         let files = self.database.get_files_for_release(release_id).await?;
-        Ok(files
-            .iter()
-            .map(|f| {
-                (
-                    f.id.clone(),
-                    std::path::Path::new(new_path).join(&f.original_filename),
-                )
-            })
-            .collect())
+        let mut dest = HashMap::with_capacity(files.len());
+        for f in &files {
+            crate::storage::path_fragment::validate_path_fragment(
+                release_id,
+                &format!("original_filename for file {}", f.id),
+                &f.original_filename,
+            )?;
+            dest.insert(
+                f.id.clone(),
+                std::path::Path::new(new_path).join(&f.original_filename),
+            );
+        }
+        Ok(dest)
     }
 
     /// Map a coven `make_local` result to bae's: a cancel before the commit is a

--- a/bae-core/src/library/manager/locality.rs
+++ b/bae-core/src/library/manager/locality.rs
@@ -241,91 +241,56 @@ impl LibraryManager {
         self.emit_download_queue_changed();
     }
 
-    /// The serial download worker loop. Parks on the queue's `Notify` whenever
-    /// the queue is paused or holds nothing queued; otherwise takes the next
-    /// queued release, runs its pin, and repeats. Process strictly one release
-    /// at a time.
-    pub(super) async fn run_download_worker(&self) {
-        loop {
-            let Some(op) = self.download_queue.next_queued() else {
-                self.download_queue.wait().await;
-                continue;
-            };
-            self.run_queued_pin(&op).await;
-        }
-    }
-
-    /// Run one queued release's pin: spawn `TransferService::pin_release_task`,
-    /// flip the entry to `Active` and register its abort handle atomically, then
-    /// drive its progress and re-emit the inline `ReleaseTransferProgress` the
-    /// storage row reads. On success drop the entry; on failure mark it `Failed`
-    /// (it stays in the queue for retry).
+    /// The serial download worker: drains the pin queue one release at a time
+    /// through [`run_serial_worker`], which owns the queue protocol (the
+    /// activate/cancel race, cancel-is-not-a-failure, remove vs mark-failed).
     ///
-    /// `cancel_download` aborts the in-flight task via the registered handle. A
-    /// cancel removes the queue entry; on its way out the drain sees the channel
-    /// close, and we check whether the entry is still present before recording a
-    /// failure — a cancelled download isn't a failure.
-    async fn run_queued_pin(&self, op: &crate::library::DownloadOp) {
+    /// All this supplies is how a pin runs: resolve the release's byte totals,
+    /// spawn `TransferService::pin_release_task`, and yield its outcome. The
+    /// outcome comes from draining the transfer's progress channel — that drain is
+    /// also what emits the inline `ReleaseTransferProgress` bar the storage row
+    /// reads — and then joining the pin task, so a panicked pin reports the panic
+    /// rather than "the channel closed".
+    ///
+    /// Success needs no follow-up here: `pin_release_blobs` already emitted
+    /// `ReleaseUpdated`, so the release's `pinned` flag flips reactively.
+    /// Completion and failure reach diagnostics from inside the transfer
+    /// (`StorageTransferCompleted` / `StorageTransferFailed`), so there is nothing
+    /// to report on the way out.
+    pub(super) async fn run_download_worker(&self) {
+        use crate::library::release_queue::{run_serial_worker, RunningOp};
         use crate::storage::transfer::TransferService;
 
-        let release_id = op.release_id.as_str();
-        let initial_progress = match self.initial_download_progress(release_id).await {
-            Ok(progress) => progress,
-            Err(error) => {
-                error!("Pin failed for release {release_id}: {error}");
-                self.download_queue
-                    .mark_failed(release_id, error.to_string());
-                self.emit_download_queue_changed();
-                return;
-            }
-        };
-        let transfer = TransferService::new(self.clone());
-        let (rx, pin_task) = transfer.pin_release_task(release_id.to_string());
-        let abort = pin_task.abort_handle();
-        // Flip to Active and register the abort handle atomically. If a cancel
-        // removed the entry in the gap since we picked it, abort the task we
-        // just spawned and bail — the release stays cloud-only.
-        if !self
-            .download_queue
-            .activate(release_id, abort.clone(), initial_progress)
-        {
-            abort.abort();
-            debug!("Pin for {release_id} cancelled before it started; aborting");
-            return;
-        }
-        self.emit_download_queue_changed();
-        // Drive the pin through the shared transfer driver; the inline
-        // `ReleaseTransferProgress` bar is emitted by `drive_transfer` itself.
-        let outcome = self
-            .drive_transfer(release_id, ReleaseStorageAction::Pin, rx)
-            .await;
-        self.download_queue.clear_active_abort();
-
-        // A cancel removed the entry while the pin was in flight. The drain
-        // ended with an Err (the aborted pin task closed its channel) and
-        // already emitted the terminal `ReleaseTransferEnded` that clears the
-        // inline bar; `cancel_download` emitted the fresh snapshot. This isn't
-        // a failure — don't re-add the entry or mark it Failed.
-        if !self.download_queue.contains(release_id) {
-            debug!("Pin for {release_id} ended after cancel; leaving queue as-is");
-            return;
-        }
-
-        match outcome {
-            Ok(()) => {
-                // The release is pinned. `pin_release_blobs` already emitted
-                // `ReleaseUpdated`, so its `pinned` flag flips true reactively —
-                // just drop the queue entry.
-                self.download_queue.remove(release_id);
-                self.emit_download_queue_changed();
-            }
-            Err(error) => {
-                error!("Pin failed for release {release_id}: {error}");
-                self.download_queue
-                    .mark_failed(release_id, error.to_string());
-                self.emit_download_queue_changed();
-            }
-        }
+        run_serial_worker(
+            &self.download_queue,
+            "Pin",
+            |op| async move {
+                let release_id = op.release_id;
+                let initial_progress = self.initial_download_progress(&release_id).await?;
+                let transfer = TransferService::new(self.clone());
+                let (rx, pin_task) = transfer.pin_release_task(release_id.clone());
+                let abort = pin_task.abort_handle();
+                let outcome = async move {
+                    let drained = self
+                        .drive_transfer(&release_id, ReleaseStorageAction::Pin, rx)
+                        .await;
+                    match pin_task.await {
+                        // The task's own failure already came through the channel.
+                        Ok(()) => drained,
+                        // Aborted by a cancel, which also removed the entry — the
+                        // driver's `contains` check is what reads that as a cancel.
+                        Err(join_error) if join_error.is_cancelled() => drained,
+                        Err(join_error) => Err(LibraryError::Storage(format!(
+                            "pin task for {release_id} panicked: {join_error}"
+                        ))),
+                    }
+                };
+                Ok((initial_progress, RunningOp { abort, outcome }))
+            },
+            || self.emit_download_queue_changed(),
+            |_release_id, _result| {},
+        )
+        .await
     }
 
     /// Unpin a release: coven moves its blobs out of `storage/pinned/` and into the

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -147,6 +147,14 @@ pub enum LibraryError {
     MasterKey(#[from] coven::MasterKeyError),
 }
 
+/// A stored fragment we refuse to join onto a local path surfaces as an import
+/// failure: the row it came from is unusable, and the copy it was for does not run.
+impl From<crate::storage::path_fragment::PathFragmentError> for LibraryError {
+    fn from(error: crate::storage::path_fragment::PathFragmentError) -> Self {
+        LibraryError::Import(error.to_string())
+    }
+}
+
 impl LibraryError {
     /// The user-facing diagnostic class the bridge renders. Membership/setup
     /// failures carry the distinctions the cloud-setup and sharing flows show as

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -491,10 +491,6 @@ pub struct ResolvedExportTags {
     pub track_number: Option<i32>,
     pub total_tracks: usize,
     pub is_digital: bool,
-    /// The album's primary release id, if any — the release whose cover art a
-    /// track export embeds. Carried here so `get_export_track_plan` reaches the
-    /// cover without re-loading the album `resolve_export_tags` already read.
-    pub primary_release_id: Option<String>,
 }
 
 /// Pre-assembled data for exporting a single track. Everything
@@ -506,18 +502,13 @@ pub struct ResolvedExportTags {
 pub struct ExportTrackPlan {
     /// Source audio files read at plan time, keyed by release file id.
     pub(crate) audio_bytes: Vec<ExportAudioBytes>,
-    pub tags: ExportTags,
+    /// The track's tag data, exactly as the filename template and the tag writer
+    /// take it — embedded rather than copied field by field, so the plan and the
+    /// template always describe the same track.
+    pub resolved: ResolvedExportTags,
     /// The cover image bytes to embed, read through coven at plan time, or `None`
     /// when the album has no primary release with a cover.
     pub cover_image_bytes: Option<Vec<u8>>,
-    /// Track number within its side, straight from the DB.
-    pub track_number: Option<i32>,
-    /// Number of tracks in the release — used for the track-total tag.
-    pub total_tracks: usize,
-    /// `true` for CD / digital / unknown releases, `false` for side-based
-    /// media like vinyl or cassette. Gates writing an ID3 disc-number tag:
-    /// disc numbers don't map to vinyl / cassette sides.
-    pub is_digital: bool,
     /// The source/silence window to encode for this export. Playback uses the
     /// stored audio format directly; export can exclude or move CUE pregaps.
     pub(crate) audio_window: ExportAudioWindow,

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -66,6 +66,14 @@ mod artist;
 mod composer;
 mod config;
 mod coven_blobs;
+/// Desktop-only, under the same predicate as the rest of the export surface (the
+/// queue field below, and `library::export`). Exporting writes a directory tree
+/// next to the user's chosen folder — a hidden staging sibling, a marker file, a
+/// rename into place — which a sandboxed iOS/Android document URL does not offer,
+/// and the preset half of it needs the desktop-only `library::export` encoder.
+/// Compiling the producers out with the worker is what makes a mobile export call
+/// a compile error rather than a release that sits `Queued` with nothing to run it.
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 mod export;
 mod identity;
 mod image;
@@ -739,7 +747,9 @@ pub struct LibraryManager {
     /// In-memory queue for "Export…" (copy a release's files out to a folder). A
     /// single serial worker drains it one release at a time. Shared across
     /// manager clones; transient (empty after a restart). Export changes no
-    /// release state — it only reads and writes to a user directory.
+    /// release state — it only reads and writes to a user directory. Desktop-only:
+    /// see the `export` module above.
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     export_queue: Arc<crate::library::ExportQueue>,
     /// The upload observer coven reports blob transitions to. coven holds only a
     /// `Weak` to it (through `WeakUploadObserver`), so this strong `Arc` is its
@@ -850,6 +860,7 @@ impl LibraryManager {
             transfer_cancels: Arc::new(Mutex::new(HashMap::new())),
             transfer_actions: Arc::new(Mutex::new(HashMap::new())),
             download_queue: Arc::new(crate::library::DownloadQueue::new()),
+            #[cfg(not(any(target_os = "ios", target_os = "android")))]
             export_queue: Arc::new(crate::library::ExportQueue::new()),
             _upload_observer: Some(observer),
         };
@@ -904,6 +915,7 @@ impl LibraryManager {
             transfer_cancels: Arc::new(Mutex::new(HashMap::new())),
             transfer_actions: Arc::new(Mutex::new(HashMap::new())),
             download_queue: Arc::new(crate::library::DownloadQueue::new()),
+            #[cfg(not(any(target_os = "ios", target_os = "android")))]
             export_queue: Arc::new(crate::library::ExportQueue::new()),
             _upload_observer: None,
         };
@@ -1168,6 +1180,7 @@ impl LibraryManager {
     /// `ExportQueueChanged`. Called at every queue mutation (enqueue, worker
     /// pick-up, per-file progress, success, failure, cancel, retry,
     /// pause/resume) so the Storage Manager's Exporting pane stays current.
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub(crate) fn emit_export_queue_changed(&self) {
         self.emit(LibraryEvent::ExportQueueChanged {
             snapshot: self.export_snapshot(),
@@ -1177,6 +1190,7 @@ impl LibraryManager {
     /// The current export-queue snapshot — per-release state built from the
     /// in-memory queue. Seeds the Exporting pane before the first
     /// `ExportQueueChanged` event arrives.
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub fn export_snapshot(&self) -> crate::library::ExportSnapshot {
         crate::library::export_snapshot::build_export_snapshot(
             &self.export_queue.ops(),

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, Mutex};
 
 use thiserror::Error;
 use tokio::sync::broadcast;
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::album_detail::{
     join_artist_names, AlbumDetail, AlbumSummary, ArtistDetail, ArtistSummary, ComposerDetail,

--- a/bae-core/src/library/manager/mod.rs
+++ b/bae-core/src/library/manager/mod.rs
@@ -834,7 +834,7 @@ impl LibraryManager {
                 coven::CovenError::Database(error) => error,
                 other => coven::DbError(other.to_string()),
             })?;
-        let database = Database::from_handle(handle.clone(), clock.clone());
+        let database = Database::from_handle(handle.clone(), clock.clone(), ids.clone());
         observer.set_database(Arc::new(database.clone()));
         observer.set_handle(handle.clone());
         let sync_status = Arc::new(Mutex::new(SyncStatusState::initial(&handle)));

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -3247,8 +3247,9 @@ async fn download_queue_active_pin_reports_file_progress() {
 
     manager.enqueue_pins(vec![release_id.clone()]).await;
 
-    let mut saw_initial = false;
-    let mut saw_completed_progress = false;
+    // The release pins one blob at a time, so the pane sees the byte total climb:
+    // 0, then the first file's 3 bytes, then both files' 7.
+    let mut seen: Vec<u64> = Vec::new();
     for _ in 0..20 {
         let event = tokio::time::timeout(std::time::Duration::from_secs(2), events.recv())
             .await
@@ -3262,35 +3263,26 @@ async fn download_queue_active_pin_reports_file_progress() {
                 continue;
             }
             if let crate::library::DownloadState::Active { progress } = op.state {
-                if progress
-                    == (crate::library::DownloadTransferProgress {
-                        bytes_done: 0,
-                        bytes_total: 7,
-                        fraction: 0.0,
-                    })
-                {
-                    saw_initial = true;
-                }
-                if progress
-                    == (crate::library::DownloadTransferProgress {
-                        bytes_done: 7,
-                        bytes_total: 7,
-                        fraction: 1.0,
-                    })
-                {
-                    saw_completed_progress = true;
+                assert_eq!(progress.bytes_total, 7, "the release's known byte total");
+                assert_eq!(
+                    progress.fraction,
+                    progress.bytes_done as f64 / 7.0,
+                    "the fraction tracks the bytes"
+                );
+                if seen.last() != Some(&progress.bytes_done) {
+                    seen.push(progress.bytes_done);
                 }
             }
         }
-        if saw_initial && saw_completed_progress {
+        if seen.contains(&7) {
             break;
         }
     }
 
-    assert!(saw_initial, "active download starts with known totals");
-    assert!(
-        saw_completed_progress,
-        "active download reports completed file bytes before leaving the queue"
+    assert_eq!(
+        seen,
+        vec![0, 3, 7],
+        "an active download reports each file's bytes as it lands, not just 0 and done",
     );
 }
 

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -3356,16 +3356,33 @@ async fn insert_export_release_rows(
     (release, inserted_files)
 }
 
+/// A Local release with one readable source file, whose stored path fragments are
+/// then overwritten with `poison` — the shape a row pulled from another device can
+/// have. bae's own row-write refuses these values, but coven applies a pulled
+/// changeset straight into SQLite, so the guard that matters is the one at the
+/// join: the export copy-out and make-Local both validate the fragment before they
+/// join it onto the user's folder.
 #[cfg(feature = "test-utils")]
-async fn insert_local_export_release_with_safe_source(
+async fn insert_local_export_release_with_poisoned_fragment(
     manager: &LibraryManager,
     source_dir: &std::path::Path,
-    folder_name: &str,
-    file_name: &str,
     bytes: &[u8],
+    poison: PoisonedFragment<'_>,
 ) -> String {
     let (release, db_files) =
-        insert_export_release_rows(manager, folder_name, &[(file_name, bytes)]).await;
+        insert_export_release_rows(manager, "Album Title", &[("track.flac", bytes)]).await;
+    match poison {
+        PoisonedFragment::OriginalFilename(value) => manager
+            .database
+            .set_original_filename_for_test(&db_files[0].id, value)
+            .await
+            .unwrap(),
+        PoisonedFragment::SourceFolderName(value) => manager
+            .database
+            .set_source_folder_name_for_test(&release.id, value)
+            .await
+            .unwrap(),
+    }
     std::fs::create_dir_all(source_dir).unwrap();
     let source_path = source_dir.join("source.flac");
     std::fs::write(&source_path, bytes).unwrap();
@@ -3380,6 +3397,12 @@ async fn insert_local_export_release_with_safe_source(
         .await
         .unwrap();
     release.id
+}
+
+#[cfg(feature = "test-utils")]
+enum PoisonedFragment<'a> {
+    OriginalFilename(&'a str),
+    SourceFolderName(&'a str),
 }
 
 /// Pausing before the first enqueue parks the worker, so the queue's in-memory
@@ -3510,12 +3533,11 @@ async fn export_writes_exact_bytes_in_source_folder_and_leaves_release_remote() 
 #[tokio::test]
 async fn export_rejects_parent_component_original_filename() {
     let (manager, temp_dir) = setup_test_manager().await;
-    let release_id = insert_local_export_release_with_safe_source(
+    let release_id = insert_local_export_release_with_poisoned_fragment(
         &manager,
         &temp_dir.path().join("source"),
-        "Album Title",
-        "../escape.flac",
         b"escape-bytes",
+        PoisonedFragment::OriginalFilename("../escape.flac"),
     )
     .await;
 
@@ -3534,12 +3556,11 @@ async fn export_rejects_parent_component_original_filename() {
 async fn export_rejects_absolute_original_filename() {
     let (manager, temp_dir) = setup_test_manager().await;
     let absolute_escape = temp_dir.path().join("absolute-escape.flac");
-    let release_id = insert_local_export_release_with_safe_source(
+    let release_id = insert_local_export_release_with_poisoned_fragment(
         &manager,
         &temp_dir.path().join("source"),
-        "Album Title",
-        absolute_escape.to_str().unwrap(),
         b"escape-bytes",
+        PoisonedFragment::OriginalFilename(absolute_escape.to_str().unwrap()),
     )
     .await;
 
@@ -3557,12 +3578,11 @@ async fn export_rejects_absolute_original_filename() {
 #[tokio::test]
 async fn export_rejects_parent_component_source_folder_name() {
     let (manager, temp_dir) = setup_test_manager().await;
-    let release_id = insert_local_export_release_with_safe_source(
+    let release_id = insert_local_export_release_with_poisoned_fragment(
         &manager,
         &temp_dir.path().join("source"),
-        "../escape-folder",
-        "track.flac",
         b"track-bytes",
+        PoisonedFragment::SourceFolderName("../escape-folder"),
     )
     .await;
 
@@ -3574,6 +3594,38 @@ async fn export_rejects_parent_component_source_folder_name() {
         &["escape-folder", "export-out"],
     )
     .await;
+}
+
+/// make-Local hands coven a map of blob id → local destination, built by joining
+/// each file's stored `original_filename` onto the folder the user picked. coven
+/// writes wherever that map points, so a `../` in a row another device wrote would
+/// materialize the release's bytes outside the chosen folder. The join refuses it,
+/// and refuses the whole release: no destination in the map may escape the target.
+#[cfg(feature = "test-utils")]
+#[tokio::test]
+async fn make_local_dest_rejects_a_traversing_original_filename() {
+    let (manager, temp_dir) = setup_test_manager().await;
+    let target = temp_dir.path().join("make-local-out");
+    let release_id = insert_local_export_release_with_poisoned_fragment(
+        &manager,
+        &temp_dir.path().join("source"),
+        b"escape-bytes",
+        PoisonedFragment::OriginalFilename("../escape.flac"),
+    )
+    .await;
+
+    let error = manager
+        .make_local_dest(&release_id, target.to_str().unwrap())
+        .await
+        .expect_err("a traversing original_filename must not produce a destination");
+    assert!(
+        error.to_string().contains("invalid path fragment"),
+        "unexpected error: {error}",
+    );
+    assert!(
+        !temp_dir.path().join("escape.flac").exists(),
+        "nothing is written outside the target folder",
+    );
 }
 
 #[cfg(feature = "test-utils")]
@@ -3595,7 +3647,7 @@ async fn assert_export_rejects_invalid_path(
         .expect_err(message);
 
     assert!(
-        error.to_string().contains("invalid export path"),
+        error.to_string().contains("invalid path fragment"),
         "unexpected error: {error}"
     );
     for path in absent_paths {

--- a/bae-core/src/library/manager/tests.rs
+++ b/bae-core/src/library/manager/tests.rs
@@ -31,9 +31,13 @@ async fn setup_test_manager() -> (LibraryManager, TempDir) {
 async fn setup_test_manager_with_library_id(library_id: &str) -> (LibraryManager, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
-    let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-        .await
-        .unwrap();
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
+    )
+    .await
+    .unwrap();
 
     // Insert the test artist that create_test_album() references
     let artist = DbArtist {
@@ -143,9 +147,13 @@ async fn setup_forget_library_manager_at(
     home: &std::path::Path,
 ) -> LibraryManager {
     let db_path = home.join("manager.db");
-    let database = Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-        .await
-        .unwrap();
+    let database = Database::new_test(
+        db_path.to_str().unwrap(),
+        Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
+    )
+    .await
+    .unwrap();
     let config = Config::with_defaults(
         library_id.to_string(),
         "test-device".to_string(),

--- a/bae-core/src/library/outbox_snapshot.rs
+++ b/bae-core/src/library/outbox_snapshot.rs
@@ -502,6 +502,7 @@ mod tests {
         let db = Database::new_test(
             tmp.path().join("test.db").to_str().unwrap(),
             Arc::new(SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .unwrap();

--- a/bae-core/src/library/release_queue.rs
+++ b/bae-core/src/library/release_queue.rs
@@ -1,15 +1,21 @@
-//! Shared in-memory serial queue for per-release background work.
+//! Shared in-memory serial queue for per-release background work, and the serial
+//! worker that drains one.
 //!
 //! Pinning and exporting both process one release at a time, keep transient
 //! in-memory rows for the queue pane, and support pause, cancel, and retry.
 //! `Extra` carries the operation-specific row payload: downloads use `()`,
 //! exports use their target directory. `Progress` carries the active-row
-//! progress shape.
+//! progress shape. [`run_serial_worker`] is the drain protocol both share — the
+//! activate/cancel race in particular is written once here rather than once per
+//! queue.
 
+use std::future::Future;
 use std::sync::Mutex;
 
 use tokio::sync::Notify;
-use tracing::warn;
+use tracing::{debug, error, warn};
+
+use super::LibraryError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReleaseQueueState<Progress> {
@@ -216,6 +222,96 @@ impl<Extra: Clone, Progress: Clone> Default for ReleaseQueue<Extra, Progress> {
     }
 }
 
+/// A queued operation that has been started: the handle a cancel aborts, and the
+/// future that yields the operation's outcome.
+pub struct RunningOp<Fut> {
+    pub abort: tokio::task::AbortHandle,
+    pub outcome: Fut,
+}
+
+/// Drain a queue serially, one release at a time, forever. The caller supplies
+/// only `start` — resolve the release's initial progress, spawn its work, and hand
+/// back the abort handle plus the future that yields its outcome — and the hooks to
+/// re-emit the queue snapshot (`on_changed`) and to report the outcome to
+/// diagnostics (`on_done`).
+///
+/// The protocol, which is why this is one function and not two:
+///
+/// - A cancel can land in the gap between picking a release and activating it, so
+///   [`ReleaseQueue::activate`] flips to `Active` and registers the abort handle
+///   under one lock: it fails exactly when the entry is already gone, and then the
+///   work we just started is aborted and dropped.
+/// - A cancel during the work removes the entry and aborts the task, so
+///   `contains` after the await is what tells a cancel from a failure. A cancelled
+///   release is neither re-added nor marked failed.
+/// - Success removes the entry; failure marks it `Failed` and leaves it for retry.
+///   A `start` that fails marks it failed the same way — nothing was spawned.
+///
+/// Every transition emits a fresh snapshot through `on_changed`.
+pub async fn run_serial_worker<Extra, Progress, Start, StartFut, Fut, Changed, Done>(
+    queue: &ReleaseQueue<Extra, Progress>,
+    label: &'static str,
+    mut start: Start,
+    mut on_changed: Changed,
+    mut on_done: Done,
+) where
+    Extra: Clone,
+    Progress: Clone,
+    Start: FnMut(ReleaseQueueOp<Extra, Progress>) -> StartFut,
+    StartFut: Future<Output = Result<(Progress, RunningOp<Fut>), LibraryError>>,
+    Fut: Future<Output = Result<(), LibraryError>>,
+    Changed: FnMut(),
+    Done: FnMut(&str, Result<(), &LibraryError>),
+{
+    loop {
+        let Some(op) = queue.next_queued() else {
+            queue.wait().await;
+            continue;
+        };
+        let release_id = op.release_id.clone();
+
+        let (progress, running) = match start(op).await {
+            Ok(started) => started,
+            Err(error) => {
+                error!("{label} failed for release {release_id}: {error}");
+                on_done(&release_id, Err(&error));
+                queue.mark_failed(&release_id, error.to_string());
+                on_changed();
+                continue;
+            }
+        };
+        let RunningOp { abort, outcome } = running;
+
+        if !queue.activate(&release_id, abort.clone(), progress) {
+            abort.abort();
+            debug!("{label} for {release_id} cancelled before it started; aborting");
+            continue;
+        }
+        on_changed();
+
+        let result = outcome.await;
+        queue.clear_active_abort();
+
+        if !queue.contains(&release_id) {
+            debug!("{label} for {release_id} ended after cancel; leaving queue as-is");
+            continue;
+        }
+
+        match result {
+            Ok(()) => {
+                on_done(&release_id, Ok(()));
+                queue.remove(&release_id);
+            }
+            Err(error) => {
+                error!("{label} failed for release {release_id}: {error}");
+                on_done(&release_id, Err(&error));
+                queue.mark_failed(&release_id, error.to_string());
+            }
+        }
+        on_changed();
+    }
+}
+
 impl<Extra: Clone> ReleaseQueue<Extra, u8> {
     pub fn set_active_percent(&self, release_id: &str, percent: u8) {
         if !self.set_active_progress(release_id, percent) {
@@ -230,6 +326,7 @@ impl<Extra: Clone> ReleaseQueue<Extra, u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn op(release_id: &str) -> ReleaseQueueOp<(), u8> {
         ReleaseQueueOp {
@@ -326,6 +423,55 @@ mod tests {
         assert!(q.is_paused());
         assert!(q.set_paused(false));
         assert!(!q.is_paused());
+    }
+
+    /// A queued operation whose task panics must leave the release `Failed` with
+    /// the panic in its message — a panicked task says so, rather than surfacing
+    /// as whatever its progress channel looked like on the way down.
+    #[tokio::test]
+    async fn a_panicking_operation_marks_the_release_failed_with_the_panic() {
+        let queue: Arc<ReleaseQueue<(), u8>> = Arc::new(ReleaseQueue::new());
+        queue.enqueue(op("rel-a"));
+
+        let worker_queue = Arc::clone(&queue);
+        let worker = tokio::spawn(async move {
+            run_serial_worker(
+                &worker_queue,
+                "Test",
+                |_op| async move {
+                    let task = tokio::spawn(async { panic!("boom") });
+                    let abort = task.abort_handle();
+                    let outcome = async move {
+                        match task.await {
+                            Ok(()) => Ok(()),
+                            Err(join_error) if join_error.is_cancelled() => Ok(()),
+                            Err(join_error) => Err(LibraryError::Storage(format!(
+                                "task panicked: {join_error}"
+                            ))),
+                        }
+                    };
+                    Ok((0, RunningOp { abort, outcome }))
+                },
+                || {},
+                |_, _| {},
+            )
+            .await;
+        });
+
+        let error = loop {
+            if let Some(ReleaseQueueState::Failed { error }) =
+                queue.ops().first().map(|o| o.state.clone())
+            {
+                break error;
+            }
+            tokio::task::yield_now().await;
+        };
+        worker.abort();
+
+        assert!(
+            error.contains("panicked"),
+            "the failure names the panic, got: {error}"
+        );
     }
 
     #[test]

--- a/bae-core/src/playback/service/tests.rs
+++ b/bae-core/src/playback/service/tests.rs
@@ -114,10 +114,13 @@ async fn seeded_library_manager_with_diagnostics(
 ) -> (TempDir, LibraryManager) {
     let home = TempDir::new().unwrap();
     let db_path = home.path().join("playback-service-test.db");
-    let database =
-        crate::db::Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-            .await
-            .unwrap();
+    let database = crate::db::Database::new_test(
+        db_path.to_str().unwrap(),
+        Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
+    )
+    .await
+    .unwrap();
     seed_test_releases(&database, releases).await;
     let library_id = "playback-service-test".to_string();
     let config = crate::config::Config::with_defaults(

--- a/bae-core/src/signals/release.rs
+++ b/bae-core/src/signals/release.rs
@@ -207,6 +207,7 @@ mod tests {
         let database = Database::new_test(
             library_root.join("test.db").to_str().unwrap(),
             Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .unwrap();
@@ -347,6 +348,7 @@ mod tests {
         let database = Database::new_test(
             library_root.join("test.db").to_str().unwrap(),
             Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .unwrap();

--- a/bae-core/src/signals/service/tests.rs
+++ b/bae-core/src/signals/service/tests.rs
@@ -102,10 +102,13 @@ async fn collect_signals(
 async fn make_library_manager() -> (crate::library::LibraryManager, TempDir) {
     let tmp = TempDir::new().unwrap();
     let clock: coven::ClockRef = Arc::new(coven::SystemClock);
-    let database =
-        crate::db::Database::new_test(tmp.path().join("test.db").to_str().unwrap(), clock.clone())
-            .await
-            .unwrap();
+    let database = crate::db::Database::new_test(
+        tmp.path().join("test.db").to_str().unwrap(),
+        clock.clone(),
+        std::sync::Arc::new(coven::UuidProvider),
+    )
+    .await
+    .unwrap();
     let library_dir = coven::StoreDir::new(tmp.path());
     // Unique id per test so keyring entries don't collide in the shared
     // process-global mock store (see `install_test_keyring`).

--- a/bae-core/src/storage/mod.rs
+++ b/bae-core/src/storage/mod.rs
@@ -2,5 +2,6 @@
 //! read/write and the blob-store layout live behind [`coven::CovenHandle`], and
 //! callers name coven's cloud types directly; what's here is bae's transfer
 //! adapter and its readable-home cloud-key policy.
+pub mod path_fragment;
 pub mod readable_path;
 pub mod transfer;

--- a/bae-core/src/storage/path_fragment.rs
+++ b/bae-core/src/storage/path_fragment.rs
@@ -1,0 +1,112 @@
+//! The one policy for the path fragments bae stores and later joins onto a
+//! local path.
+//!
+//! `release_files.original_filename` and `releases.source_folder_name` are synced
+//! columns: another device wrote them, and this device joins them onto a
+//! directory the user chose — the export copy-out (`<target>/<source_folder>/
+//! <original_filename>`) and make-Local (`<new_path>/<original_filename>`). coven
+//! writes wherever the host's destination map points, so a fragment that escapes
+//! that directory is an arbitrary local write on every device that pulls the row.
+//!
+//! A fragment is a **relative, `/`-separated path of ordinary components**. It is
+//! validated where it enters the database (so a library never holds a name it
+//! cannot materialize) and again at each join (so a row from another device, or
+//! from an older build, is refused rather than followed).
+
+use std::path::{Component, Path};
+
+/// A stored fragment that is not a relative path of ordinary components. Carries
+/// the release and column it came from, because the value is data another device
+/// wrote and the reader needs to know which row to look at.
+#[derive(Debug, thiserror::Error)]
+#[error("invalid path fragment for release {release_id} {label} {value:?}: {reason}")]
+pub struct PathFragmentError {
+    pub release_id: String,
+    pub label: String,
+    pub value: String,
+    pub reason: &'static str,
+}
+
+/// Accept a fragment only if joining it onto a directory stays inside that
+/// directory and means the same thing on every device of the library.
+///
+/// The component rule is closed: every [`Component`] must be [`Component::Normal`].
+/// That one condition subsumes an absolute path (`RootDir`), a Windows drive/UNC
+/// prefix (`Prefix` — on Windows `Path::join` onto a drive-absolute path like
+/// `C:/evil` *replaces* the base entirely), a `..` (`ParentDir`), and a `.`
+/// (`CurDir`). Empty, NUL, and backslash are rejected up front: a backslash is a
+/// separator on Windows and a literal character elsewhere, so one stored name
+/// would mean two different things on two devices sharing the library.
+pub fn validate_path_fragment(
+    release_id: &str,
+    label: &str,
+    value: &str,
+) -> Result<(), PathFragmentError> {
+    let reject = |reason: &'static str| {
+        Err(PathFragmentError {
+            release_id: release_id.to_string(),
+            label: label.to_string(),
+            value: value.to_string(),
+            reason,
+        })
+    };
+    if value.is_empty() {
+        return reject("path is empty");
+    }
+    if value.contains('\0') {
+        return reject("path contains a NUL byte");
+    }
+    if value.contains('\\') {
+        return reject("path contains a backslash");
+    }
+    if Path::new(value)
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return reject("path is absolute or contains a non-normal (.. / . / drive) component");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_normal_relative_fragments() {
+        for ok in ["track.flac", "CD1/track.flac", "Disc 1/01 - Song.flac"] {
+            validate_path_fragment("r", "l", ok).unwrap_or_else(|e| panic!("{ok:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn rejects_empty_nul_and_backslash() {
+        // `C:\evil` and any other backslash fragment is refused on every
+        // platform — a separator on Windows, a stray literal elsewhere.
+        for bad in ["", "a\0b", "CD1\\track.flac", r"C:\evil", r"..\evil"] {
+            validate_path_fragment("r", "l", bad).expect_err(bad);
+        }
+    }
+
+    #[test]
+    fn rejects_absolute_and_traversal() {
+        // Non-`Normal` components: an absolute `RootDir`, a `..` `ParentDir`
+        // (leading or interior), and a leading `.` `CurDir`.
+        for bad in ["/etc/passwd", "..", "../evil", "a/../etc/passwd", "./evil"] {
+            validate_path_fragment("r", "l", bad).expect_err(bad);
+        }
+    }
+
+    // On Windows a drive-absolute (`C:/evil`) or UNC (`\\server\share`) value
+    // parses to a `Prefix`/`RootDir` component, and `Path::join` onto it would
+    // discard the base directory entirely; the all-`Normal` rule rejects it.
+    // On Unix `C:` is just an ordinary directory name, so this case is
+    // Windows-specific and cannot run on the macOS/Linux CI host.
+    #[cfg(windows)]
+    #[test]
+    fn rejects_windows_drive_and_unc() {
+        for bad in ["C:/evil", r"C:\evil", r"\\server\share\evil"] {
+            validate_path_fragment("r", "l", bad).expect_err(bad);
+        }
+    }
+}

--- a/bae-core/src/storage/readable_path.rs
+++ b/bae-core/src/storage/readable_path.rs
@@ -49,15 +49,6 @@ pub fn image_extension(content_type: &ContentType) -> &'static str {
     }
 }
 
-/// Replace path separators in a single path component (a folder name or a
-/// filename) so it can't open an unintended sub-level. A real on-disk name has
-/// none (the filesystem forbids `/`), so this is purely defensive against an odd
-/// source; it does not otherwise alter the name, since the `{release_id}` level
-/// already makes every key unique.
-fn safe_component(component: &str) -> String {
-    component.replace(['/', '\\'], "_")
-}
-
 /// The cloud key for a release file on a browsable home, RELATIVE to the
 /// `release_files` namespace coven prepends:
 /// `{album_id}/{release_id}/{source_folder}/{filename}`, mirroring the folder the
@@ -65,18 +56,22 @@ fn safe_component(component: &str) -> String {
 /// that level is then omitted; the `{release_id}` level keeps the key unique
 /// either way. (`source_folder_name` comes from `Path::file_name`, which is `None`
 /// or a non-empty name, so `Some("")` never occurs and isn't guarded here.)
+///
+/// `filename` is `release_files.original_filename` — the file's path relative to
+/// the release folder, so a disc subfolder (`CD1/track.flac`) is part of it and
+/// nests in the key, exactly as it nests on disk when the release is exported or
+/// made local. Both fragments were validated as relative paths of ordinary
+/// components when their rows were written
+/// ([`crate::storage::path_fragment`]), so nothing here can escape the key's
+/// namespace or its release prefix.
 pub fn audio_key(
     album_id: &str,
     release_id: &str,
     source_folder: Option<&str>,
     filename: &str,
 ) -> String {
-    let filename = safe_component(filename);
     match source_folder {
-        Some(folder) => format!(
-            "{album_id}/{release_id}/{}/{filename}",
-            safe_component(folder)
-        ),
+        Some(folder) => format!("{album_id}/{release_id}/{folder}/{filename}"),
         None => format!("{album_id}/{release_id}/{filename}"),
     }
 }
@@ -125,12 +120,19 @@ mod tests {
     }
 
     #[test]
-    fn safe_component_strips_path_separators_only() {
-        // A stray separator in either the folder or the filename can't open a
-        // sub-level; everything else is verbatim.
+    fn audio_key_nests_a_subfoldered_filename() {
+        // `original_filename` carries the file's path within the release folder,
+        // so a disc subfolder nests in the key — the browsable bucket mirrors the
+        // folder the release was imported from, and matches what an export writes
+        // to disk.
         assert_eq!(
-            audio_key("album-1", "rel-1", Some("a/b"), "sub/dir\\track.flac"),
-            "album-1/rel-1/a_b/sub_dir_track.flac"
+            audio_key(
+                "album-1",
+                "rel-1",
+                Some("Album [FLAC]"),
+                "CD1/01 Track.flac"
+            ),
+            "album-1/rel-1/Album [FLAC]/CD1/01 Track.flac"
         );
         // Spaces, punctuation, unicode all pass through untouched — the
         // {release_id} level already guarantees uniqueness.

--- a/bae-core/src/storage/transfer.rs
+++ b/bae-core/src/storage/transfer.rs
@@ -336,10 +336,13 @@ mod tests {
     {
         let home = TempDir::new().unwrap();
         let db_path = home.path().join("transfer-test.db");
-        let database =
-            crate::db::Database::new_test(db_path.to_str().unwrap(), Arc::new(coven::SystemClock))
-                .await
-                .unwrap();
+        let database = crate::db::Database::new_test(
+            db_path.to_str().unwrap(),
+            Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
+        )
+        .await
+        .unwrap();
 
         let transport = Arc::new(RecordingTransport::new(vec![]));
         let config = DatadogDiagnosticsConfig {

--- a/bae-core/src/ui/event_bus.rs
+++ b/bae-core/src/ui/event_bus.rs
@@ -538,6 +538,7 @@ mod tests {
             .block_on(Database::new_test(
                 tmp.path().join("test.db").to_str().unwrap(),
                 Arc::new(coven::SystemClock),
+                std::sync::Arc::new(coven::UuidProvider),
             ))
             .unwrap();
         let library_id = format!("test-{}", uuid::Uuid::new_v4());

--- a/bae-core/src/util/fs.rs
+++ b/bae-core/src/util/fs.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// The content hash coven's blob declarations require on every blob-bearing
 /// row (`BlobDecl::hash_column`): the lowercase-hex SHA-256 of the blob's
@@ -33,44 +33,4 @@ pub fn hash_file(path: &Path) -> std::io::Result<String> {
 pub fn hash_bytes(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     hex::encode(Sha256::digest(bytes))
-}
-
-/// Move a directory to a new location. Tries rename (fast, same volume),
-/// falls back to recursive copy + delete.
-pub fn move_directory(source: &Path, dest_dir: &Path) -> Result<PathBuf, String> {
-    let folder_name = source
-        .file_name()
-        .ok_or_else(|| "Invalid source path".to_string())?;
-    let dest = dest_dir.join(folder_name);
-
-    if dest.exists() {
-        return Err(format!("Destination already exists: {}", dest.display()));
-    }
-
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create destination directory: {e}"))?;
-    }
-
-    if std::fs::rename(source, &dest).is_err() {
-        copy_dir_recursive(source, &dest).map_err(|e| format!("Failed to move directory: {e}"))?;
-        std::fs::remove_dir_all(source)
-            .map_err(|e| format!("Failed to clean up source after copy: {e}"))?;
-    }
-
-    Ok(dest)
-}
-
-fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let dest_path = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_dir_recursive(&entry.path(), &dest_path)?;
-        } else {
-            std::fs::copy(entry.path(), dest_path)?;
-        }
-    }
-    Ok(())
 }

--- a/bae-core/tests/alac_fixtures.rs
+++ b/bae-core/tests/alac_fixtures.rs
@@ -94,6 +94,7 @@ async fn import_single_m4a_fixture(
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");
@@ -329,6 +330,7 @@ async fn import_cue_alac_pair() {
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");

--- a/bae-core/tests/test_album_sort.rs
+++ b/bae-core/tests/test_album_sort.rs
@@ -12,6 +12,7 @@ async fn setup_db() -> (Database, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_candidate_text_fixtures.rs
+++ b/bae-core/tests/test_candidate_text_fixtures.rs
@@ -243,6 +243,7 @@ async fn make_library_manager() -> (bae_core::library::LibraryManager, TempDir) 
     let database = bae_core::db::Database::new_test(
         tmp.path().join("test.db").to_str().unwrap(),
         clock.clone(),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-core/tests/test_cue_ape.rs
+++ b/bae-core/tests/test_cue_ape.rs
@@ -134,6 +134,7 @@ async fn test_cue_ape_records_correct_durations() {
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");
@@ -320,6 +321,7 @@ async fn test_cue_ape_records_track_timing() {
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");
@@ -450,6 +452,7 @@ impl CueApeTestFixture {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let library_dir = StoreDir::new(temp_dir.path().to_path_buf());

--- a/bae-core/tests/test_cue_flac.rs
+++ b/bae-core/tests/test_cue_flac.rs
@@ -378,6 +378,7 @@ async fn import_cue_flac_fixture(temp_root: &Path) -> (LibraryManager, String) {
     let database = Database::new_test(
         db_dir.join("test.db").to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");
@@ -451,6 +452,7 @@ impl CueFlacCaptureFixture {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let library_dir = StoreDir::new(temp_dir.path().to_path_buf());

--- a/bae-core/tests/test_delete.rs
+++ b/bae-core/tests/test_delete.rs
@@ -16,6 +16,7 @@ async fn setup_test_environment() -> (LibraryManager, Database, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_export.rs
+++ b/bae-core/tests/test_export.rs
@@ -45,6 +45,7 @@ impl ExportFixture {
         let db = Database::new_test(
             db_dir.join("test.db").to_str().unwrap(),
             Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .unwrap();

--- a/bae-core/tests/test_import_operations.rs
+++ b/bae-core/tests/test_import_operations.rs
@@ -27,6 +27,7 @@ async fn create_test_db() -> (Database, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -1878,6 +1878,31 @@ async fn remote_transition_failure_rolls_back_finalized_works() {
     );
 }
 
+/// coven verifies a blob's plaintext against its row's content hash on every
+/// cloud fetch, so a `covers` row must describe the bytes actually stored — the
+/// resized thumbnail the import writes, never the image it was made from. A row
+/// hashing anything else makes the cover unreadable on every other device.
+async fn assert_cover_row_describes_stored_bytes(f: &ImportFixture, release_id: &str) {
+    let cover =
+        f.db.find_library_image(release_id, &LibraryImageType::Cover)
+            .await
+            .unwrap()
+            .expect("cover row");
+    let bytes = support::read_cover_image_blob(&f.db, &f.library_manager, release_id)
+        .await
+        .expect("cover blob readable");
+    assert_eq!(
+        cover.content_hash.as_deref(),
+        Some(bae_core::util::fs::hash_bytes(&bytes).as_str()),
+        "the covers row's hash must be the hash of the stored blob",
+    );
+    assert_eq!(
+        cover.file_size,
+        bytes.len() as i64,
+        "the covers row's file_size must be the size of the stored blob",
+    );
+}
+
 /// 6. Import with local cover art: covers row + the cover blob in coven's local store.
 #[tokio::test]
 async fn import_with_cover_art() {
@@ -1924,6 +1949,8 @@ async fn import_with_cover_art() {
         .await
         .expect("cover blob should be readable");
     assert!(!cover_bytes.is_empty(), "cover bytes should not be empty");
+
+    assert_cover_row_describes_stored_bytes(&f, &release_id).await;
 }
 
 /// An oversized folder cover is resized to a ≤600 JPEG thumbnail at import: the
@@ -1981,7 +2008,8 @@ async fn import_resizes_oversized_cover_to_jpeg_thumbnail() {
     );
     let decoded = image::load_from_memory(&cover_bytes).unwrap();
     assert_eq!((decoded.width(), decoded.height()), (600, 600));
-    assert_eq!(cover.file_size, cover_bytes.len() as i64);
+
+    assert_cover_row_describes_stored_bytes(&f, &release_id).await;
 }
 
 /// On a browsable home the readable cloud_path is computed AT IMPORT — for every
@@ -2810,6 +2838,8 @@ async fn unknown_import_seeds_embedded_cover_when_no_folder_image() {
     );
     let decoded = image::load_from_memory(&bytes).unwrap();
     assert_eq!((decoded.width(), decoded.height()), EMBEDDED_COVER_DIMS);
+
+    assert_cover_row_describes_stored_bytes(&f, &release_id).await;
 }
 
 /// A folder image outranks the embedded picture: when both exist, the

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -2061,10 +2061,10 @@ async fn import_on_browsable_home_writes_readable_cloud_paths_at_import() {
     let files = f.db.get_files_for_release(&release_id).await.unwrap();
     assert!(!files.is_empty(), "the import recorded release files");
     for file in &files {
-        // The readable key is `{album}/{release}/{source_folder}/{filename}` with
-        // path separators in the filename sanitized to `_` (so a `scans/back.jpg`
-        // image file keys as `.../scans_back.jpg`); assert the readable prefix +
-        // that the file's own name component is present, not the raw path.
+        // The readable key is `{album}/{release}/{source_folder}/{original_filename}`,
+        // and `original_filename` is the file's path within the release folder — so a
+        // `scans/back.jpg` image file keys under a `scans/` level, mirroring the
+        // folder the release was imported from.
         let cp = file.cloud_path.as_deref().unwrap_or_else(|| {
             panic!(
                 "file {} has no cloud_path on a browsable home",
@@ -2075,10 +2075,10 @@ async fn import_on_browsable_home_writes_readable_cloud_paths_at_import() {
             cp.starts_with(&prefix),
             "audio cloud_path {cp} is under the release prefix {prefix}",
         );
-        let leaf = file.original_filename.rsplit('/').next().unwrap();
         assert!(
-            cp.ends_with(leaf),
-            "audio cloud_path {cp} ends with the file's name {leaf}",
+            cp.ends_with(&file.original_filename),
+            "audio cloud_path {cp} ends with the file's stored path {}",
+            file.original_filename,
         );
     }
 

--- a/bae-core/tests/test_import_service.rs
+++ b/bae-core/tests/test_import_service.rs
@@ -61,6 +61,7 @@ impl ImportFixture {
         let db = Database::new_test(
             db_dir.join("test.db").to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .unwrap();
@@ -3130,6 +3131,7 @@ async fn import_truncated_album(verify: bool) -> Result<(String, String), String
     let db = Database::new_test(
         db_dir.join("test.db").to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-core/tests/test_library_events.rs
+++ b/bae-core/tests/test_library_events.rs
@@ -20,6 +20,7 @@ async fn setup() -> (LibraryManager, Database, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_playback_behavior.rs
+++ b/bae-core/tests/test_playback_behavior.rs
@@ -437,6 +437,7 @@ where
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await?;
     let database_arc = Arc::new(database.clone());
@@ -589,6 +590,7 @@ impl PlaybackTestFixture {
         let database = Database::new_test(
             db_path.to_str().expect("db path is valid UTF-8"),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .expect("open the cloned playback database");
@@ -1070,6 +1072,7 @@ impl CueFlacTestFixture {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let database_arc = Arc::new(database.clone());
@@ -3361,6 +3364,7 @@ impl HighSampleRateTestFixture {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let database_arc = Arc::new(database.clone());
@@ -3809,6 +3813,7 @@ async fn test_restore_emits_seeked_at_saved_position() {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();
@@ -3905,6 +3910,7 @@ async fn test_restore_drops_context_when_cursor_past_shrunk_tracks() {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();
@@ -4028,6 +4034,7 @@ async fn test_play_persists_then_stop_clears_playback_state() {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();
@@ -4203,6 +4210,7 @@ async fn restore_test_library() -> RestoreTestLibrary {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();
@@ -4267,6 +4275,7 @@ async fn empty_test_library() -> (LibraryManager, tokio::runtime::Handle, TempDi
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();
@@ -4544,6 +4553,7 @@ impl CloudOnlyPlaybackFixture {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let library_dir = StoreDir::new(temp_dir.path().to_path_buf());
@@ -4925,6 +4935,7 @@ impl MultiWindowPlayback {
         let database = Database::new_test(
             db_path.to_str().expect("db path is valid UTF-8"),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await
         .expect("open the cloned multi-window database");
@@ -5963,6 +5974,7 @@ impl RemoteMultiWindowPlayback {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let library_dir = StoreDir::new(temp_dir.path().to_path_buf());

--- a/bae-core/tests/test_playback_cpu.rs
+++ b/bae-core/tests/test_playback_cpu.rs
@@ -306,6 +306,7 @@ impl PlaybackTestFixture {
         let database = Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         )
         .await?;
         let database_arc = Arc::new(database.clone());

--- a/bae-core/tests/test_playback_state.rs
+++ b/bae-core/tests/test_playback_state.rs
@@ -10,6 +10,7 @@ async fn setup_db() -> (Database, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_reset_metadata.rs
+++ b/bae-core/tests/test_reset_metadata.rs
@@ -27,6 +27,7 @@ async fn setup() -> (LibraryManager, Database, TempDir) {
     let database = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-core/tests/test_sql_read_tripwire.rs
+++ b/bae-core/tests/test_sql_read_tripwire.rs
@@ -53,6 +53,7 @@ async fn pure_reads_run_off_the_sync_journal() {
     let db = Database::new_test(
         tmp.path().join("tripwire.db").to_str().unwrap(),
         Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-core/tests/test_storage.rs
+++ b/bae-core/tests/test_storage.rs
@@ -80,6 +80,7 @@ async fn test_local_import() {
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");
@@ -227,6 +228,7 @@ async fn test_local_delete_preserves_files() {
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("database");
@@ -324,6 +326,7 @@ async fn run_import_with_cover_test() {
     let database = Database::new_test(
         db_file.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .expect("Failed to create database");

--- a/bae-core/tests/test_storage_state_machine.rs
+++ b/bae-core/tests/test_storage_state_machine.rs
@@ -74,6 +74,7 @@ async fn setup_manager(
     let db = Database::new_test(
         db_path.to_str().unwrap(),
         std::sync::Arc::new(coven::SystemClock),
+        std::sync::Arc::new(coven::UuidProvider),
     )
     .await
     .unwrap();

--- a/bae-test-support/src/lib.rs
+++ b/bae-test-support/src/lib.rs
@@ -316,6 +316,7 @@ pub fn setup_fresh_library(
         .block_on(bae_core::db::Database::new_test(
             db_path.to_str().unwrap(),
             std::sync::Arc::new(coven::SystemClock),
+            std::sync::Arc::new(coven::UuidProvider),
         ))
         .expect("create database");
 


### PR DESCRIPTION
Stacked on #355 — review that one first; this PR's diff is only the eight commits on top.

Three live bugs in the storage layer, plus the consolidation that keeps them from coming back.

Every imported cover was stored with the hash of bytes we did not store. All three cover sources hashed the original, and the funnel then re-encoded to JPEG (always — `resize_cover` re-encodes even a small image) and wrote *those* bytes, patching only the size and content type. The hash column is coven's content hash, verified against the decrypted bytes on a remote fetch, so every folder, embedded, and remote-imported cover would fail verification on another device. `change_cover` got this right, which is exactly why nobody noticed. One constructor now derives size, type, and hash together from the bytes about to be stored, so the wrong thing is no longer expressible. No repair sweep: existing rows already carry a NULL hash from a migration a day old, and both NULL and wrong fail the same fetch loudly, which is the correct behavior for a hash that doesn't match.

Export accepted the job on mobile and never ran it. The producer half compiled on iOS and Android; the worker that drains the queue was desktop-only. A mobile caller got `Ok(())`, an event, and a row that sat in Queued forever. The whole surface is now compiled out there, so a mobile call is a compile error rather than a silent hang.

A path fragment another device wrote was joined onto a local path with no validation. `make_local_dest` joined `original_filename` — a synced column — onto a user-chosen folder and handed it to coven, which checks only that it is UTF-8. The guard for exactly this existed, was documented as bae's concern rather than coven's, and was private to the export path. It is now one un-gated policy applied at both the row-write and the join, because coven applies a pulled changeset straight into SQLite and the write-side guard never sees another device's row. This also surfaced a scanner bug: `relative_path` was built from `to_string_lossy()`, so it was backslash-separated on Windows.

The rest: the download progress bar could only ever show 0% or 100% (the type carried `bytes_done`, `fraction`, and a bounds check for a value nothing could produce — releases now pin blob by blob, which is what coven does internally anyway); the serial queue drain existed twice with a divergent panic path; the db layer minted ids with `Uuid::new_v4()` behind the injected provider's back; and `move_directory`, which nothing called, is gone.

## Test plan

- Regression tests for all three bugs, each verified to fail against the pre-fix code: the stored cover row must describe the stored bytes; `make_local_dest` must reject a traversing `original_filename`; pin progress must report intermediate values.
- Rust: fmt, clippy across five configurations, dead_code, machete, deny, doc — all green. All crate tests green; bae-core suite 22 binaries, 0 failures.
- macOS: full chain green (bridge, xcodegen, xcodebuild, baeTests, swift-format, swiftlint, periphery). iOS: clippy and baeTests green. Android: clippy green.
- Android Gradle steps did not finish locally (five agents saturating one machine) — relying on CI for those.