### PR TITLE
vm: pin winget source, skip installer caches, add the tidy sweep

### DIFF
--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -46,6 +46,10 @@ ssh tom@<ip> 'schtasks /run /tn vmShot'        # screenshot → C:\Users\tom\vms
 
 ## Hard-won facts baked into these scripts
 
+- **winget needs `--source winget` on every install**: the `msstore` source
+  fails certificate validation (0x8a15005e) on a fresh VM, and an unpinned
+  `winget install` aborts when any source errors — even after the community
+  source already found the package.
 - **x64, not ARM, for now**: prebuilt FFmpeg ships x64 (ARM artifact exists as
   of `windows-arm64` work — switch when bae grows its ARM lane); Windows runs
   x64 under emulation. `cargo test` must pass `--target x86_64-pc-windows-msvc`

--- a/scripts/vm/guest/tidy.ps1
+++ b/scripts/vm/guest/tidy.ps1
@@ -1,0 +1,61 @@
+# Shrink the VM: remove non-dev preinstalls and flush OS caches, keeping
+# everything a build touches (cargo registry, sccache, NuGet, target trees,
+# toolchains). Idempotent; run over SSH after provisioning, or any time.
+# Ends with a ReTrim so the freed blocks propagate to the host's sparse qcow2.
+
+$ErrorActionPreference = 'Continue'
+
+# Preinstalled consumer apps. Windows Terminal, Store, and Calculator stay.
+$bloat = @(
+  'Clipchamp.Clipchamp', 'Microsoft.BingNews', 'Microsoft.BingWeather',
+  'Microsoft.BingSearch', 'Microsoft.GamingApp', 'Microsoft.Xbox*',
+  'Microsoft.ZuneMusic', 'Microsoft.ZuneVideo',
+  'Microsoft.MicrosoftSolitaireCollection', 'Microsoft.People',
+  'Microsoft.Todos', 'Microsoft.OutlookForWindows', 'MSTeams',
+  'Microsoft.MicrosoftOfficeHub', 'Microsoft.GetHelp', 'Microsoft.Getstarted',
+  'Microsoft.WindowsFeedbackHub', 'Microsoft.549981C3F5F10', # Cortana
+  'Microsoft.Copilot', 'MicrosoftCorporationII.QuickAssist',
+  'Microsoft.YourPhone', 'Microsoft.WindowsSoundRecorder',
+  'Microsoft.MicrosoftStickyNotes', 'Microsoft.PowerAutomateDesktop',
+  'Microsoft.DevHome', 'Microsoft.OneDriveSync', 'Microsoft.WindowsMaps',
+  'Microsoft.WindowsAlarms', 'MicrosoftCorporationII.MicrosoftFamily'
+)
+foreach ($name in $bloat) {
+  Get-AppxPackage -AllUsers -Name $name | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+  Get-AppxProvisionedPackage -Online | Where-Object DisplayName -Like $name |
+    Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue | Out-Null
+}
+
+# OneDrive's desktop installer (separate from the Appx sync stub).
+$od = "$env:SystemRoot\SysWOW64\OneDriveSetup.exe", "$env:SystemRoot\System32\OneDriveSetup.exe" |
+  Where-Object { Test-Path $_ } | Select-Object -First 1
+if ($od) { & $od /uninstall; Start-Sleep 5 }
+
+# hiberfil.sys — no reason to hibernate a VM.
+powercfg /h off
+
+# ~7 GB Windows Update staging reservation.
+DISM /Online /Set-ReservedStorageState /State:Disabled
+
+# System Restore snapshots — the VM's rollback story is the qcow2 on the host.
+Disable-ComputerRestore -Drive 'C:\' -ErrorAction SilentlyContinue
+vssadmin delete shadows /all /quiet
+
+# Windows Update + Delivery Optimization download caches.
+net stop wuauserv
+Remove-Item -Recurse -Force "$env:SystemRoot\SoftwareDistribution\Download\*" -ErrorAction SilentlyContinue
+net start wuauserv
+Delete-DeliveryOptimizationCache -Force -ErrorAction SilentlyContinue
+
+# Superseded component-store payloads.
+DISM /Online /Cleanup-Image /StartComponentCleanup
+
+# Temp dirs and recycle bin. Build caches live elsewhere and are untouched.
+Remove-Item -Recurse -Force "$env:TEMP\*" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:SystemRoot\Temp\*" -ErrorAction SilentlyContinue
+Clear-RecycleBin -Force -ErrorAction SilentlyContinue
+
+# Tell the virtual disk which blocks are free so the host qcow2 stays sparse.
+Optimize-Volume -DriveLetter C -ReTrim -Verbose
+
+Get-PSDrive C | Select-Object Used, Free

--- a/scripts/vm/provision.sh
+++ b/scripts/vm/provision.sh
@@ -11,10 +11,10 @@ SSH="ssh tom@${VM}"
 FFMPEG_VERSION="$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+-bae[0-9]+' .github/workflows/windows.yml | head -1)"
 
 echo "== toolchain (winget) =="
-$SSH 'winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements --silent & winget install --id Microsoft.DotNet.SDK.8 -e --accept-package-agreements --silent & winget install --id Rustlang.Rustup -e --accept-package-agreements --silent & winget install --id LLVM.LLVM -e --accept-package-agreements --silent & winget install --id Mozilla.sccache -e --accept-package-agreements --silent & winget install --id Microsoft.WinDbg -e --accept-package-agreements --silent & winget install --id Microsoft.WindowsAppRuntime.1.6 -e --accept-package-agreements --silent & winget install --id Microsoft.DotNet.DesktopRuntime.8 --architecture x64 -e --accept-package-agreements --silent'
+$SSH 'winget install --id Git.Git --source winget -e --accept-source-agreements --accept-package-agreements --silent & winget install --id Microsoft.DotNet.SDK.8 --source winget -e --accept-package-agreements --silent & winget install --id Rustlang.Rustup --source winget -e --accept-package-agreements --silent & winget install --id LLVM.LLVM --source winget -e --accept-package-agreements --silent & winget install --id Mozilla.sccache --source winget -e --accept-package-agreements --silent & winget install --id Microsoft.WinDbg --source winget -e --accept-package-agreements --silent & winget install --id Microsoft.WindowsAppRuntime.1.6 --source winget -e --accept-package-agreements --silent & winget install --id Microsoft.DotNet.DesktopRuntime.8 --source winget --architecture x64 -e --accept-package-agreements --silent'
 
 echo "== VS Build Tools (the long one) =="
-$SSH 'winget install --id Microsoft.VisualStudio.2022.BuildTools -e --accept-package-agreements --silent --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.UWP.BuildTools"'
+$SSH 'winget install --id Microsoft.VisualStudio.2022.BuildTools --source winget -e --accept-package-agreements --silent --override "--quiet --wait --nocache --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.UWP.BuildTools"'
 
 echo "== rust toolchain =="
 $SSH '"%USERPROFILE%\.cargo\bin\rustup" toolchain install 1.95.0 --profile minimal && "%USERPROFILE%\.cargo\bin\rustup" target add x86_64-pc-windows-msvc --toolchain 1.95.0 && "%USERPROFILE%\.cargo\bin\rustup" default 1.95.0'
@@ -24,7 +24,7 @@ $SSH "\"%ProgramFiles%\\Git\\cmd\\git.exe\" clone --branch ${BRANCH} https://git
 $SSH 'cd /d C:\bae && "%ProgramFiles%\Git\cmd\git.exe" submodule update --init --recursive'
 
 echo "== ffmpeg dist (${FFMPEG_VERSION}, self-contained) =="
-$SSH "powershell -Command \"\$dist = 'C:\\bae\\bae-ffmpeg\\dist'; New-Item -ItemType Directory -Force \$dist | Out-Null; curl.exe -L https://github.com/bae-fm/bae-ffmpeg/releases/download/${FFMPEG_VERSION}/ffmpeg-windows-x86_64.zip -o \$env:TEMP\\ffmpeg.zip; Expand-Archive -Path \$env:TEMP\\ffmpeg.zip -DestinationPath \$dist -Force; New-Item -ItemType Directory -Force \$dist\\lib | Out-Null; Copy-Item \$dist\\bin\\*.lib \$dist\\lib\\ -Force\""
+$SSH "powershell -Command \"\$dist = 'C:\\bae\\bae-ffmpeg\\dist'; New-Item -ItemType Directory -Force \$dist | Out-Null; curl.exe -L https://github.com/bae-fm/bae-ffmpeg/releases/download/${FFMPEG_VERSION}/ffmpeg-windows-x86_64.zip -o \$env:TEMP\\ffmpeg.zip; Expand-Archive -Path \$env:TEMP\\ffmpeg.zip -DestinationPath \$dist -Force; Remove-Item \$env:TEMP\\ffmpeg.zip; New-Item -ItemType Directory -Force \$dist\\lib | Out-Null; Copy-Item \$dist\\bin\\*.lib \$dist\\lib\\ -Force\""
 
 echo "== uniffi-bindgen-cs =="
 $SSH '"%USERPROFILE%\.cargo\bin\cargo" install --git https://github.com/NordSecurity/uniffi-bindgen-cs.git --tag "v0.11.0+v0.31.0" uniffi-bindgen-cs --locked'


### PR DESCRIPTION
Provisioning a fresh Windows VM failed at the first step: the msstore winget source fails certificate validation (0x8a15005e) on a new install, and an unpinned `winget install` aborts when any configured source errors — even though the community source had already resolved every package. Pinning `--source winget` fixes the whole toolchain stage.

The rest keeps the VM disk small without slowing iteration: VS Build Tools skips its multi-GB payload cache (`--nocache` — modify/repair re-downloads on demand; builds never read it), the FFmpeg zip is removed after extraction, and a new `tidy.ps1` sweeps consumer preinstalls and OS caches (hibernation file, update caches, reserved storage, restore points), finishing with a ReTrim so the freed blocks actually shrink the host's sparse qcow2. Build caches — cargo registry, sccache, NuGet, target trees — are untouched.

## Test plan
- [x] `provision.sh` re-run against the fresh VM proceeds past the winget stage (previously aborted on every package)
- [ ] `tidy.ps1` run over SSH after provisioning; disk usage before/after recorded in the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXNfTnuhabiCkyDV2iMCNF